### PR TITLE
Add placeholder TestStand session artifacts (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-15T23:56:38.871Z",
+  "cachedAtUtc": "2025-10-16T00:03:18.686Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,17 @@ artifacts/vsix/
 tests/results/
 tests/results
 tests/results/**
+!tests/results
+!tests/results/
 !tests/results/.gitkeep
+!tests/results/cli-only/
+!tests/results/cli-only/README.md
+!tests/results/teststand-session/
+!tests/results/teststand-session/session-index.json
 # Local dashboard output
 tools/dashboard/dashboard.html
 # Root-level CI artifacts (timestamped at runtime; never commit)
-results/
+/results/
 # Local temp workdirs created during ad-hoc runs
 .tmp-smoke/
 tmp-*/

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,8 +1,8 @@
 {
   "schema": "agent-handoff/test-results@v1",
-  "generatedAt": "2025-10-15T23:57:13Z",
+  "generatedAt": "2025-10-16T00:05:38Z",
   "status": "blocked",
-  "total": 3,
+  "total": 4,
   "failureCount": 2,
   "results": [
     {
@@ -31,6 +31,15 @@
       "startedAt": "2025-10-15T23:56:30Z",
       "completedAt": "2025-10-15T23:56:40Z",
       "durationMs": 10000
+    },
+    {
+      "command": "npm run session:teststand:validate",
+      "exitCode": 0,
+      "stdout": "npm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.\n\n> compare-vi-cli-action@0.5.0 session:teststand:validate\n> npm run schema:validate -- --schema docs/schema/generated/teststand-compare-session.schema.json --data fixtures/teststand-session/session-index.json --data tests/results/teststand-session/session-index.json --optional\n\nnpm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.\n\n> compare-vi-cli-action@0.5.0 schema:validate\n> tsc -p tsconfig.cli.json && node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data fixtures/teststand-session/session-index.json --data tests/results/teststand-session/session-index.json --optional\n[schema] Validated 2 file(s) against /workspace/compare-vi-cli-action/docs/schema/generated/teststand-compare-session.schema.json.\n",
+      "stderr": "",
+      "startedAt": "2025-10-16T00:03:40Z",
+      "completedAt": "2025-10-16T00:03:46Z",
+      "durationMs": 6000
     }
   ]
 }

--- a/tests/results/cli-only/README.md
+++ b/tests/results/cli-only/README.md
@@ -1,0 +1,7 @@
+# CLI-only session artifacts
+
+This directory captures example outputs from a LabVIEW CLI-only compare run so schema validation
+and documentation walkthroughs remain available in environments without LabVIEW installed.
+
+The files are intentionally light-weight: populate them with locally generated artefacts when the
+CLI is available, or copy the fixture set under `fixtures/teststand-session/` for quick validation.

--- a/tests/results/teststand-session/session-index.json
+++ b/tests/results/teststand-session/session-index.json
@@ -1,0 +1,58 @@
+{
+  "schema": "teststand-compare-session/v1",
+  "at": "2025-10-16T12:34:56.789Z",
+  "warmup": {
+    "mode": "detect",
+    "events": "_warmup/labview-runtime.ndjson"
+  },
+  "compare": {
+    "events": "compare/compare-events.ndjson",
+    "capture": "compare/lvcompare-capture.json",
+    "report": true,
+    "command": "lvcompare --diff --nobdcosm --nofppos --noattr --out compare-report.html VI1.vi VI2.vi",
+    "cliPath": "C:/Program Files/National Instruments/Shared/LabVIEW CLI/LabVIEWCLI.exe",
+    "cli": {
+      "path": "C:/Program Files/National Instruments/Shared/LabVIEW CLI/LabVIEWCLI.exe",
+      "version": "25.0.0f0",
+      "reportType": "html",
+      "reportPath": "compare-report.html",
+      "status": "ok",
+      "message": "compare completed",
+      "artifacts": {
+        "reportSizeBytes": 187654,
+        "imageCount": 2,
+        "exportDir": "compare/images",
+        "images": [
+          {
+            "index": 0,
+            "mimeType": "image/png",
+            "dataLength": 1024,
+            "byteLength": 2048,
+            "savedPath": "compare/images/diff-0.png",
+            "source": "lvcompare"
+          },
+          {
+            "index": 1,
+            "mimeType": "image/png",
+            "dataLength": 2048,
+            "byteLength": 4096,
+            "savedPath": "compare/images/diff-1.png",
+            "source": "lvcompare"
+          }
+        ]
+      }
+    },
+    "policy": "cli-only",
+    "mode": "lvcompare",
+    "autoCli": true,
+    "sameName": false,
+    "timeoutSeconds": 120
+  },
+  "outcome": {
+    "exitCode": 0,
+    "seconds": 12.345,
+    "command": "lvcompare --diff --nobdcosm --nofppos --noattr --out compare-report.html VI1.vi VI2.vi",
+    "diff": false
+  },
+  "error": null
+}


### PR DESCRIPTION
## Summary
- add a tracked TestStand session index under `tests/results/teststand-session/` so schema validation has local data available
- document the `tests/results/cli-only/` directory and adjust `.gitignore` so the curated artifacts remain versioned while other results stay ignored
- capture the successful schema validation run in the agent handoff summary and refresh the standing-priority cache timestamp

Refs #127.

## Testing
- npm run session:teststand:validate

------
https://chatgpt.com/codex/tasks/task_b_68f03631a604832d92216004689cf314