### PR TITLE
Add CLI quote schema validation (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,5 +372,6 @@ publish helper to build per-RID archives and checksums for distribution.
 - Quick smoke
   - `./comparevi-cli version`
   - `./comparevi-cli tokenize --input 'foo -x=1 "bar baz"'`
+  - `./comparevi-cli quote --path 'C:/Program Files/National Instruments/LabVIEW 2025/LabVIEW.exe'`
   - `./comparevi-cli procs`
 

--- a/dist/tools/cli/validate-cli.js
+++ b/dist/tools/cli/validate-cli.js
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { cliArtifactMetaSchema, cliProcsSchema, cliTokenizeSchema, cliVersionSchema, } from '../schemas/definitions.js';
+import { cliArtifactMetaSchema, cliQuoteSchema, cliProcsSchema, cliTokenizeSchema, cliVersionSchema, } from '../schemas/definitions.js';
 function resolveCliDll() {
     const override = process.env.CLI_DLL;
     if (override) {
@@ -65,11 +65,14 @@ function main() {
     const dll = resolveCliDll();
     const versionValidator = compileValidator('cli-version', zodToJsonSchema(cliVersionSchema, { target: 'jsonSchema7', name: 'cli-version' }));
     const tokenizeValidator = compileValidator('cli-tokenize', zodToJsonSchema(cliTokenizeSchema, { target: 'jsonSchema7', name: 'cli-tokenize' }));
+    const quoteValidator = compileValidator('cli-quote', zodToJsonSchema(cliQuoteSchema, { target: 'jsonSchema7', name: 'cli-quote' }));
     const procsValidator = compileValidator('cli-procs', zodToJsonSchema(cliProcsSchema, { target: 'jsonSchema7', name: 'cli-procs' }));
     const versionData = runCli(dll, ['version']);
     validate('comparevi-cli version', versionData, versionValidator);
     const tokenizeData = runCli(dll, ['tokenize', '--input', 'foo -x=1 "bar baz"']);
     validate('comparevi-cli tokenize', tokenizeData, tokenizeValidator);
+    const quoteData = runCli(dll, ['quote', '--path', 'C:/Program Files/National Instruments/LabVIEW 2025/LabVIEW.exe']);
+    validate('comparevi-cli quote', quoteData, quoteValidator);
     const procsData = runCli(dll, ['procs']);
     validate('comparevi-cli procs', procsData, procsValidator);
     const metaData = readArtifactMeta();

--- a/dist/tools/schemas/definitions.js
+++ b/dist/tools/schemas/definitions.js
@@ -342,6 +342,10 @@ export const cliTokenizeSchema = z.object({
     raw: z.array(z.string()),
     normalized: z.array(z.string()),
 });
+export const cliQuoteSchema = z.object({
+    input: z.string().nullable(),
+    quoted: z.string(),
+});
 export const cliProcsSchema = z.object({
     labviewPids: z.array(nonNegativeInteger),
     lvcomparePids: z.array(nonNegativeInteger),
@@ -448,6 +452,12 @@ export const schemas = [
         fileName: 'cli-tokenize.schema.json',
         description: 'Output emitted by comparevi-cli tokenize.',
         schema: cliTokenizeSchema,
+    },
+    {
+        id: 'cli-quote',
+        fileName: 'cli-quote.schema.json',
+        description: 'Output emitted by comparevi-cli quote.',
+        schema: cliQuoteSchema,
     },
     {
         id: 'cli-procs',

--- a/docs/schema/generated/cli-quote.schema.json
+++ b/docs/schema/generated/cli-quote.schema.json
@@ -1,0 +1,27 @@
+{
+  "$ref": "#/definitions/cli-quote",
+  "definitions": {
+    "cli-quote": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quoted": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "input",
+        "quoted"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Output emitted by comparevi-cli quote.",
+  "$id": "urn:compare-vi-cli-action:schema:cli-quote"
+}

--- a/tools/cli/validate-cli.ts
+++ b/tools/cli/validate-cli.ts
@@ -8,6 +8,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import {
   cliArtifactMetaSchema,
+  cliQuoteSchema,
   cliProcsSchema,
   cliTokenizeSchema,
   cliVersionSchema,
@@ -93,6 +94,11 @@ function main() {
     zodToJsonSchema(cliTokenizeSchema, { target: 'jsonSchema7', name: 'cli-tokenize' }) as Record<string, unknown>,
   );
 
+  const quoteValidator = compileValidator(
+    'cli-quote',
+    zodToJsonSchema(cliQuoteSchema, { target: 'jsonSchema7', name: 'cli-quote' }) as Record<string, unknown>,
+  );
+
   const procsValidator = compileValidator(
     'cli-procs',
     zodToJsonSchema(cliProcsSchema, { target: 'jsonSchema7', name: 'cli-procs' }) as Record<string, unknown>,
@@ -103,6 +109,9 @@ function main() {
 
   const tokenizeData = runCli(dll, ['tokenize', '--input', 'foo -x=1 "bar baz"']);
   validate('comparevi-cli tokenize', tokenizeData, tokenizeValidator);
+
+  const quoteData = runCli(dll, ['quote', '--path', 'C:/Program Files/National Instruments/LabVIEW 2025/LabVIEW.exe']);
+  validate('comparevi-cli quote', quoteData, quoteValidator);
 
   const procsData = runCli(dll, ['procs']);
   validate('comparevi-cli procs', procsData, procsValidator);

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -374,6 +374,11 @@ export const cliTokenizeSchema = z.object({
   normalized: z.array(z.string()),
 });
 
+export const cliQuoteSchema = z.object({
+  input: z.string().nullable(),
+  quoted: z.string(),
+});
+
 export const cliProcsSchema = z.object({
   labviewPids: z.array(nonNegativeInteger),
   lvcomparePids: z.array(nonNegativeInteger),
@@ -486,6 +491,12 @@ export const schemas = [
     fileName: 'cli-tokenize.schema.json',
     description: 'Output emitted by comparevi-cli tokenize.',
     schema: cliTokenizeSchema,
+  },
+  {
+    id: 'cli-quote',
+    fileName: 'cli-quote.schema.json',
+    description: 'Output emitted by comparevi-cli quote.',
+    schema: cliQuoteSchema,
   },
   {
     id: 'cli-procs',


### PR DESCRIPTION
## Summary
- add a zod schema for the comparevi-cli quote output and generate the corresponding JSON schema
- extend the CLI validation helper to exercise the quote command alongside existing checks
- document the quote smoke test command in the README for quick reference

## Testing
- npm run build
- npm run schemas:generate

Refs #127.

------
https://chatgpt.com/codex/tasks/task_b_68f03ee82aa8832daa09c1e9c7d1455e