### PR TITLE
docs: add AGENTS.md contributor guide and runbook

### DIFF
--- a/PR_RELEASE_DESCRIPTION_v0.5.0.md
+++ b/PR_RELEASE_DESCRIPTION_v0.5.0.md
@@ -1,16 +1,19 @@
 # Release v0.5.0 – Summary & Checklist
 
 Summary
+
 - Deterministic CI on self-hosted Windows (concurrency, timeouts, preflight, guard)
 - Session index artifacts across workflows with schema-lite validation and stepSummary
 - Fixture manifest bytes policy (`bytes` replaces `minBytes`), validator `sizeMismatch`
 - Drift/report hardening (execJson source), YAML + docs hygiene (actionlint early)
 
 Release Artifacts
+
 - Notes: RELEASE_NOTES_v0.5.0.md
 - Changelog section: CHANGELOG.md (v0.5.0)
 
 Validation (must be green)
+
 - [ ] Pester tests (windows-latest)
 - [ ] Pester (self-hosted, IncludeIntegration=true)
 - [ ] Fixture Drift (Windows/Ubuntu)
@@ -18,10 +21,12 @@ Validation (must be green)
 - [ ] No stray LabVIEW.exe (guard summary)
 
 Upgrade Notes
+
 - Consumers of fixtures.manifest.json must read `bytes` instead of `minBytes`
 - Action inputs/outputs unchanged; new JSON artifacts are additive
 
-Post‑merge
+Post-merge
+
 - [ ] Tag v0.5.0 on main
 - [ ] Monitor release workflows/artifacts
 - [ ] Open follow-ups: workflow composites; managed arg tokenizer adoption

--- a/RELEASE_NOTES_v0.5.0.md
+++ b/RELEASE_NOTES_v0.5.0.md
@@ -1,10 +1,11 @@
 # Release v0.5.0
 
 Highlights
+
 - Deterministic CI on self-hosted Windows
   - Per-ref concurrency with cancel-in-progress, job timeouts
   - Preflight gate: refuse to start if LabVIEW.exe is running; clear error
-  - Post-run guard (opt‑in) to snapshot/cleanup and append summary
+  - Post-run guard (opt-in) to snapshot/cleanup and append summary
 - Stable session visibility
   - Dispatcher emits `tests/results/session-index.json` with pointers and a ready-to-append `stepSummary`
   - All relevant workflows validate session-index schema (lite) and upload artifact
@@ -16,16 +17,20 @@ Highlights
   - Added AGENTS.md and docs link checker; fixed workflow YAML issues
 
 Upgrade Notes
-- If you consume `fixtures.manifest.json`, migrate parsing from `minBytes` → `bytes`
+
+- If you consume `fixtures.manifest.json`, migrate parsing from `minBytes` to `bytes`
 - No changes to action inputs/outputs; dispatcher JSON artifacts are additive
 
 Validation Checklist
+
 - [ ] Pester (hosted Windows) unit tests green
-- [ ] Pester (self‑hosted Windows) with integration enabled passes preflight and runs clean
-- [ ] Fixture Drift (Windows/Ubuntu) green; report shows “Source: execJson” when rendered
-- [ ] Validate workflow: actionlint OK; docs link check OK (markdownlint may remain policy‑driven)
+- [ ] Pester (self-hosted Windows) with integration enabled passes preflight and runs clean
+- [ ] Fixture Drift (Windows/Ubuntu) green; report shows "Source: execJson" when rendered
+- [ ] Validate workflow: actionlint OK; docs link check OK (markdownlint may remain policy-driven)
 - [ ] No LabVIEW.exe left open after jobs (guard shows zero or expected cleanup)
 
-Post‑Release
+Post-Release
+
 - Tag v0.5.0 on main
-- Open follow‑ups for composites consolidation and managed tokenizer adoption (separate PRs)
+- Open follow-ups for composites consolidation and managed tokenizer adoption (separate PRs)
+

--- a/tmp-agg/PR_RELEASE_v0.5.0.md
+++ b/tmp-agg/PR_RELEASE_v0.5.0.md
@@ -1,29 +1,34 @@
 # Release v0.5.0 (RC merge)
 
 ## Summary
+
 - Session index (`session-index.json`) added with status, summary counts, artifact pointers, run context URLs, and a pre-rendered `stepSummary`.
 - New schema: `docs/schemas/session-index-v1.schema.json` and schema-lite validation wired in CI (validate, self-hosted, hosted, smoke, integration-on-label).
-- Drift action hardened: reliable `drift-summary.json` discovery (timestamped and direct paths) + debug breadcrumbs; “unknown” status resolved.
+- Drift action hardened: reliable `drift-summary.json` discovery (timestamped and direct paths) + debug breadcrumbs; "unknown" status resolved.
 - Dispatcher: hard gate on running `LabVIEW.exe`; LVCompare post-run cleanup is opt-in via `CLEAN_LVCOMPARE=1`.
 - Artifact manifest includes `session-index.json`; workflows append session index summaries and upload as artifact.
-- Manifest size policy migrated `minBytes` → `bytes` (exact).
+- Manifest size policy migrated `minBytes` to `bytes` (exact).
 
 ## Breaking
+
 - `fixtures.manifest.json` now requires `bytes` instead of `minBytes`. Repo tooling and validators updated.
 
 ## Checklist
+
 - [x] Version bumped to `0.5.0`
 - [x] CHANGELOG updated with 2025-10-05 release
 - [x] CI green on RC: drift, validate, pester (self-hosted/hosted), smoke
 - [x] Session index schema added and validated in CI
 - [x] markdownlint clean
 - [x] New/updated tests passing (unit + aggregation artifact tracking)
-- [x] Drift “unknown” status resolved (Windows job)
+- [x] Drift "unknown" status resolved (Windows job)
 - [ ] Tag `v0.5.0` after merge to `main`
 - [ ] Announce + update any external docs if needed
 
 ## Post-merge steps
+
 1) Tag `v0.5.0` to trigger "Release on tag":
    - `git tag v0.5.0 && git push origin v0.5.0`
 2) Verify GitHub Release populated from CHANGELOG
 3) Monitor workflows on `main`
+


### PR DESCRIPTION
This PR adds AGENTS.md with:
- Concise contributor guide (structure, commands, style, testing, PR tips)
- Pinned Agent Runbook (Windows policy, LVCompare-only, invoker handshake/telemetry, safe toggles, triage tips)

Scope: docs-only; no workflow or code changes. CI should run Validate/lint and skip heavy self-hosted as configured.

Requested checks:
- Validate (actionlint, markdownlint)
- Docs link check
