### PR TITLE
ci/invoker one-shot + no-console CompareVI + runbook test popup fix

### DIFF
--- a/.github/actions/ensure-invoker/action.yml
+++ b/.github/actions/ensure-invoker/action.yml
@@ -1,0 +1,27 @@
+name: Ensure Invoker (one-shot)
+description: No-op start/stop markers for per-job invoker lifecycle
+inputs:
+  mode:
+    description: 'start | stop'
+    required: false
+    default: 'start'
+runs:
+  using: composite
+  steps:
+    - name: Ensure invoker marker
+      shell: pwsh
+      run: |
+        $mode = '${{ inputs.mode }}'
+        $root = (Get-Location).Path
+        $dir  = Join-Path $root 'tests/results/_invoker'
+        if ($mode -eq 'start') {
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          $state = [ordered]@{ schema='invoker-marker/v1'; mode='start'; atUtc=(Get-Date).ToUniversalTime().ToString('o') }
+          $state | ConvertTo-Json -Depth 4 | Out-File -FilePath (Join-Path $dir 'state.json') -Encoding utf8
+          Write-Host 'Invoker (one-shot) start marker written.'
+        } elseif ($mode -eq 'stop') {
+          try { Remove-Item -LiteralPath (Join-Path $dir 'state.json') -Force -ErrorAction SilentlyContinue } catch {}
+          Write-Host 'Invoker (one-shot) stop marker removed.'
+        } else {
+          Write-Host "::notice::Unknown mode: $mode (noop)"
+        }

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -27,6 +27,10 @@ jobs:
       include_integration: ${{ steps.b.outputs.normalized }}
     steps:
       - uses: actions/checkout@v5
+      - name: Ensure Invoker (start)
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: start
       - name: Normalize include_integration
         id: b
         uses: ./.github/actions/bool-normalize
@@ -177,6 +181,12 @@ jobs:
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
           process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
 
+      - name: Ensure Invoker (stop)
+        if: always()
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: stop
+
       - name: Append determinism summary
         if: always()
         shell: pwsh
@@ -214,6 +224,10 @@ jobs:
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
+      - name: Ensure Invoker (start)
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: start
       - name: Fixture Drift Orchestrator
         uses: ./.github/actions/fixture-drift
         with:
@@ -238,6 +252,12 @@ jobs:
           snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
           process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
+
+      - name: Ensure Invoker (stop)
+        if: always()
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: stop
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           snapshot-path: tests/results/${{ matrix.category }}/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
-          process-names: 'conhost,pwsh,LabVIEW,LVCompare'
+          process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
 
       - name: Append determinism summary
         if: always()
@@ -237,7 +237,7 @@ jobs:
         with:
           snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
-          process-names: 'conhost,pwsh,LabVIEW,LVCompare'
+          process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
-          process-names: 'conhost,pwsh,LabVIEW,LVCompare'
+          process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
 
       - name: Append determinism summary
         if: always()

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -51,6 +51,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Ensure Invoker (start)
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: start
 
       - name: Detect docs-only change
         id: docs
@@ -183,6 +187,11 @@ jobs:
           snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
           process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
+      - name: Ensure Invoker (stop)
+        if: always()
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: stop
 
       - name: Append determinism summary
         if: always()

--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -1,0 +1,22 @@
+name: PR Auto-merge (on label)
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-automerge:
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (merge method)
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: MERGE
+

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   loop-max-iterations:
     description: "Max iterations for loop mode (0 = until diff when fail-on-diff=false, or single pass)."
     required: false
-    default: '25'
+    default: '1'
   loop-interval-seconds:
     description: "Interval between iterations in loop mode (fractional seconds supported)."
     required: false

--- a/docs/action-outputs.md
+++ b/docs/action-outputs.md
@@ -59,7 +59,7 @@ Interval between iterations in loop mode (fractional seconds supported).
 Max iterations for loop mode (0 = until diff when fail-on-diff=false, or single pass).
 
 - Required: false
-- Default: `25`
+- Default: `1`
 
 ### loop-simulate
 

--- a/instruction.txt
+++ b/instruction.txt
@@ -1,0 +1,98 @@
+Agent Handoff: Orchestrated CI, Categories, and Dispatch Stabilization
+
+  State summary
+
+  - Orchestrated pipeline restored with category split for Pester:
+      - normalize → lint → preflight → pester-category (matrix) → drift → publish.
+  - Dispatcher hardened:
+      - Invoke-PesterTests.ps1 adds -IncludePatterns/-ExcludePatterns (filters test file list).
+      - Determinism composite (iterations=3, interval=0, Exact) wired.
+      - Dispatcher profile composite (timeout=150s, emit failures JSON, detect leaks with grace) wired.
+  - Summaries improved (job step summaries):
+      - Determinism, Runner Identity, Session (session-index.json), Top Failures (from JSON/XML), Artifact Map, Re-run hint.
+      - Publish aggregates per-category totals via tools/Summarize-PesterCategories.ps1.
+  - Dispatch utilities added:
+      - tools/New-SampleId.ps1 (ts‑based IDs by default).
+      - tools/Dispatch-WithSample.ps1 (resolves repo + workflow id; dispatches with fallback to REST; prints recent runs).
+
+  Critical fixes applied
+
+  - Removed duplicate jobs and fixed broken needs:
+      - drift now needs: [pester-category] (not “pester”).
+      - publish now needs: [lint, pester-category, drift].
+  - Single definitions for drift and publish kept; no duplicates in ci-orchestrated.yml.
+
+  What likely caused your last “already defined” errors
+
+  - GitHub had a prior version of .github/workflows/ci-orchestrated.yml with two drift/publish blocks. I have re‑normalized the file; commits to develop:
+      - b943231 fix(ci): drift needs pester-category (not pester)
+      - fab578c fix(ci): restore drift and publish jobs; correct needs
+      - f2f8229 add per-category publish summary
+      - e2efc68 restore category splits; dispatcher supports patterns
+
+  Verification checklist (do this first)
+
+  1. Confirm orchestrated YAML is current in GitHub:
+      - Open Actions → “CI Orchestrated (deterministic chain)”
+      - Click “View workflow file” to verify a single drift: and publish: block exist, and drift needs pester-category.
+  2. Lint locally:
+      - ./bin/actionlint -color (or run Validate workflow).
+
+  How to run (deterministic dispatch)
+
+  - Generate sample_id and dispatch orchestrated on develop:
+      - pwsh -File tools/Dispatch-WithSample.ps1 ci-orchestrated.yml -Ref develop -IncludeIntegration true
+  - The helper prints:
+      - Fresh sample_id
+      - Exact gh command used
+      - Recent runs list (last 15)
+  - If run not visible yet, wait ~10–15 seconds; GitHub sometimes lags after workflow file changes.
+
+  Files you’ll touch
+
+  - .github/workflows/ci-orchestrated.yml (single orchestrated chain; per-category artifacts and publish summary)
+  - Invoke-PesterTests.ps1 (pattern filtering and existing config)
+  - tools/Dispatch-WithSample.ps1, tools/New-SampleId.ps1 (dispatch)
+  - Summaries:
+      - tools/Write-DeterminismSummary.ps1
+      - tools/Write-RunnerIdentity.ps1
+      - tools/Write-SessionIndexSummary.ps1
+      - tools/Write-PesterTopFailures.ps1
+      - tools/Write-ArtifactMap.ps1
+      - tools/Summarize-PesterCategories.ps1
+
+  If dispatch still “does nothing”
+
+  - Confirm workflow name/id resolution:
+      - gh workflow list -R <owner/repo> --json name,path,id
+      - Ensure “ci-orchestrated.yml” exists and its id appears.
+  - Use REST fallback (built into helper). If needed, run manually:
+      - gh api repos/<owner>/<repo>/actions/workflows/<id>/dispatches -X POST -F ref=develop -F inputs[sample_id]=<id> -F inputs[include_integration]=true
+  - Reopen the workflow file in GH UI to verify it matches the local version (CRLF warnings resolved; GH should parse it fine).
+
+  Category patterns (tune as needed)
+
+  - dispatcher: Invoke-PesterTests*, PesterAvailability*, NestedDispatcher*
+  - fixtures: Fixtures., FixtureValidation, FixtureSummary*, ViBinaryHandling*, FixtureValidationDiff*
+  - schema: Schema., SchemaLite
+  - comparevi: CompareVI*, CanonicalCli, Args.Tokenization
+  - loop: CompareLoop*, Run-AutonomousIntegrationLoop*, LoopMetrics, Integration‑ControlLoop*, IntegrationControlLoop*
+  - psummary: PesterSummary*, Write-PesterSummaryToStepSummary*, AggregationHints*
+  - workflow: Workflow*, On‑FixtureValidationFail, Watch.FlakyRecovery, FunctionShadowing*, FunctionProxy, RunSummary.Tool*, Action.CompositeOutputs,
+  Binding.MinRepro, ArtifactTracking*, Guard.*
+
+  Next steps (plan)
+
+  1. Trigger ci-orchestrated on develop via tools/Dispatch-WithSample.ps1 and wait for publish.
+  2. Verify publish summary shows per-category lines (status, totals, duration).
+  3. Adjust IncludePatterns/ExcludePatterns if flakiness/noise discovered; re-run categories.
+  4. If dispatch visibility is still intermittent, I can add a poller to the Dispatch-WithSample helper to wait until the new run appears and output the run URL.
+
+  Troubleshooting
+
+  - “drift already defined / publish already defined”:
+      - Confirm only one drift: and publish: appear in ci-orchestrated.yml (search by ‘^drift:’ or ‘^publish:’).
+  - “depends on unknown job 'pester'”:
+      - Replace any needs: [pester] with needs: [pester-category].
+  - gh CLI errors (view --json unsupported):
+      - The helper no longer relies on view --json; it uses list + ConvertFrom-Json.

