### PR TITLE
dispatch: support /run orchestrated on develop

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -22,7 +22,12 @@ jobs:
             OWNER|MEMBER|COLLABORATOR) echo "Authorized commenter: $AUTHOR_ASSOC" ;;
             *) echo "Not authorized ($AUTHOR_ASSOC). Skipping."; exit 0 ;;
           esac
-          if [ -z "$XCLI_PAT" ]; then echo "XCLI_PAT not set; cannot dispatch."; exit 0; fi
+
+      - name: Select auth token (PAT or GITHUB_TOKEN)
+        id: auth
+        shell: bash
+        run: |
+          if [ -n "$XCLI_PAT" ]; then echo "token=$XCLI_PAT" >> "$GITHUB_OUTPUT"; else echo "token=$GITHUB_TOKEN" >> "$GITHUB_OUTPUT"; fi
 
       - name: Normalize command
         id: cmd
@@ -34,13 +39,16 @@ jobs:
           if echo "$body" | grep -qE '^/run +mock'; then echo "target=mock" >> "$GITHUB_OUTPUT"; fi
           if echo "$body" | grep -qE '^/run +smoke'; then echo "target=smoke" >> "$GITHUB_OUTPUT"; fi
           if echo "$body" | grep -qE '^/run +pester-selfhosted'; then echo "target=pester-selfhosted" >> "$GITHUB_OUTPUT"; fi
+          if echo "$body" | grep -qE '^/run +orchestrated'; then echo "target=orchestrated" >> "$GITHUB_OUTPUT"; fi
 
       - name: Resolve target ref (PR head when same-repo, else main)
         id: ref
         shell: bash
+        env:
+          AUTH: ${{ steps.auth.outputs.token }}
         run: |
           pr="$PR_NUMBER"
-          resp=$(curl -s -H "Authorization: Bearer $XCLI_PAT" -H "Accept: application/vnd.github+json" \
+          resp=$(curl -s -H "Authorization: Bearer $AUTH" -H "Accept: application/vnd.github+json" \
                   "https://api.github.com/repos/$REPO/pulls/$pr")
           echo "$resp" > pr.json
           head_ref=$(python3 -c "import json; j=json.load(open('pr.json')); print(j.get('head',{}).get('ref',''))")
@@ -52,6 +60,56 @@ jobs:
             echo "target_ref=main" >> "$GITHUB_OUTPUT"
             echo "fork=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Parse orchestrated options from comment
+        id: orch
+        if: steps.cmd.outputs.target == 'orchestrated'
+        shell: bash
+        env:
+          RAW_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Defaults
+          strategy="matrix"
+          integ="true"
+          sample=""
+          tail=$(printf "%s" "$RAW_BODY" | sed -n 's#^/run[[:space:]]\+orchestrated[[:space:]]\?##Ip')
+          read -r -a arr <<< "$tail"
+          for tok in "${arr[@]}"; do
+            case "$tok" in
+              strategy=*) strategy="${tok#strategy=}" ;;
+              single) strategy="single" ;;
+              matrix) strategy="matrix" ;;
+              include_integration=*) integ="${tok#include_integration=}" ;;
+              integration=true|include_integration=true) integ="true" ;;
+              integration=false|include_integration=false) integ="false" ;;
+              sample=*|sample_id=*) sample="${tok#*=}" ;;
+            esac
+          done
+          if [ -z "$sample" ]; then sample="$(date +%Y%m%d-%H%M%S)-oc"; fi
+          {
+            echo "strategy=$strategy"
+            echo "include_integration=$integ"
+            echo "sample_id=$sample"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch orchestrated workflow
+        if: steps.cmd.outputs.target == 'orchestrated'
+        shell: bash
+        env:
+          TARGET_REF: ${{ steps.ref.outputs.target_ref }}
+          STRATEGY: ${{ steps.orch.outputs.strategy }}
+          INCLUDE: ${{ steps.orch.outputs.include_integration }}
+          SAMPLE: ${{ steps.orch.outputs.sample_id }}
+          AUTH: ${{ steps.auth.outputs.token }}
+        run: |
+          printf '{"ref":"%s","inputs":{"include_integration":"%s","strategy":"%s","sample_id":"%s"}}' \
+            "$TARGET_REF" "$INCLUDE" "$STRATEGY" "$SAMPLE" > payload.json
+          cat payload.json
+          curl -s -X POST \
+           -H "Authorization: Bearer $AUTH" \
+           -H "Accept: application/vnd.github+json" \
+           "https://api.github.com/repos/$REPO/actions/workflows/ci-orchestrated.yml/dispatches" \
+           -d @payload.json | cat
 
       - name: Parse smoke options from comment
         id: parse


### PR DESCRIPTION
This PR cherry-picks the minimal command-dispatch updates onto develop so PR comments can trigger the unified orchestration immediately:

- Add /run orchestrated {single|matrix} handler with include_integration and sample_id parsing
- Use AUTH fallback (XCLI_PAT or GITHUB_TOKEN) for API calls (PR head ref + dispatch)

After merge, agents (and humans) can comment on PRs:
- /run orchestrated single include_integration=true sample_id=YYYYMMDD-HHmmSS-oc
- /run orchestrated matrix include_integration=true sample_id=YYYYMMDD-HHmmSS-oc

This does not change any orchestrated workflow logic — it only enables the comment entry point on develop.