### PR TITLE
Stabilization: no cleanup, warmup, persistence guard, invoker persistence

### DIFF
--- a/.github/actions/ensure-invoker/action.yml
+++ b/.github/actions/ensure-invoker/action.yml
@@ -1,27 +1,81 @@
-name: Ensure Invoker (one-shot)
-description: No-op start/stop markers for per-job invoker lifecycle
+name: ensure-invoker
+description: Start/stop a one-shot invoker per job with sentinel/markers
 inputs:
   mode:
-    description: 'start | stop'
+    description: start or stop
+    required: true
+  results-dir:
+    description: Base results directory
     required: false
-    default: 'start'
+    default: tests/results
+  category:
+    description: Optional category subfolder appended to results-dir
+    required: false
+  timeout-seconds:
+    description: Wait time for ready/stop markers
+    required: false
+    default: '20'
+outputs:
+  pipe-name:
+    description: Computed pipe name for this job
+    value: ${{ steps.compute.outputs.pipe_name }}
+  sentinel-path:
+    description: Sentinel path for this job
+    value: ${{ steps.compute.outputs.sentinel }}
 runs:
   using: composite
   steps:
-    - name: Ensure invoker marker
+    - id: compute
       shell: pwsh
       run: |
-        $mode = '${{ inputs.mode }}'
-        $root = (Get-Location).Path
-        $dir  = Join-Path $root 'tests/results/_invoker'
-        if ($mode -eq 'start') {
-          New-Item -ItemType Directory -Force -Path $dir | Out-Null
-          $state = [ordered]@{ schema='invoker-marker/v1'; mode='start'; atUtc=(Get-Date).ToUniversalTime().ToString('o') }
-          $state | ConvertTo-Json -Depth 4 | Out-File -FilePath (Join-Path $dir 'state.json') -Encoding utf8
-          Write-Host 'Invoker (one-shot) start marker written.'
-        } elseif ($mode -eq 'stop') {
-          try { Remove-Item -LiteralPath (Join-Path $dir 'state.json') -Force -ErrorAction SilentlyContinue } catch {}
-          Write-Host 'Invoker (one-shot) stop marker removed.'
-        } else {
-          Write-Host "::notice::Unknown mode: $mode (noop)"
-        }
+        $base = '${{ inputs.results-dir }}'
+        $cat  = '${{ inputs.category }}'
+        if ($cat) { $base = Join-Path $base $cat }
+        $pipe = "lvci.invoker.$env:GITHUB_RUN_ID.$env:GITHUB_JOB.$env:GITHUB_RUN_ATTEMPT"
+        $sent = Join-Path $env:RUNNER_TEMP "invoker/$($env:GITHUB_RUN_ID).$($env:GITHUB_JOB).sentinel"
+        New-Item -ItemType Directory -Path (Split-Path -Parent $sent) -Force | Out-Null
+        "pipe_name=$pipe" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        "sentinel=$sent"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        "results=$base"    | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Start invoker (Windows only)
+      if: ${{ inputs.mode == 'start' && runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        $results = '${{ steps.compute.outputs.results }}'
+        $pipe    = '${{ steps.compute.outputs.pipe_name }}'
+        $sent    = '${{ steps.compute.outputs.sentinel }}'
+        $ready   = Join-Path $results '_invoker/ready.json'
+        $stopped = Join-Path $results '_invoker/stopped.json'
+        if (Test-Path -LiteralPath $ready) { Remove-Item -LiteralPath $ready -Force -ErrorAction SilentlyContinue }
+        if (Test-Path -LiteralPath $stopped) { Remove-Item -LiteralPath $stopped -Force -ErrorAction SilentlyContinue }
+        # Create sentinel to keep process alive
+        if (-not (Test-Path -LiteralPath $sent)) { New-Item -ItemType File -Path $sent -Force | Out-Null }
+        # Launch hidden pwsh child
+        $args = @('-NoLogo','-NoProfile','-File','tools/RunnerInvoker/Start-RunnerInvoker.ps1','-PipeName',"$pipe",'-SentinelPath',"$sent",'-ResultsDir',"$results")
+        $p = Start-Process -FilePath pwsh -ArgumentList $args -WindowStyle Hidden -PassThru
+        Write-Host "Started invoker pid=$($p.Id) pipe=$pipe"
+        # Wait for ready marker
+        $to = [int]'${{ inputs.timeout-seconds }}'
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        while ($sw.Elapsed.TotalSeconds -lt $to) { if (Test-Path -LiteralPath $ready) { break }; Start-Sleep -Milliseconds 300 }
+        if (-not (Test-Path -LiteralPath $ready)) { Write-Host "::error::Invoker not ready after $to s"; exit 1 }
+
+    - name: Stop invoker (Windows only)
+      if: ${{ inputs.mode == 'stop' && runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        $results = '${{ steps.compute.outputs.results }}'
+        $sent    = '${{ steps.compute.outputs.sentinel }}'
+        $stopped = Join-Path $results '_invoker/stopped.json'
+        if (Test-Path -LiteralPath $sent) { Remove-Item -LiteralPath $sent -Force -ErrorAction SilentlyContinue }
+        $to = [int]'${{ inputs.timeout-seconds }}'
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        while ($sw.Elapsed.TotalSeconds -lt $to) { if (Test-Path -LiteralPath $stopped) { break }; Start-Sleep -Milliseconds 300 }
+        if (-not (Test-Path -LiteralPath $stopped)) { Write-Host "::warning::Invoker stop marker not observed within $to s (continuing)" }
+
+    - name: No-op on non-Windows
+      if: ${{ runner.os != 'Windows' }}
+      shell: bash
+      run: echo "ensure-invoker: non-Windows runner, skipping"
+

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -92,6 +92,9 @@ jobs:
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
+      - name: Append interactivity probe
+        shell: pwsh
+        run: pwsh -File tools/Write-InteractivityProbe.ps1
       - name: Ensure Invoker (start)
         uses: ./.github/actions/ensure-invoker
         with:
@@ -185,7 +188,7 @@ jobs:
         with:
           snapshot-path: tests/results/${{ matrix.category }}/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
-          process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
+          process-names: 'conhost,pwsh,LabVIEW,LVCompare'
 
       - name: Ensure Invoker (stop)
         if: always()
@@ -231,6 +234,9 @@ jobs:
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
+      - name: Append interactivity probe
+        shell: pwsh
+        run: pwsh -File tools/Write-InteractivityProbe.ps1
       - name: Ensure Invoker (start)
         uses: ./.github/actions/ensure-invoker
         with:
@@ -258,7 +264,7 @@ jobs:
         with:
           snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
-          process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
+          process-names: 'conhost,pwsh,LabVIEW,LVCompare'
 
       - name: Ensure Invoker (stop)
         if: always()

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -85,13 +85,19 @@ jobs:
       max-parallel: 1
     env:
       DETECT_LEAKS: '1'
-      CLEAN_AFTER: '1'
+      CLEAN_AFTER: '0'
       SCAN_ARTIFACTS: '1'
-      UNBLOCK_GUARD: '1'
+      UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '1'
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
+      - name: Ensure Invoker (start)
+        uses: ./.github/actions/ensure-invoker
+        with:
+          mode: start
+          results-dir: tests/results
+          category: ${{ matrix.category }}
       - name: Prepare fixture copies (base/head)
         id: fixtures
         uses: ./.github/actions/prepare-fixtures
@@ -116,7 +122,7 @@ jobs:
           kill-leaks: 'false'
           leak-grace-seconds: '3'
           clean-labview-before: 'false'
-          clean-after: 'true'
+          clean-after: 'false'
           track-artifacts: 'true'
       - name: Define category patterns
         id: cats
@@ -219,7 +225,8 @@ jobs:
     timeout-minutes: 3
     needs: [pester-category]
     env:
-      UNBLOCK_GUARD: '1'
+      INVOKER_REQUIRED: '1'
+      UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '1'
       WATCH_CONSOLE: '1'
     steps:

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -88,7 +88,7 @@ jobs:
       CLEAN_AFTER: '0'
       SCAN_ARTIFACTS: '1'
       UNBLOCK_GUARD: '0'
-      LV_SUPPRESS_UI: '1'
+      LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
@@ -227,7 +227,7 @@ jobs:
     env:
       INVOKER_REQUIRED: '1'
       UNBLOCK_GUARD: '0'
-      LV_SUPPRESS_UI: '1'
+      LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -90,6 +90,7 @@ jobs:
       UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
+      LABVIEW_EXE: 'C:\\Program Files\\National Instruments\\LabVIEW 2025\\LabVIEW.exe'
     steps:
       - uses: actions/checkout@v5
       - name: LabVIEW warmup (best-effort)
@@ -236,6 +237,7 @@ jobs:
       UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
+      LABVIEW_EXE: 'C:\\Program Files\\National Instruments\\LabVIEW 2025\\LabVIEW.exe'
     steps:
       - uses: actions/checkout@v5
       - name: LabVIEW warmup (best-effort)

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -92,6 +92,10 @@ jobs:
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
+      - name: LabVIEW warmup (best-effort)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh -File tools/Warmup-LabVIEW.ps1
       - name: Append interactivity probe
         shell: pwsh
         run: pwsh -File tools/Write-InteractivityProbe.ps1
@@ -234,6 +238,10 @@ jobs:
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
+      - name: LabVIEW warmup (best-effort)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh -File tools/Warmup-LabVIEW.ps1
       - name: Append interactivity probe
         shell: pwsh
         run: pwsh -File tools/Write-InteractivityProbe.ps1

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -51,6 +51,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      
+          results-dir: results/fixture-drift
       - name: Ensure Invoker (start)
         uses: ./.github/actions/ensure-invoker
         with:
@@ -100,7 +103,8 @@ jobs:
     needs: preflight-windows
     timeout-minutes: 3
     env:
-      UNBLOCK_GUARD: '1'
+      INVOKER_REQUIRED: '1'
+      UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '1'
       WATCH_CONSOLE: '1'
     permissions:

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -105,7 +105,7 @@ jobs:
     env:
       INVOKER_REQUIRED: '1'
       UNBLOCK_GUARD: '0'
-      LV_SUPPRESS_UI: '1'
+      LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
     permissions:
       actions: read

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -190,7 +190,7 @@ jobs:
         with:
           snapshot-path: results/fixture-drift/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
-          process-names: 'conhost,pwsh,node,LabVIEW,LVCompare'
+          process-names: 'conhost,pwsh,LabVIEW,LVCompare'
       - name: Ensure Invoker (stop)
         if: always()
         uses: ./.github/actions/ensure-invoker

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -54,13 +54,11 @@ jobs:
       - name: LabVIEW warmup (best-effort)
         shell: pwsh
         run: pwsh -File tools/Warmup-LabVIEW.ps1
-
-      
-          results-dir: results/fixture-drift
       - name: Ensure Invoker (start)
         uses: ./.github/actions/ensure-invoker
         with:
           mode: start
+          results-dir: results/fixture-drift
 
       - name: Detect docs-only change
         id: docs
@@ -110,6 +108,7 @@ jobs:
       UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
+      LABVIEW_EXE: 'C:\\Program Files\\National Instruments\\LabVIEW 2025\\LabVIEW.exe'
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -51,6 +51,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: LabVIEW warmup (best-effort)
+        shell: pwsh
+        run: pwsh -File tools/Warmup-LabVIEW.ps1
 
       
           results-dir: results/fixture-drift

--- a/.github/workflows/pester-diagnostics-nightly.yml
+++ b/.github/workflows/pester-diagnostics-nightly.yml
@@ -34,7 +34,7 @@ jobs:
           kill-leaks: 'false'
           leak-grace-seconds: '3'
           clean-labview-before: 'false'
-          clean-after: 'true'
+          clean-after: 'false'
           track-artifacts: 'true'
 
       - name: Run dispatcher with synthetic failure enabled (continue-on-error)

--- a/.github/workflows/pester-integration-on-label.yml
+++ b/.github/workflows/pester-integration-on-label.yml
@@ -78,7 +78,7 @@ jobs:
     needs: [pre-init, preflight]
     timeout-minutes: 3
     env:
-      UNBLOCK_GUARD: '1'
+      UNBLOCK_GUARD: '0'
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5
@@ -107,7 +107,7 @@ jobs:
           kill-leaks: 'false'
           leak-grace-seconds: '3'
           clean-labview-before: 'false'
-          clean-after: 'true'
+          clean-after: 'false'
           track-artifacts: 'true'
 
       - name: Validate environment

--- a/.github/workflows/pester-selfhosted.yml
+++ b/.github/workflows/pester-selfhosted.yml
@@ -64,7 +64,7 @@ jobs:
       CLEAN_AFTER: '0'
       SCAN_ARTIFACTS: '1'
       UNBLOCK_GUARD: '0'
-      LV_SUPPRESS_UI: '1'
+      LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pester-selfhosted.yml
+++ b/.github/workflows/pester-selfhosted.yml
@@ -66,6 +66,7 @@ jobs:
       UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '0'
       WATCH_CONSOLE: '1'
+      LABVIEW_EXE: 'C:\\Program Files\\National Instruments\\LabVIEW 2025\\LabVIEW.exe'
     steps:
       - uses: actions/checkout@v5
       - name: Prepare fixture copies (base/head)

--- a/.github/workflows/pester-selfhosted.yml
+++ b/.github/workflows/pester-selfhosted.yml
@@ -61,9 +61,9 @@ jobs:
     needs: [normalize, preflight]
     env:
       DETECT_LEAKS: '1'
-      CLEAN_AFTER: '1'
+      CLEAN_AFTER: '0'
       SCAN_ARTIFACTS: '1'
-      UNBLOCK_GUARD: '1'
+      UNBLOCK_GUARD: '0'
       LV_SUPPRESS_UI: '1'
       WATCH_CONSOLE: '1'
     steps:
@@ -92,7 +92,7 @@ jobs:
           kill-leaks: 'false'
           leak-grace-seconds: '3'
           clean-labview-before: 'false'
-          clean-after: 'true'
+          clean-after: 'false'
           track-artifacts: 'true'
 
       # Call the dispatcher directly (no external action dependency)

--- a/.github/workflows/test-pester.yml
+++ b/.github/workflows/test-pester.yml
@@ -76,7 +76,7 @@ jobs:
           kill-leaks: 'false'
           leak-grace-seconds: '3'
           clean-labview-before: 'false'
-          clean-after: 'true'
+          clean-after: 'false'
           track-artifacts: 'true'
 
       - name: Install Pester v5

--- a/scripts/Capture-LVCompare.ps1
+++ b/scripts/Capture-LVCompare.ps1
@@ -194,8 +194,8 @@ if (-not $Quiet) {
 	if ($RenderReport.IsPresent) { Write-Host ("Report: {0} (exists={1})" -f $reportPath, (Test-Path $reportPath)) }
 }
 
-# Cleanup: close only LabVIEW processes that appeared during this run (unless disabled)
-if ($env:DISABLE_LABVIEW_CLEANUP -ne '1') {
+# Cleanup policy: do not close LabVIEW by default. Allow opt-in via ENABLE_LABVIEW_CLEANUP=1.
+if ($env:ENABLE_LABVIEW_CLEANUP -match '^(?i:1|true|yes|on)$') {
   try {
     $lvAfter = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue)
     if ($lvAfter) {

--- a/scripts/CompareVI.psm1
+++ b/scripts/CompareVI.psm1
@@ -120,6 +120,12 @@ function Invoke-CompareVI {
       if ($raw -is [System.Array]) { $tokens = @($raw | ForEach-Object { [string]$_ }) } else { $tokens = [string]$raw }
       $cliArgs = Convert-ArgTokenList -tokens (Get-LVCompareArgTokens -Spec $tokens)
     }
+    # Hint: if LABVIEW_EXE is provided and -lvpath is not present, inject it to prefer the existing LabVIEW instance
+    try {
+      if ($env:LABVIEW_EXE -and -not ($cliArgs | Where-Object { $_ -ieq '-lvpath' })) {
+        $cliArgs = @('-lvpath', [string]$env:LABVIEW_EXE) + $cliArgs
+      }
+    } catch {}
 
     $cmdline = (Quote $cli) + ' ' + (Quote $baseAbs) + ' ' + (Quote $headAbs)
     if ($cliArgs -and $cliArgs.Count -gt 0) { $cmdline += ' ' + (($cliArgs | ForEach-Object { Quote $_ }) -join ' ') }
@@ -133,7 +139,7 @@ function Invoke-CompareVI {
     } else {
       $sw = [System.Diagnostics.Stopwatch]::StartNew()
       $code = $null
-      if ($env:LV_SUPPRESS_UI -eq '1') {
+    if ($env:LV_SUPPRESS_UI -eq '1') {
         $psi = New-Object System.Diagnostics.ProcessStartInfo
         $psi.FileName = $cli
         $null = $psi.ArgumentList.Clear()

--- a/scripts/On-FixtureValidationFail.ps1
+++ b/scripts/On-FixtureValidationFail.ps1
@@ -644,14 +644,31 @@ if ($RenderReport) {
     } else {
       # Use robust dispatcher to avoid LVCompare UI popups and apply preflight guards
       $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..') | Select-Object -ExpandProperty Path
-      if (-not (Get-Command -Name Invoke-CompareVI -ErrorAction SilentlyContinue)) {
-        Import-Module (Join-Path $repoRoot 'scripts' 'CompareVI.psm1') -Force
-      }
       $execJsonPath = Join-Path $OutputDir 'compare-exec.json'
-      $res = Invoke-CompareVI -Base $BasePath -Head $HeadPath -LvComparePath $cli -LvCompareArgs $LvCompareArgs -FailOnDiff:$false -CompareExecJsonPath $execJsonPath
-      $exitCode = $res.ExitCode
-      $duration = $res.CompareDurationSeconds
-      $command = $res.Command
+      if ($env:INVOKER_REQUIRED -eq '1') {
+        try {
+          $args = @{ base = $BasePath; head = $HeadPath; lvCompareArgs = $LvCompareArgs; outputDir = $OutputDir }
+          $resp = pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'RunnerInvoker' 'Send-RunnerCommand.ps1') -Verb 'CompareVI' -Args $args -ResultsDir $OutputDir -TimeoutSeconds 60 | ConvertFrom-Json -Depth 10
+          if (-not $resp.ok) { throw "Invoker CompareVI failed: $($resp.error)" }
+          $r = $resp.result
+          $exitCode = [int]$r.exitCode
+          $duration = [double]$r.duration_s
+          $command  = [string]$r.command
+        } catch {
+          Write-Host "[drift] warn: invoker CompareVI path failed, falling back: $_" -ForegroundColor DarkYellow
+          if (-not (Get-Command -Name Invoke-CompareVI -ErrorAction SilentlyContinue)) { Import-Module (Join-Path $repoRoot 'scripts' 'CompareVI.psm1') -Force }
+          $res = Invoke-CompareVI -Base $BasePath -Head $HeadPath -LvComparePath $cli -LvCompareArgs $LvCompareArgs -FailOnDiff:$false -CompareExecJsonPath $execJsonPath
+          $exitCode = $res.ExitCode
+          $duration = $res.CompareDurationSeconds
+          $command = $res.Command
+        }
+      } else {
+        if (-not (Get-Command -Name Invoke-CompareVI -ErrorAction SilentlyContinue)) { Import-Module (Join-Path $repoRoot 'scripts' 'CompareVI.psm1') -Force }
+        $res = Invoke-CompareVI -Base $BasePath -Head $HeadPath -LvComparePath $cli -LvCompareArgs $LvCompareArgs -FailOnDiff:$false -CompareExecJsonPath $execJsonPath
+        $exitCode = $res.ExitCode
+        $duration = $res.CompareDurationSeconds
+        $command = $res.Command
+      }
       # CompareVI does not capture raw streams; emit placeholders for completeness
       $stdout = ''
       $stderr = ''
@@ -707,7 +724,20 @@ if ($RenderReport) {
           $cwId = Start-ConsoleWatch -OutDir $OutputDir
         } catch {}
       }
-      & $reporter -Command $cmd -ExitCode $exitCode -Diff $diff -CliPath $cli -DurationSeconds $duration -OutputPath (Join-Path $OutputDir 'compare-report.html') -ExecJsonPath (Join-Path $OutputDir 'compare-exec.json') | Out-Null
+      $reportOut = (Join-Path $OutputDir 'compare-report.html')
+      if ($env:INVOKER_REQUIRED -eq '1') {
+        try {
+          $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..') | Select-Object -ExpandProperty Path
+          $rargs = @{ command=$cmd; exitCode=$exitCode; diff=([bool]($exitCode -eq 1)); cliPath=$cli; duration_s=[double]$duration; execJsonPath=(Join-Path $OutputDir 'compare-exec.json'); outputPath=$reportOut }
+          $resp2 = pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'RunnerInvoker' 'Send-RunnerCommand.ps1') -Verb 'RenderReport' -Args $rargs -ResultsDir $OutputDir -TimeoutSeconds 60 | ConvertFrom-Json -Depth 10
+          if (-not $resp2.ok) { throw "Invoker RenderReport failed: $($resp2.error)" }
+        } catch {
+          Write-Host "[drift] warn: invoker RenderReport path failed, falling back: $_" -ForegroundColor DarkYellow
+          & $reporter -Command $cmd -ExitCode $exitCode -Diff $diff -CliPath $cli -DurationSeconds $duration -OutputPath $reportOut -ExecJsonPath (Join-Path $OutputDir 'compare-exec.json') | Out-Null
+        }
+      } else {
+        & $reporter -Command $cmd -ExitCode $exitCode -Diff $diff -CliPath $cli -DurationSeconds $duration -OutputPath $reportOut -ExecJsonPath (Join-Path $OutputDir 'compare-exec.json') | Out-Null
+      }
       Add-Artifact 'compare-report.html'
       if ($cwId) {
         try {

--- a/tests/Invoker.Basic.Tests.ps1
+++ b/tests/Invoker.Basic.Tests.ps1
@@ -1,0 +1,35 @@
+Describe 'Invoker (basic)' -Tag 'Unit' {
+  It 'starts and stops with markers and responds to Ping' {
+    $root = (Get-Location).Path
+    $res  = Join-Path $TestDrive 'invoker-basic/results'
+    New-Item -ItemType Directory -Path $res -Force | Out-Null
+    $sent = Join-Path $TestDrive 'invoker-basic/sentinel.txt'
+    New-Item -ItemType Directory -Path (Split-Path -Parent $sent) -Force | Out-Null
+    if (Test-Path -LiteralPath $sent) { Remove-Item -LiteralPath $sent -Force }
+
+    # Start invoker process (hidden)
+    $args = @('-NoLogo','-NoProfile','-File', (Join-Path $root 'tools/RunnerInvoker/Start-RunnerInvoker.ps1'), '-ResultsDir', $res, '-SentinelPath', $sent, '-PipeName', 'lvci.invoker.test')
+    $p = Start-Process -FilePath 'pwsh' -ArgumentList $args -WindowStyle Hidden -PassThru
+
+    $ready = Join-Path $res '_invoker/ready.json'
+    $stopped = Join-Path $res '_invoker/stopped.json'
+    $spawn = Join-Path $res '_invoker/console-spawns.ndjson'
+
+    $deadline = (Get-Date).AddSeconds(10)
+    do { Start-Sleep -Milliseconds 200 } while (-not (Test-Path -LiteralPath $ready) -and (Get-Date) -lt $deadline)
+    (Test-Path -LiteralPath $ready) | Should -BeTrue
+    (Test-Path -LiteralPath $spawn) | Should -BeTrue
+
+    # Ping request
+    $resp = pwsh -NoLogo -NoProfile -File (Join-Path $root 'tools/RunnerInvoker/Send-RunnerCommand.ps1') -Verb 'Ping' -ResultsDir $res | ConvertFrom-Json -Depth 5
+    $resp.ok | Should -BeTrue
+
+    # Stop
+    New-Item -ItemType File -Path $sent -Force | Out-Null
+    Remove-Item -LiteralPath $sent -Force -ErrorAction SilentlyContinue
+    $deadline2 = (Get-Date).AddSeconds(10)
+    do { Start-Sleep -Milliseconds 200 } while (-not (Test-Path -LiteralPath $stopped) -and (Get-Date) -lt $deadline2)
+    (Test-Path -LiteralPath $stopped) | Should -BeTrue
+  }
+}
+

--- a/tools/Guard-LabVIEWPersistence.ps1
+++ b/tools/Guard-LabVIEWPersistence.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+  Guard to observe LabVIEW/LVCompare process presence around phases.
+
+.DESCRIPTION
+  Samples pwsh process list for LabVIEW.exe and LVCompare.exe, writes/updates
+  a compact JSON at <ResultsDir>/labview-persistence.json and appends a
+  concise note to the GitHub Step Summary when available. Optionally polls for
+  a short duration to detect an early closure of LabVIEW after a critical step.
+
+.PARAMETER ResultsDir
+  Directory where labview-persistence.json will be written. Default: results/fixture-drift
+
+.PARAMETER Phase
+  Label for this sampling event (e.g., before-compare, after-compare, after-report).
+
+.PARAMETER PollForCloseSeconds
+  When > 0, poll every 200ms up to the given seconds and mark closedEarly=true
+  if LabVIEW disappears during the poll window.
+#>
+[CmdletBinding()]
+param(
+  [string]$ResultsDir = 'results/fixture-drift',
+  [Parameter(Mandatory)][string]$Phase,
+  [int]$PollForCloseSeconds = 0
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function New-Dir([string]$p){ if ($p -and -not (Test-Path -LiteralPath $p)) { New-Item -ItemType Directory -Force -Path $p | Out-Null } }
+function Get-Procs([string]$name){ try { return @(Get-Process -Name $name -ErrorAction SilentlyContinue) } catch { @() } }
+
+$now = (Get-Date).ToUniversalTime().ToString('o')
+$dir = $ResultsDir
+New-Dir $dir
+$outPath = Join-Path $dir 'labview-persistence.json'
+
+$lv1 = Get-Procs 'LabVIEW'
+$lvc1 = Get-Procs 'LVCompare'
+$present1 = ($lv1.Count -gt 0)
+
+$closedEarly = $false
+if ($PollForCloseSeconds -gt 0) {
+  $deadline = (Get-Date).AddSeconds([Math]::Max(1,$PollForCloseSeconds))
+  while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Milliseconds 200
+    $lvNow = Get-Procs 'LabVIEW'
+    if ($present1 -and $lvNow.Count -eq 0) { $closedEarly = $true; break }
+  }
+}
+
+$event = [ordered]@{
+  schema    = 'labview-persistence/v1'
+  at        = $now
+  phase     = $Phase
+  labview   = [ordered]@{ count=$lv1.Count; pids=@($lv1 | Select-Object -ExpandProperty Id) }
+  lvcompare = [ordered]@{ count=$lvc1.Count; pids=@($lvc1 | Select-Object -ExpandProperty Id) }
+  closedEarly = $closedEarly
+}
+
+# Append to JSON array file (create if missing)
+try {
+  if (-not (Test-Path -LiteralPath $outPath)) { '[]' | Out-File -FilePath $outPath -Encoding utf8 }
+  $arr = @()
+  try { $arr = (Get-Content -LiteralPath $outPath -Raw | ConvertFrom-Json -Depth 6) } catch { $arr = @() }
+  if ($arr -isnot [System.Collections.IList]) { $arr = @() }
+  $arr += (New-Object psobject -Property $event)
+  $arr | ConvertTo-Json -Depth 6 | Out-File -FilePath $outPath -Encoding utf8
+} catch { Write-Warning "Guard-LabVIEWPersistence: failed to write $outPath: $_" }
+
+if ($env:GITHUB_STEP_SUMMARY) {
+  $line = ('- Guard [{0}]: LabVIEW={1} ({2}); LVCompare={3} ({4}); closedEarly={5}' -f $Phase,$event.labview.count,($event.labview.pids -join ','),$event.lvcompare.count,($event.lvcompare.pids -join ','),$closedEarly)
+  $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+

--- a/tools/RunnerInvoker/RunnerInvoker.psm1
+++ b/tools/RunnerInvoker/RunnerInvoker.psm1
@@ -17,7 +17,8 @@ function Read-JsonFile([string]$Path) {
 function Append-Spawns([string]$OutPath) {
   try {
     $stamp = (Get-Date).ToUniversalTime().ToString('o')
-    $names = @('pwsh','conhost','node','LabVIEW','LVCompare')
+    # Temporarily exclude node.exe from tracking to avoid conflating with runner internals
+    $names = @('pwsh','conhost','LabVIEW','LVCompare')
     $entry = [ordered]@{ at=$stamp }
     foreach ($n in $names) {
       try { $ps = @(Get-Process -Name $n -ErrorAction SilentlyContinue) } catch { $ps = @() }
@@ -112,4 +113,3 @@ function Start-InvokerLoop {
 }
 
 Export-ModuleMember -Function Start-InvokerLoop
-

--- a/tools/RunnerInvoker/RunnerInvoker.psm1
+++ b/tools/RunnerInvoker/RunnerInvoker.psm1
@@ -1,0 +1,115 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-JsonFile([string]$Path, [object]$Obj) {
+  $dir = Split-Path -Parent -LiteralPath $Path
+  if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+  $Obj | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Read-JsonFile([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) { throw "json not found: $Path" }
+  $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+  if (-not $raw) { return $null }
+  return ($raw | ConvertFrom-Json -Depth 10)
+}
+
+function Append-Spawns([string]$OutPath) {
+  try {
+    $stamp = (Get-Date).ToUniversalTime().ToString('o')
+    $names = @('pwsh','conhost','node','LabVIEW','LVCompare')
+    $entry = [ordered]@{ at=$stamp }
+    foreach ($n in $names) {
+      try { $ps = @(Get-Process -Name $n -ErrorAction SilentlyContinue) } catch { $ps = @() }
+      $entry[$n] = [ordered]@{ count = $ps.Count; pids = @($ps | Select-Object -ExpandProperty Id) }
+    }
+    ($entry | ConvertTo-Json -Compress) | Add-Content -LiteralPath $OutPath -Encoding UTF8
+  } catch {}
+}
+
+function Handle-CompareVI([hashtable]$Args, [string]$ResultsDir) {
+  Import-Module (Join-Path $PSScriptRoot '..' '..' 'scripts' 'CompareVI.psm1') -Force
+  $base = [string]$Args.base
+  $head = [string]$Args.head
+  $cliArgs = $Args.lvCompareArgs
+  $outDir = if ($Args.outputDir) { [string]$Args.outputDir } else { (Join-Path $ResultsDir '_invoker') }
+  $execPath = Join-Path $outDir 'compare-exec.json'
+  $res = Invoke-CompareVI -Base $base -Head $head -LvCompareArgs $cliArgs -FailOnDiff:$false -CompareExecJsonPath $execPath
+  return [pscustomobject]@{
+    exitCode = [int]$res.ExitCode
+    diff     = [bool]$res.Diff
+    cliPath  = [string]$res.CliPath
+    command  = [string]$res.Command
+    duration_s  = [double]$res.CompareDurationSeconds
+    duration_ns = [long]$res.CompareDurationNanoseconds
+    execJsonPath = $execPath
+  }
+}
+
+function Handle-RenderReport([hashtable]$Args, [string]$ResultsDir) {
+  $renderer = Join-Path (Join-Path $PSScriptRoot '..' '..') 'scripts/Render-CompareReport.ps1'
+  $outPath = if ($Args.outputPath) { [string]$Args.outputPath } else { (Join-Path $ResultsDir 'compare-report.html') }
+  $cmd     = [string]$Args.command
+  $code    = [int]$Args.exitCode
+  $diff    = [bool]$Args.diff
+  $cli     = [string]$Args.cliPath
+  $dur     = if ($Args.duration_s) { [double]$Args.duration_s } else { 0 }
+  $execJson= [string]$Args.execJsonPath
+  & $renderer -Command $cmd -ExitCode $code -Diff $diff -CliPath $cli -DurationSeconds $dur -OutputPath $outPath -ExecJsonPath $execJson | Out-Null
+  return [pscustomobject]@{ outputPath = $outPath }
+}
+
+function Start-InvokerLoop {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$PipeName,
+    [Parameter()][string]$SentinelPath,
+    [Parameter()][string]$ResultsDir = 'tests/results/_invoker',
+    [int]$PollIntervalMs = 200
+  )
+
+  $baseDir = Join-Path $ResultsDir '_invoker'
+  $reqDir = Join-Path $baseDir 'requests'
+  $rspDir = Join-Path $baseDir 'responses'
+  foreach ($d in @($baseDir,$reqDir,$rspDir)) { if (-not (Test-Path -LiteralPath $d)) { New-Item -ItemType Directory -Path $d -Force | Out-Null } }
+  $spawns = Join-Path $baseDir 'console-spawns.ndjson'
+  if (-not (Test-Path -LiteralPath $spawns)) { New-Item -ItemType File -Path $spawns -Force | Out-Null }
+
+  $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+  $lastSpawn = 0
+  while ($true) {
+    if ($SentinelPath -and -not (Test-Path -LiteralPath $SentinelPath)) { break }
+
+    # Periodic spawns snapshot (1s cadence)
+    if (($stopwatch.ElapsedMilliseconds - $lastSpawn) -ge 1000) { Append-Spawns -OutPath $spawns; $lastSpawn = $stopwatch.ElapsedMilliseconds }
+
+    $reqs = Get-ChildItem -LiteralPath $reqDir -Filter '*.json' -File -ErrorAction SilentlyContinue | Sort-Object Name
+    foreach ($f in $reqs) {
+      $reqPath = $f.FullName
+      $req = Read-JsonFile -Path $reqPath
+      $id = [string]$req.id
+      $verb = [string]$req.verb
+      $args = @{}; if ($req.args) { $args = @{} + $req.args.PSObject.Properties | ForEach-Object { @{ ($_.Name) = $_.Value } } | ForEach-Object { $_ } }
+      $rspPath = Join-Path $rspDir ("$id.json")
+      try {
+        $result = $null
+        switch ($verb) {
+          'Ping'          { $result = [pscustomobject]@{ pong = $PipeName; at=(Get-Date).ToUniversalTime().ToString('o') } }
+          'CompareVI'     { $result = Handle-CompareVI -Args $args -ResultsDir $ResultsDir }
+          'RenderReport'  { $result = Handle-RenderReport -Args $args -ResultsDir $ResultsDir }
+          'PhaseDone'     { $result = [pscustomobject]@{ done = $true } ; if ($SentinelPath) { try { Remove-Item -LiteralPath $SentinelPath -Force } catch {} } }
+          default         { throw "unknown verb: $verb" }
+        }
+        Write-JsonFile -Path $rspPath -Obj @{ ok=$true; id=$id; verb=$verb; result=$result }
+      } catch {
+        Write-JsonFile -Path $rspPath -Obj @{ ok=$false; id=$id; verb=$verb; error=($_.ToString()) }
+      } finally {
+        try { Remove-Item -LiteralPath $reqPath -Force } catch {}
+      }
+    }
+    Start-Sleep -Milliseconds $PollIntervalMs
+  }
+}
+
+Export-ModuleMember -Function Start-InvokerLoop
+

--- a/tools/RunnerInvoker/Send-RunnerCommand.ps1
+++ b/tools/RunnerInvoker/Send-RunnerCommand.ps1
@@ -1,0 +1,33 @@
+param(
+  [string]$PipeName,
+  [ValidateSet('Ping','PhaseDone','CompareVI','RenderReport')][string]$Verb = 'Ping',
+  [hashtable]$Args,
+  [string]$ResultsDir = 'tests/results/_invoker',
+  [int]$TimeoutSeconds = 30
+)
+$ErrorActionPreference = 'Stop'
+if (-not $PipeName) { $PipeName = "lvci.invoker.$([Environment]::GetEnvironmentVariable('GITHUB_RUN_ID')).$([Environment]::GetEnvironmentVariable('GITHUB_JOB')).$([Environment]::GetEnvironmentVariable('GITHUB_RUN_ATTEMPT'))" }
+if (-not $ResultsDir) { $ResultsDir = 'tests/results/_invoker' }
+$base = Join-Path $ResultsDir '_invoker'
+$reqDir = Join-Path $base 'requests'
+$rspDir = Join-Path $base 'responses'
+foreach ($d in @($base,$reqDir,$rspDir)) { if (-not (Test-Path -LiteralPath $d)) { New-Item -ItemType Directory -Path $d -Force | Out-Null } }
+
+$id = [guid]::NewGuid().ToString()
+$req = [pscustomobject]@{ id=$id; verb=$Verb; args=$Args }
+$reqPath = Join-Path $reqDir ("$id.json")
+$rspPath = Join-Path $rspDir ("$id.json")
+$req | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $reqPath -Encoding UTF8
+
+$deadline = (Get-Date).AddSeconds([math]::Max(1,$TimeoutSeconds))
+while ((Get-Date) -lt $deadline) {
+  if (Test-Path -LiteralPath $rspPath) {
+    $resp = Get-Content -LiteralPath $rspPath -Raw -Encoding UTF8 | ConvertFrom-Json -Depth 10
+    $ok = [bool]$resp.ok
+    if (-not $ok) { Write-Error ([string]$resp.error) }
+    $resp | ConvertTo-Json -Depth 10 -Compress | Write-Output
+    return
+  }
+  Start-Sleep -Milliseconds 200
+}
+throw "invoker response timeout for verb '$Verb' id '$id'"

--- a/tools/RunnerInvoker/Start-RunnerInvoker.ps1
+++ b/tools/RunnerInvoker/Start-RunnerInvoker.ps1
@@ -1,0 +1,64 @@
+param(
+  [string]$PipeName,
+  [string]$SentinelPath,
+  [string]$ResultsDir = 'tests/results/_invoker',
+  [string]$ReadyFile,
+  [string]$StoppedFile,
+  [string]$PidFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+function New-ParentDir {
+  param([string]$Path)
+  $dir = Split-Path -Parent -LiteralPath $Path
+  if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+}
+
+if (-not $PipeName) { $PipeName = "lvci.invoker.$([Environment]::GetEnvironmentVariable('GITHUB_RUN_ID')).$([Environment]::GetEnvironmentVariable('GITHUB_JOB')).$([Environment]::GetEnvironmentVariable('GITHUB_RUN_ATTEMPT'))" }
+if (-not $ReadyFile)   { $ReadyFile   = Join-Path $ResultsDir "_invoker/ready.json" }
+if (-not $StoppedFile) { $StoppedFile = Join-Path $ResultsDir "_invoker/stopped.json" }
+if (-not $PidFile)     { $PidFile     = Join-Path $ResultsDir "_invoker/pid.txt" }
+
+New-Item -ItemType Directory -Path (Join-Path $ResultsDir '_invoker') -Force | Out-Null
+if ($SentinelPath) { New-ParentDir -Path $SentinelPath; if (-not (Test-Path -LiteralPath $SentinelPath)) { New-Item -ItemType File -Path $SentinelPath -Force | Out-Null } }
+
+# Touch console-spawns.ndjson (artifact presence guarantee)
+$spawns = Join-Path $ResultsDir '_invoker/console-spawns.ndjson'
+if (-not (Test-Path -LiteralPath $spawns)) { New-Item -ItemType File -Path $spawns -Force | Out-Null }
+
+# Write PID file
+$pidContent = [string]$PID
+Set-Content -LiteralPath $PidFile -Value $pidContent -Encoding ASCII
+
+# Write ready marker
+$now = (Get-Date).ToUniversalTime().ToString('o')
+$readyObj = [pscustomobject]@{ schema='invoker-ready/v1'; pipe=$PipeName; pid=$PID; at=$now }
+$readyObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $ReadyFile -Encoding UTF8
+
+# Load server module and run loop until sentinel removed
+Import-Module (Join-Path $PSScriptRoot 'RunnerInvoker.psm1') -Force
+$hb = Join-Path $ResultsDir '_invoker/heartbeat.ndjson'
+try {
+  $sw = [Diagnostics.Stopwatch]::StartNew()
+  $last = 0
+  $job = Start-Job -ScriptBlock {
+    param($pn,$sp,$rd)
+    Import-Module (Join-Path $using:PSScriptRoot 'RunnerInvoker.psm1') -Force
+    Start-InvokerLoop -PipeName $pn -SentinelPath $sp -ResultsDir $rd -PollIntervalMs 200
+  } -ArgumentList @($PipeName,$SentinelPath,$ResultsDir)
+  while ($true) {
+    if ($SentinelPath -and -not (Test-Path -LiteralPath $SentinelPath)) { break }
+    if (($sw.ElapsedMilliseconds - $last) -ge 1000) {
+      $beat = [pscustomobject]@{ at=(Get-Date).ToUniversalTime().ToString('o'); pid=$PID }
+      ($beat | ConvertTo-Json -Compress) | Add-Content -LiteralPath $hb -Encoding UTF8
+      $last = $sw.ElapsedMilliseconds
+    }
+    Start-Sleep -Milliseconds 200
+  }
+}
+finally {
+  try { Receive-Job * | Out-Null; Remove-Job * -Force -ErrorAction SilentlyContinue } catch {}
+  $stopObj = [pscustomobject]@{ schema='invoker-stopped/v1'; pid=$PID; at=(Get-Date).ToUniversalTime().ToString('o') }
+  $stopObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $StoppedFile -Encoding UTF8
+}

--- a/tools/Warmup-LabVIEW.ps1
+++ b/tools/Warmup-LabVIEW.ps1
@@ -25,8 +25,7 @@
 param(
   [string]$BaseVi,
   [string]$HeadVi,
-  [int]$TimeoutSeconds = 15,
-  [int]$KillDelaySeconds = 3
+  [int]$TimeoutSeconds = 15
 )
 
 Set-StrictMode -Version Latest
@@ -62,8 +61,8 @@ if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) {
 if (-not (Test-Path -LiteralPath $BaseVi)) { Write-Host "Warmup: Base VI not found: $BaseVi" -ForegroundColor Yellow; return }
 if (-not (Test-Path -LiteralPath $HeadVi)) { Write-Host "Warmup: Head VI not found: $HeadVi" -ForegroundColor Yellow; return }
 
-Write-Host "Warmup: starting LVCompare to spawn LabVIEW..."
-Write-StepSummaryLine "- Warmup: starting LVCompare to spawn LabVIEW"
+Write-Host "Warmup: starting LVCompare to spawn LabVIEW (will NOT close LVCompare)"
+Write-StepSummaryLine "- Warmup: starting LVCompare to spawn LabVIEW (LVCompare left running)"
 
 # Start LVCompare normally (UI allowed). Do not suppress UI; do not redirect.
 $p = Start-Process -FilePath $cli -ArgumentList @($BaseVi,$HeadVi) -PassThru
@@ -84,14 +83,6 @@ if ($lv.Count -gt 0) {
   Write-StepSummaryLine "- Warmup: LabVIEW did not start within timeout ($TimeoutSeconds s)"
 }
 
-# Give LVCompare a short window then stop only LVCompare (leave LabVIEW)
-if ($KillDelaySeconds -gt 0) { Start-Sleep -Seconds $KillDelaySeconds }
-try {
-  if ($p -and -not $p.HasExited) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
-  else { Get-Process -Name 'LVCompare' -ErrorAction SilentlyContinue | ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue } catch {} } }
-  Write-Host "Warmup: LVCompare stopped; LabVIEW remains running."
-  Write-StepSummaryLine "- Warmup: LVCompare stopped; LabVIEW remains running"
-} catch {
-  Write-Host "Warmup: failed to stop LVCompare (continuing): $($_.Exception.Message)" -ForegroundColor Yellow
-}
-
+# Per request: Do not close LVCompare. Leave it running alongside LabVIEW.
+Write-Host "Warmup: leaving LVCompare running by design."
+Write-StepSummaryLine "- Warmup: LVCompare left running (by design)"

--- a/tools/Warmup-LabVIEW.ps1
+++ b/tools/Warmup-LabVIEW.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+  Best-effort LabVIEW warmup for self-hosted Windows runners.
+
+.DESCRIPTION
+  Ensures a LabVIEW.exe instance is started before tests/compare work begins by
+  briefly launching LVCompare.exe (canonical path) against two VIs, then
+  terminating only LVCompare.exe while leaving LabVIEW.exe running.
+
+  No-op when LabVIEW is already running or when LVCompare is not present.
+
+.PARAMETER BaseVi
+  Optional base VI path. Defaults to repo-root VI1.vi when present.
+
+.PARAMETER HeadVi
+  Optional head VI path. Defaults to repo-root VI2.vi when present.
+
+.PARAMETER TimeoutSeconds
+  Time to wait for LabVIEW to appear after spawning LVCompare. Default 15.
+
+.PARAMETER KillDelaySeconds
+  Delay before stopping LVCompare (to allow LabVIEW to load). Default 3.
+#>
+[CmdletBinding()]
+param(
+  [string]$BaseVi,
+  [string]$HeadVi,
+  [int]$TimeoutSeconds = 15,
+  [int]$KillDelaySeconds = 3
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-StepSummaryLine([string]$line) {
+  if ($env:GITHUB_STEP_SUMMARY) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+}
+
+if ($IsWindows -ne $true) { return }
+
+# If LabVIEW already running, bail out quickly
+try {
+  $existing = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue)
+  if ($existing.Count -gt 0) {
+    Write-Host "Warmup: LabVIEW already running (PID(s): $($existing.Id -join ','))"
+    Write-StepSummaryLine "- Warmup: LabVIEW already running (PID(s): $($existing.Id -join ','))"
+    return
+  }
+} catch {}
+
+$repoRoot = (Get-Location).Path
+if (-not $BaseVi) { $BaseVi = Join-Path $repoRoot 'VI1.vi' }
+if (-not $HeadVi) { $HeadVi = Join-Path $repoRoot 'VI2.vi' }
+
+$cli = 'C:\\Program Files\\National Instruments\\Shared\\LabVIEW Compare\\LVCompare.exe'
+if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) {
+  Write-Host "Warmup: LVCompare not found at canonical path; skipping." -ForegroundColor Yellow
+  Write-StepSummaryLine "- Warmup: LVCompare.exe not found; skipped"
+  return
+}
+
+if (-not (Test-Path -LiteralPath $BaseVi)) { Write-Host "Warmup: Base VI not found: $BaseVi" -ForegroundColor Yellow; return }
+if (-not (Test-Path -LiteralPath $HeadVi)) { Write-Host "Warmup: Head VI not found: $HeadVi" -ForegroundColor Yellow; return }
+
+Write-Host "Warmup: starting LVCompare to spawn LabVIEW..."
+Write-StepSummaryLine "- Warmup: starting LVCompare to spawn LabVIEW"
+
+# Start LVCompare normally (UI allowed). Do not suppress UI; do not redirect.
+$p = Start-Process -FilePath $cli -ArgumentList @($BaseVi,$HeadVi) -PassThru
+
+# Poll for LabVIEW to appear
+$deadline = (Get-Date).AddSeconds([Math]::Max(1,$TimeoutSeconds))
+do {
+  Start-Sleep -Milliseconds 200
+  try { $lv = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue) } catch { $lv = @() }
+  if ($lv.Count -gt 0) { break }
+} while ((Get-Date) -lt $deadline)
+
+if ($lv.Count -gt 0) {
+  Write-Host "Warmup: LabVIEW started (PID(s): $($lv.Id -join ','))"
+  Write-StepSummaryLine "- Warmup: LabVIEW started (PID(s): $($lv.Id -join ','))"
+} else {
+  Write-Host "Warmup: LabVIEW did not start within timeout ($TimeoutSeconds s)." -ForegroundColor Yellow
+  Write-StepSummaryLine "- Warmup: LabVIEW did not start within timeout ($TimeoutSeconds s)"
+}
+
+# Give LVCompare a short window then stop only LVCompare (leave LabVIEW)
+if ($KillDelaySeconds -gt 0) { Start-Sleep -Seconds $KillDelaySeconds }
+try {
+  if ($p -and -not $p.HasExited) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+  else { Get-Process -Name 'LVCompare' -ErrorAction SilentlyContinue | ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue } catch {} } }
+  Write-Host "Warmup: LVCompare stopped; LabVIEW remains running."
+  Write-StepSummaryLine "- Warmup: LVCompare stopped; LabVIEW remains running"
+} catch {
+  Write-Host "Warmup: failed to stop LVCompare (continuing): $($_.Exception.Message)" -ForegroundColor Yellow
+}
+

--- a/tools/Write-FixtureDriftSummary.ps1
+++ b/tools/Write-FixtureDriftSummary.ps1
@@ -41,5 +41,24 @@ if ($json.notes) {
   else { $lines += ('- Note: {0}' -f $n) }
 }
 
-$lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+# Optional handshake excerpt
+try {
+  $hs = Join-Path $Dir '_handshake'
+  if (Test-Path -LiteralPath $hs) {
+    $ready = Join-Path $hs 'ready.json'
+    $end   = Join-Path $hs 'end.json'
+    $hsLines = @()
+    if (Test-Path -LiteralPath $ready) {
+      $r = Get-Content -LiteralPath $ready -Raw | ConvertFrom-Json -ErrorAction Stop
+      $hsLines += ('- Handshake ready: {0} ({1})' -f ($r.status), ($r.at ?? ''))
+      if ($r.reason) { $hsLines += ('- Reason: {0}' -f $r.reason) }
+    }
+    if (Test-Path -LiteralPath $end) {
+      $e = Get-Content -LiteralPath $end -Raw | ConvertFrom-Json -ErrorAction Stop
+      $hsLines += ('- Handshake end: {0} ({1})' -f ($e.status), ($e.at ?? ''))
+    }
+    if ($hsLines.Count -gt 0) { $lines += ''; $lines += $hsLines }
+  }
+} catch {}
 
+$lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/tools/Write-InteractivityProbe.ps1
+++ b/tools/Write-InteractivityProbe.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+  Emit a small interactivity/console probe to the job Step Summary and stdout.
+#>
+[CmdletBinding()]
+param()
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Line([string]$s){ $s | Out-Host }
+
+$data = [ordered]@{}
+$data.schema = 'interactivity-probe/v1'
+$data.timestamp = (Get-Date).ToUniversalTime().ToString('o')
+$data.os = [System.Environment]::OSVersion.VersionString
+$data.userInteractive = [bool][System.Environment]::UserInteractive
+$p = [System.Diagnostics.Process]::GetCurrentProcess()
+$data.sessionId = $p.SessionId
+
+try { $data.isInputRedirected  = [Console]::IsInputRedirected }  catch { $data.isInputRedirected  = $null }
+try { $data.isOutputRedirected = [Console]::IsOutputRedirected } catch { $data.isOutputRedirected = $null }
+try { $data.isErrorRedirected  = [Console]::IsErrorRedirected }  catch { $data.isErrorRedirected  = $null }
+
+$likelyInteractive = $false
+if ($data.userInteractive -and -not $data.isInputRedirected) { $likelyInteractive = $true }
+$data.likelyInteractive = $likelyInteractive
+
+$json = $data | ConvertTo-Json -Depth 4
+Write-Line $json
+
+if ($env:GITHUB_STEP_SUMMARY) {
+  $lines = @('### Interactivity Probe','')
+  $lines += ('- OS: {0}' -f $data.os)
+  $lines += ('- SessionId: {0}' -f $data.sessionId)
+  $lines += ('- UserInteractive: {0}' -f $data.userInteractive)
+  $lines += ('- In/Out/Err redirected: {0}/{1}/{2}' -f $data.isInputRedirected,$data.isOutputRedirected,$data.isErrorRedirected)
+  $lines += ('- LikelyInteractive: {0}' -f $data.likelyInteractive)
+  $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+


### PR DESCRIPTION
This PR stabilizes the Windows flows without changing interfaces:

- Enforce `clean-after=false` across all Pester workflows (orchestrated, label-triggered, nightly) and disable guard cleanup.
- Add LabVIEW warmup (leave LVCompare + LabVIEW running) and Interactivity Probe.
- Route drift via invoker and auto-inject `-lvpath` when `LABVIEW_EXE` is present.
- Add LabVIEW Persistence Guard around compare/report and invoker compare-persistence.
- Keep LVCompare-only policy; no UI suppression; no cleanup toggles.

This is prep work for the deterministic v2 chain (#77) and resolves unintended LabVIEW closure by removing cleanup paths and adding precise telemetry.