### PR TITLE
Persist VS Code provider selection across sessions (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T03:19:08.236Z",
+  "cachedAtUtc": "2025-10-16T14:47:45.856Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",
@@ -12,5 +12,5 @@
   "commentCount": null,
   "bodyDigest": null,
   "lastFetchSource": "cache",
-  "lastFetchError": "Failed to fetch issue #134 via gh CLI (gh CLI not found)"
+  "lastFetchError": "Failed to fetch issue #134 via gh CLI (To get started with GitHub CLI, please run:  gh auth login\nAlternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.)"
 }

--- a/tests/results/_agent/handoff/test-summary.json
+++ b/tests/results/_agent/handoff/test-summary.json
@@ -1,36 +1,36 @@
 {
   "schema": "agent-handoff/test-results@v1",
-  "generatedAt": "2025-10-16T02:58:35.097Z",
+  "generatedAt": "2025-10-16T14:48:21.139Z",
   "status": "passed",
   "total": 3,
   "failureCount": 0,
   "results": [
     {
-      "command": "npm run priority:test",
+      "command": "node tools/npm/run-script.mjs priority:test",
       "exitCode": 0,
-      "stdout": "\n> compare-vi-cli-action@0.5.0 priority:test\n> node --test \"tools/priority/__tests__/*.mjs\"\n\nTAP version 13\n# Subtest: handoff issue summary matches schema\nok 1 - handoff issue summary matches schema\n  ---\n  duration_ms: 150.97627\n  type: 'test'\n  ...\n# Subtest: handoff router matches schema\nok 2 - handoff router matches schema\n  ---\n  duration_ms: 47.846819\n  type: 'test'\n  ...\n# Subtest: handoff hook summary matches schema\nok 3 - handoff hook summary matches schema\n  ---\n  duration_ms: 41.513019\n  type: 'test'\n  ...\n# Subtest: handoff release summary matches schema\nok 4 - handoff release summary matches schema\n  ---\n  duration_ms: 24.006446\n  type: 'test'\n  ...\n# Subtest: handoff test summary matches schema\nok 5 - handoff test summary matches schema\n  ---\n  duration_ms: 41.182548\n  type: 'test'\n  ...\n# Subtest: handoff session capsule matches schema\nok 6 - handoff session capsule matches schema\n  ---\n  duration_ms: 33.432927\n  type: 'test'\n  ...\n# Subtest: createSnapshot normalizes lists and produces stable digest\nok 7 - createSnapshot normalizes lists and produces stable digest\n  ---\n  duration_ms: 19.312529\n  type: 'test'\n  ...\n# Subtest: buildRouter honours policy map and default actions\nok 8 - buildRouter honours policy map and default actions\n  ---\n  duration_ms: 1.676416\n  type: 'test'\n  ...\n# Subtest: buildRouter adds fallback validation action when needed\nok 9 - buildRouter adds fallback validation action when needed\n  ---\n  duration_ms: 0.426044\n  type: 'test'\n  ...\n1..9\n# tests 9\n# suites 0\n# pass 9\n# fail 0\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 794.758856",
-      "stderr": "npm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.",
-      "startedAt": "2025-10-16T02:58:32.779Z",
-      "completedAt": "2025-10-16T02:58:33.969Z",
-      "durationMs": 1190
+      "stdout": "\n> compare-vi-cli-action@0.5.0 priority:test\n> node --test \"tools/priority/__tests__/*.mjs\"\n\nTAP version 13\n# Subtest: parseGitRemoteUrl handles SSH remotes\nok 1 - parseGitRemoteUrl handles SSH remotes\n  ---\n  duration_ms: 1.270676\n  type: 'test'\n  ...\n# Subtest: parseGitRemoteUrl handles HTTPS remotes\nok 2 - parseGitRemoteUrl handles HTTPS remotes\n  ---\n  duration_ms: 0.396238\n  type: 'test'\n  ...\n# Subtest: parseGitRemoteUrl handles git+https repository URLs\nok 3 - parseGitRemoteUrl handles git+https repository URLs\n  ---\n  duration_ms: 0.219791\n  type: 'test'\n  ...\n# Subtest: parseGitRemoteUrl handles ssh protocol URLs\nok 4 - parseGitRemoteUrl handles ssh protocol URLs\n  ---\n  duration_ms: 0.192996\n  type: 'test'\n  ...\n# Subtest: parseGitRemoteUrl returns null for invalid remotes\nok 5 - parseGitRemoteUrl returns null for invalid remotes\n  ---\n  duration_ms: 0.442992\n  type: 'test'\n  ...\n# Subtest: handoff issue summary matches schema\nok 6 - handoff issue summary matches schema\n  ---\n  duration_ms: 111.087008\n  type: 'test'\n  ...\n# Subtest: handoff router matches schema\nok 7 - handoff router matches schema\n  ---\n  duration_ms: 43.364536\n  type: 'test'\n  ...\n# Subtest: handoff hook summary matches schema\nok 8 - handoff hook summary matches schema\n  ---\n  duration_ms: 32.034867\n  type: 'test'\n  ...\n# Subtest: handoff release summary matches schema\nok 9 - handoff release summary matches schema\n  ---\n  duration_ms: 20.006698\n  type: 'test'\n  ...\n# Subtest: handoff test summary matches schema\nok 10 - handoff test summary matches schema\n  ---\n  duration_ms: 28.43826\n  type: 'test'\n  ...\n# Subtest: handoff session capsule matches schema\nok 11 - handoff session capsule matches schema\n  ---\n  duration_ms: 18.807433\n  type: 'test'\n  ...\n# Subtest: createSnapshot normalizes lists and produces stable digest\nok 12 - createSnapshot normalizes lists and produces stable digest\n  ---\n  duration_ms: 14.179864\n  type: 'test'\n  ...\n# Subtest: buildRouter honours policy map and default actions\nok 13 - buildRouter honours policy map and default actions\n  ---\n  duration_ms: 0.966846\n  type: 'test'\n  ...\n# Subtest: buildRouter adds fallback validation action when needed\nok 14 - buildRouter adds fallback validation action when needed\n  ---\n  duration_ms: 0.296033\n  type: 'test'\n  ...\n1..14\n# tests 14\n# suites 0\n# pass 14\n# fail 0\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 715.105272",
+      "stderr": "",
+      "startedAt": "2025-10-16T14:48:19.106Z",
+      "completedAt": "2025-10-16T14:48:20.190Z",
+      "durationMs": 1084
     },
     {
-      "command": "npm run hooks:test",
+      "command": "node tools/npm/run-script.mjs hooks:test",
       "exitCode": 0,
-      "stdout": "\n> compare-vi-cli-action@0.5.0 hooks:test\n> node --test \"tools/hooks/__tests__/*.mjs\"\n\nTAP version 13\n# Subtest: detectPlane detects GitHub Ubuntu\nok 1 - detectPlane detects GitHub Ubuntu\n  ---\n  duration_ms: 6.858384\n  type: 'test'\n  ...\n# Subtest: detectPlane detects GitHub Windows\nok 2 - detectPlane detects GitHub Windows\n  ---\n  duration_ms: 0.43118\n  type: 'test'\n  ...\n# Subtest: detectPlane detects WSL\nok 3 - detectPlane detects WSL\n  ---\n  duration_ms: 0.350337\n  type: 'test'\n  ...\n# Subtest: detectPlane detects macOS\nok 4 - detectPlane detects macOS\n  ---\n  duration_ms: 0.227267\n  type: 'test'\n  ...\n# Subtest: detectPlane defaults to linux bash\nok 5 - detectPlane defaults to linux bash\n  ---\n  duration_ms: 0.297941\n  type: 'test'\n  ...\n# Subtest: resolveEnforcement respects explicit env\nok 6 - resolveEnforcement respects explicit env\n  ---\n  duration_ms: 0.265623\n  type: 'test'\n  ...\n# Subtest: resolveEnforcement defaults to fail on CI\nok 7 - resolveEnforcement defaults to fail on CI\n  ---\n  duration_ms: 0.380715\n  type: 'test'\n  ...\n# Subtest: resolveEnforcement defaults to warn locally\nok 8 - resolveEnforcement defaults to warn locally\n  ---\n  duration_ms: 0.195816\n  type: 'test'\n  ...\n# Subtest: normalizeSummary zeroes timestamp and duration and sorts steps\nok 9 - normalizeSummary zeroes timestamp and duration and sorts steps\n  ---\n  duration_ms: 2.645994\n  type: 'test'\n  ...\n1..9\n# tests 9\n# suites 0\n# pass 9\n# fail 0\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 343.910103",
-      "stderr": "npm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.",
-      "startedAt": "2025-10-16T02:58:33.970Z",
-      "completedAt": "2025-10-16T02:58:34.714Z",
-      "durationMs": 744
+      "stdout": "\n> compare-vi-cli-action@0.5.0 hooks:test\n> node --test \"tools/hooks/__tests__/*.mjs\"\n\nTAP version 13\n# Subtest: detectPlane detects GitHub Ubuntu\nok 1 - detectPlane detects GitHub Ubuntu\n  ---\n  duration_ms: 5.044819\n  type: 'test'\n  ...\n# Subtest: detectPlane detects GitHub Windows\nok 2 - detectPlane detects GitHub Windows\n  ---\n  duration_ms: 0.227811\n  type: 'test'\n  ...\n# Subtest: detectPlane detects WSL\nok 3 - detectPlane detects WSL\n  ---\n  duration_ms: 0.249157\n  type: 'test'\n  ...\n# Subtest: detectPlane detects macOS\nok 4 - detectPlane detects macOS\n  ---\n  duration_ms: 0.197981\n  type: 'test'\n  ...\n# Subtest: detectPlane defaults to linux bash\nok 5 - detectPlane defaults to linux bash\n  ---\n  duration_ms: 0.19991\n  type: 'test'\n  ...\n# Subtest: resolveEnforcement respects explicit env\nok 6 - resolveEnforcement respects explicit env\n  ---\n  duration_ms: 0.206038\n  type: 'test'\n  ...\n# Subtest: resolveEnforcement defaults to fail on CI\nok 7 - resolveEnforcement defaults to fail on CI\n  ---\n  duration_ms: 0.257032\n  type: 'test'\n  ...\n# Subtest: resolveEnforcement defaults to warn locally\nok 8 - resolveEnforcement defaults to warn locally\n  ---\n  duration_ms: 0.208154\n  type: 'test'\n  ...\n# Subtest: normalizeSummary zeroes timestamp and duration and sorts steps\nok 9 - normalizeSummary zeroes timestamp and duration and sorts steps\n  ---\n  duration_ms: 1.67078\n  type: 'test'\n  ...\n1..9\n# tests 9\n# suites 0\n# pass 9\n# fail 0\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 248.244274",
+      "stderr": "",
+      "startedAt": "2025-10-16T14:48:20.191Z",
+      "completedAt": "2025-10-16T14:48:20.800Z",
+      "durationMs": 609
     },
     {
-      "command": "npm run semver:check",
+      "command": "node tools/npm/run-script.mjs semver:check",
       "exitCode": 0,
-      "stdout": "\n> compare-vi-cli-action@0.5.0 semver:check\n> node tools/priority/validate-semver.mjs\n\n{\n  \"schema\": \"priority/semver-check@v1\",\n  \"version\": \"0.5.0\",\n  \"valid\": true,\n  \"issues\": [],\n  \"checkedAt\": \"2025-10-16T02:58:35.055Z\"\n}",
-      "stderr": "npm warn Unknown env config \"http-proxy\". This will stop working in the next major version of npm.",
-      "startedAt": "2025-10-16T02:58:34.714Z",
-      "completedAt": "2025-10-16T02:58:35.095Z",
-      "durationMs": 381
+      "stdout": "\n> compare-vi-cli-action@0.5.0 semver:check\n> node tools/priority/validate-semver.mjs\n\n{\n  \"schema\": \"priority/semver-check@v1\",\n  \"version\": \"0.5.0\",\n  \"valid\": true,\n  \"issues\": [],\n  \"checkedAt\": \"2025-10-16T14:48:21.100Z\"\n}",
+      "stderr": "",
+      "startedAt": "2025-10-16T14:48:20.801Z",
+      "completedAt": "2025-10-16T14:48:21.138Z",
+      "durationMs": 337
     }
   ],
   "runner": {}

--- a/vscode/comparevi-helper/test/suite/extension.test.js
+++ b/vscode/comparevi-helper/test/suite/extension.test.js
@@ -264,6 +264,13 @@ suite('CompareVI extension', () => {
     expect(state.activeProviderId).to.equal('gcli');
   });
 
+  test('active provider selection persists in workspace state', () => {
+    testingApi.setActiveProvider('gcli');
+    expect(testingApi.getStoredActiveProviderId()).to.equal('gcli');
+    testingApi.setActiveProvider('comparevi');
+    expect(testingApi.getStoredActiveProviderId()).to.equal('comparevi');
+  });
+
   test('toggle diff as success command updates setting and status bar', async () => {
     const config = vscode.workspace.getConfiguration();
     await config.update('comparevi.diffAsSuccess', false, vscode.ConfigurationTarget.Workspace);


### PR DESCRIPTION
## Summary
- persist the active CLI provider choice in workspace state so the CompareVI panel reopens on the previously selected provider (#127)
- expose the stored provider for test hooks and add coverage for the persistence behaviour
- refresh the node-based priority handoff test summary after rerunning the shimmed commands

## Testing
- node tools/npm/run-script.mjs priority:handoff-tests
- npm run test:unit --prefix vscode/comparevi-helper
- npm run test:ext --prefix vscode/comparevi-helper *(fails: VS Code runtime missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f1052c0df0832d98b94b252b7b744e