--- a/scripts/Generate-PullRequestCompareReport.ps1
+++ b/scripts/Generate-PullRequestCompareReport.ps1
@@ -13,7 +13,7 @@
 [CmdletBinding()] param(
   [string]$OutputDirectory = 'compare-artifacts',
   [switch]$LoopMode,
-  [int]$LoopIterations = 15,
+[int]$LoopIterations = 3,
   [double]$LoopIntervalSeconds = 0,
   [ValidateSet('Exact','StreamingReservoir','Hybrid')] [string]$QuantileStrategy = 'StreamingReservoir',
   [int]$StreamCapacity = 300,

--- a/tmp-Dispatch-WithSample.ps1
+++ b/tmp-Dispatch-WithSample.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+  Dispatch a workflow with a freshly-generated sample_id.
+.PARAMETER Workflow
+  Workflow file (e.g., ci-orchestrated.yml) or workflow name.
+.PARAMETER Ref
+  Branch or ref to run against (default: develop).
+.PARAMETER IncludeIntegration
+  Optional 'true'/'false' to set include_integration input.
+.PARAMETER ExtraInput
+  Additional -f name=value pairs (array of strings) to pass to gh workflow run.
+.NOTES
+  Requires GitHub CLI (gh) authenticated with repo: actions permissions.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)][string]$Workflow,
+  [string]$Ref = 'develop',
+  [ValidateSet('true','false')][string]$IncludeIntegration,
+  [string[]]$ExtraInput,
+  [int]$WaitSeconds = 8
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-Gh() { if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'gh CLI not found. Install GitHub CLI.' } }
+
+Assert-Gh
+$sid = & (Join-Path $PSScriptRoot 'New-SampleId.ps1')
+
+# Resolve repo via gh (most reliable)
+$repo = $null
+try { $repo = (gh repo view --json nameWithOwner --jq .nameWithOwner) } catch {}
+if (-not $repo) {
+  $repo = $env:GITHUB_REPOSITORY
+}
+if (-not $repo) {
+  try { $url = git remote get-url origin 2>$null; if ($url -match 'github\.com[:/](.+?/.+?)(?:\.git)?$') { $repo = $Matches[1] } } catch {}
+}
+if (-not $repo) { throw 'Unable to determine repository. Set GITHUB_REPOSITORY or ensure gh is authenticated.' }
+
+# Resolve workflow id for robust dispatch
+$wfId = $null
+try { $wfId = (gh workflow view $Workflow -R $repo --json id --jq .id) } catch {}
+if (-not $wfId) {
+  try {
+    $listJson = gh workflow list -R $repo --json name,path,id
+    $list = $null; try { $list = $listJson | ConvertFrom-Json -ErrorAction Stop } catch {}
+    if ($list) {
+      foreach ($wf in $list) {
+        if ($wf.path -and $wf.path.ToString().ToLower().EndsWith($Workflow.ToLower())) { $wfId = $wf.id; break }
+      }
+    }
+  } catch {}
+}
+if (-not $wfId) { $wfId = $Workflow }
+
+$cmd = @('workflow','run', $wfId, '-R', $repo, '-r', $Ref, '-f', "sample_id=$sid")
+if ($IncludeIntegration) { $cmd += @('-f', "include_integration=$IncludeIntegration") }
+if ($ExtraInput) { foreach ($kv in $ExtraInput) { $cmd += @('-f', $kv) } }
+
+Write-Host "Dispatching: gh $($cmd -join ' ')"
+try {
+  gh @cmd | Out-Null
+} catch {
+  Write-Host "gh workflow run failed, attempting REST dispatch via gh api..." -ForegroundColor Yellow
+  $apiPath = "repos/$repo/actions/workflows/$wfId/dispatches"
+  $form = @('-X','POST','-H','Accept: application/vnd.github+json','-F',("ref={0}" -f $Ref),'-F',("inputs[sample_id]={0}" -f $sid))
+  if ($IncludeIntegration) { $form += @('-F', ("inputs[include_integration]={0}" -f $IncludeIntegration)) }
+  gh api $apiPath @form | Out-Null
+}
+Write-Host "Dispatched with sample_id=$sid"
+
+# Brief wait and list recent runs to confirm presence
+if ($WaitSeconds -gt 0) { Start-Sleep -Seconds $WaitSeconds }
+Write-Host 'Recent runs (last 15):'
+gh run list -R $repo -L 15 | Out-Host
+Write-Host 'If not visible yet, it may take a few seconds to appear.'
+

