### PR TITLE
feat: add operations names payload to CLI (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,4 +373,5 @@ publish helper to build per-RID archives and checksums for distribution.
 - `./comparevi-cli quote --path 'C:/Program Files/National Instruments/LabVIEW 2025/LabVIEW.exe'`
 - `./comparevi-cli procs`
 - `./comparevi-cli operations`
+- `./comparevi-cli operations --names-only`
 

--- a/dist/tools/cli/validate-cli.js
+++ b/dist/tools/cli/validate-cli.js
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { cliArtifactMetaSchema, cliOperationsSchema, cliQuoteSchema, cliProcsSchema, cliTokenizeSchema, cliVersionSchema, } from '../schemas/definitions.js';
+import { cliArtifactMetaSchema, cliOperationNamesSchema, cliOperationsSchema, cliQuoteSchema, cliProcsSchema, cliTokenizeSchema, cliVersionSchema, } from '../schemas/definitions.js';
 function resolveCliDll() {
     const override = process.env.CLI_DLL;
     if (override) {
@@ -68,6 +68,7 @@ function main() {
     const quoteValidator = compileValidator('cli-quote', zodToJsonSchema(cliQuoteSchema, { target: 'jsonSchema7', name: 'cli-quote' }));
     const procsValidator = compileValidator('cli-procs', zodToJsonSchema(cliProcsSchema, { target: 'jsonSchema7', name: 'cli-procs' }));
     const operationsValidator = compileValidator('cli-operations', zodToJsonSchema(cliOperationsSchema, { target: 'jsonSchema7', name: 'cli-operations' }));
+    const operationNamesValidator = compileValidator('cli-operation-names', zodToJsonSchema(cliOperationNamesSchema, { target: 'jsonSchema7', name: 'cli-operation-names' }));
     const versionData = runCli(dll, ['version']);
     validate('comparevi-cli version', versionData, versionValidator);
     const tokenizeData = runCli(dll, ['tokenize', '--input', 'foo -x=1 "bar baz"']);
@@ -78,6 +79,8 @@ function main() {
     validate('comparevi-cli procs', procsData, procsValidator);
     const operationsData = runCli(dll, ['operations']);
     validate('comparevi-cli operations', operationsData, operationsValidator);
+    const operationsNamesData = runCli(dll, ['operations', '--names-only']);
+    validate('comparevi-cli operations --names-only', operationsNamesData, operationNamesValidator);
     const metaData = readArtifactMeta();
     if (metaData) {
         const metaValidator = compileValidator('cli-artifact-meta', zodToJsonSchema(cliArtifactMetaSchema, { target: 'jsonSchema7', name: 'cli-artifact-meta' }));

--- a/dist/tools/schemas/definitions.js
+++ b/dist/tools/schemas/definitions.js
@@ -386,6 +386,20 @@ export const cliOperationsSchema = z
         });
     }
 });
+export const cliOperationNamesSchema = z
+    .object({
+    schema: z.literal('comparevi-cli/operation-names@v1'),
+    operationCount: nonNegativeInteger,
+    names: z.array(z.string().min(1)).min(1),
+})
+    .superRefine((value, ctx) => {
+    if (value.operationCount !== value.names.length) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'operationCount must equal names.length',
+        });
+    }
+});
 const cliArtifactFileSchema = z.object({
     path: z.string().min(1),
     sha256: hexSha256,
@@ -506,6 +520,12 @@ export const schemas = [
         fileName: 'cli-operations.schema.json',
         description: 'Operations catalog exposed by comparevi-cli operations.',
         schema: cliOperationsSchema,
+    },
+    {
+        id: 'cli-operation-names',
+        fileName: 'cli-operation-names.schema.json',
+        description: 'Sorted operation names exposed by comparevi-cli operations --names-only.',
+        schema: cliOperationNamesSchema,
     },
     {
         id: 'cli-artifact-meta',

--- a/docs/schema/generated/cli-operation-names.schema.json
+++ b/docs/schema/generated/cli-operation-names.schema.json
@@ -1,0 +1,35 @@
+{
+  "$ref": "#/definitions/cli-operation-names",
+  "definitions": {
+    "cli-operation-names": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "comparevi-cli/operation-names@v1"
+        },
+        "operationCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "names": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "schema",
+        "operationCount",
+        "names"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Sorted operation names exposed by comparevi-cli operations --names-only.",
+  "$id": "urn:compare-vi-cli-action:schema:cli-operation-names"
+}

--- a/src/CompareVi.Shared.Tests/OperationCatalogFormatterTests.cs
+++ b/src/CompareVi.Shared.Tests/OperationCatalogFormatterTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Text.Json.Nodes;
 using CompareVi.Shared;
 using Xunit;
@@ -37,6 +39,21 @@ namespace CompareVi.Shared.Tests
             var found = OperationCatalogFormatter.TryCreateOperationPayload("does-not-exist", out _);
 
             Assert.False(found);
+        }
+
+        [Fact]
+        public void CreateOperationNamesPayload_ReturnsSortedNames()
+        {
+            var payload = OperationCatalogFormatter.CreateOperationNamesPayload();
+
+            Assert.Equal("comparevi-cli/operation-names@v1", payload["schema"]!.GetValue<string>());
+            var names = Assert.IsType<JsonArray>(payload["names"]);
+            Assert.NotEmpty(names);
+            Assert.Equal(payload["operationCount"]!.GetValue<int>(), names.Count);
+
+            var nameStrings = names.Select(node => node!.GetValue<string>()).ToArray();
+            var sorted = nameStrings.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToArray();
+            Assert.Equal(sorted, nameStrings);
         }
     }
 }

