### PR TITLE
Add g-cli provider for LabVIEW CLI abstraction (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ CLI-only quick start (64-bit Windows):
 - On self-hosted runners with LabVIEW CLI installed, automation defaults the CLI path to
   `C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.exe` when no
   overrides are set.
+- When [g-cli](https://github.com/ni/g-cli) is installed, the shared CLI abstraction registers it as
+  provider `gcli`. The resolver checks `GCLI_PATH`, the system `PATH`, and canonical install
+  directories (for example `C:\Program Files\G-CLI\bin\g-cli.exe` or `/usr/local/bin/g-cli`). Use
+  `LVCLI_PROVIDER=gcli` to force g-cli selection or `LVCLI_PROVIDER=labviewcli` to prefer the NI
+  LabVIEW CLI implementation.
 - To force CLI-only compare end-to-end (no LVCompare invocation):
   - Set `LVCI_COMPARE_MODE=labview-cli` and `LVCI_COMPARE_POLICY=cli-only`.
   - Run either wrapper:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -52,12 +52,18 @@ Artefacts: `tests/results/pester-leak-report.json`, `tests/results/pester-artifa
 | `LVCI_COMPARE_MODE` | Select compare mechanism: `labview-cli` or `lvcompare` |
 | `LVCI_COMPARE_POLICY` | Mode policy: `lv-first` (default), `cli-first`, `cli-only`, `lv-only` |
 | `LABVIEW_CLI_PATH` | Optional override for `LabVIEWCLI.exe` (defaults below) |
+| `GCLI_PATH` | Optional override for `g-cli` binary discovery |
+| `LVCLI_PROVIDER` | Force provider selection (`gcli`, `labviewcli`, or `auto`) |
 
 Notes:
 
 - On 64-bit Windows hosts, automation defaults the CLI path to:
   `C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.exe` when
   no CLI path overrides are set.
+- When g-cli is installed, the abstraction checks `GCLI_PATH`, the system `PATH`, and canonical
+  install directories (for example `C:\Program Files\G-CLI\bin\g-cli.exe` or
+  `/usr/local/bin/g-cli`). Set `LVCLI_PROVIDER=gcli` to lock selection to g-cli or
+  `LVCLI_PROVIDER=labviewcli` to prefer NI's LabVIEW CLI even when both are present.
 - With `LVCI_COMPARE_POLICY=cli-only` (or `LVCI_COMPARE_MODE=labview-cli` and not `lv-only`), both
   the wrapper and the TestStand harness invoke the LabVIEW CLI directly to generate an HTML report
   and enrich `lvcompare-capture.json` with an `environment.cli` metadata block (path, version,

--- a/docs/LabVIEWCliShimPattern.md
+++ b/docs/LabVIEWCliShimPattern.md
@@ -9,6 +9,8 @@ This document defines the supported pattern for creating LabVIEW CLI shims that 
 ## Responsibilities
 
 - Import `tools/LabVIEWCli.psm1` and rely on its provider resolution, parameter normalisation, and environment guards.
+- Provider selection now includes both NI LabVIEW CLI (`labviewcli`) and g-cli (`gcli`). The abstraction chooses the first
+  provider with a resolvable binary unless `LVCLI_PROVIDER` forces a specific implementation.
 - Map legacy or convenience parameters to the canonical LabVIEW CLI operation schema rather than duplicating validation logic.
 - Optionally override `LABVIEWCLI_PATH` for the duration of the call, restoring the original value afterwards.
 - Invoke the appropriate exported function (`Invoke-LVOperation` or one of the typed helpers such as `Invoke-LVCreateComparisonReport`) and return its result.

--- a/tests/LabVIEWCli.GCliProvider.Tests.ps1
+++ b/tests/LabVIEWCli.GCliProvider.Tests.ps1
@@ -1,0 +1,100 @@
+Set-StrictMode -Version Latest
+
+Describe 'LabVIEW CLI g-cli provider' -Tag 'Unit' {
+  BeforeAll {
+    $modulePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/providers/gcli/Provider.psm1'
+    $script:ProviderModule = Import-Module $modulePath -Force -PassThru
+    $script:Provider = New-LVProvider
+  }
+
+  AfterAll {
+    if ($script:ProviderModule) {
+      Remove-Module $script:ProviderModule -ErrorAction SilentlyContinue
+    }
+    Remove-Variable -Name Provider -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name ProviderModule -Scope Script -ErrorAction SilentlyContinue
+  }
+
+  It 'exposes provider metadata' {
+    $Provider.Name() | Should -Be 'gcli'
+    foreach ($op in @('CloseLabVIEW','CreateComparisonReport','RunVI','RunVIAnalyzer','RunUnitTests','MassCompile','ExecuteBuildSpec')) {
+      $Provider.Supports($op) | Should -BeTrue
+    }
+    $Provider.Supports('UnknownOp') | Should -BeFalse
+  }
+
+  It 'builds RunVI arguments with booleans and positional inputs' {
+    $args = $Provider.BuildArgs('RunVI', @{
+      viPath = 'C:\fixture\RunMe.vi'
+      showFP = $true
+      abortOnError = $false
+      arguments = @('one','two')
+    })
+    $args | Should -Be @(
+      '--operation','RunVI',
+      '--viPath','C:\fixture\RunMe.vi',
+      '--showFP','true',
+      '--abortOnError','false',
+      '--argument','one',
+      '--argument','two'
+    )
+  }
+
+  It 'builds CreateComparisonReport arguments with optional fields' {
+    $args = $Provider.BuildArgs('CreateComparisonReport', @{
+      vi1 = 'C:\base.vi'
+      vi2 = 'C:\head.vi'
+      reportPath = 'C:\reports\diff.html'
+      reportType = 'HTML'
+    })
+    $args | Should -Be @(
+      '--operation','CreateComparisonReport',
+      '--vi1','C:\base.vi',
+      '--vi2','C:\head.vi',
+      '--reportPath','C:\reports\diff.html',
+      '--reportType','HTML'
+    )
+  }
+
+  It 'omits optional CreateComparisonReport arguments when not provided' {
+    $args = $Provider.BuildArgs('CreateComparisonReport', @{
+      vi1 = 'C:\base.vi'
+      vi2 = 'C:\head.vi'
+    })
+    $args | Should -Be @(
+      '--operation','CreateComparisonReport',
+      '--vi1','C:\base.vi',
+      '--vi2','C:\head.vi'
+    )
+  }
+
+  It 'builds MassCompile arguments with mixed value types' {
+    $args = $Provider.BuildArgs('MassCompile', @{
+      directoryToCompile = 'C:\src'
+      massCompileLogFile = 'C:\logs\mass.txt'
+      appendToMassCompileLog = $true
+      numOfVIsToCache = 25
+      reloadLVSBs = $false
+    })
+    $args | Should -Be @(
+      '--operation','MassCompile',
+      '--directoryToCompile','C:\src',
+      '--massCompileLogFile','C:\logs\mass.txt',
+      '--appendToMassCompileLog','true',
+      '--numOfVIsToCache','25',
+      '--reloadLVSBs','false'
+    )
+  }
+
+  It 'uses buildSpec alias when provided' {
+    $args = $Provider.BuildArgs('ExecuteBuildSpec', @{
+      projectPath = 'C:\proj.lvproj'
+      buildSpec = 'BuildAlias'
+    })
+    $args | Should -Be @(
+      '--operation','ExecuteBuildSpec',
+      '--projectPath','C:\proj.lvproj',
+      '--buildSpecName','BuildAlias'
+    )
+  }
+}

--- a/tools/providers/gcli/Provider.psm1
+++ b/tools/providers/gcli/Provider.psm1
@@ -1,0 +1,152 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-GCliCandidatePaths {
+  $candidates = @()
+  foreach ($envName in @('GCLI_PATH','GCLI_EXE','GCLI_BIN','G_CLI_PATH','GCLI')) {
+    $value = [System.Environment]::GetEnvironmentVariable($envName)
+    if (-not [string]::IsNullOrWhiteSpace($value)) {
+      $candidates += $value
+    }
+  }
+  try {
+    $command = Get-Command 'g-cli' -ErrorAction Stop
+    if ($command -and $command.Source -ne 'Alias') {
+      if ($command.Path) { $candidates += $command.Path }
+    }
+  } catch {}
+
+  if ($IsWindows) {
+    $roots = @([System.Environment]::GetEnvironmentVariable('ProgramFiles'), [System.Environment]::GetEnvironmentVariable('ProgramFiles(x86)'))
+    foreach ($root in $roots) {
+      if ([string]::IsNullOrWhiteSpace($root)) { continue }
+      $candidates += (Join-Path $root 'G-CLI\\bin\\g-cli.exe')
+    }
+  } else {
+    $candidates += '/usr/local/bin/g-cli'
+    $candidates += '/usr/bin/g-cli'
+    $candidates += '/opt/g-cli/bin/g-cli'
+  }
+
+  return $candidates | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Resolve-GCliBinaryPath {
+  foreach ($candidate in Get-GCliCandidatePaths) {
+    try {
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $candidate).Path
+      }
+    } catch {
+      # Ignore resolution failures; fall back to next candidate.
+    }
+  }
+  return $null
+}
+
+function Convert-ToBoolString {
+  param([bool]$Value)
+  if ($Value) { return 'true' }
+  return 'false'
+}
+
+function Add-GCliArgument {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter()][object]$Value,
+    [Parameter(Mandatory)][ref]$Buffer
+  )
+  if ($null -eq $Value -or ([string]::IsNullOrWhiteSpace([string]$Value) -and -not ($Value -is [bool]) -and -not ($Value -is [int]))) {
+    return
+  }
+  $flag = '--' + $Name
+  switch ($Value) {
+    { $_ -is [bool] } {
+      $Buffer.Value += @($flag, (Convert-ToBoolString $Value))
+    }
+    { $_ -is [System.Collections.IEnumerable] -and -not ($_ -is [string]) } {
+      foreach ($item in $Value) {
+        if ($null -eq $item -or [string]::IsNullOrWhiteSpace([string]$item)) { continue }
+        $Buffer.Value += @($flag, [string]$item)
+      }
+    }
+    default {
+      $Buffer.Value += @($flag, [string]$Value)
+    }
+  }
+}
+
+function Get-GCliArgs {
+  param(
+    [Parameter(Mandatory)][string]$Operation,
+    [Parameter()][hashtable]$Params
+  )
+
+  $args = @('--operation', $Operation)
+  switch ($Operation) {
+    'CloseLabVIEW' {
+      Add-GCliArgument -Name 'labviewPath' -Value $Params.labviewPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'labviewVersion' -Value $Params.labviewVersion -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'labviewBitness' -Value $Params.labviewBitness -Buffer ([ref]$args)
+    }
+    'CreateComparisonReport' {
+      Add-GCliArgument -Name 'vi1' -Value $Params.vi1 -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'vi2' -Value $Params.vi2 -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'reportPath' -Value $Params.reportPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'reportType' -Value $Params.reportType -Buffer ([ref]$args)
+    }
+    'RunVI' {
+      Add-GCliArgument -Name 'viPath' -Value $Params.viPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'showFP' -Value $Params.showFP -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'abortOnError' -Value $Params.abortOnError -Buffer ([ref]$args)
+      if ($Params.ContainsKey('arguments') -and $Params.arguments) {
+        Add-GCliArgument -Name 'argument' -Value @($Params.arguments) -Buffer ([ref]$args)
+      }
+    }
+    'RunVIAnalyzer' {
+      Add-GCliArgument -Name 'configPath' -Value $Params.configPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'reportPath' -Value $Params.reportPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'reportSaveType' -Value $Params.reportSaveType -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'configPassword' -Value $Params.configPassword -Buffer ([ref]$args)
+    }
+    'RunUnitTests' {
+      Add-GCliArgument -Name 'projectPath' -Value $Params.projectPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'junitReportPath' -Value $Params.junitReportPath -Buffer ([ref]$args)
+    }
+    'MassCompile' {
+      Add-GCliArgument -Name 'directoryToCompile' -Value $Params.directoryToCompile -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'massCompileLogFile' -Value $Params.massCompileLogFile -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'appendToMassCompileLog' -Value $Params.appendToMassCompileLog -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'numOfVIsToCache' -Value $Params.numOfVIsToCache -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'reloadLVSBs' -Value $Params.reloadLVSBs -Buffer ([ref]$args)
+    }
+    'ExecuteBuildSpec' {
+      Add-GCliArgument -Name 'projectPath' -Value $Params.projectPath -Buffer ([ref]$args)
+      Add-GCliArgument -Name 'targetName' -Value $Params.targetName -Buffer ([ref]$args)
+      $specName = if ($Params.buildSpec) { $Params.buildSpec } else { $Params.buildSpecName }
+      Add-GCliArgument -Name 'buildSpecName' -Value $specName -Buffer ([ref]$args)
+    }
+    default {
+      throw "Operation '$Operation' not yet implemented for g-cli provider."
+    }
+  }
+
+  return $args
+}
+
+function New-LVProvider {
+  $provider = New-Object PSObject
+  $provider | Add-Member ScriptMethod Name { 'gcli' }
+  $provider | Add-Member ScriptMethod ResolveBinaryPath { Resolve-GCliBinaryPath }
+  $provider | Add-Member ScriptMethod Supports {
+    param($Operation)
+    return @('CloseLabVIEW','CreateComparisonReport','RunVI','RunVIAnalyzer','RunUnitTests','MassCompile','ExecuteBuildSpec') -contains $Operation
+  }
+  $provider | Add-Member ScriptMethod BuildArgs {
+    param($Operation,$Params)
+    return (Get-GCliArgs -Operation $Operation -Params $Params)
+  }
+  return $provider
+}
+
+Export-ModuleMember -Function New-LVProvider


### PR DESCRIPTION
## Summary
- extend the LabVIEW CLI abstraction (#127) with a g-cli provider that resolves the binary from common locations and builds provider-aware arguments
- add focused Pester unit coverage for the new provider to lock argument formatting and provider metadata
- document g-cli discovery, LVCLI_PROVIDER overrides, and multi-provider selection in the README and environment references

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Script tests/LabVIEWCli.GCliProvider.Tests.ps1 -Output Detailed"` *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f01e8d6a9c832d9ecca767a438f78c