### PR TITLE
Expand TestStand session schema metadata (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T22:18:20.030Z",
+  "cachedAtUtc": "2025-10-15T22:22:26.650Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/dist/tools/schemas/definitions.js
+++ b/dist/tools/schemas/definitions.js
@@ -273,17 +273,29 @@ const dispatcherResultsGuardSchema = z
     message: z.string().min(1),
 })
     .passthrough();
+const warmupModeSchema = z.enum(['detect', 'spawn', 'skip']);
+const warmupEventsSchema = z.union([z.string().min(1), z.null()]);
+const compareCliSchema = z.object({}).passthrough();
+const comparePolicySchema = z.enum(['lv-first', 'cli-first', 'cli-only', 'lv-only']);
 const testStandCompareSessionSchema = z.object({
     schema: z.literal('teststand-compare-session/v1'),
     at: isoString,
     warmup: z.object({
-        events: z.string().min(1),
+        mode: warmupModeSchema,
+        events: warmupEventsSchema,
     }),
     compare: z.object({
         events: z.string().min(1),
         capture: z.string().min(1),
         report: z.boolean(),
+        command: z.string().min(1).optional(),
         cliPath: z.string().min(1).optional(),
+        cli: compareCliSchema.optional(),
+        policy: comparePolicySchema.optional(),
+        mode: z.string().min(1).optional(),
+        autoCli: z.boolean().optional(),
+        sameName: z.boolean().optional(),
+        timeoutSeconds: z.number().min(0).optional(),
     }),
     outcome: z
         .object({
@@ -293,7 +305,7 @@ const testStandCompareSessionSchema = z.object({
         diff: z.boolean().optional(),
     })
         .nullable(),
-    error: z.string().optional(),
+    error: z.union([z.string().min(1), z.null()]).optional(),
 });
 const invokerEventSchema = z.object({
     timestamp: isoString,

--- a/docs/schema/generated/teststand-compare-session.schema.json
+++ b/docs/schema/generated/teststand-compare-session.schema.json
@@ -64,7 +64,9 @@
               "minLength": 1
             },
             "cli": {
-              "type": "object"
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
             },
             "policy": {
               "type": "string",
@@ -78,6 +80,16 @@
             "mode": {
               "type": "string",
               "minLength": 1
+            },
+            "autoCli": {
+              "type": "boolean"
+            },
+            "sameName": {
+              "type": "boolean"
+            },
+            "timeoutSeconds": {
+              "type": "number",
+              "minimum": 0
             }
           },
           "required": [
@@ -118,7 +130,8 @@
         "error": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             {
               "type": "null"

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -296,17 +296,32 @@ const dispatcherResultsGuardSchema = z
   })
   .passthrough();
 
+const warmupModeSchema = z.enum(['detect', 'spawn', 'skip']);
+const warmupEventsSchema = z.union([z.string().min(1), z.null()]);
+
+const compareCliSchema = z.object({}).passthrough();
+
+const comparePolicySchema = z.enum(['lv-first', 'cli-first', 'cli-only', 'lv-only']);
+
 const testStandCompareSessionSchema = z.object({
   schema: z.literal('teststand-compare-session/v1'),
   at: isoString,
   warmup: z.object({
-    events: z.string().min(1),
+    mode: warmupModeSchema,
+    events: warmupEventsSchema,
   }),
   compare: z.object({
     events: z.string().min(1),
     capture: z.string().min(1),
     report: z.boolean(),
+    command: z.string().min(1).optional(),
     cliPath: z.string().min(1).optional(),
+    cli: compareCliSchema.optional(),
+    policy: comparePolicySchema.optional(),
+    mode: z.string().min(1).optional(),
+    autoCli: z.boolean().optional(),
+    sameName: z.boolean().optional(),
+    timeoutSeconds: z.number().min(0).optional(),
   }),
   outcome: z
     .object({
@@ -316,7 +331,7 @@ const testStandCompareSessionSchema = z.object({
       diff: z.boolean().optional(),
     })
     .nullable(),
-  error: z.string().optional(),
+  error: z.union([z.string().min(1), z.null()]).optional(),
 });
 
 const invokerEventSchema = z.object({


### PR DESCRIPTION
## Summary
- extend the TestStand compare session schema to require warmup mode and accept CLI metadata, policy, and timeout fields
- regenerate the compiled schema module and published JSON schema to match the richer session index
- refresh the standing priority cache after syncing the current priority issue

## Testing
- npm run schemas:generate

------
https://chatgpt.com/codex/tasks/task_b_68f01e852f74832daaa206d64e6da2d8