### PR TITLE
Fix CompareVI profile button disabled state (#127)

### DIFF
--- a/vscode/comparevi-helper/extension.js
+++ b/vscode/comparevi-helper/extension.js
@@ -1921,9 +1921,7 @@ class ViCompareViewProvider {
         runBtn.disabled = !canRun;
         compareActiveBtn.disabled = !canRun;
         runCommitBtn.disabled = !canRun;
-        if (!canRun) {
-          runProfileBtn.disabled = true;
-        }
+        runProfileBtn.disabled = !canRun;
         testHintEl.textContent = payload.testSummary || (payload.testConfigured ? '' : 'Configure comparevi.panel.testTask or comparevi.panel.testCommand to enable Run Tests.');
         const d = payload.diag || {};
         renderDiag(!!d.baseExists, diagBaseIcon, diagBaseText, 'Base VI exists', d.basePath ? '(' + d.basePath + ')' : '');


### PR DESCRIPTION
## Summary
- ensure the CompareVI profile run button toggles with provider availability so it re-enables when CompareVI becomes active again

## Testing
- `npm run test:unit --prefix vscode/comparevi-helper`


------
https://chatgpt.com/codex/tasks/task_b_68f1291ebc8c832dbe786df7a01635f8