### PR TITLE
dispatcher: embed local action bundles alongside manifests (#88)

### DIFF
--- a/.github/actions/normalize-command/action.yml
+++ b/.github/actions/normalize-command/action.yml
@@ -11,4 +11,4 @@ outputs:
     description: Detected target (unit|mock|smoke|pester-selfhosted|orchestrated)
 runs:
   using: node20
-  main: dist/actions/normalize-command.js
+  main: index.js

--- a/.github/actions/normalize-command/index.js
+++ b/.github/actions/normalize-command/index.js
@@ -1,0 +1,60 @@
+"use strict";
+// Minimal JS/TS action without external deps.
+// Reads INPUT_BODY, writes multi-line 'comment' and single-line 'target' to GITHUB_OUTPUT.
+function getEnv(name) {
+    return process.env[name];
+}
+function appendOutput(lines) {
+    const outPath = getEnv('GITHUB_OUTPUT');
+    if (!outPath) {
+        throw new Error('GITHUB_OUTPUT not set');
+    }
+    const fs = require('fs');
+    fs.appendFileSync(outPath, lines.join('\n') + '\n', { encoding: 'utf8' });
+}
+function setOutput(name, value) {
+    // single-line safe output (no newlines)
+    const safe = value.replace(/\r?\n/g, ' ').trim();
+    appendOutput([`${name}=${safe}`]);
+}
+function setOutputMultiline(name, value) {
+    const delim = '__CMD_BODY__';
+    appendOutput([`${name}<<${delim}`, value, delim]);
+}
+function detectTarget(lower) {
+    const m = lower.match(/^\s*\/run\s+(\S+)/);
+    if (!m)
+        return '';
+    const first = m[1];
+    switch (first) {
+        case 'unit':
+        case 'mock':
+        case 'smoke':
+        case 'pester-selfhosted':
+        case 'orchestrated':
+            return first;
+        default:
+            return '';
+    }
+}
+function run() {
+    const body = getEnv('INPUT_BODY') || '';
+    const lower = body.toLowerCase();
+    setOutputMultiline('comment', lower);
+    const target = detectTarget(lower);
+    if (target)
+        setOutput('target', target);
+}
+try {
+    run();
+}
+catch (err) {
+    // Best-effort error emission (so consumers see failure reason)
+    const msg = err && err.message ? err.message : String(err);
+    try {
+        appendOutput([`error=${msg}`]);
+    }
+    catch { }
+    process.stderr.write(`normalize-command error: ${msg}\n`);
+    process.exit(1);
+}

--- a/.github/actions/parse-orchestrated/action.yml
+++ b/.github/actions/parse-orchestrated/action.yml
@@ -13,4 +13,4 @@ outputs:
     description: Sampling correlation id
 runs:
   using: node20
-  main: dist/actions/parse-orchestrated.js
+  main: index.js

--- a/.github/actions/parse-orchestrated/index.js
+++ b/.github/actions/parse-orchestrated/index.js
@@ -1,0 +1,142 @@
+function getEnv(name) {
+    return process.env[name];
+}
+function appendOutput(lines) {
+    const outPath = getEnv('GITHUB_OUTPUT');
+    if (!outPath)
+        throw new Error('GITHUB_OUTPUT not set');
+    const fs = require('fs');
+    fs.appendFileSync(outPath, lines.join('\n') + '\n', { encoding: 'utf8' });
+}
+function setOutput(name, value) {
+    const safe = (value ?? '').toString().replace(/\r?\n/g, ' ').trim();
+    appendOutput([`${name}=${safe}`]);
+}
+function pad2(n) { return n < 10 ? '0' + n : '' + n; }
+function formatSampleSuffix(d = new Date()) {
+    const yyyy = d.getFullYear();
+    const mm = pad2(d.getMonth() + 1);
+    const dd = pad2(d.getDate());
+    const HH = pad2(d.getHours());
+    const MM = pad2(d.getMinutes());
+    const SS = pad2(d.getSeconds());
+    return `${yyyy}${mm}${dd}-${HH}${MM}${SS}-oc`;
+}
+function parseBoolToken(tok) {
+    const lc = tok.toLowerCase();
+    if (['true', 'yes', '1', 'on'].includes(lc))
+        return 'true';
+    if (['false', 'no', '0', 'off'].includes(lc))
+        return 'false';
+    return lc; // pass-through
+}
+function parse(body) {
+    let strategy = 'matrix';
+    let include = 'true';
+    let sample = '';
+    const lower = body.toLowerCase();
+    const m = lower.match(/\s*\/run\s+orchestrated(.*)$/is);
+    if (!m) {
+        return { strategy, include, sample: formatSampleSuffix() };
+    }
+    const tailRaw = body.substring(body.toLowerCase().indexOf(m[0]) + '/run orchestrated'.length).trim();
+    const tokens = tailRaw.split(/\s+/).filter(Boolean);
+    let expectStrategy = false;
+    let expectInclude = false;
+    let expectSample = false;
+    for (const tok of tokens) {
+        if (expectStrategy) {
+            const lc = tok.toLowerCase();
+            if (lc === 'single' || lc === 'matrix')
+                strategy = lc;
+            else
+                strategy = lc;
+            expectStrategy = false;
+            continue;
+        }
+        if (expectInclude) {
+            include = parseBoolToken(tok);
+            expectInclude = false;
+            continue;
+        }
+        if (expectSample) {
+            sample = tok;
+            expectSample = false;
+            continue;
+        }
+        const lc = tok.toLowerCase();
+        const clean = lc.replace(/:/g, '=').replace(/^--/, '');
+        // strategy keyword expects next token
+        if (lc === 'strategy') {
+            expectStrategy = true;
+            continue;
+        }
+        // strategy=...
+        if (clean.startsWith('strategy=')) {
+            const v = clean.substring('strategy='.length);
+            if (v === 'single' || v === 'matrix')
+                strategy = v;
+            continue;
+        }
+        // shorthand toggles
+        if (['single', 'single=true', 'single=yes', 'single=1', 'single=on', '--single'].includes(clean)) {
+            strategy = 'single';
+            continue;
+        }
+        if (['matrix', 'matrix=true', 'matrix=yes', 'matrix=1', 'matrix=on', '--matrix'].includes(clean)) {
+            strategy = 'matrix';
+            continue;
+        }
+        // explicit integration toggles
+        if (['integration=true', 'include_integration=true'].includes(clean)) {
+            include = 'true';
+            continue;
+        }
+        if (['integration=false', 'include_integration=false'].includes(clean)) {
+            include = 'false';
+            continue;
+        }
+        // include_integration=...
+        if (clean.startsWith('include_integration=')) {
+            include = clean.substring('include_integration='.length);
+            continue;
+        }
+        // integration/include_integration keyword expects next token
+        if (clean === 'include_integration' || clean === 'integration') {
+            expectInclude = true;
+            continue;
+        }
+        // sample tokens
+        if (lc.startsWith('sample=') || lc.startsWith('sample_id=')) {
+            sample = tok.substring(tok.indexOf('=') + 1);
+            continue;
+        }
+        if (lc === 'sample' || lc === 'sample_id') {
+            expectSample = true;
+            continue;
+        }
+    }
+    if (!sample)
+        sample = formatSampleSuffix();
+    return { strategy, include, sample };
+}
+function run() {
+    const body = getEnv('INPUT_BODY') || '';
+    const out = parse(body);
+    setOutput('strategy', out.strategy);
+    setOutput('include_integration', out.include);
+    setOutput('sample_id', out.sample);
+}
+try {
+    run();
+}
+catch (err) {
+    const msg = err?.message || String(err);
+    try {
+        appendOutput([`error=${msg}`]);
+    }
+    catch { }
+    process.stderr.write(`parse-orchestrated error: ${msg}\n`);
+    process.exit(1);
+}
+export {};


### PR DESCRIPTION
- Copy compiled normalize-command + parse-orchestrated JS into each action folder as `index.js`
- Point action.yml `main` at `index.js`
- Leave dist output intact, but actions now run without relying on dist relative paths
- Validated with `tools/PrePush-Checks.ps1`

This resolves dispatcher metadata/path errors after adding checkout.

Refs: #88