### PR TITLE
Fix invoker warmup race and compare outcome summary (#87)

### DIFF
--- a/.github/actions/ensure-invoker/action.yml
+++ b/.github/actions/ensure-invoker/action.yml
@@ -117,6 +117,19 @@ runs:
           exit 1
         }
 
+    - name: Invoker ping (Windows only)
+      if: ${{ inputs.mode == 'start' && runner.os == 'Windows' && steps.start.outputs.ready == 'true' }}
+      shell: pwsh
+      run: |
+        $args = @(
+          '-PipeName','${{ steps.compute.outputs.pipe_name }}',
+          '-ResultsDir','${{ steps.compute.outputs.results }}',
+          '-TimeoutSeconds','15',
+          '-Retries','5',
+          '-RetryDelaySeconds','2'
+        )
+        pwsh -File tools/RunnerInvoker/Wait-InvokerReady.ps1 @args
+
     - name: Stop invoker (Windows only)
       if: ${{ inputs.mode == 'stop' && runner.os == 'Windows' }}
       shell: pwsh
@@ -134,3 +147,4 @@ runs:
       if: ${{ runner.os != 'Windows' }}
       shell: bash
       run: echo ensure-invoker non-Windows runner, skipping
+

--- a/.github/actions/fixture-drift/action.yml
+++ b/.github/actions/fixture-drift/action.yml
@@ -173,6 +173,24 @@ runs:
         }
         "status=$status" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
         if ($sumPath) { "summary_path=$sumPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8 }
+        $searchBase = $null
+        if ($latest) {
+          try {
+            $resolvedLatest = (Resolve-Path -LiteralPath $latest.FullName -ErrorAction Stop).Path
+          } catch {
+            $resolvedLatest = $latest.FullName
+          }
+          $searchBase = $resolvedLatest
+        } elseif ($outDir) {
+          try {
+            $searchBase = (Resolve-Path -LiteralPath $outDir -ErrorAction Stop).Path
+          } catch {
+            $searchBase = $outDir
+          }
+        } else {
+          $searchBase = $root
+        }
+        if ($searchBase) { "results_dir=$searchBase" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8 }
         # Do not fail here to allow artifact upload and comment; a later step will enforce failure.
 
         # DEBUG: emit breadcrumbs to console and step summary to aid diagnosis when status is unknown or artifacts are missing
@@ -243,6 +261,20 @@ runs:
         if ($env:REPORT_DELAY_MS) { $lines += ("- Report delay (ms): {0}" -f $env:REPORT_DELAY_MS) }
         $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
         } catch { Write-Host "[drift-debug] failed to emit debug breadcrumbs: $_" }
+
+    - name: Summarize compare outcome
+      if: always()
+      shell: pwsh
+      run: |
+        $base = '${{ steps.orchestrate.outputs.results_dir }}'
+        if (-not $base) { $base = 'results/fixture-drift' }
+        try { $resolved = (Resolve-Path -LiteralPath $base -ErrorAction Stop).Path } catch { $resolved = $base }
+        if (-not (Test-Path -LiteralPath $resolved)) {
+          Write-Host "::notice::Compare outcome directory missing: $resolved"
+          exit 0
+        }
+        $outJson = Join-Path $resolved 'compare-outcome.json'
+        pwsh -NoLogo -NoProfile -File "${{ github.workspace }}/tools/Parse-CompareExec.ps1" -SearchDir $resolved -OutJson $outJson
 
     - name: Upload drift artifacts (with retention)
       if: always() && inputs.upload-artifacts == 'true' && (inputs.only-upload-on-failure != 'true' || steps.orchestrate.outputs.status != 'ok') && inputs.retention-days != ''

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -359,14 +359,15 @@ jobs:
       if: ${{ always() }}
       shell: pwsh
       run: |
