### PR TITLE
Update handoff context for missing PowerShell (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T23:43:56.747Z",
+  "cachedAtUtc": "2025-10-15T23:46:04.166Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -1,61 +1,39 @@
 # Agent Handoff - Compare VI CLI Action
 
 ## Context Snapshot
-- Standing priority: `npm run priority:sync` → `.agent_priority_cache.json` (standing issue snapshot)
-- Current branch: `issue/127-cli-metadata-html` (tracking `origin/issue/127-cli-metadata-html`)
-- Local telemetry captured under `tests/results/_agent/handoff/`:
-  - `local-status.txt`, `local-diff.txt`, `branch.txt`, `head-sha.txt`
-- Latest work:
-  - `tools/Invoke-LVCompare.ps1` now auto-resolves `LabVIEWCLI.exe`, blocks `cli-only` mode when the binary is missing, and emits CLI metadata for TestStand consumers.
-  - `tools/TestStand-CompareHarness.ps1` / `tools/Run-DX.ps1` record warmup mode, compare policy/mode, flag overrides, and CLI details in `session-index.json`; harness exposes `-Warmup detect|spawn|skip` plus LVCompare flag passthrough.
-  - `tools/LabVIEWCli.psm1` surfaces provider names in verbose output, applies consistent headless toggles, and falls back to registered providers when given a string.
-  - `docs/LabVIEWCliShimPattern.md` (new) documents Shim Pattern v1.0; README, ENVIRONMENT, and TestStand plan docs reference the pattern and new warmup guidance.
-  - Added guard-crumb unit coverage in `tests/Invoke-PesterTests.Tests.ps1`; updated `docs/schema/generated/teststand-compare-session.schema.json` for the richer session index.
-- Quick smoke: `npm run priority:handoff-tests` (passed; includes session capsule schema coverage). Latest CLI-only compare via `tools/Invoke-LVCompare.ps1` (diff=True, exit=1) with report artifacts in `tests/results/cli-only/`. TestStand harness run (`tools/TestStand-CompareHarness.ps1 -Warmup detect -RenderReport -CloseLabVIEW`) succeeded (exit=0, diff=False) and wrote `tests/results/teststand-session/session-index.json` with the new CLI metadata.
+- Standing priority refreshed via `npm run priority:sync`; GH CLI unavailable so cache points to issue #134 (`Standing priority: evolve CompareVI helper into N-provider CLI companion`).
+- Working branch: `issue/134-cli-companion` (created locally; no remote configured in this container).
+- LabVIEW safety toggles exported in this shell (`LV_SUPPRESS_UI=1`, `LV_NO_ACTIVATE=1`, `LV_CURSOR_RESTORE=1`, `LV_IDLE_WAIT_SECONDS=2`, `LV_IDLE_MAX_WAIT_SECONDS=5`).
+- PowerShell (`pwsh`) is **not** available in this container, so LabVIEW guard/rogue scans and Pester orchestration could not execute.
+- Schema validation attempted with `node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json` → command succeeded but reported `No files matched` because `tests/results/teststand-session/` is absent in this workspace.
+- Captured handoff telemetry under `tests/results/_agent/handoff/test-summary.json` (`agent-handoff/test-results@v1`) summarizing the blocked commands above.
+- No CLI-only or TestStand harness artifacts exist locally; reproduction will require a workspace that includes LabVIEW CLI and generated session outputs.
 
 ## Status & Known Gaps
-1) Rogue LabVIEW process detected (`tools/Detect-RogueLV.ps1` -> PID 30776). Needs manual close or re-run detection until cleared before any LVCompare work.
-2) Test coverage still outstanding:
-   a. Full dispatcher sweep (`Invoke-PesterTests.ps1 -IntegrationMode exclude`) — previous attempt aborted early.
-   b. Additional harness permutations (`-Warmup skip`, custom flags) and schema validation (`node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json`).
-   c. Optional: rerun targeted Pester modules (`tests/TestStand-CompareHarness.Tests.ps1` if authored).
-3) PR hygiene: refresh #127 description/screenshots with CLI metadata, session capsule context, and harness artifacts; confirm `Validate` remains required on `develop`.
+1. PowerShell tooling is missing. All `pwsh`-based workflows (rogue detection, `Invoke-PesterTests.ps1`, harness scripts) are currently blocked.
+2. TestStand session artifacts referenced in prior handoffs (`tests/results/teststand-session/session-index.json`, CLI NDJSON, reports) are not present, so schema validation and documentation updates remain outstanding.
+3. Dispatcher sweep (`Invoke-PesterTests.ps1 -IntegrationMode exclude`) and targeted coverage for the TestStand harness have not run in this environment.
+4. Issue/PR context for #134 still needs refreshing once artifacts/tests are regenerated (include CLI metadata, session capsule pointers, and validation status).
 
 ## Suggested Next Actions
