### PR TITLE
Structure TestStand session CLI metadata schema (#127)

### DIFF
--- a/dist/tools/schemas/definitions.js
+++ b/dist/tools/schemas/definitions.js
@@ -72,6 +72,15 @@ const cliArtifactsSchema = z
     images: z.array(cliArtifactsImageSchema).optional(),
 })
     .passthrough();
+const cliInfoSchema = z.object({
+    path: z.string().min(1).optional(),
+    version: z.string().min(1).optional(),
+    reportType: z.string().min(1).optional(),
+    reportPath: z.string().min(1).optional(),
+    status: z.string().min(1).optional(),
+    message: z.string().min(1).optional(),
+    artifacts: cliArtifactsSchema.optional(),
+});
 const lvCompareEnvironmentSchema = z
     .object({
     lvcompareVersion: z.string().min(1).optional(),
@@ -81,17 +90,7 @@ const lvCompareEnvironmentSchema = z
     arch: z.string().min(1).optional(),
     compareMode: z.string().min(1).optional(),
     comparePolicy: z.string().min(1).optional(),
-    cli: z
-        .object({
-        path: z.string().min(1).optional(),
-        version: z.string().min(1).optional(),
-        reportType: z.string().min(1).optional(),
-        reportPath: z.string().min(1).optional(),
-        status: z.string().min(1).optional(),
-        message: z.string().min(1).optional(),
-        artifacts: cliArtifactsSchema.optional(),
-    })
-        .optional(),
+    cli: cliInfoSchema.optional(),
     runner: z
         .object({
         labels: z.array(z.string().min(1)).optional(),
@@ -275,7 +274,7 @@ const dispatcherResultsGuardSchema = z
     .passthrough();
 const warmupModeSchema = z.enum(['detect', 'spawn', 'skip']);
 const warmupEventsSchema = z.union([z.string().min(1), z.null()]);
-const compareCliSchema = z.object({}).passthrough();
+const compareCliSchema = cliInfoSchema;
 const comparePolicySchema = z.enum(['lv-first', 'cli-first', 'cli-only', 'lv-only']);
 const testStandCompareSessionSchema = z.object({
     schema: z.literal('teststand-compare-session/v1'),

--- a/docs/schema/generated/teststand-compare-session.schema.json
+++ b/docs/schema/generated/teststand-compare-session.schema.json
@@ -65,8 +65,84 @@
             },
             "cli": {
               "type": "object",
-              "properties": {},
-              "additionalProperties": true
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "version": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "reportType": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "reportPath": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "status": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "message": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "artifacts": {
+                  "type": "object",
+                  "properties": {
+                    "reportSizeBytes": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "imageCount": {
+                      "$ref": "#/definitions/teststand-compare-session/properties/compare/properties/cli/properties/artifacts/properties/reportSizeBytes"
+                    },
+                    "exportDir": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "images": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "index": {
+                            "$ref": "#/definitions/teststand-compare-session/properties/compare/properties/cli/properties/artifacts/properties/reportSizeBytes"
+                          },
+                          "mimeType": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "dataLength": {
+                            "$ref": "#/definitions/teststand-compare-session/properties/compare/properties/cli/properties/artifacts/properties/reportSizeBytes"
+                          },
+                          "byteLength": {
+                            "$ref": "#/definitions/teststand-compare-session/properties/compare/properties/cli/properties/artifacts/properties/reportSizeBytes"
+                          },
+                          "savedPath": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "source": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "decodeError": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": false
             },
             "policy": {
               "type": "string",

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -81,6 +81,16 @@ const cliArtifactsSchema = z
   })
   .passthrough();
 
+const cliInfoSchema = z.object({
+  path: z.string().min(1).optional(),
+  version: z.string().min(1).optional(),
+  reportType: z.string().min(1).optional(),
+  reportPath: z.string().min(1).optional(),
+  status: z.string().min(1).optional(),
+  message: z.string().min(1).optional(),
+  artifacts: cliArtifactsSchema.optional(),
+});
+
 const lvCompareEnvironmentSchema = z
   .object({
     lvcompareVersion: z.string().min(1).optional(),
@@ -90,17 +100,7 @@ const lvCompareEnvironmentSchema = z
     arch: z.string().min(1).optional(),
     compareMode: z.string().min(1).optional(),
     comparePolicy: z.string().min(1).optional(),
-    cli: z
-      .object({
-        path: z.string().min(1).optional(),
-        version: z.string().min(1).optional(),
-        reportType: z.string().min(1).optional(),
-        reportPath: z.string().min(1).optional(),
-        status: z.string().min(1).optional(),
-        message: z.string().min(1).optional(),
-        artifacts: cliArtifactsSchema.optional(),
-      })
-      .optional(),
+    cli: cliInfoSchema.optional(),
     runner: z
       .object({
         labels: z.array(z.string().min(1)).optional(),
@@ -299,7 +299,7 @@ const dispatcherResultsGuardSchema = z
 const warmupModeSchema = z.enum(['detect', 'spawn', 'skip']);
 const warmupEventsSchema = z.union([z.string().min(1), z.null()]);
 
-const compareCliSchema = z.object({}).passthrough();
+const compareCliSchema = cliInfoSchema;
 
 const comparePolicySchema = z.enum(['lv-first', 'cli-first', 'cli-only', 'lv-only']);
 


### PR DESCRIPTION
## Summary
- refactor the schema definitions to share a CLI metadata shape between capture and TestStand session outputs (#127)
- regenerate the TestStand session JSON schema so compare.cli now validates path/version/report metadata (#127)

## Testing
- npm run schemas:generate

------
https://chatgpt.com/codex/tasks/task_b_68f022f02824832db84a77868489a1aa