-        $resDir = Join-Path 'tests/results' '${{ matrix.category }}'
+        $category = '${{ matrix.category }}'
+        $resDir = Join-Path 'tests/results' $category
         $sumPath = Join-Path $resDir 'pester-summary.json'
         if (Test-Path -LiteralPath $sumPath) {
           try {
             $s = Get-Content -LiteralPath $sumPath -Raw | ConvertFrom-Json -ErrorAction Stop
             $tot = $s.totals
             $lines = @(
-              "### Pester Status (${ {matrix.category} })",
+              "### Pester Status ($category)",
               "- Result: $($s.result)",
               "- Tests: $($tot.tests)  Passed: $($tot.passed)  Failed: $($tot.failed)",
               if ($s.durationSeconds -ne $null) { "- Duration (s): $($s.durationSeconds)" } else { $null }

--- a/tools/Parse-CompareExec.ps1
+++ b/tools/Parse-CompareExec.ps1
@@ -2,28 +2,116 @@ param(
   [string]$SearchDir = '.',
   [string]$OutJson = 'compare-outcome.json'
 )
+
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$paths = Get-ChildItem -Path $SearchDir -Recurse -Include compare-exec.json -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
-if (-not $paths) { Write-Host 'No compare-exec.json found'; exit 0 }
-$best = $paths | Select-Object -First 1
-$data = Get-Content -LiteralPath $best -Raw | ConvertFrom-Json
-$out = [ordered]@{
-  file = $best
-  diff = $data.diff
-  exitCode = $data.exitCode
-  durationMs = $data.durationMs
-  cliPath = $data.cliPath
-  command = $data.command
-}
-$out | ConvertTo-Json -Depth 5 | Out-File -FilePath $OutJson -Encoding utf8
-if ($env:GITHUB_STEP_SUMMARY) {
-  $lines = @('### Compare Outcome','')
-  $lines += ('- File: {0}' -f $best)
-  $lines += ('- diff: {0}' -f $data.diff)
-  $lines += ('- exitCode: {0}' -f $data.exitCode)
-  $lines += ('- durationMs: {0}' -f $data.durationMs)
-  $lines += ('- cliPath: {0}' -f $data.cliPath)
-  $lines += ('- command: {0}' -f $data.command)
-  $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+try { $resolvedDir = (Resolve-Path -LiteralPath $SearchDir -ErrorAction Stop).Path } catch { $resolvedDir = $SearchDir }
+
+$capturePath = @(Get-ChildItem -Path $resolvedDir -Recurse -Include lvcompare-capture.json -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName) | Sort-Object -Descending | Select-Object -First 1
+$execPath    = @(Get-ChildItem -Path $resolvedDir -Recurse -Include compare-exec.json    -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName) | Sort-Object -Descending | Select-Object -First 1
+
+$summaryLines = @('### Compare Outcome','')
+
+$payload = [ordered]@{
+  source      = 'missing'
+  file        = $null
+  diff        = $null
+  exitCode    = $null
+  durationMs  = $null
+  cliPath     = $null
+  command     = $null
+  stdoutPath  = $null
+  stdoutLen   = $null
+  stderrPath  = $null
+  stderrLen   = $null
+  reportPath  = $null
+  captureJson = $capturePath
+  capture     = [ordered]@{ status = 'missing'; reason = 'no_capture_json'; path = $capturePath }
+  compareExec = [ordered]@{ status = 'missing'; reason = 'no_exec_json'; path = $execPath }
 }
 
+if ($capturePath -and (Test-Path -LiteralPath $capturePath)) {
+  try {
+    $cap = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 6
+    $payload.capture.status = 'ok'
+    $payload.source = 'capture'
+    $payload.file = $capturePath
+    if ($cap.exitCode -ne $null) { $payload.exitCode = [int]$cap.exitCode }
+    if ($cap.command) { $payload.command = [string]$cap.command }
+    if ($cap.cliPath) { $payload.cliPath = [string]$cap.cliPath }
+    if ($cap.seconds -ne $null) { $payload.durationMs = [math]::Round([double]$cap.seconds * 1000,3) }
+    if ($payload.exitCode -ne $null) { $payload.diff = ($payload.exitCode -eq 1) }
+    if ($cap.stdoutLen -ne $null) { $payload.stdoutLen = [int]$cap.stdoutLen }
+    if ($cap.stderrLen -ne $null) { $payload.stderrLen = [int]$cap.stderrLen }
+    $capDir = Split-Path -Parent $capturePath
+    $stdoutCandidate = Join-Path $capDir 'lvcompare-stdout.txt'
+    if (Test-Path -LiteralPath $stdoutCandidate) { $payload.stdoutPath = $stdoutCandidate }
+    $stderrCandidate = Join-Path $capDir 'lvcompare-stderr.txt'
+    if (Test-Path -LiteralPath $stderrCandidate) { $payload.stderrPath = $stderrCandidate }
+    $reportCandidate = Join-Path $capDir 'compare-report.html'
+    if (Test-Path -LiteralPath $reportCandidate) { $payload.reportPath = $reportCandidate }
+  } catch {
+    $payload.capture.status = 'error'
+    $payload.capture.reason = $_.Exception.Message
+  }
+}
+
+if ($execPath -and (Test-Path -LiteralPath $execPath)) {
+  try {
+    $exec = Get-Content -LiteralPath $execPath -Raw | ConvertFrom-Json -Depth 6
+    $payload.compareExec.status = 'ok'
+    $payload.compareExec.path = $execPath
+    if ($exec.exitCode -ne $null) { $payload.compareExec.exitCode = [int]$exec.exitCode }
+    if ($exec.diff -ne $null) { $payload.compareExec.diff = [bool]$exec.diff }
+    if ($payload.source -eq 'compare-exec') {
+      $payload.file = $execPath
+      $payload.exitCode = $payload.compareExec.exitCode
+      $payload.diff = $payload.compareExec.diff
+      if ($exec.PSObject.Properties.Name -contains 'durationMs') {
+        $payload.durationMs = [double]$exec.durationMs
+      } elseif ($exec.PSObject.Properties.Name -contains 'duration_s') {
+        $payload.durationMs = [math]::Round([double]$exec.duration_s * 1000,3)
+      }
+      if ($exec.cliPath) { $payload.cliPath = [string]$exec.cliPath }
+      if ($exec.command) { $payload.command = [string]$exec.command }
+    } elseif ($payload.source -eq 'capture') {
+      # enrich capture-based payload with exec details when available
+      if ($payload.exitCode -eq $null -and $exec.exitCode -ne $null) { $payload.exitCode = [int]$exec.exitCode }
+      if ($payload.diff -eq $null -and $exec.diff -ne $null) { $payload.diff = [bool]$exec.diff }
+      if ($payload.durationMs -eq $null) {
+        if ($exec.PSObject.Properties.Name -contains 'durationMs') { $payload.durationMs = [double]$exec.durationMs }
+        elseif ($exec.PSObject.Properties.Name -contains 'duration_s') { $payload.durationMs = [math]::Round([double]$exec.duration_s * 1000,3) }
+      }
+    } else {
+      $payload.source = 'compare-exec'
+      $payload.file = $execPath
+      $payload.exitCode = $payload.compareExec.exitCode
+      $payload.diff = $payload.compareExec.diff
+      if ($exec.cliPath) { $payload.cliPath = [string]$exec.cliPath }
+      if ($exec.command) { $payload.command = [string]$exec.command }
+      if ($exec.PSObject.Properties.Name -contains 'durationMs') { $payload.durationMs = [double]$exec.durationMs }
+      elseif ($exec.PSObject.Properties.Name -contains 'duration_s') { $payload.durationMs = [math]::Round([double]$exec.duration_s * 1000,3) }
+    }
+  } catch {
+    $payload.compareExec.status = 'error'
+    $payload.compareExec.reason = $_.Exception.Message
+  }
+}
+
+if ($payload.source -eq 'missing' -and -not $capturePath -and -not $execPath) {
+  $summaryLines += ('- No compare artifacts found under: {0}' -f $resolvedDir)
+} else {
+  if ($payload.file) { $summaryLines += ('- File: {0}' -f $payload.file) }
+  if ($payload.diff -ne $null) { $summaryLines += ('- diff: {0}' -f $payload.diff) }
+  if ($payload.exitCode -ne $null) { $summaryLines += ('- exitCode: {0}' -f $payload.exitCode) }
+  if ($payload.durationMs -ne $null) { $summaryLines += ('- durationMs: {0}' -f $payload.durationMs) }
+  if ($payload.cliPath) { $summaryLines += ('- cliPath: {0}' -f $payload.cliPath) }
+  if ($payload.command) { $summaryLines += ('- command: {0}' -f $payload.command) }
+}
+
+$payload | ConvertTo-Json -Depth 8 | Out-File -FilePath $OutJson -Encoding utf8
+
+if ($env:GITHUB_STEP_SUMMARY) {
+  $summaryLines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}

--- a/tools/RunnerInvoker/Wait-InvokerReady.ps1
+++ b/tools/RunnerInvoker/Wait-InvokerReady.ps1
@@ -1,0 +1,33 @@
+#Requires -Version 7.0
+param(
+  [Parameter(Mandatory)][string]$PipeName,
+  [Parameter(Mandatory)][string]$ResultsDir,
+  [int]$TimeoutSeconds = 15,
+  [int]$Retries = 3,
+  [int]$RetryDelaySeconds = 2
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'RunnerInvoker.psm1') -Force
+
+if ($Retries -lt 1) { $Retries = 1 }
+if ($TimeoutSeconds -lt 1) { $TimeoutSeconds = 1 }
+
+for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+  try {
+    $result = Invoke-RunnerRequest -ResultsDir $ResultsDir -Verb 'Ping' -CommandArgs @{ pipe = $PipeName } -TimeoutSeconds $TimeoutSeconds
+    if ($result -and $result.pong) {
+      Write-Host ("Invoker ping attempt #{0}: ok (pong={1})" -f $attempt, $result.pong) -ForegroundColor Green
+      return
+    }
+    throw "Unexpected ping response: $($result | ConvertTo-Json -Compress)"
+  } catch {
+    if ($attempt -ge $Retries) {
+      throw "Invoker ping failed after $Retries attempt(s): $($_.Exception.Message)"
+    }
+    Write-Host ("Invoker ping attempt #{0} failed: {1}. Retrying in {2}s..." -f $attempt, $_.Exception.Message, $RetryDelaySeconds) -ForegroundColor Yellow
+    Start-Sleep -Seconds ([math]::Max(1,$RetryDelaySeconds))
+  }
+}


### PR DESCRIPTION
## Summary
- ensure-invoker now pings the runner loop before returning READY; added Wait-InvokerReady helper
- fixture-drift action surfaces compare-exec summary via Parse-CompareExec.ps1 and writes compare-outcome.json
- Parse-CompareExec.ps1 emits richer JSON + step summary; tests updated

## Testing
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/ParseCompareExec.Tests.ps1"
- pwsh -File tools/Lint-Markdown.ps1 -All (expected existing MD013/MD041)