### PR TITLE
dispatcher: drop ESM export from parse action

### DIFF
--- a/.github/actions/parse-orchestrated/index.cjs
+++ b/.github/actions/parse-orchestrated/index.cjs
@@ -139,4 +139,3 @@ catch (err) {
     process.stderr.write(`parse-orchestrated error: ${msg}\n`);
     process.exit(1);
 }
-export {};


### PR DESCRIPTION
Follow-up fix: removes the stray `export {}` at the end of `.github/actions/parse-orchestrated/index.cjs` so Node20 CommonJS runtime loads without SyntaxError.

Refs: #88