### PR TITLE
Record standing priority fetch source (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T22:22:26.650Z",
+  "cachedAtUtc": "2025-10-15T22:36:21.023Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",
@@ -10,5 +10,7 @@
   "assignees": [],
   "milestone": null,
   "commentCount": null,
-  "bodyDigest": null
+  "bodyDigest": null,
+  "lastFetchSource": "cache",
+  "lastFetchError": "Failed to fetch issue #134 via gh CLI"
 }


### PR DESCRIPTION
## Summary
- extend the standing priority sync script to track whether data came from a live fetch or cache fallback and surface that in the step summary
- persist the fetch source and any error message in the priority cache for later inspection

## Testing
- npm run priority:sync
- node --test tools/priority/__tests__/snapshot.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68f021125a7c832d8748764890b9c1c4