--- a/tmp-win-drift.log
+++ b/tmp-win-drift.log
@@ -1,0 +1,581 @@
+Fixture Drift (Windows)	Set up job	∩╗┐2025-10-06T01:16:44.8036146Z Current runner version: '2.328.0'
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8048860Z Runner name: 'USAUSLT-Z7DLW6G'
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8049358Z Runner group name: 'Default'
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8049893Z Machine name: 'USAUSLT-Z7DLW6G'
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8052097Z ##[group]GITHUB_TOKEN Permissions
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8053698Z Actions: read
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8053980Z Contents: read
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8054275Z Metadata: read
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8054545Z PullRequests: write
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8054836Z ##[endgroup]
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8056087Z Secret source: Actions
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8056452Z Prepare workflow directory
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8502429Z Prepare all required actions
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:44.8530943Z Getting action download info
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:45.2747529Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
+Fixture Drift (Windows)	Set up job	2025-10-06T01:16:46.2537217Z Complete job name: Fixture Drift (Windows)
+Fixture Drift (Windows)	Checkout	∩╗┐2025-10-06T01:16:46.3432559Z ##[group]Run actions/checkout@v4
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3433470Z with:
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3433767Z   fetch-depth: 0
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3434190Z   repository: LabVIEW-Community-CI-CD/compare-vi-cli-action
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3437435Z   token: ***
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3438430Z   ssh-strict: true
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3439374Z   ssh-user: git
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3439785Z   persist-credentials: true
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3440190Z   clean: true
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3440495Z   sparse-checkout-cone-mode: true
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3440908Z   fetch-tags: false
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3441200Z   show-progress: true
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3441534Z   lfs: false
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3441795Z   submodules: false
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3442150Z   set-safe-directory: true
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3442931Z env:
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3444729Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3445098Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3445410Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.3446083Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.4757745Z Syncing repository: LabVIEW-Community-CI-CD/compare-vi-cli-action
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.4759312Z ##[group]Getting Git version info
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.4759892Z Working directory is 'C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action'
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5053441Z [command]"C:\Program Files\Git\cmd\git.exe" version
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5772181Z git version 2.51.0.windows.1
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5850654Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5866427Z Copying 'C:\Users\svelderr\.gitconfig' to 'C:\actions-runner\_work\_temp\688a460d-d18f-4904-9a6b-48b109a094ec\.gitconfig'
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5906324Z Temporarily overriding HOME='C:\actions-runner\_work\_temp\688a460d-d18f-4904-9a6b-48b109a094ec' before making global git config changes
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5907655Z Adding repository directory to the temporary git global config as a safe directory
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.5915211Z [command]"C:\Program Files\Git\cmd\git.exe" config --global --add safe.directory C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.6873972Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --get remote.origin.url
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.7759876Z https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.7830129Z ##[group]Removing previously created refs, to avoid conflicts
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.7838646Z [command]"C:\Program Files\Git\cmd\git.exe" rev-parse --symbolic-full-name --verify --quiet HEAD
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.8645969Z HEAD
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.9565223Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:46.9571310Z [command]"C:\Program Files\Git\cmd\git.exe" submodule status
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.5082529Z ##[group]Cleaning the repository
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.5089888Z [command]"C:\Program Files\Git\cmd\git.exe" clean -ffdx
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.5891616Z [command]"C:\Program Files\Git\cmd\git.exe" reset --hard HEAD
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.6798724Z HEAD is now at cf5a1bb Merge 9a61ba6f8816c087a6a1fd9313f68d327fa5e3a1 into b943231ae2fb2238a8bd012dadccfe198abe9528
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.6846342Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.6944337Z ##[group]Disabling automatic garbage collection
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.6952347Z [command]"C:\Program Files\Git\cmd\git.exe" config --local gc.auto 0
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.7714749Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.7715155Z ##[group]Setting up auth
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.7724590Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:48.8481981Z [command]"C:\Program Files\Git\cmd\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:50.4287141Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:50.5062764Z [command]"C:\Program Files\Git\cmd\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:52.1258114Z [command]"C:\Program Files\Git\cmd\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:52.2109301Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:52.2109765Z ##[group]Fetching the repository
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:52.2120335Z [command]"C:\Program Files\Git\cmd\git.exe" -c protocol.version=2 fetch --prune --no-recurse-submodules --unshallow origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +cf5a1bb512aa04a365c41e29df34bc69f68e3be5:refs/remotes/pull/69/merge
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.1882360Z From https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.1882818Z    7f0051e..9a61ba6  fix/orchestrated-yml-dedupe -> origin/fix/orchestrated-yml-dedupe
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.2331801Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.2332228Z ##[group]Determining the checkout info
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.2332484Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.2342013Z [command]"C:\Program Files\Git\cmd\git.exe" sparse-checkout disable
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.3215583Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --unset-all extensions.worktreeConfig
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.4051911Z ##[group]Checking out the ref
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.4060352Z [command]"C:\Program Files\Git\cmd\git.exe" checkout --progress --force refs/remotes/pull/69/merge
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.5161174Z HEAD is now at cf5a1bb Merge 9a61ba6f8816c087a6a1fd9313f68d327fa5e3a1 into b943231ae2fb2238a8bd012dadccfe198abe9528
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.5236495Z ##[endgroup]
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.6253492Z [command]"C:\Program Files\Git\cmd\git.exe" log -1 --format=%H
+Fixture Drift (Windows)	Checkout	2025-10-06T01:16:53.7166814Z cf5a1bb512aa04a365c41e29df34bc69f68e3be5
+Fixture Drift (Windows)	Detect docs-only change	∩╗┐2025-10-06T01:16:53.7846961Z ##[group]Run $ErrorActionPreference = 'Continue'
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7847374Z [36;1m$ErrorActionPreference = 'Continue'[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7847557Z [36;1m$docsOnly = 'false'[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7847724Z [36;1mif ('pull_request' -eq 'pull_request') {[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7847978Z [36;1m  $ownerRepo = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7848234Z [36;1m  $pr = '69'[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7848500Z [36;1m  $uri = "https://api.github.com/repos/$ownerRepo/pulls/$pr/files"[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7849114Z [36;1m  $headers = @{ Authorization = "***"; 'X-GitHub-Api-Version' = '2022-11-28'; Accept='application/vnd.github+json' }[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7849383Z [36;1m  try {[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7849632Z [36;1m    $files = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7849912Z [36;1m    $names = @($files | ForEach-Object { $_.filename })[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7850090Z [36;1m    if ($names.Count -gt 0) {[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7850279Z [36;1m      $isDocs = $true[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7850421Z [36;1m      foreach ($n in $names) {[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7850638Z [36;1m        $inDocs = ($n -like 'docs/**' -or $n -like '**/*.md')[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7850837Z [36;1m        $isSchema = ($n -like 'docs/schemas/**')[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7851927Z [36;1m        if (-not $inDocs -or $isSchema) { $isDocs = $false; break }[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7852091Z [36;1m      }[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7852205Z [36;1m      if ($isDocs) { $docsOnly = 'true' }[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7852372Z [36;1m    }[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7852470Z [36;1m  } catch {[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7852692Z [36;1m    Write-Host '::notice::Docs-only detection skipped (unable to query PR files). Treating as non-docs.'[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7852979Z [36;1m  }[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7853075Z [36;1m}[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7853251Z [36;1m"docs_only=$docsOnly" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7862723Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7862932Z env:
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7863030Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7863136Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7863232Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:53.7863349Z ##[endgroup]
+Fixture Drift (Windows)	Detect docs-only change	2025-10-06T01:16:54.4947931Z ##[notice]Docs-only detection skipped (unable to query PR files). Treating as non-docs.
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	∩╗┐2025-10-06T01:16:54.7005604Z ##[group]Run $ErrorActionPreference = 'Stop'
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7005924Z [36;1m$ErrorActionPreference = 'Stop'[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7006163Z [36;1m$tmp = Join-Path $env:RUNNER_TEMP ("fixtures-" + [guid]::NewGuid().ToString())[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7006426Z [36;1mNew-Item -ItemType Directory -Force -Path $tmp | Out-Null[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7006631Z [36;1m$base = Join-Path $tmp 'base.vi'[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7006766Z [36;1m$head = Join-Path $tmp 'head.vi'[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7007000Z [36;1mCopy-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'VI1.vi') -Destination $base -Force[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7007317Z [36;1mCopy-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'VI2.vi') -Destination $head -Force[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7007643Z [36;1m"base=$base`nhead=$head" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7012544Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7012742Z env:
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7012892Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7012997Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7013092Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Prepare fixture copies (base/head)	2025-10-06T01:16:54.7013186Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	∩╗┐2025-10-06T01:16:55.2879928Z Prepare all required actions
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:55.2880353Z Getting action download info
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:55.5006156Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761093Z ##[group]Run ./.github/actions/fixture-drift
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761263Z with:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761373Z   render-report: true
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761489Z   comment-on-fail: true
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761612Z   upload-artifacts: true
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761742Z   artifact-name: fixture-drift-windows
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7761892Z   soft-fail: false
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7762122Z   base-path: C:\actions-runner\_work\_temp\fixtures-46008be3-ca18-432c-bb30-8317c5acab4d\base.vi
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7762482Z   head-path: C:\actions-runner\_work\_temp\fixtures-46008be3-ca18-432c-bb30-8317c5acab4d\head.vi
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7762732Z   only-upload-on-failure: true
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7762913Z   lv-compare-args: -nobdcosm -nofppos -noattr
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7763124Z   report-delay-ms: 150
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7763233Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7763322Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7763438Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7763536Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.7763635Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8073570Z ##[group]Run $ErrorActionPreference = 'Stop'
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8073772Z [36;1m$ErrorActionPreference = 'Stop'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8073943Z [36;1mif ('true' -eq 'true' -and $IsWindows -ne $true) { [0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8074231Z [36;1m  throw 'Report rendering requires Windows runners. Use render-report: false for non-Windows platforms.' [0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8074760Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8074997Z [36;1m$vf = Join-Path "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action" 'tools/Validate-Fixtures.ps1'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8075405Z [36;1m$of = Join-Path "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action" 'scripts/On-FixtureValidationFail.ps1'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8075758Z [36;1mif (-not (Test-Path -LiteralPath $vf)) { throw "Missing validator script: $vf" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8076032Z [36;1mif (-not (Test-Path -LiteralPath $of)) { throw "Missing orchestrator script: $of" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8080050Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8080224Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8080305Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8080404Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8080495Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:56.8080582Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3258598Z ##[group]Run $ErrorActionPreference = 'Stop'
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3258812Z [36;1m$ErrorActionPreference = 'Stop'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3258986Z [36;1m$strictPath = Join-Path (Get-Location) 'strict.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3259193Z [36;1m$overridePath = Join-Path (Get-Location) 'override.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3259631Z [36;1mpwsh -NoLogo -NoProfile -File "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action/tools/Validate-Fixtures.ps1" -Json | Out-File -FilePath $strictPath -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3260321Z [36;1mpwsh -NoLogo -NoProfile -File "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action/tools/Validate-Fixtures.ps1" -Json -TestAllowFixtureUpdate | Out-File -FilePath $overridePath -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3264637Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3264824Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3264914Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3265018Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3265115Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:57.3265222Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6099944Z ##[group]Run $ErrorActionPreference = 'Stop'
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6100240Z [36;1m$ErrorActionPreference = 'Stop'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6100492Z [36;1m$strictPath = Join-Path (Get-Location) 'strict.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6100784Z [36;1mif (-not (Test-Path -LiteralPath $strictPath)) { exit 0 }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6102698Z [36;1mtry {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6102988Z [36;1m  $j = Get-Content -LiteralPath $strictPath -Raw | ConvertFrom-Json -ErrorAction Stop[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6103308Z [36;1m} catch { exit 0 }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6103542Z [36;1m$written = $false; $path = ''; $reason = ''[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6103748Z [36;1mtry {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6103929Z [36;1m  if ($j.autoManifest) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6104128Z [36;1m    $written = [bool]$j.autoManifest.written[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6104374Z [36;1m    $path    = [string]$j.autoManifest.path[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6104619Z [36;1m    $reason  = [string]$j.autoManifest.reason[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6104823Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6105115Z [36;1m} catch {}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6105268Z [36;1mif ($written) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6105507Z [36;1m  if ($env:GITHUB_STEP_SUMMARY) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6105708Z [36;1m    $lines = @('### Fixture Manifest Refresh','')[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6105947Z [36;1m    $lines += ('- Written: {0}' -f $written)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6106214Z [36;1m    if ($reason) { $lines += ('- Reason: {0}' -f $reason) }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6106436Z [36;1m    if ($path) { $lines += ('- Path: {0}' -f $path) }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6106731Z [36;1m    $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6129890Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6130212Z [36;1m  "written=true`npath=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6130431Z [36;1m} else {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6130612Z [36;1m  "written=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6131293Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6136145Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6136318Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6136410Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6136507Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6136608Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:16:59.6136694Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1001709Z ##[group]Run $ErrorActionPreference = 'Continue'
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1002012Z [36;1m$ErrorActionPreference = 'Continue'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1002204Z [36;1m# Optional settle delay for report rendering[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1002394Z [36;1mif ('150') { $env:REPORT_DELAY_MS = '150' }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1002620Z [36;1m# Let the orchestrator choose its timestamped subdirectory by default.[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1002910Z [36;1m# Only pass -OutputDir when the caller provided a custom directory.[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1003138Z [36;1m$outDir = ''[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1003298Z [36;1m$strictPath = Join-Path (Get-Location) 'strict.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1003542Z [36;1m$overridePath = Join-Path (Get-Location) 'override.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1003783Z [36;1m$args = @('-StrictJson',$strictPath,'-OverrideJson',$overridePath)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1004112Z [36;1mif ('true' -eq 'true') { $args += '-RenderReport' }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1004660Z [36;1mif ('C:\actions-runner\_work\_temp\fixtures-46008be3-ca18-432c-bb30-8317c5acab4d\base.vi') { $args += @('-BasePath','C:\actions-runner\_work\_temp\fixtures-46008be3-ca18-432c-bb30-8317c5acab4d\base.vi') }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1005471Z [36;1mif ('C:\actions-runner\_work\_temp\fixtures-46008be3-ca18-432c-bb30-8317c5acab4d\head.vi') { $args += @('-HeadPath','C:\actions-runner\_work\_temp\fixtures-46008be3-ca18-432c-bb30-8317c5acab4d\head.vi') }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1006091Z [36;1mif ('-nobdcosm -nofppos -noattr') { $args += @('-LvCompareArgs','-nobdcosm -nofppos -noattr') }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1006420Z [36;1mif ($outDir) { $args += @('-OutputDir',$outDir) }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1006860Z [36;1mpwsh -NoLogo -NoProfile -File "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action/scripts/On-FixtureValidationFail.ps1" @args[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1007268Z [36;1m$exit = $LASTEXITCODE[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1008353Z [36;1m$root = Join-Path (Get-Location) 'results/fixture-drift'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1008595Z [36;1m$latest = $null[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1008736Z [36;1mif (Test-Path $root) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1008920Z [36;1m  $dirs = Get-ChildItem -LiteralPath $root -Directory[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1009253Z [36;1m  $tsDirs = @($dirs | Where-Object { $_.Name -match '^[0-9]{8}T[0-9]{6}Z$' })[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1009474Z [36;1m  if ($tsDirs.Count -gt 0) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1009711Z [36;1m    $latest = $tsDirs | Sort-Object Name -Descending | Select-Object -First 1[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1009911Z [36;1m  } else {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1010126Z [36;1m    $latest = $dirs | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1010359Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1010452Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1010609Z [36;1m$sumPath = $null[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1010739Z [36;1m$status = 'unknown'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1010876Z [36;1mif ($latest) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1011054Z [36;1m  $sumPath = Join-Path $latest.FullName 'drift-summary.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1011265Z [36;1m  if (Test-Path $sumPath) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1011475Z [36;1m    $j = Get-Content -LiteralPath $sumPath -Raw | ConvertFrom-Json[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1011707Z [36;1m    if ($j.status) { $status = [string]$j.status }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1011867Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1011959Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1012297Z [36;1m# Fallback: handle callers that wrote directly to results/fixture-drift or a custom output directory without a timestamped child[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1013371Z [36;1mif (-not $latest -and -not $sumPath) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1013579Z [36;1m  $directSum = Join-Path $root 'drift-summary.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1013823Z [36;1m  if (Test-Path $directSum) { $sumPath = $directSum }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1013983Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1014094Z [36;1mif (-not $sumPath -and $outDir) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1014345Z [36;1m  $odSum = Join-Path $outDir 'drift-summary.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1014546Z [36;1m  if (Test-Path $odSum) { $sumPath = $odSum }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1014745Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1014876Z [36;1mif (-not $status -or $status -eq 'unknown') {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1015064Z [36;1m  if ($sumPath -and (Test-Path $sumPath)) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1015453Z [36;1m    try { $j2 = Get-Content -LiteralPath $sumPath -Raw | ConvertFrom-Json; if ($j2.status) { $status = [string]$j2.status } } catch {}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1016306Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1016610Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1017070Z [36;1m"status=$status" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1018117Z [36;1mif ($sumPath) { "summary_path=$sumPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8 }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1018670Z [36;1m# Do not fail here to allow artifact upload and comment; a later step will enforce failure.[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1019037Z [36;1m[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1019408Z [36;1m# DEBUG: emit breadcrumbs to console and step summary to aid diagnosis when status is unknown or artifacts are missing[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1019762Z [36;1mtry {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1020000Z [36;1m  Write-Host "[drift-debug] orchestrator exit: $exit"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1020261Z [36;1m  Write-Host "[drift-debug] results root: $root"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1020480Z [36;1m  if (Test-Path $root) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1020698Z [36;1m    $latestName = if ($latest) { $latest.Name } else { '<none>' }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1020969Z [36;1m    Write-Host "[drift-debug] latest dir: $latestName"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1021205Z [36;1m    Write-Host "[drift-debug] summary path: $sumPath"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1021414Z [36;1m    # Shallow list of latest dir[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1021576Z [36;1m    if ($latest) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1022048Z [36;1m      Get-ChildItem -LiteralPath $latest.FullName -Force -ErrorAction SilentlyContinue | ForEach-Object { Write-Host ("  - {0}" -f $_.Name) }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1023094Z [36;1m    }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1023218Z [36;1m  } else {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1023447Z [36;1m    Write-Host "[drift-debug] results root missing: $root"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1023654Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1023827Z [36;1m  # If summary exists, echo a compact view and basic fields[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1024125Z [36;1m  if ($sumPath -and (Test-Path $sumPath)) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1024345Z [36;1m    try {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1024519Z [36;1m      $raw = Get-Content -LiteralPath $sumPath -Raw[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1024742Z [36;1m      $j2 = $raw | ConvertFrom-Json -ErrorAction Stop[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1025001Z [36;1m      $catCnt = if ($j2.categories) { $j2.categories.Count } else { 0 }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1025464Z [36;1m      Write-Host ("[drift-debug] summary: schema={0} status={1} exitCode={2} categories={3}" -f $j2.schema,$j2.status,$j2.exitCode,$catCnt)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1025926Z [36;1m    } catch { Write-Host "[drift-debug] failed to parse drift-summary.json: $_" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1026198Z [36;1m  } else {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1026378Z [36;1m    Write-Host "[drift-debug] drift-summary.json not found"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1026588Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1026755Z [36;1m  # Append to step summary (short block)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1026933Z [36;1m$lines = @('### Fixture Drift (debug)','')[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1027121Z [36;1m$lines += ("- Orchestrator exit: {0}" -f $exit)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1027652Z [36;1m$lines += ("- Status: {0}" -f $status)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1027824Z [36;1m$lines += ("- Results root: {0}" -f $root)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1028034Z [36;1m$latestName = if ($latest) { $latest.Name } else { '<none>' }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1028276Z [36;1m$sumDisp = if ($sumPath) { $sumPath } else { '<none>' }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1028498Z [36;1m$lines += ("- Latest dir: {0}" -f $latestName)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1028694Z [36;1m$lines += ("- Summary path: {0}" -f $sumDisp)[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1028967Z [36;1mif ($env:REPORT_DELAY_MS) { $lines += ("- Report delay (ms): {0}" -f $env:REPORT_DELAY_MS) }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1029389Z [36;1m$lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1029700Z [36;1m} catch { Write-Host "[drift-debug] failed to emit debug breadcrumbs: $_" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1035835Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1036057Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1036164Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1036316Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1036443Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:00.1036557Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1405087Z [drift-debug] orchestrator exit: 0
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1410936Z [drift-debug] results root: C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action\results\fixture-drift
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1424710Z [drift-debug] latest dir: 20251006T011700Z
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1429302Z [drift-debug] summary path: C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action\results\fixture-drift\20251006T011700Z\drift-summary.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1483483Z   - drift-summary.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1489534Z   - fixtures.manifest.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1493736Z   - handshake-end.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1497928Z   - handshake-reset.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1503059Z   - handshake-start.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1506752Z   - validator-override.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1511469Z   - validator-strict.json
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.1551722Z [drift-debug] summary: schema=fixture-drift-summary-v1 status=ok exitCode=0 categories=0
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3238605Z ##[group]Run $root = Join-Path (Get-Location) 'results/fixture-drift'
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3238913Z [36;1m$root = Join-Path (Get-Location) 'results/fixture-drift'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3239366Z [36;1mif (Test-Path $root) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3239651Z [36;1m  $latest = Get-ChildItem -LiteralPath $root -Directory | Sort-Object Name -Descending | Select-Object -First 1[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3240043Z [36;1m  if ($latest) { $sum = Join-Path $latest.FullName 'drift-summary.json' } else { $sum = $null }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3240279Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3240389Z [36;1mif ($sum -and (Test-Path $sum)) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3240587Z [36;1m  $j = Get-Content -LiteralPath $sum -Raw | ConvertFrom-Json[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3240766Z [36;1m  $lines = @()[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3240909Z [36;1m  $lines += '### Fixture Drift Summary'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3241058Z [36;1m  $lines += ''[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3241206Z [36;1m  if ($j.schema) { $lines += "- Schema: $($j.schema)" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3241446Z [36;1m  if ($j.generatedAtUtc) { $lines += "- GeneratedAtUtc: $($j.generatedAtUtc)" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3241663Z [36;1m  $lines += "- Status: $($j.status)"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3241832Z [36;1m  $lines += "- ExitCode: $($j.exitCode)"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242036Z [36;1m  $cat = if ($j.categories) { ($j.categories -join ', ') } else { 'none' }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242244Z [36;1m  $lines += "- Categories: $cat"[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242386Z [36;1m  $lines += ''[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242505Z [36;1m  if ($j.artifactPaths) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242649Z [36;1m    $lines += 'Artifacts:'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242816Z [36;1m    foreach ($a in $j.artifactPaths) { $lines += "- $a" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3242982Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3243335Z [36;1m  if ($j.files) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3243461Z [36;1m    $lines += ''[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3243579Z [36;1m    $lines += 'Files:'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3243715Z [36;1m    foreach ($f in $j.files) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3243893Z [36;1m      $p = $f.path; $t = $f.lastWriteTimeUtc; $len = $f.length[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3244148Z [36;1m      if ($len -ne $null) { $lines += "- $p ΓÇö $t ($len bytes)" } else { $lines += "- $p ΓÇö $t" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3244353Z [36;1m    }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3244448Z [36;1m  }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3244625Z [36;1m  $lines -join "`n" | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3244839Z [36;1m} else {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3245038Z [36;1m  'No drift-summary.json found' | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3245263Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3249476Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3249740Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3249849Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3249953Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3250057Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.3250153Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8625501Z ##[group]Run $root = Join-Path (Get-Location) 'results/fixture-drift'
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8625828Z [36;1m$root = Join-Path (Get-Location) 'results/fixture-drift'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8626065Z [36;1mif (-not (Test-Path $root)) { return }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8626378Z [36;1m$latest = Get-ChildItem -LiteralPath $root -Directory | Sort-Object Name -Descending | Select-Object -First 1[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8626682Z [36;1mif (-not $latest) { return }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8626879Z [36;1m$sum = Join-Path $latest.FullName 'drift-summary.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8627078Z [36;1mif (-not (Test-Path $sum)) { return }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8627472Z [36;1m$schemaPath = Join-Path "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action" 'docs/schemas/fixture-drift-summary-v1.schema.json'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8627860Z [36;1mif (Test-Path $schemaPath) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8628282Z [36;1m  pwsh -NoLogo -NoProfile -File "C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action/tools/Invoke-JsonSchemaLite.ps1" -JsonPath $sum -SchemaPath $schemaPath[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8628787Z [36;1m  # Do not fail the job here; schema errors will have been printed for diagnosis.[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8629928Z [36;1m  if ($LASTEXITCODE -ne 0) { Write-Host "Schema-lite validation returned code $LASTEXITCODE" }[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8630144Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8634787Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8634981Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8635083Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8635184Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8635298Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:01.8635390Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.6579878Z Schema-lite validation passed.
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9878936Z ##[group]Run if ('ok' -ne 'ok') {
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9879103Z [36;1mif ('ok' -ne 'ok') {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9879266Z [36;1m  Write-Error "Fixture drift validation failed (status=ok)."[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9879433Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9883246Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9883435Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9883519Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9883618Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9883707Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:02.9883796Z ##[endgroup]
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4901805Z ##[group]Run if ($env:GITHUB_STEP_SUMMARY) {
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4901999Z [36;1mif ($env:GITHUB_STEP_SUMMARY) {[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4902137Z [36;1m  $lines = @('### Docs Pointers','')[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4902301Z [36;1m  $lines += '- Fixture Drift: ./docs/FIXTURE_DRIFT.md'[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4902537Z [36;1m  $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4902996Z [36;1m}[0m
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4907272Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4907450Z env:
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4907536Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4907632Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4907729Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Fixture Drift Orchestrator	2025-10-06T01:17:03.4907814Z ##[endgroup]
+Fixture Drift (Windows)	Session index post (best-effort)	∩╗┐2025-10-06T01:17:03.9577030Z Prepare all required actions
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:03.9577306Z Getting action download info
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1719741Z ##[group]Run ./.github/actions/session-index-post
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1719913Z with:
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720018Z   results-dir: results/fixture-drift
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720145Z   validate-schema: true
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720251Z   upload: true
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720364Z   artifact-name: fixture-drift-session-index
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720496Z env:
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720577Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720664Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720768Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.1720859Z ##[endgroup]
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2009602Z ##[group]Run $dir = 'results/fixture-drift'
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2009814Z [36;1m$dir = 'results/fixture-drift'[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2009982Z [36;1m$idx = Join-Path $dir 'session-index.json'[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2010140Z [36;1mif (Test-Path $idx) {[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2010262Z [36;1m  try {[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2010446Z [36;1m    $j = Get-Content $idx -Raw | ConvertFrom-Json -ErrorAction Stop[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2010640Z [36;1m    if ($j.stepSummary) {[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2010854Z [36;1m      $j.stepSummary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2011071Z [36;1m    } else {[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2011455Z [36;1m      ("Session index available: {0}" -f $idx) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2012545Z [36;1m    }[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2012701Z [36;1m  } catch { Write-Host "::warning::Failed to read session index: $_" }[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2012884Z [36;1m} else {[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2013021Z [36;1m  Write-Host '::notice::session-index.json not found.'[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2013173Z [36;1m}[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2017050Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2017223Z env:
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2017316Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2017425Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2017520Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.2017619Z ##[endgroup]
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.5588661Z ##[notice]session-index.json not found.
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7130788Z ##[group]Run $dir = 'results/fixture-drift'
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7131006Z [36;1m$dir = 'results/fixture-drift'[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7131237Z [36;1m$idx = Join-Path $dir 'session-index.json'[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7131431Z [36;1mif (Test-Path $idx) {[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7131777Z [36;1m  pwsh -File tools/Invoke-JsonSchemaLite.ps1 -JsonPath $idx -SchemaPath docs/schemas/session-index-v1.schema.json[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7141943Z [36;1m  if ($LASTEXITCODE -ne 0) { Write-Host "::warning::Schema-lite returned $LASTEXITCODE for session index" }[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7142465Z [36;1m} else { Write-Host '::notice::session-index.json not present for validation.' }[0m
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7148026Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7148264Z env:
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7148378Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7148506Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7148625Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:04.7148743Z ##[endgroup]
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.0824798Z ##[notice]session-index.json not present for validation.
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2426475Z ##[group]Run actions/upload-artifact@v4
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2426630Z with:
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2426732Z   name: fixture-drift-session-index
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2426882Z   path: results/fixture-drift/session-index.json
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2427699Z   if-no-files-found: warn
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2427815Z   compression-level: 6
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2427913Z   overwrite: false
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2428010Z   include-hidden-files: false
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2428122Z env:
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2428199Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2428290Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2428378Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.2428467Z ##[endgroup]
+Fixture Drift (Windows)	Session index post (best-effort)	2025-10-06T01:17:05.4844931Z ##[warning]No files were found with the provided path: results/fixture-drift/session-index.json. No artifacts will be uploaded.
+Fixture Drift (Windows)	Runner Unblock Guard	∩╗┐2025-10-06T01:17:05.5254447Z Prepare all required actions
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5317859Z ##[group]Run ./.github/actions/runner-unblock-guard
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318054Z with:
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318223Z   snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318436Z   cleanup: true
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318573Z   process-names: conhost,pwsh,LabVIEW,LVCompare
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318725Z env:
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318834Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5318935Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5319039Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5319136Z ##[endgroup]
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5640486Z ##[group]Run $ErrorActionPreference = 'Stop'
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5640746Z [36;1m$ErrorActionPreference = 'Stop'[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5640952Z [36;1m$snapPath = 'results/fixture-drift/runner-unblock-snapshot.json'[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5641263Z [36;1m$procNames = 'conhost,pwsh,LabVIEW,LVCompare'.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5641618Z [36;1m$doCleanup = ('true' -eq 'true') -or ($env:UNBLOCK_GUARD -eq '1')[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5641965Z [36;1m$procs = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -in $procNames } | Select-Object ProcessName,Id,StartTime)[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5642365Z [36;1m$jobs  = @(Get-Job -ErrorAction SilentlyContinue | Select-Object Id,Name,State,HasMoreData)[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5643605Z [36;1m$snap = [ordered]@{ processes=$procs; jobs=$jobs; cleanupPerformed=$false }[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5643809Z [36;1m$dir = Split-Path -Parent $snapPath[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5644057Z [36;1mif ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5644356Z [36;1m$snap | ConvertTo-Json -Depth 5 | Out-File -FilePath $snapPath -Encoding utf8[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5644545Z [36;1m$cleanupNote = ''[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5644659Z [36;1mif ($doCleanup) {[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5644797Z [36;1m  $stoppedLV = 0; $stoppedLVC = 0; $stoppedJobs = 0[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5645194Z [36;1m  try { Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue | ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue; $stoppedLV++ } catch {} } } catch {}[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5646744Z [36;1m  try { Get-Process -Name 'LVCompare' -ErrorAction SilentlyContinue | ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue; $stoppedLVC++ } catch {} } } catch {}[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5647407Z [36;1m  try { $gj = @(Get-Job -ErrorAction SilentlyContinue); foreach ($j in $gj) { try { Stop-Job -Job $j -ErrorAction SilentlyContinue; Remove-Job -Job $j -Force -ErrorAction SilentlyContinue; $stoppedJobs++ } catch {} } } catch {}[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5647830Z [36;1m  $snap.cleanupPerformed = $true[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5648054Z [36;1m  $snap.cleanup = [ordered]@{ LabVIEW=$stoppedLV; LVCompare=$stoppedLVC; Jobs=$stoppedJobs }[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5648342Z [36;1m  $snap | ConvertTo-Json -Depth 6 | Out-File -FilePath $snapPath -Encoding utf8[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5649295Z [36;1m  $cleanupNote = ('Cleanup: LabVIEW={0}, LVCompare={1}, Jobs={2}' -f $stoppedLV,$stoppedLVC,$stoppedJobs)[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5649821Z [36;1m}[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5649936Z [36;1m$lines = @('### Runner Unblock Guard','')[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5650105Z [36;1m$lines += ('- Process count: {0}' -f $procs.Count)[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5650636Z [36;1m$lines += ('- Pester job count: {0}' -f $jobs.Count)[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5650791Z [36;1m$lines += ''[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5650914Z [36;1m$lines += ('Snapshot: {0}' -f $snapPath)[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5651135Z [36;1mif ($cleanupNote) { $lines += ('- ' + $cleanupNote) }[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5651451Z [36;1m$lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8[0m
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5659353Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5663036Z env:
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5663171Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5663310Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5663448Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Runner Unblock Guard	2025-10-06T01:17:05.5663590Z ##[endgroup]
+Fixture Drift (Windows)	Append determinism summary	∩╗┐2025-10-06T01:17:06.2144587Z ##[group]Run pwsh -File tools/Write-DeterminismSummary.ps1
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2144913Z [36;1mpwsh -File tools/Write-DeterminismSummary.ps1[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2149022Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2149224Z env:
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2149328Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2149428Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2149533Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:06.2149626Z ##[endgroup]
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.1927279Z [31;1mParserError: [0mC:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action\tools\Write-DeterminismSummary.ps1:13[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.1928569Z [31;1m[0m[36;1mLine |[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.1929625Z [31;1m[0m[36;1m[36;1m  13 | [0m   if ([36;1m$env:[0m$name -ne $null -and "$($env:$name)" -ne '') { return "$($ ΓÇª[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.1930735Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m       ~~~~~[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.1932069Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mVariable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.1933735Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m[36;1m     | [31;1mdelimit the name.[0m
+Fixture Drift (Windows)	Append determinism summary	2025-10-06T01:17:07.5039493Z ##[error]Process completed with exit code 1.
+Fixture Drift (Windows)	Append runner identity	∩╗┐2025-10-06T01:17:07.5524086Z ##[group]Run pwsh -File tools/Write-RunnerIdentity.ps1 -SampleId ''
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5524671Z [36;1mpwsh -File tools/Write-RunnerIdentity.ps1 -SampleId ''[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5530628Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5530924Z env:
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5531078Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5531243Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5531407Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:07.5531564Z ##[endgroup]
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.5333004Z [31;1mParserError: [0mC:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action\tools\Write-RunnerIdentity.ps1:20[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.5333543Z [31;1m[0m[36;1mLine |[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.5334800Z [31;1m[0m[36;1m[36;1m  20 | [0m function Get-Env($n){ if ([36;1m$env:[0m$n -ne $null) { return "$($env:$n)" }  ΓÇª[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.5335542Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                           ~~~~~[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.5336414Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mVariable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.5337112Z [31;1m[0m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m[36;1m     | [31;1mdelimit the name.[0m
+Fixture Drift (Windows)	Append runner identity	2025-10-06T01:17:08.8357535Z ##[error]Process completed with exit code 1.
+Fixture Drift (Windows)	Append fixture drift summary	∩╗┐2025-10-06T01:17:08.8822804Z ##[group]Run pwsh -File tools/Write-FixtureDriftSummary.ps1 -Dir 'results/fixture-drift'
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8823315Z [36;1mpwsh -File tools/Write-FixtureDriftSummary.ps1 -Dir 'results/fixture-drift'[0m
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8828486Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8828692Z env:
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8829179Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8829279Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8829375Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Append fixture drift summary	2025-10-06T01:17:08.8829467Z ##[endgroup]
+Fixture Drift (Windows)	Append artifact map	∩╗┐2025-10-06T01:17:10.1191046Z ##[group]Run $list = 'results/fixture-drift/drift-summary.json;results/fixture-drift/compare-report.html;results/fixture-drift/session-index.json'
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1191728Z [36;1m$list = 'results/fixture-drift/drift-summary.json;results/fixture-drift/compare-report.html;results/fixture-drift/session-index.json'[0m
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1192183Z [36;1mpwsh -File tools/Write-ArtifactMap.ps1 -PathsList $list -Title 'Artifacts'[0m
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1196706Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1196902Z env:
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1197004Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1197105Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1197208Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Append artifact map	2025-10-06T01:17:10.1197304Z ##[endgroup]
+Fixture Drift (Windows)	Re-run hint	∩╗┐2025-10-06T01:17:11.1537711Z ##[group]Run pwsh -File tools/Write-RerunHint.ps1 -Workflow 'fixture-drift.yml' -SampleId ''
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1538394Z [36;1mpwsh -File tools/Write-RerunHint.ps1 -Workflow 'fixture-drift.yml' -SampleId ''[0m
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1543696Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1543892Z env:
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1543999Z   UNBLOCK_GUARD: 1
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1544105Z   LV_SUPPRESS_UI: 1
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1544208Z   WATCH_CONSOLE: 1
+Fixture Drift (Windows)	Re-run hint	2025-10-06T01:17:11.1544304Z ##[endgroup]
+Fixture Drift (Windows)	Post Checkout	∩╗┐2025-10-06T01:17:12.1442031Z Post job cleanup.
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.3090123Z [command]"C:\Program Files\Git\cmd\git.exe" version
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.3777023Z git version 2.51.0.windows.1
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.3845695Z Copying 'C:\Users\svelderr\.gitconfig' to 'C:\actions-runner\_work\_temp\20cf504c-4d91-4596-9580-b0538d6b647d\.gitconfig'
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.3885545Z Temporarily overriding HOME='C:\actions-runner\_work\_temp\20cf504c-4d91-4596-9580-b0538d6b647d' before making global git config changes
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.3886636Z Adding repository directory to the temporary git global config as a safe directory
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.3894081Z [command]"C:\Program Files\Git\cmd\git.exe" config --global --add safe.directory C:\actions-runner\_work\compare-vi-cli-action\compare-vi-cli-action
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.4717883Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:12.5569187Z [command]"C:\Program Files\Git\cmd\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:14.1042365Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:14.1881142Z http.https://github.com/.extraheader
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:14.1944909Z [command]"C:\Program Files\Git\cmd\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Fixture Drift (Windows)	Post Checkout	2025-10-06T01:17:14.2756984Z [command]"C:\Program Files\Git\cmd\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Fixture Drift (Windows)	Complete job	∩╗┐2025-10-06T01:17:15.9294838Z Cleaning up orphan processes

--- a/tmp_ci.yml
+++ b/tmp_ci.yml
@@ -1,8 +1,6 @@
 name: CI Orchestrated (deterministic chain)
 
 on:
-  push:
-    branches: [ develop ]
   workflow_dispatch:
     inputs:
       include_integration:
@@ -106,6 +104,7 @@ jobs:
         id: dprofile
         uses: ./.github/actions/dispatcher-profile
         with:
+          timeout-seconds: '150'
           emit-failures-json-always: 'true'
           detect-leaks: 'true'
           fail-on-leaks: 'false'
@@ -140,6 +139,7 @@ jobs:
             -TestsPath tests `
             -IncludeIntegration '${{ needs.normalize.outputs.include_integration }}' `
             -ResultsPath $resDir `
+            -TimeoutSeconds ${{ steps.dprofile.outputs.timeout_seconds }} `
             -EmitFailuresJsonAlways `
             -IncludePatterns $inc
 
@@ -313,6 +313,7 @@ jobs:
   
 
   
+
 
 
 

--- a/tools/Dispatch-WithSample.ps1
+++ b/tools/Dispatch-WithSample.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+  Dispatch a workflow with a freshly-generated sample_id.
+.PARAMETER Workflow
+  Workflow file (e.g., ci-orchestrated.yml) or workflow name.
+.PARAMETER Ref
+  Branch or ref to run against (default: develop).
+.PARAMETER IncludeIntegration
+  Optional 'true'/'false' to set include_integration input.
+.PARAMETER ExtraInput
+  Additional -f name=value pairs (array of strings) to pass to gh workflow run.
+.NOTES
+  Requires GitHub CLI (gh) authenticated with repo: actions permissions.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)][string]$Workflow,
+  [string]$Ref = 'develop',
+  [ValidateSet('true','false')][string]$IncludeIntegration,
+  [string[]]$ExtraInput,
+  [int]$WaitSeconds = 8
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-Gh() { if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'gh CLI not found. Install GitHub CLI.' } }
+
+Assert-Gh
+$sid = & (Join-Path $PSScriptRoot 'New-SampleId.ps1')
+
+# Resolve repo via gh (most reliable)
+$repo = $null
+try { $repo = (gh repo view --json nameWithOwner --jq .nameWithOwner) } catch {}
+if (-not $repo) {
+  $repo = $env:GITHUB_REPOSITORY
+}
+if (-not $repo) {
+  try { $url = git remote get-url origin 2>$null; if ($url -match 'github\.com[:/](.+?/.+?)(?:\.git)?$') { $repo = $Matches[1] } } catch {}
+}
+if (-not $repo) { throw 'Unable to determine repository. Set GITHUB_REPOSITORY or ensure gh is authenticated.' }
+
+# Resolve workflow id for robust dispatch
+$wfId = $null
+try { $wfId = (gh workflow view $Workflow -R $repo --json id --jq .id) } catch {}
+if (-not $wfId) {
+  try {
+    $listJson = gh workflow list -R $repo --json name,path,id
+    $list = $null; try { $list = $listJson | ConvertFrom-Json -ErrorAction Stop } catch {}
+    if ($list) {
+      foreach ($wf in $list) {
+        if ($wf.path -and $wf.path.ToString().ToLower().EndsWith($Workflow.ToLower())) { $wfId = $wf.id; break }
+      }
+    }
+  } catch {}
+}
+if (-not $wfId) { $wfId = $Workflow }
+
+$cmd = @('workflow','run', $wfId, '-R', $repo, '-r', $Ref, '-f', "sample_id=$sid")
+if ($IncludeIntegration) { $cmd += @('-f', "include_integration=$IncludeIntegration") }
+if ($ExtraInput) { foreach ($kv in $ExtraInput) { $cmd += @('-f', $kv) } }
+
+Write-Host "Dispatching: gh $($cmd -join ' ')"
+try {
+  gh @cmd | Out-Null
+} catch {
+  Write-Host "gh workflow run failed, attempting REST dispatch via gh api..." -ForegroundColor Yellow
+  $apiPath = "repos/$repo/actions/workflows/$wfId/dispatches"
+  $form = @('-X','POST','-H','Accept: application/vnd.github+json','-F',("ref={0}" -f $Ref),'-F',("inputs[sample_id]={0}" -f $sid))
+  if ($IncludeIntegration) { $form += @('-F', ("inputs[include_integration]={0}" -f $IncludeIntegration)) }
+  gh api $apiPath @form | Out-Null
+}
+Write-Host "Dispatched with sample_id=$sid"
+
+# Brief wait and list recent runs to confirm presence
+if ($WaitSeconds -gt 0) { Start-Sleep -Seconds $WaitSeconds }
+Write-Host 'Recent runs (last 15):'
+gh run list -R $repo -L 15 | Out-Host
+Write-Host 'If not visible yet, it may take a few seconds to appear.'

--- a/tools/New-SampleId.ps1
+++ b/tools/New-SampleId.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+  Generate a sample_id for workflow_dispatch runs.
+.DESCRIPTION
+  Emits a compact, readable sample id by default (ts-YYYYMMDD-HHMMSS-XXXX).
+  Can emit GUID with -Format guid.
+.PARAMETER Prefix
+  Optional prefix to add before the id.
+.PARAMETER Format
+  'ts' (default) or 'guid'.
+.OUTPUTS
+  Writes the id to stdout and sets GITHUB_OUTPUT 'sample_id' if available.
+#>
+[CmdletBinding()]
+param(
+  [string]$Prefix,
+  [ValidateSet('ts','guid')][string]$Format = 'ts'
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function New-TsId {
+  $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+  $rnd = -join ((48..57 + 97..122) | Get-Random -Count 4 | ForEach-Object {[char]$_})
+  "ts-$ts-$rnd"
+}
+
+$id = if ($Format -eq 'guid') { [guid]::NewGuid().ToString() } else { New-TsId }
+if ($Prefix) { $id = "$Prefix$id" }
+
+if ($env:GITHUB_OUTPUT) { "sample_id=$id" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8 }
+Write-Output $id
+


### PR DESCRIPTION
- CompareVI: hidden ProcessStartInfo; post-exit LabVIEW cleanup (≤10s)
- Tests: runbook invokes in-process (no Start-Process pwsh)
- Guard: capture node.exe in snapshots
- Invoker: per-job start/stop markers
- Orchestrated: pre/post invoker markers in category + drift jobs
- Auto-run on push to develop; PR automerge on label