### PR TITLE
dispatcher: point local actions to repo dist outputs (#88)

### DIFF
--- a/.github/actions/normalize-command/action.yml
+++ b/.github/actions/normalize-command/action.yml
@@ -11,4 +11,4 @@ outputs:
     description: Detected target (unit|mock|smoke|pester-selfhosted|orchestrated)
 runs:
   using: node20
-  main: dist/actions/normalize-command.js
+  main: ../../dist/actions/normalize-command.js

--- a/.github/actions/parse-orchestrated/action.yml
+++ b/.github/actions/parse-orchestrated/action.yml
@@ -13,4 +13,4 @@ outputs:
     description: Sampling correlation id
 runs:
   using: node20
-  main: dist/actions/parse-orchestrated.js
+  main: ../../dist/actions/parse-orchestrated.js


### PR DESCRIPTION
Fixes dispatcher error loading local actions by pointing the manifests at the built JS under `dist/actions/...` relative to the repo root.

- normalize-command & parse-orchestrated action.yml now use `../../dist/actions/*.js`
- No code changes; existing dist bundle remains in repo

Refs: #88