--- a/src/CompareVi.Tools.Cli/Program.cs
+++ b/src/CompareVi.Tools.Cli/Program.cs
@@ -54,7 +54,7 @@ internal static class Program
         Console.WriteLine("  comparevi-cli tokenize --input \"arg string\"");
         Console.WriteLine("  comparevi-cli procs");
         Console.WriteLine("  comparevi-cli quote --path <path>");
-        Console.WriteLine("  comparevi-cli operations [--name <operation>]");
+        Console.WriteLine("  comparevi-cli operations [--name <operation>] [--names-only]");
     }
 
     private static int CmdVersion()
@@ -136,16 +136,37 @@ internal static class Program
     private static int CmdOperations(string[] args)
     {
         string? operationName = null;
+        var namesOnly = false;
         for (int i = 1; i < args.Length; i++)
         {
             if (args[i].Equals("--name", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
             {
                 operationName = args[i + 1];
                 i++;
+                continue;
+            }
+
+            if (args[i].Equals("--names", StringComparison.OrdinalIgnoreCase) ||
+                args[i].Equals("--names-only", StringComparison.OrdinalIgnoreCase))
+            {
+                namesOnly = true;
             }
         }
 
         operationName = operationName?.Trim();
+
+        if (namesOnly && !string.IsNullOrEmpty(operationName))
+        {
+            Console.Error.WriteLine("--names-only cannot be combined with --name.");
+            return 2;
+        }
+
+        if (namesOnly)
+        {
+            var payload = OperationCatalogFormatter.CreateOperationNamesPayload();
+            Console.WriteLine(payload.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            return 0;
+        }
 
         if (string.IsNullOrEmpty(operationName))
         {

--- a/tools/cli/validate-cli.ts
+++ b/tools/cli/validate-cli.ts
@@ -8,6 +8,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import {
   cliArtifactMetaSchema,
+  cliOperationNamesSchema,
   cliOperationsSchema,
   cliQuoteSchema,
   cliProcsSchema,
@@ -110,6 +111,11 @@ function main() {
     zodToJsonSchema(cliOperationsSchema, { target: 'jsonSchema7', name: 'cli-operations' }) as Record<string, unknown>,
   );
 
+  const operationNamesValidator = compileValidator(
+    'cli-operation-names',
+    zodToJsonSchema(cliOperationNamesSchema, { target: 'jsonSchema7', name: 'cli-operation-names' }) as Record<string, unknown>,
+  );
+
   const versionData = runCli(dll, ['version']);
   validate('comparevi-cli version', versionData, versionValidator);
 
@@ -124,6 +130,9 @@ function main() {
 
   const operationsData = runCli(dll, ['operations']);
   validate('comparevi-cli operations', operationsData, operationsValidator);
+
+  const operationsNamesData = runCli(dll, ['operations', '--names-only']);
+  validate('comparevi-cli operations --names-only', operationsNamesData, operationNamesValidator);
 
   const metaData = readArtifactMeta();
   if (metaData) {

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -425,6 +425,21 @@ export const cliOperationsSchema = z
     }
   });
 
+export const cliOperationNamesSchema = z
+  .object({
+    schema: z.literal('comparevi-cli/operation-names@v1'),
+    operationCount: nonNegativeInteger,
+    names: z.array(z.string().min(1)).min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (value.operationCount !== value.names.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'operationCount must equal names.length',
+      });
+    }
+  });
+
 const cliArtifactFileSchema = z.object({
   path: z.string().min(1),
   sha256: hexSha256,
@@ -550,6 +565,12 @@ export const schemas = [
     fileName: 'cli-operations.schema.json',
     description: 'Operations catalog exposed by comparevi-cli operations.',
     schema: cliOperationsSchema,
+  },
+  {
+    id: 'cli-operation-names',
+    fileName: 'cli-operation-names.schema.json',
+    description: 'Sorted operation names exposed by comparevi-cli operations --names-only.',
+    schema: cliOperationNamesSchema,
   },
   {
     id: 'cli-artifact-meta',


### PR DESCRIPTION
## Summary
- add a --names-only switch to `comparevi-cli operations` for listing sorted catalog names
- expose an operation names payload helper with unit coverage and wire it into CLI validation
- document the new option and generate a JSON schema for the names payload

## Testing
- node tools/npm/run-script.mjs build
- node tools/npm/run-script.mjs schemas:generate

------
https://chatgpt.com/codex/tasks/task_b_68f12db69434832d9e89ed43552b803e