### PR TITLE
Exclude VS Code extension sources from root TypeScript build (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T23:26:50.309Z",
+  "cachedAtUtc": "2025-10-15T23:34:18.290Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,8 @@
     "outDir": "dist"
   },
   "include": ["tools/**/*.ts", "src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "tools/vscode/comparevi-extension/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- stop the root tsconfig from compiling the VS Code extension tree so local builds no longer require vscode typings
- refresh the standing priority cache after running `npm run priority:sync`

## Testing
- npm run build
- npm run hooks:pre-commit
- npm run hooks:multi
- npm run hooks:schema
- npm run hooks:test
- npm run priority:test

------
https://chatgpt.com/codex/tasks/task_b_68f02f59593c832da79b4706c5e6712c