-1) No rogue LabVIEW processes detected (last scan clean). Keep running `tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900 -AppendToStepSummary` before long compare/test sessions.
-2) Validate `tests/results/teststand-session/session-index.json` against the updated schema:
+1. Re-run the LabVIEW safety helper once `pwsh` is available: `pwsh -File tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim` (or at minimum `tools/Detect-RogueLV.ps1`).
+2. Generate fresh CLI-only and TestStand session artifacts on a machine with LabVIEW CLI access, then copy `tests/results/cli-only/` and `tests/results/teststand-session/` back into the repo.
+3. After artifacts exist, rerun the schema validator:
    - `node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json`
-   - Optional: rerun harness with `-Warmup skip -Flags '--ignore-case' --ignore-whitespace` to capture LVCompare fallback.
-3) Run the dispatcher sweep:
+4. Execute the dispatcher sweep and any targeted Pester modules once PowerShell is installed:
    - `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude`
-   - Triage output artifacts (`tests/results/pester-summary.json`, `pester-results.xml`) and update `tests/results/_agent/handoff/test-summary.json` as needed.
-4) Execute outstanding targeted coverage if time permits:
-   - `Invoke-Pester tests/Invoke-LVCompare.Tests.ps1`
-   - `Invoke-Pester tests/TestStand-CompareHarness.Tests.ps1` (if authored)
-5) Update #127 PR/issue notes with:
-   - CLI-only capture summary (`tests/results/cli-only/`)
-   - TestStand harness session index screenshot/JSON snippet
-   - Session capsule introduction
-   - Confirmation of pending tests (dispatcher, additional harness permutations)
+   - Optionally `pwsh -File Invoke-PesterTests.ps1 -TestsPath tests/TestStand-CompareHarness.Tests.ps1`
+5. Update issue/PR #134 with regenerated artifact notes, schema validation outcomes, and the refreshed handoff/test summaries.
 
 ## First Actions for the Next Agent
-1. Review the snapshots in `tests/results/_agent/handoff/` (branch/head/status/diff) and fetch/pull `origin/issue/127-cli-metadata-html`.
-2. Validate `tests/results/teststand-session/session-index.json` with the schema command above (record output in `tests/results/_agent/handoff/test-summary.json` if rerun).
-3. Run `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude`; capture summary artifacts and update the handoff telemetry.
-4. Review CLI artifacts (`tests/results/cli-only/`, `tests/results/teststand-session/`) and attach highlights/screenshots to the #127 PR update.
-5. Commit and push the outstanding changes (see `tests/results/_agent/handoff/local-status.txt`) referencing `#127`; ensure session capsules remain for future context.
+1. Ensure PowerShell 7+ is available; rerun `tools/Print-AgentHandoff.ps1 -ApplyToggles` (or equivalent) to capture a clean rogue scan before proceeding with LabVIEW compares.
+2. Fetch or regenerate the missing `tests/results/teststand-session/` and `tests/results/cli-only/` directories so schema validation and documentation review can resume.
+3. Re-run `node dist/tools/schemas/validate-json.js ...` against the restored session index and record the outcome in `tests/results/_agent/handoff/test-summary.json`.
+4. Kick off `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude` and archive the resulting summaries (`tests/results/pester-summary.json`, XML report) for PR context.
+5. Commit/push updates referencing `#127` per repo convention, ensuring handoff telemetry stays in sync.
 
 ## Notes for Next Agent
