### PR TITLE
chore: refresh handoff context (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T23:15:55.187Z",
+  "cachedAtUtc": "2025-10-15T23:26:50.309Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -54,6 +54,8 @@
 - Current workspace snapshot is missing the `tests/results/teststand-session/` directory referenced above, so schema validation
   commands and report reviews will need fresh artifacts before they can run again.
 - Container image does not include `pwsh`; LabVIEW safety toggles from `tools/Print-AgentHandoff.ps1` could not be applied.
+- Captured `npm run priority:test` results at `tests/results/_agent/handoff/test-summary.json` (schema validated) noting the
+  absence of `tests/results/teststand-session/session-index.json` artifacts in this workspace.
 
 
 


### PR DESCRIPTION
## Summary
- refresh the cached standing priority snapshot so the workspace reflects the latest sync attempt
- expand the agent handoff notes with the new priority test run details for #127

## Testing
- npm run priority:test
- node dist/tools/schemas/validate-json.js --schema docs/schemas/handoff-test-results-v1.schema.json --data tests/results/_agent/handoff/test-summary.json

------
https://chatgpt.com/codex/tasks/task_b_68f02da20944832db9e94fded8b59c26