### PR TITLE
Refresh handoff telemetry after cached priority sync (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T00:20:43.163Z",
+  "cachedAtUtc": "2025-10-16T00:28:35.441Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -13,12 +13,15 @@
   installing PowerShell through the package manager is currently blocked.
 - `npm run priority:handoff-tests` fails immediately (`pwsh: not found`), so no automated
   hook/semver coverage captured yet in this workspace.
+- Re-ran `npm run priority:sync`; the run still falls back to the cached standing-issue metadata
+  because `gh` is unavailable in the container.
 - A placeholder TestStand session folder (`tests/results/teststand-session/`) now exists; it currently
   mirrors the committed fixture so schema validation commands can execute, but it still needs to be
   replaced with freshly captured artifacts from a real run.
 - Schema validation re-run with the placeholder data via `node dist/tools/schemas/validate-json.js
   --schema docs/schema/generated/teststand-compare-session.schema.json --data
-  tests/results/teststand-session/session-index.json`; command succeeds locally.
+  tests/results/teststand-session/session-index.json`; command succeeds locally (latest run
+  timestamped 2025-10-16T00:27Z).
 - Updated handoff telemetry recorded in `tests/results/_agent/handoff/test-summary.json`
   (`agent-handoff/test-results@v1`) capturing the blocked handoff script, schema attempt, apt
   failure details, and the latest `npm run priority:sync` rerun (still limited to cached metadata
@@ -84,3 +87,6 @@
   `npm run priority:sync` after installing `gh` to refresh directly from GitHub.
 - Container image does not ship LabVIEW or LabVIEW CLI; expect to run compare/harness workflows on a
   Windows host with the required tooling.
+- `tests/results/_agent/handoff/test-summary.json` refreshed at 2025-10-16T00:28Z to log the latest
+  `npm run priority:sync` rerun and the additional schema validation check (still referencing the
+  placeholder TestStand session data).

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,8 +1,8 @@
 {
   "schema": "agent-handoff/test-results@v1",
-  "generatedAt": "2025-10-16T00:20:57Z",
+  "generatedAt": "2025-10-16T00:28:55Z",
   "status": "failed",
-  "total": 5,
+  "total": 7,
   "failureCount": 2,
   "results": [
     {
@@ -49,12 +49,31 @@
       "startedAt": "2025-10-16T00:20:43Z",
       "completedAt": "2025-10-16T00:20:43Z",
       "durationMs": 0
+    },
+    {
+      "command": "npm run priority:sync",
+      "exitCode": 0,
+      "stdout": "npm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.\n\n> compare-vi-cli-action@0.5.0 priority:sync\n> node tools/priority/sync-standing-priority.mjs\n\n[priority] gh CLI not found; falling back to cached standing-priority issue number\n[priority] Standing issue: #134\n[priority] Fetch failed: Command not found: gh\n",
+      "stderr": "",
+      "startedAt": "2025-10-16T00:24:50Z",
+      "completedAt": "2025-10-16T00:24:50Z",
+      "durationMs": 0
+    },
+    {
+      "command": "node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json",
+      "exitCode": 0,
+      "stdout": "[schema] Validated 1 file(s) against /workspace/compare-vi-cli-action/docs/schema/generated/teststand-compare-session.schema.json.\n",
+      "stderr": "",
+      "startedAt": "2025-10-16T00:27:45Z",
+      "completedAt": "2025-10-16T00:27:45Z",
+      "durationMs": 0
     }
   ],
   "notes": [
     "PowerShell tarball install via GitHub releases blocked by proxy (wget 403).",
     "Copied fixtures/teststand-session/session-index.json into tests/results/teststand-session/ as a placeholder.",
     "Replace the placeholder TestStand results with fresh artifacts once tooling access is restored.",
-    "Re-ran npm run priority:sync; cache refreshed from local snapshot because gh remains unavailable."
+    "Re-ran npm run priority:sync; cache refreshed from local snapshot because gh remains unavailable.",
+    "Repeated schema validation locally to confirm placeholder TestStand session still matches the generated schema."
   ]
 }


### PR DESCRIPTION
## Summary
- refresh the cached standing-priority snapshot after rerunning `npm run priority:sync`
- extend AGENT_HANDOFF.txt with the additional priority sync run and schema validation timestamp
- append the latest priority sync and schema validation executions to the handoff test-summary log

## Testing
- npm run priority:sync
- node dist/tools/schemas/validate-json.js --schema docs/schema/generated/teststand-compare-session.schema.json --data tests/results/teststand-session/session-index.json

------
https://chatgpt.com/codex/tasks/task_b_68f03c192388832dba6578d8b3087344