### PR TITLE
Add CLI provider metadata to TestStand session schema

### DIFF
--- a/dist/tools/schemas/definitions.js
+++ b/dist/tools/schemas/definitions.js
@@ -273,18 +273,61 @@ const dispatcherResultsGuardSchema = z
     message: z.string().min(1),
 })
     .passthrough();
+const testStandCliReportImageSchema = z
+    .object({
+    index: z.number().int().nonnegative(),
+    dataLength: z.number().int().nonnegative(),
+    mimeType: z.string().min(1).optional(),
+    source: z.string().min(1).optional(),
+    byteLength: z.number().int().nonnegative().optional(),
+    savedPath: z.string().min(1).optional(),
+    decodeError: z.string().min(1).optional(),
+})
+    .strict();
+const testStandCliArtifactsSchema = z
+    .object({
+    reportSizeBytes: z.number().int().nonnegative().optional(),
+    imageCount: z.number().int().nonnegative().optional(),
+    exportDir: z.string().min(1).optional(),
+    images: z.array(testStandCliReportImageSchema).optional(),
+})
+    .strict();
+const testStandCliInfoSchema = z
+    .object({
+    path: z.string().min(1),
+    version: z.string().min(1).optional(),
+    reportPath: z.string().min(1).optional(),
+    reportType: z.string().min(1).optional(),
+    status: z.string().min(1).optional(),
+    message: z.string().min(1).optional(),
+    provider: z.string().min(1).optional(),
+    artifacts: testStandCliArtifactsSchema.optional(),
+})
+    .strict();
 const testStandCompareSessionSchema = z.object({
     schema: z.literal('teststand-compare-session/v1'),
     at: isoString,
-    warmup: z.object({
-        events: z.string().min(1),
-    }),
-    compare: z.object({
+    warmup: z
+        .object({
+        mode: z.enum(['detect', 'spawn', 'skip']),
+        events: z.union([z.string().min(1), z.null()]),
+    })
+        .strict(),
+    compare: z
+        .object({
         events: z.string().min(1),
         capture: z.string().min(1),
         report: z.boolean(),
+        command: z.string().min(1).optional(),
         cliPath: z.string().min(1).optional(),
-    }),
+        cli: testStandCliInfoSchema.optional(),
+        policy: z.enum(['lv-first', 'cli-first', 'cli-only', 'lv-only']).optional(),
+        mode: z.string().min(1).optional(),
+        autoCli: z.boolean().optional(),
+        sameName: z.boolean().optional(),
+        timeoutSeconds: z.number().int().nonnegative().optional(),
+    })
+        .strict(),
     outcome: z
         .object({
         exitCode: z.number(),
@@ -292,8 +335,9 @@ const testStandCompareSessionSchema = z.object({
         command: z.string().optional(),
         diff: z.boolean().optional(),
     })
+        .strict()
         .nullable(),
-    error: z.string().optional(),
+    error: z.union([z.string(), z.null()]).optional(),
 });
 const invokerEventSchema = z.object({
     timestamp: isoString,

--- a/docs/schema/generated/teststand-compare-session.schema.json
+++ b/docs/schema/generated/teststand-compare-session.schema.json
@@ -64,7 +64,100 @@
               "minLength": 1
             },
             "cli": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "reportPath": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "reportType": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "status": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "message": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "provider": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "artifacts": {
+                  "type": "object",
+                  "properties": {
+                    "reportSizeBytes": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "imageCount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "exportDir": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "images": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "index": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "dataLength": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "mimeType": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "source": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "byteLength": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "savedPath": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "decodeError": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "dataLength"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "additionalProperties": false
             },
             "policy": {
               "type": "string",
@@ -78,6 +171,16 @@
             "mode": {
               "type": "string",
               "minLength": 1
+            },
+            "autoCli": {
+              "type": "boolean"
+            },
+            "sameName": {
+              "type": "boolean"
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "minimum": 0
             }
           },
           "required": [
@@ -116,13 +219,9 @@
           ]
         },
         "error": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "string",
+            "null"
           ]
         }
       },

