### PR TITLE
Refresh handoff test summary after schema validation (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T00:03:18.686Z",
+  "cachedAtUtc": "2025-10-16T00:10:40.852Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,7 +1,7 @@
 {
   "schema": "agent-handoff/test-results@v1",
-  "generatedAt": "2025-10-16T00:05:38Z",
-  "status": "blocked",
+  "generatedAt": "2025-10-16T00:11:53Z",
+  "status": "failed",
   "total": 4,
   "failureCount": 2,
   "results": [
@@ -17,10 +17,10 @@
     {
       "command": "node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json",
       "exitCode": 0,
-      "stdout": "[schema] No files matched pattern 'tests/results/teststand-session/session-index.json'.\n[schema] No data files validated (globs empty).\n",
+      "stdout": "[schema] Validated 1 file(s) against /workspace/compare-vi-cli-action/docs/schema/generated/teststand-compare-session.schema.json.\n",
       "stderr": "",
-      "startedAt": "2025-10-15T23:52:30Z",
-      "completedAt": "2025-10-15T23:52:30Z",
+      "startedAt": "2025-10-16T00:11:47Z",
+      "completedAt": "2025-10-16T00:11:47Z",
       "durationMs": 0
     },
     {
@@ -41,5 +41,8 @@
       "completedAt": "2025-10-16T00:03:46Z",
       "durationMs": 6000
     }
+  ],
+  "notes": [
+    "PowerShell tarball install via GitHub releases blocked by proxy (wget 403)."
   ]
 }


### PR DESCRIPTION
## Summary
- reran the standing-priority sync so the cache reflects the latest timestamp from `npm run priority:sync`
- updated the handoff test summary to record the successful schema validation run and note the proxy-blocked PowerShell install attempt

## Testing
- node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json


------
https://chatgpt.com/codex/tasks/task_b_68f037ce1c94832daa1bdce3611edbf2