### PR TITLE
Fail fast when matrix invoker isn't ready (#88)

### DIFF
--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -268,7 +268,6 @@ jobs:
         results-dir: tests/results
     - name: Ensure Invoker (start)
       id: inv_start_matrix
-      continue-on-error: true
       uses: ./.github/actions/ensure-invoker
       with:
         mode: start
@@ -356,7 +355,7 @@ jobs:
           -IncludePatterns $inc
 
     - name: Summarize Pester results (job-level)
-      if: ${{ always() }}
+      if: ${{ steps.inv_start_matrix.outputs.ready == 'true' }}
       shell: pwsh
       run: |
         $category = '${{ matrix.category }}'


### PR DESCRIPTION
## Summary
- fail the matrix job immediately when the invoker start times out
- only run the matrix summary step when READY data exists to prevent parsing errors

## Testing
- pwsh -File tools/Run-NonLVChecksInDocker.ps1 -SkipMarkdown -SkipDocs -SkipWorkflow