### PR TITLE
feat: add provider switch telemetry to VS Code companion (#127)

### DIFF
--- a/vscode/comparevi-helper/lib/providerSwitcher.js
+++ b/vscode/comparevi-helper/lib/providerSwitcher.js
@@ -1,0 +1,54 @@
+function createProviderSwitcher({ setActiveProvider, listProviderMetadata, getActiveProviderId, recordTelemetry }) {
+  if (typeof setActiveProvider !== 'function') {
+    throw new TypeError('setActiveProvider must be a function');
+  }
+  const metadataFn = typeof listProviderMetadata === 'function' ? listProviderMetadata : (() => []);
+  const activeIdFn = typeof getActiveProviderId === 'function' ? getActiveProviderId : (() => undefined);
+  const telemetryFn = typeof recordTelemetry === 'function'
+    ? recordTelemetry
+    : (() => Promise.resolve());
+
+  return async function switchProvider(providerId, { recordTelemetry: shouldRecord = false, telemetryReason } = {}) {
+    const previousId = activeIdFn();
+    const result = setActiveProvider(providerId);
+    if (!result) {
+      return false;
+    }
+
+    if (shouldRecord && previousId !== providerId) {
+      try {
+        const metadataList = metadataFn();
+        const meta = Array.isArray(metadataList)
+          ? metadataList.find((item) => item && item.id === providerId)
+          : undefined;
+        const available = meta ? !meta.disabled : true;
+        const payload = {
+          from: previousId ?? null,
+          to: providerId,
+          available,
+          reason: telemetryReason || 'manual'
+        };
+        const status = meta?.status;
+        if (status && typeof status === 'object') {
+          if (typeof status.message === 'string' && status.message.trim().length) {
+            payload.status = status.message;
+          }
+          if (typeof status.ok === 'boolean') {
+            payload.statusOk = status.ok;
+          }
+        }
+        await telemetryFn('comparevi.provider.switch', payload);
+      } catch (error) {
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn('[comparevi] failed to record provider switch telemetry', error);
+        }
+      }
+    }
+
+    return true;
+  };
+}
+
+module.exports = {
+  createProviderSwitcher
+};

--- a/vscode/comparevi-helper/test/unit/provider-switch-telemetry.test.js
+++ b/vscode/comparevi-helper/test/unit/provider-switch-telemetry.test.js
@@ -1,0 +1,64 @@
+const { createProviderSwitcher } = require('../../lib/providerSwitcher');
+
+describe('provider switch telemetry helper', () => {
+  let setActiveProviderMock;
+  let listProviderMetadataMock;
+  let getActiveProviderIdMock;
+  let telemetryMock;
+  let switchProvider;
+
+  beforeEach(() => {
+    setActiveProviderMock = vi.fn(() => true);
+    listProviderMetadataMock = vi.fn(() => []);
+    getActiveProviderIdMock = vi.fn(() => undefined);
+    telemetryMock = vi.fn(() => Promise.resolve());
+    switchProvider = createProviderSwitcher({
+      setActiveProvider: setActiveProviderMock,
+      listProviderMetadata: listProviderMetadataMock,
+      getActiveProviderId: getActiveProviderIdMock,
+      recordTelemetry: telemetryMock
+    });
+  });
+
+  it('records telemetry when switching providers', async () => {
+    getActiveProviderIdMock.mockReturnValueOnce('comparevi');
+    listProviderMetadataMock.mockReturnValueOnce([
+      { id: 'comparevi', disabled: false, status: { ok: true, message: 'CompareVI ready' } },
+      { id: 'gcli', disabled: true, status: { ok: false, message: 'g-cli missing' } }
+    ]);
+
+    const result = await switchProvider('gcli', { recordTelemetry: true, telemetryReason: 'test' });
+
+    expect(result).toBe(true);
+    expect(setActiveProviderMock).toHaveBeenCalledWith('gcli');
+    expect(telemetryMock).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = telemetryMock.mock.calls[0];
+    expect(eventName).toBe('comparevi.provider.switch');
+    expect(payload).toMatchObject({
+      from: 'comparevi',
+      to: 'gcli',
+      available: false,
+      reason: 'test',
+      status: 'g-cli missing',
+      statusOk: false
+    });
+  });
+
+  it('skips telemetry when provider remains unchanged', async () => {
+    getActiveProviderIdMock.mockReturnValueOnce('comparevi');
+
+    const result = await switchProvider('comparevi', { recordTelemetry: true, telemetryReason: 'test' });
+
+    expect(result).toBe(true);
+    expect(telemetryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false when underlying setActiveProvider fails', async () => {
+    setActiveProviderMock.mockReturnValueOnce(false);
+
+    const result = await switchProvider('missing', { recordTelemetry: true });
+
+    expect(result).toBe(false);
+    expect(telemetryMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable provider switch helper that records telemetry metadata before returning control
- update the VS Code companion to emit provider-switch telemetry, refresh the panel when the provider changes, and clean up the flag cache naming
- cover the helper with unit tests that exercise successful, unchanged, and failed switches

## Testing
- node tools/npm/run-script.mjs --prefix vscode/comparevi-helper test:unit

------
https://chatgpt.com/codex/tasks/task_b_68f10a3288c0832d9f8bfa1f455f8bfb