### PR TITLE
Add TestStand session index sample for schema validation (#127)

### DIFF
--- a/docs/TESTSTAND_INTEGRATION_PLAN.md
+++ b/docs/TESTSTAND_INTEGRATION_PLAN.md
@@ -29,6 +29,11 @@ This produces:
 - `compare/lvcompare-capture.json`, `compare/compare-events.ndjson`, `compare-report.html`
 - `session-index.json` summarising the run (warmup mode, compare policy/mode, CLI metadata, decoded artefact summary)
 
+The repository includes a reference capture at `fixtures/teststand-session/session-index.json` so schema validation stays
+available even when fresh harness artefacts are not present. `npm run session:teststand:validate` now checks both the sample
+and any `tests/results/teststand-session/session-index.json` produced locally, allowing agents to verify shape changes without
+rerunning LabVIEW.
+
 Validate the session index with `npm run session:teststand:validate` so schema regressions surface immediately when the harness
 outputs change.
 

--- a/fixtures/teststand-session/session-index.json
+++ b/fixtures/teststand-session/session-index.json
@@ -1,0 +1,58 @@
+{
+  "schema": "teststand-compare-session/v1",
+  "at": "2025-10-15T22:48:30.123Z",
+  "warmup": {
+    "mode": "detect",
+    "events": "_warmup/labview-runtime.ndjson"
+  },
+  "compare": {
+    "events": "compare/compare-events.ndjson",
+    "capture": "compare/lvcompare-capture.json",
+    "report": true,
+    "command": "lvcompare --diff --nobdcosm --nofppos --noattr --out compare-report.html VI1.vi VI2.vi",
+    "cliPath": "C:/Program Files/National Instruments/Shared/LabVIEW CLI/LabVIEWCLI.exe",
+    "cli": {
+      "path": "C:/Program Files/National Instruments/Shared/LabVIEW CLI/LabVIEWCLI.exe",
+      "version": "25.0.0f0",
+      "reportType": "html",
+      "reportPath": "compare-report.html",
+      "status": "ok",
+      "message": "compare completed",
+      "artifacts": {
+        "reportSizeBytes": 187654,
+        "imageCount": 2,
+        "exportDir": "compare/images",
+        "images": [
+          {
+            "index": 0,
+            "mimeType": "image/png",
+            "dataLength": 1024,
+            "byteLength": 2048,
+            "savedPath": "compare/images/diff-0.png",
+            "source": "lvcompare"
+          },
+          {
+            "index": 1,
+            "mimeType": "image/png",
+            "dataLength": 2048,
+            "byteLength": 4096,
+            "savedPath": "compare/images/diff-1.png",
+            "source": "lvcompare"
+          }
+        ]
+      }
+    },
+    "policy": "cli-only",
+    "mode": "lvcompare",
+    "autoCli": true,
+    "sameName": false,
+    "timeoutSeconds": 120
+  },
+  "outcome": {
+    "exitCode": 0,
+    "seconds": 12.345,
+    "command": "lvcompare --diff --nobdcosm --nofppos --noattr --out compare-report.html VI1.vi VI2.vi",
+    "diff": false
+  },
+  "error": null
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "derive:env": "node dist/src/env/derive-env.js --json",
     "schema:validate": "tsc -p tsconfig.cli.json && node dist/tools/schemas/validate-json.js",
     "schema:watcher:validate": "npm run schema:validate -- --schema docs/schema/watcher-telemetry.v1.schema.json --data tests/results/_agent/handoff/watcher-telemetry.json --optional",
-    "session:teststand:validate": "npm run schema:validate -- --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json",
+    "session:teststand:validate": "npm run schema:validate -- --schema docs/schema/generated/teststand-compare-session.schema.json --data fixtures/teststand-session/session-index.json --data tests/results/teststand-session/session-index.json --optional",
     "generate:outputs": "node dist/generate-action-outputs.js",
     "schemas:generate": "tsc -p tsconfig.cli.json && node dist/tools/schemas/generate-schemas.js",
     "cli:validate": "tsc -p tsconfig.cli.json && node dist/tools/cli/validate-cli.js",


### PR DESCRIPTION
## Summary
- add a reference TestStand session-index capture so schema validation is available without regenerating harness artifacts
- teach the `session:teststand:validate` script to check the fixture alongside any locally produced results
- document the fixture so agents know where to grab the sample capture

## Testing
- npm run session:teststand:validate

References #127.

------
https://chatgpt.com/codex/tasks/task_b_68f02c4d6c54832d9f0764000ce384c0