-- Watcher telemetry (`tests/results/_agent/handoff/watcher-telemetry.json`) shows `stopped`; no trim required.
-- Session capsules accumulate under `tests/results/_agent/sessions/`; latest is `session-20251014T210508271Z-9a3ee054e211.json`.
-- CLI-only artifacts: `tests/results/cli-only/lvcompare-capture.json`, `events.ndjson`, `cli-report.html`.
-- TestStand harness artifacts: `tests/results/teststand-session/session-index.json`, warmup NDJSON, CLI report/images.
-- Pending git changes listed in `tests/results/_agent/handoff/local-status.txt` (ensure staging/commits reference `#127`).
-- Current workspace snapshot is missing the `tests/results/teststand-session/` directory referenced above, so schema validation
-  commands and report reviews will need fresh artifacts before they can run again.
-- Container image does not include `pwsh`; LabVIEW safety toggles from `tools/Print-AgentHandoff.ps1` could not be applied.
-- Captured `npm run priority:test` results at `tests/results/_agent/handoff/test-summary.json` (schema validated) noting the
-  absence of `tests/results/teststand-session/session-index.json` artifacts in this workspace.
-
-
-
+- `tests/results/_agent/handoff/test-summary.json` records today\'s blocked commands (status `blocked`, failureCount=2).
+- No watcher telemetry exists for this session (container lacks prior `_agent/handoff/` assets).
+- `.agent_priority_cache.json` currently reflects cached metadata for issue #134; rerun `npm run priority:sync` after installing `gh` to refresh directly from GitHub.
+- Container image does not ship LabVIEW or LabVIEW CLI; expect to run compare/harness workflows on a Windows host with the required tooling.

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,0 +1,36 @@
+{
+  "schema": "agent-handoff/test-results@v1",
+  "generatedAt": "2025-10-15T23:48:16Z",
+  "status": "blocked",
+  "total": 3,
+  "failureCount": 2,
+  "results": [
+    {
+      "command": "pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900 -AppendToStepSummary",
+      "exitCode": 127,
+      "stdout": "bash: command not found: pwsh",
+      "stderr": "",
+      "startedAt": "2025-10-15T23:46:30Z",
+      "completedAt": "2025-10-15T23:46:30Z",
+      "durationMs": 0
+    },
+    {
+      "command": "node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json",
+      "exitCode": 0,
+      "stdout": "[schema] No files matched pattern 'tests/results/teststand-session/session-index.json'.\n[schema] No data files validated (globs empty).",
+      "stderr": "",
+      "startedAt": "2025-10-15T23:47:10Z",
+      "completedAt": "2025-10-15T23:47:10Z",
+      "durationMs": 0
+    },
+    {
+      "command": "pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude",
+      "exitCode": 127,
+      "stdout": "bash: command not found: pwsh",
+      "stderr": "",
+      "startedAt": "2025-10-15T23:47:45Z",
+      "completedAt": "2025-10-15T23:47:45Z",
+      "durationMs": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- refresh the cached standing-priority snapshot after running `npm run priority:sync`
- rewrite `AGENT_HANDOFF.txt` to capture the current PowerShell-less workspace, missing artifacts, and next steps for #134
- add `tests/results/_agent/handoff/test-summary.json` documenting the blocked commands executed in this container

## Testing
- node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json *(reports no matching files)*
- pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900 -AppendToStepSummary *(blocked: pwsh not installed)*
- pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude *(blocked: pwsh not installed)*


------
https://chatgpt.com/codex/tasks/task_b_68f0322942d8832da2f903ebbea5461c