--- a/tools/Invoke-LVCompare.ps1
+++ b/tools/Invoke-LVCompare.ps1
@@ -328,6 +328,9 @@ function Invoke-LabVIEWCLICompare {
 
   $cliPath = $cliResult.cliPath
   $cliInfoOrdered = [ordered]@{ path = $cliPath }
+  if ($cliResult.provider -and -not [string]::IsNullOrWhiteSpace($cliResult.provider)) {
+    $cliInfoOrdered.provider = $cliResult.provider
+  }
   $cliVer = Get-FileProductVersion -Path $cliPath
   if ($cliVer) { $cliInfoOrdered.version = $cliVer }
   if ($reportPath) { $cliInfoOrdered.reportPath = $reportPath }
@@ -336,6 +339,12 @@ function Invoke-LabVIEWCLICompare {
   }
   if ($cliResult.normalizedParams -and $cliResult.normalizedParams.PSObject.Properties.Name -contains 'reportType' -and $cliResult.normalizedParams.reportType) {
     $cliInfoOrdered.reportType = $cliResult.normalizedParams.reportType
+  }
+  if ($cliResult.normalizedParams -and $cliResult.normalizedParams.PSObject.Properties.Name -contains 'provider') {
+    $providerValue = $cliResult.normalizedParams.provider
+    if ($providerValue -is [string] -and -not [string]::IsNullOrWhiteSpace($providerValue)) {
+      $cliInfoOrdered.provider = $providerValue
+    }
   }
 
   $cliMeta = Get-LabVIEWCliOutputMetadata -StdOut $cliResult.stdout -StdErr $cliResult.stderr

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -296,18 +296,64 @@ const dispatcherResultsGuardSchema = z
   })
   .passthrough();
 
+const testStandCliReportImageSchema = z
+  .object({
+    index: z.number().int().nonnegative(),
+    dataLength: z.number().int().nonnegative(),
+    mimeType: z.string().min(1).optional(),
+    source: z.string().min(1).optional(),
+    byteLength: z.number().int().nonnegative().optional(),
+    savedPath: z.string().min(1).optional(),
+    decodeError: z.string().min(1).optional(),
+  })
+  .strict();
+
+const testStandCliArtifactsSchema = z
+  .object({
+    reportSizeBytes: z.number().int().nonnegative().optional(),
+    imageCount: z.number().int().nonnegative().optional(),
+    exportDir: z.string().min(1).optional(),
+    images: z.array(testStandCliReportImageSchema).optional(),
+  })
+  .strict();
+
+const testStandCliInfoSchema = z
+  .object({
+    path: z.string().min(1),
+    version: z.string().min(1).optional(),
+    reportPath: z.string().min(1).optional(),
+    reportType: z.string().min(1).optional(),
+    status: z.string().min(1).optional(),
+    message: z.string().min(1).optional(),
+    provider: z.string().min(1).optional(),
+    artifacts: testStandCliArtifactsSchema.optional(),
+  })
+  .strict();
+
 const testStandCompareSessionSchema = z.object({
   schema: z.literal('teststand-compare-session/v1'),
   at: isoString,
-  warmup: z.object({
-    events: z.string().min(1),
-  }),
-  compare: z.object({
-    events: z.string().min(1),
-    capture: z.string().min(1),
-    report: z.boolean(),
-    cliPath: z.string().min(1).optional(),
-  }),
+  warmup: z
+    .object({
+      mode: z.enum(['detect', 'spawn', 'skip']),
+      events: z.union([z.string().min(1), z.null()]),
+    })
+    .strict(),
+  compare: z
+    .object({
+      events: z.string().min(1),
+      capture: z.string().min(1),
+      report: z.boolean(),
+      command: z.string().min(1).optional(),
+      cliPath: z.string().min(1).optional(),
+      cli: testStandCliInfoSchema.optional(),
+      policy: z.enum(['lv-first', 'cli-first', 'cli-only', 'lv-only']).optional(),
+      mode: z.string().min(1).optional(),
+      autoCli: z.boolean().optional(),
+      sameName: z.boolean().optional(),
+      timeoutSeconds: z.number().int().nonnegative().optional(),
+    })
+    .strict(),
   outcome: z
     .object({
       exitCode: z.number(),
@@ -315,8 +361,9 @@ const testStandCompareSessionSchema = z.object({
       command: z.string().optional(),
       diff: z.boolean().optional(),
     })
+    .strict()
     .nullable(),
-  error: z.string().optional(),
+  error: z.union([z.string(), z.null()]).optional(),
 });
 
 const invokerEventSchema = z.object({


### PR DESCRIPTION
## Summary
- surface the selected LabVIEW CLI provider in Invoke-LVCompare session captures
- enrich the TestStand session schema to describe provider metadata, warmup mode, and compare flags
- regenerate the compiled schema bundle

## Testing
- npm run schemas:generate

------
https://chatgpt.com/codex/tasks/task_b_68f01ac9cdcc832d8d34a19a10729a0d