### PR TITLE
Document priority sync rerun in handoff artifacts (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T00:15:05.874Z",
+  "cachedAtUtc": "2025-10-16T00:20:43.163Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -20,8 +20,9 @@
   --schema docs/schema/generated/teststand-compare-session.schema.json --data
   tests/results/teststand-session/session-index.json`; command succeeds locally.
 - Updated handoff telemetry recorded in `tests/results/_agent/handoff/test-summary.json`
-  (`agent-handoff/test-results@v1`) capturing the blocked handoff script, schema attempt, and apt
-  failure details.
+  (`agent-handoff/test-results@v1`) capturing the blocked handoff script, schema attempt, apt
+  failure details, and the latest `npm run priority:sync` rerun (still limited to cached metadata
+  because `gh` is unavailable).
 
 ## Status & Known Gaps
 1. PowerShell tooling is still missing. All `pwsh`-based workflows (rogue detection,
@@ -74,8 +75,9 @@
 
 ## Notes for Next Agent
 - `tests/results/_agent/handoff/test-summary.json` now records `npm run priority:handoff-tests`
-  (blocked: `pwsh` missing), the schema validation attempt (no matching data files), and the failed
-  `apt-get update` (HTTP 403).
+  (blocked: `pwsh` missing), the schema validation attempt (no matching data files), the failed
+  `apt-get update` (HTTP 403), and the successful `npm run priority:sync` rerun (still backed by the
+  cached standing-priority snapshot).
 - No watcher telemetry exists for this session; container still lacks `_agent/handoff/` watcher
   assets.
 - `.agent_priority_cache.json` currently reflects cached metadata for issue #134; rerun

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,8 +1,8 @@
 {
   "schema": "agent-handoff/test-results@v1",
-  "generatedAt": "2025-10-16T00:11:53Z",
+  "generatedAt": "2025-10-16T00:20:57Z",
   "status": "failed",
-  "total": 4,
+  "total": 5,
   "failureCount": 2,
   "results": [
     {
@@ -40,11 +40,21 @@
       "startedAt": "2025-10-16T00:03:40Z",
       "completedAt": "2025-10-16T00:03:46Z",
       "durationMs": 6000
+    },
+    {
+      "command": "npm run priority:sync",
+      "exitCode": 0,
+      "stdout": "npm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.\n\n> compare-vi-cli-action@0.5.0 priority:sync\n> node tools/priority/sync-standing-priority.mjs\n\n[priority] gh CLI not found; falling back to cached standing-priority issue number\n[priority] Standing issue: #134\n[priority] Fetch failed: Command not found: gh\n",
+      "stderr": "",
+      "startedAt": "2025-10-16T00:20:43Z",
+      "completedAt": "2025-10-16T00:20:43Z",
+      "durationMs": 0
     }
   ],
   "notes": [
     "PowerShell tarball install via GitHub releases blocked by proxy (wget 403).",
     "Copied fixtures/teststand-session/session-index.json into tests/results/teststand-session/ as a placeholder.",
-    "Replace the placeholder TestStand results with fresh artifacts once tooling access is restored."
+    "Replace the placeholder TestStand results with fresh artifacts once tooling access is restored.",
+    "Re-ran npm run priority:sync; cache refreshed from local snapshot because gh remains unavailable."
   ]
 }


### PR DESCRIPTION
## Summary
- refresh the cached standing-priority snapshot timestamp after rerunning `npm run priority:sync`
- extend the agent handoff notes to mention the new priority sync entry and its cached fallback status
- log the successful priority sync rerun in `tests/results/_agent/handoff/test-summary.json` alongside the existing failures

## Testing
- `npm run priority:sync`


------
https://chatgpt.com/codex/tasks/task_b_68f03a1f46b4832d830bba441677b5e1