### PR TITLE
Update handoff telemetry for blocked PowerShell install (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T23:51:39.455Z",
+  "cachedAtUtc": "2025-10-15T23:56:38.871Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -1,39 +1,78 @@
 # Agent Handoff - Compare VI CLI Action
 
 ## Context Snapshot
-- Standing priority refreshed via `npm run priority:sync`; cache still points to issue #134 (`Standing priority: evolve CompareVI helper into N-provider CLI companion`).
+- Standing priority refreshed via `npm run priority:sync`; cache still points to issue #134
+  (`Standing priority: evolve CompareVI helper into N-provider CLI companion`). The sync fell back
+  to cached metadata because the GitHub CLI (`gh`) is not installed.
 - Working branch: `issue/134-cli-companion` (local only in this container).
-- LabVIEW safety toggles exported in this shell (`LV_SUPPRESS_UI=1`, `LV_NO_ACTIVATE=1`, `LV_CURSOR_RESTORE=1`, `LV_IDLE_WAIT_SECONDS=2`, `LV_IDLE_MAX_WAIT_SECONDS=5`).
-- PowerShell (`pwsh`) remains unavailable, so LabVIEW guard/rogue scans and Pester orchestration are still blocked.
-- `npm run priority:handoff-tests` fails immediately (`pwsh: not found`), so no automated hook/semver coverage captured yet in this workspace.
-- Schema validation attempted with `node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json`; command succeeds but reports `No files matched` because `tests/results/teststand-session/` is absent locally.
-- Updated handoff telemetry recorded in `tests/results/_agent/handoff/test-summary.json` (`agent-handoff/test-results@v1`) capturing the blocked handoff script and schema attempt.
+- LabVIEW safety toggles exported in this shell (`LV_SUPPRESS_UI=1`, `LV_NO_ACTIVATE=1`,
+  `LV_CURSOR_RESTORE=1`, `LV_IDLE_WAIT_SECONDS=2`, `LV_IDLE_MAX_WAIT_SECONDS=5`).
+- PowerShell (`pwsh`) remains unavailable, so LabVIEW guard/rogue scans and Pester orchestration are
+  still blocked.
+- `apt-get update` cannot reach upstream mirrors in this environment (HTTP 403 responses), so
+  installing PowerShell through the package manager is currently blocked.
+- `npm run priority:handoff-tests` fails immediately (`pwsh: not found`), so no automated
+  hook/semver coverage captured yet in this workspace.
+- Schema validation attempted with `node dist/tools/schemas/validate-json.js --schema
+  docs/schema/generated/teststand-compare-session.schema.json --data
+  tests/results/teststand-session/session-index.json`; command succeeds but reports `No files matched`
+  because `tests/results/teststand-session/` is absent locally.
+- Updated handoff telemetry recorded in `tests/results/_agent/handoff/test-summary.json`
+  (`agent-handoff/test-results@v1`) capturing the blocked handoff script, schema attempt, and apt
+  failure details.
 
 ## Status & Known Gaps
-1. PowerShell tooling is still missing. All `pwsh`-based workflows (rogue detection, `Invoke-PesterTests.ps1`, priority handoff script) remain blocked until PowerShell is installed.
-2. TestStand session artifacts (`tests/results/teststand-session/session-index.json`) and CLI-only outputs are absent, so schema validation and related documentation cannot progress yet.
-3. Dispatcher sweep (`Invoke-PesterTests.ps1 -IntegrationMode exclude`) and targeted TestStand harness coverage have not run in this environment.
-4. Issue/PR context for #134 still needs refreshed notes once artifacts/tests are regenerated (include CLI metadata, session capsules, validation status).
+1. PowerShell tooling is still missing. All `pwsh`-based workflows (rogue detection,
+   `Invoke-PesterTests.ps1`, priority handoff script) remain blocked until PowerShell is installed.
+2. Package installation is currently blocked by outbound HTTP 403 errors from Ubuntu mirrors
+   (`apt-get update` fails), so resolving the PowerShell gap may require alternate distribution
+   channels or proxy configuration.
+3. TestStand session artifacts (`tests/results/teststand-session/session-index.json`) and CLI-only
+   outputs are absent, so schema validation and related documentation cannot progress yet.
+4. Dispatcher sweep (`Invoke-PesterTests.ps1 -IntegrationMode exclude`) and targeted TestStand
+   harness coverage have not run in this environment.
+5. Issue/PR context for #134 still needs refreshed notes once artifacts/tests are regenerated
+   (include CLI metadata, session capsules, validation status).
 
 ## Suggested Next Actions
-1. Install or enable PowerShell 7+, then re-run the LabVIEW safety helper: `pwsh -File tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim` (or at minimum `tools/Detect-RogueLV.ps1`).
-2. Generate or copy fresh CLI-only and TestStand session artifacts on a host with LabVIEW CLI access; populate `tests/results/cli-only/` and `tests/results/teststand-session/` locally.
+1. Restore package manager access or obtain an offline installer so PowerShell 7+ can be installed.
+   Once available, re-run the LabVIEW safety helper: `pwsh -File tools/Print-AgentHandoff.ps1
+   -ApplyToggles -AutoTrim` (or at minimum `tools/Detect-RogueLV.ps1`).
+2. Generate or copy fresh CLI-only and TestStand session artifacts on a host with LabVIEW CLI
+   access; populate `tests/results/cli-only/` and `tests/results/teststand-session/` locally.
 3. Re-run the schema validator once artifacts exist:
-   - `node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json`
+   ```
+   node dist/tools/schemas/validate-json.js \
+     --schema docs/schema/generated/teststand-compare-session.schema.json \
+     --data tests/results/teststand-session/session-index.json
+   ```
 4. Execute dispatcher coverage once PowerShell is available:
    - `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude`
    - Optionally `pwsh -File Invoke-PesterTests.ps1 -TestsPath tests/TestStand-CompareHarness.Tests.ps1`
-5. Update issue/PR #134 with regenerated artifact notes, schema validation outcomes, and refreshed handoff/test summaries.
+5. Update issue/PR #134 with regenerated artifact notes, schema validation outcomes, and refreshed
+   handoff/test summaries once tooling and artifacts are restored.
 
 ## First Actions for the Next Agent
-1. Ensure PowerShell 7+ is available; rerun `tools/Print-AgentHandoff.ps1 -ApplyToggles` (or equivalent) to capture a clean rogue scan before proceeding with LabVIEW compares.
-2. Fetch or regenerate the missing `tests/results/teststand-session/` and `tests/results/cli-only/` directories so schema validation and documentation review can resume.
-3. Re-run `node dist/tools/schemas/validate-json.js ...` against the restored session index and record the outcome in `tests/results/_agent/handoff/test-summary.json`.
-4. Kick off `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude` and archive the resulting summaries (`tests/results/pester-summary.json`, XML report) for PR context.
-5. Commit/push updates referencing `#127` per repo convention, ensuring handoff telemetry stays in sync.
+1. Restore package manager connectivity (or provide an alternative installer) so PowerShell 7+
+   is available, then rerun `tools/Print-AgentHandoff.ps1 -ApplyToggles` (or equivalent) to capture
+   a clean rogue scan before proceeding with LabVIEW compares.
+2. Fetch or regenerate the missing `tests/results/teststand-session/` and `tests/results/cli-only/`
+   directories so schema validation and documentation review can resume.
+3. Re-run `node dist/tools/schemas/validate-json.js ...` against the restored session index and
+   record the outcome in `tests/results/_agent/handoff/test-summary.json`.
+4. Kick off `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude` and archive the resulting
+   summaries (`tests/results/pester-summary.json`, XML report) for PR context once PowerShell is
+   operational.
+5. Commit/push updates referencing `#127` per repo convention, ensuring handoff telemetry stays in
+   sync.
 
 ## Notes for Next Agent
-- `tests/results/_agent/handoff/test-summary.json` now records `npm run priority:handoff-tests` (blocked: `pwsh` missing) and the schema validation attempt (no matching data files).
-- No watcher telemetry exists for this session; container still lacks `_agent/handoff/` watcher assets.
-- `.agent_priority_cache.json` currently reflects cached metadata for issue #134; rerun `npm run priority:sync` after installing `gh` to refresh directly from GitHub.
-- Container image does not ship LabVIEW or LabVIEW CLI; expect to run compare/harness workflows on a Windows host with the required tooling.
+- `tests/results/_agent/handoff/test-summary.json` now records `npm run priority:handoff-tests`
+  (blocked: `pwsh` missing), the schema validation attempt (no matching data files), and the failed
+  `apt-get update` (HTTP 403).
+- No watcher telemetry exists for this session; container still lacks `_agent/handoff/` watcher
+  assets.
+- `.agent_priority_cache.json` currently reflects cached metadata for issue #134; rerun
+  `npm run priority:sync` after installing `gh` to refresh directly from GitHub.
+- Container image does not ship LabVIEW or LabVIEW CLI; expect to run compare/harness workflows on a
+  Windows host with the required tooling.

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,9 +1,9 @@
 {
   "schema": "agent-handoff/test-results@v1",
-  "generatedAt": "2025-10-15T23:52:39Z",
+  "generatedAt": "2025-10-15T23:57:13Z",
   "status": "blocked",
-  "total": 2,
-  "failureCount": 1,
+  "total": 3,
+  "failureCount": 2,
   "results": [
     {
       "command": "npm run priority:handoff-tests",
@@ -22,6 +22,15 @@
       "startedAt": "2025-10-15T23:52:30Z",
       "completedAt": "2025-10-15T23:52:30Z",
       "durationMs": 0
+    },
+    {
+      "command": "apt-get update",
+      "exitCode": 100,
+      "stdout": "E: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed.\nE: Failed to fetch http://apt.llvm.org/noble/dists/llvm-toolchain-noble-20/InRelease  403  Forbidden [IP: 172.30.0.35 8080]\nE: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed.\nE: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-security/InRelease  403  Forbidden [IP: 172.30.0.35 8080]\nE: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.\nE: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble/InRelease  403  Forbidden [IP: 172.30.0.35 8080]\nE: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-updates/InRelease  403  Forbidden [IP: 172.30.0.35 8080]\nE: The repository 'http://archive.ubuntu.com/ubuntu noble-updates InRelease' is not signed.\nE: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-backports/InRelease  403  Forbidden [IP: 172.30.0.35 8080]\nE: The repository 'http://archive.ubuntu.com/ubuntu noble-backports InRelease' is not signed.\n",
+      "stderr": "",
+      "startedAt": "2025-10-15T23:56:30Z",
+      "completedAt": "2025-10-15T23:56:40Z",
+      "durationMs": 10000
     }
   ]
 }


### PR DESCRIPTION
## Summary
- note that priority sync is still relying on cached data because `gh` is unavailable
- document the failed `apt-get update` attempt and expand handoff guidance for restoring PowerShell access
- record the apt failure in `tests/results/_agent/handoff/test-summary.json`

## Testing
- npm run priority:sync
- apt-get update *(fails: Ubuntu mirrors return HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68f034a09c7c832d9be3207fc9f94d16