### PR TITLE
feat: Gate drift (aggregate) and consolidated Windows summary (develop, part 1)

### DIFF
--- a/.github/actions/fixture-drift/action.yml
+++ b/.github/actions/fixture-drift/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: Optional settle delay before report generation (ms)
     required: false
     default: '150'
+  suppress-summary:
+    description: Suppress writing to GITHUB_STEP_SUMMARY (use when parent consolidates summary)
+    required: false
+    default: 'false'
 
 outputs:
   status:
@@ -84,6 +88,8 @@ runs:
     - name: Manifest refresh detection and summary
       id: manifest
       shell: pwsh
+      env:
+        SUPPRESS_SUMMARY: ${{ inputs.suppress-summary }}
       run: |
         $ErrorActionPreference = 'Stop'
         $strictPath = Join-Path (Get-Location) 'strict.json'
@@ -100,7 +106,7 @@ runs:
           }
         } catch {}
         if ($written) {
-          if ($env:GITHUB_STEP_SUMMARY) {
+          if ($env:GITHUB_STEP_SUMMARY -and ($env:SUPPRESS_SUMMARY -ne 'true')) {
             $lines = @('### Fixture Manifest Refresh','')
             $lines += ('- Written: {0}' -f $written)
             if ($reason) { $lines += ('- Reason: {0}' -f $reason) }
@@ -409,7 +415,7 @@ runs:
         }
 
     - name: Finalize job status (soft)
-      if: inputs.soft-fail == 'true'
+      if: inputs.soft-fail == 'true' && inputs.suppress-summary != 'true'
       shell: pwsh
       run: |
         $s = '${{ steps.orchestrate.outputs.status }}'
@@ -422,7 +428,7 @@ runs:
         if ($s -ne 'ok') { Write-Host "Soft-fail enabled: not failing job despite status='$s'." }
 
     - name: Append docs pointers
-      if: always()
+      if: always() && inputs.suppress-summary != 'true'
       shell: pwsh
       run: |
         if ($env:GITHUB_STEP_SUMMARY) {


### PR DESCRIPTION
This PR prepares develop for the refined Fixture Drift flow:

- Composite: add `suppress-summary` input so upstream jobs can suppress composite summaries
  and consolidate output in the Windows job.
- Next change (follow-up in this PR): introduce `pre-init` and `gate` jobs and have Windows
  print the single consolidated summary using Gate outputs (ubuntu status/summary, preflight result, docs-only).

Submitting in two parts to keep reviewable diffs. After this merges, I will patch
`.github/workflows/fixture-drift.yml` to mirror the RC Gate pattern.