### PR TITLE
feat: add providers catalog command to CLI (#127)

### DIFF
--- a/src/CompareVi.Shared.Tests/ProviderCatalogFormatterTests.cs
+++ b/src/CompareVi.Shared.Tests/ProviderCatalogFormatterTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+using CompareVi.Shared;
+using Xunit;
+
+namespace CompareVi.Shared.Tests
+{
+    public class ProviderCatalogFormatterTests
+    {
+        [Fact]
+        public void CreateProvidersListPayload_ReturnsSchemaAndCount()
+        {
+            var payload = ProviderCatalogFormatter.CreateProvidersListPayload();
+
+            Assert.Equal("comparevi-cli/providers@v1", payload["schema"]!.GetValue<string>());
+            Assert.True(payload["providerCount"]!.GetValue<int>() > 0);
+
+            var providers = Assert.IsType<JsonArray>(payload["providers"]);
+            Assert.NotEmpty(providers);
+        }
+
+        [Fact]
+        public void TryCreateProviderPayload_FindsProviderIgnoringCase()
+        {
+            var found = ProviderCatalogFormatter.TryCreateProviderPayload("LABVIEWCLI", out var payload);
+
+            Assert.True(found);
+            Assert.Equal("comparevi-cli/provider@v1", payload["schema"]!.GetValue<string>());
+            Assert.Equal("labviewcli", payload["providerId"]!.GetValue<string>());
+
+            var provider = Assert.IsType<JsonObject>(payload["provider"]);
+            Assert.Equal("labviewcli", provider["id"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void TryCreateProviderPayload_ReturnsFalseWhenMissing()
+        {
+            var found = ProviderCatalogFormatter.TryCreateProviderPayload("does-not-exist", out _);
+
+            Assert.False(found);
+        }
+
+        [Fact]
+        public void CreateProviderNamesPayload_ReturnsSortedIdentifiers()
+        {
+            var payload = ProviderCatalogFormatter.CreateProviderNamesPayload();
+
+            Assert.Equal("comparevi-cli/provider-names@v1", payload["schema"]!.GetValue<string>());
+            var names = Assert.IsType<JsonArray>(payload["names"]);
+            Assert.NotEmpty(names);
+            Assert.Equal(payload["providerCount"]!.GetValue<int>(), names.Count);
+
+            var nameValues = names.Select(node => node!.GetValue<string>()).ToArray();
+            var sorted = nameValues.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToArray();
+            Assert.Equal(sorted, nameValues);
+        }
+    }
+}

--- a/src/CompareVi.Shared/CompareVi.Shared.csproj
+++ b/src/CompareVi.Shared/CompareVi.Shared.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\..\tools\providers\spec\operations.json" Link="Operations\operations.json" />
+    <EmbeddedResource Include="..\..\tools\providers\spec\providers.json" Link="Providers\providers.json" />
   </ItemGroup>
 </Project>
 

--- a/src/CompareVi.Shared/ProviderCatalog.cs
+++ b/src/CompareVi.Shared/ProviderCatalog.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace CompareVi.Shared
+{
+    public sealed record ProviderBinarySpec(
+        IReadOnlyList<string> Env)
+    {
+        public bool HasEnvOverrides => Env.Count > 0;
+    }
+
+    public sealed record ProviderSpec(
+        string Id,
+        string? DisplayName,
+        string? Description,
+        ProviderBinarySpec? Binary,
+        IReadOnlyList<string> Operations)
+    {
+        public string PrimaryName => DisplayName ?? Id;
+
+        public bool SupportsOperation(string operation) =>
+            Operations.Contains(operation, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed record ProviderCatalogDocument(IReadOnlyList<ProviderSpec> Providers)
+    {
+        public int ProviderCount => Providers.Count;
+
+        public ProviderSpec? Find(string nameOrId)
+        {
+            return Providers.FirstOrDefault(provider =>
+                string.Equals(provider.Id, nameOrId, StringComparison.OrdinalIgnoreCase) ||
+                (!string.IsNullOrWhiteSpace(provider.DisplayName) &&
+                 string.Equals(provider.DisplayName, nameOrId, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        internal static ProviderCatalogDocument FromJson(JsonObject root)
+        {
+            if (!root.TryGetPropertyValue("providers", out var providersNode) || providersNode is not JsonArray providersArray)
+            {
+                throw new InvalidDataException("Provider spec is missing a 'providers' array.");
+            }
+
+            var providers = new List<ProviderSpec>(providersArray.Count);
+
+            foreach (var item in providersArray)
+            {
+                if (item is not JsonObject providerObj)
+                {
+                    continue;
+                }
+
+                if (!providerObj.TryGetPropertyValue("id", out var idNode) || idNode is not JsonValue idValue ||
+                    !idValue.TryGetValue(out string? id) || string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                string? displayName = null;
+                if (providerObj.TryGetPropertyValue("displayName", out var displayNameNode) && displayNameNode is JsonValue displayNameValue)
+                {
+                    displayNameValue.TryGetValue(out displayName);
+                }
+
+                string? description = null;
+                if (providerObj.TryGetPropertyValue("description", out var descriptionNode) && descriptionNode is JsonValue descriptionValue)
+                {
+                    descriptionValue.TryGetValue(out description);
+                }
+
+                ProviderBinarySpec? binarySpec = null;
+                if (providerObj.TryGetPropertyValue("binary", out var binaryNode) && binaryNode is JsonObject binaryObj)
+                {
+                    var envOverrides = new List<string>();
+                    if (binaryObj.TryGetPropertyValue("env", out var envNode) && envNode is JsonArray envArray)
+                    {
+                        foreach (var envItem in envArray)
+                        {
+                            if (envItem is JsonValue envValue && envValue.TryGetValue(out string? envName) &&
+                                !string.IsNullOrWhiteSpace(envName))
+                            {
+                                envOverrides.Add(envName);
+                            }
+                        }
+                    }
+
+                    binarySpec = new ProviderBinarySpec(envOverrides);
+                }
+
+                var operations = new List<string>();
+                if (providerObj.TryGetPropertyValue("operations", out var operationsNode) && operationsNode is JsonArray operationsArray)
+                {
+                    foreach (var opNode in operationsArray)
+                    {
+                        if (opNode is JsonValue opValue && opValue.TryGetValue(out string? operationName) &&
+                            !string.IsNullOrWhiteSpace(operationName))
+                        {
+                            operations.Add(operationName);
+                        }
+                    }
+                }
+
+                providers.Add(new ProviderSpec(id!, displayName, description, binarySpec, operations));
+            }
+
+            return new ProviderCatalogDocument(providers);
+        }
+    }
+
+    public static class ProviderCatalog
+    {
+        private const string ResourceName = "CompareVi.Shared.Providers.providers.json";
+
+        public static JsonObject LoadRaw()
+        {
+            using var stream = typeof(ProviderCatalog).Assembly.GetManifestResourceStream(ResourceName)
+                ?? throw new InvalidOperationException($"Embedded providers spec '{ResourceName}' not found.");
+
+            if (JsonNode.Parse(stream) is not JsonObject root)
+            {
+                throw new InvalidDataException("Embedded providers spec is not a JSON object.");
+            }
+
+            return (JsonObject)root.DeepClone();
+        }
+
+        public static ProviderCatalogDocument Load()
+        {
+            var raw = LoadRaw();
+            return ProviderCatalogDocument.FromJson(raw);
+        }
+    }
+}

--- a/src/CompareVi.Shared/ProviderCatalogFormatter.cs
+++ b/src/CompareVi.Shared/ProviderCatalogFormatter.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace CompareVi.Shared
+{
+    public static class ProviderCatalogFormatter
+    {
+        private const string ProvidersSchema = "comparevi-cli/providers@v1";
+        private const string ProviderSchema = "comparevi-cli/provider@v1";
+        private const string ProviderNamesSchema = "comparevi-cli/provider-names@v1";
+
+        public static JsonObject CreateProvidersListPayload()
+        {
+            var catalog = ProviderCatalog.Load();
+            var providersArray = new JsonArray();
+
+            foreach (var provider in catalog.Providers.OrderBy(p => p.PrimaryName, StringComparer.OrdinalIgnoreCase))
+            {
+                providersArray.Add(CreateProviderJson(provider));
+            }
+
+            return new JsonObject
+            {
+                ["schema"] = ProvidersSchema,
+                ["providerCount"] = catalog.ProviderCount,
+                ["providers"] = providersArray,
+            };
+        }
+
+        public static bool TryCreateProviderPayload(string providerNameOrId, out JsonObject payload)
+        {
+            if (string.IsNullOrWhiteSpace(providerNameOrId))
+            {
+                throw new ArgumentException("Provider name or identifier must be provided.", nameof(providerNameOrId));
+            }
+
+            var catalog = ProviderCatalog.Load();
+            var match = catalog.Find(providerNameOrId);
+            if (match is null)
+            {
+                payload = null!;
+                return false;
+            }
+
+            payload = new JsonObject
+            {
+                ["schema"] = ProviderSchema,
+                ["providerId"] = match.Id,
+                ["provider"] = CreateProviderJson(match),
+            };
+            return true;
+        }
+
+        public static JsonObject CreateProviderNamesPayload()
+        {
+            var catalog = ProviderCatalog.Load();
+            var names = new List<string>();
+
+            foreach (var provider in catalog.Providers)
+            {
+                names.Add(provider.Id);
+            }
+
+            names.Sort(StringComparer.OrdinalIgnoreCase);
+
+            var namesArray = new JsonArray();
+            foreach (var name in names)
+            {
+                namesArray.Add(name);
+            }
+
+            return new JsonObject
+            {
+                ["schema"] = ProviderNamesSchema,
+                ["providerCount"] = names.Count,
+                ["names"] = namesArray,
+            };
+        }
+
+        private static JsonObject CreateProviderJson(ProviderSpec provider)
+        {
+            var providerJson = new JsonObject
+            {
+                ["id"] = provider.Id,
+            };
+
+            if (!string.IsNullOrWhiteSpace(provider.DisplayName))
+            {
+                providerJson["displayName"] = provider.DisplayName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(provider.Description))
+            {
+                providerJson["description"] = provider.Description;
+            }
+
+            if (provider.Binary is { } binary && binary.HasEnvOverrides)
+            {
+                var envArray = new JsonArray();
+                foreach (var envName in binary.Env)
+                {
+                    envArray.Add(envName);
+                }
+
+                if (envArray.Count > 0)
+                {
+                    providerJson["binary"] = new JsonObject
+                    {
+                        ["env"] = envArray,
+                    };
+                }
+            }
+
+            if (provider.Operations.Count > 0)
+            {
+                var operationsArray = new JsonArray();
+                foreach (var operation in provider.Operations.OrderBy(op => op, StringComparer.OrdinalIgnoreCase))
+                {
+                    operationsArray.Add(operation);
+                }
+
+                providerJson["operations"] = operationsArray;
+            }
+
+            return providerJson;
+        }
+    }
+}

--- a/src/CompareVi.Tools.Cli/Program.cs
+++ b/src/CompareVi.Tools.Cli/Program.cs
@@ -30,6 +30,8 @@ internal static class Program
                     return CmdQuote(args);
                 case "operations":
                     return CmdOperations(args);
+                case "providers":
+                    return CmdProviders(args);
                 default:
                     Console.Error.WriteLine($"Unknown command: {cmd}");
                     PrintHelp();
@@ -55,6 +57,7 @@ internal static class Program
         Console.WriteLine("  comparevi-cli procs");
         Console.WriteLine("  comparevi-cli quote --path <path>");
         Console.WriteLine("  comparevi-cli operations [--name <operation>] [--names-only]");
+        Console.WriteLine("  comparevi-cli providers [--name <provider>] [--names-only]");
     }
 
     private static int CmdVersion()
@@ -182,6 +185,59 @@ internal static class Program
         }
 
         Console.Error.WriteLine($"Operation '{operationName}' was not found in the operations catalog.");
+        return 3;
+    }
+
+    private static int CmdProviders(string[] args)
+    {
+        string? providerName = null;
+        var namesOnly = false;
+
+        for (int i = 1; i < args.Length; i++)
+        {
+            if (args[i].Equals("--name", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                providerName = args[i + 1];
+                i++;
+                continue;
+            }
+
+            if (args[i].Equals("--names", StringComparison.OrdinalIgnoreCase) ||
+                args[i].Equals("--names-only", StringComparison.OrdinalIgnoreCase))
+            {
+                namesOnly = true;
+            }
+        }
+
+        providerName = providerName?.Trim();
+
+        if (namesOnly && !string.IsNullOrEmpty(providerName))
+        {
+            Console.Error.WriteLine("--names-only cannot be combined with --name.");
+            return 2;
+        }
+
+        if (namesOnly)
+        {
+            var payload = ProviderCatalogFormatter.CreateProviderNamesPayload();
+            Console.WriteLine(payload.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            return 0;
+        }
+
+        if (string.IsNullOrEmpty(providerName))
+        {
+            var payload = ProviderCatalogFormatter.CreateProvidersListPayload();
+            Console.WriteLine(payload.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            return 0;
+        }
+
+        if (ProviderCatalogFormatter.TryCreateProviderPayload(providerName!, out var providerPayload))
+        {
+            Console.WriteLine(providerPayload.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            return 0;
+        }
+
+        Console.Error.WriteLine($"Provider '{providerName}' was not found in the providers catalog.");
         return 3;
     }
 }

--- a/tools/providers/spec/providers.json
+++ b/tools/providers/spec/providers.json
@@ -1,0 +1,25 @@
+{
+  "providers": [
+    {
+      "id": "labviewcli",
+      "displayName": "LabVIEW CLI",
+      "description": "Executes LabVIEW command-line operations via the LabVIEWCLI.exe companion.",
+      "binary": {
+        "env": [
+          "LABVIEWCLI_PATH",
+          "LABVIEW_CLI_PATH",
+          "LABVIEW_CLI"
+        ]
+      },
+      "operations": [
+        "CloseLabVIEW",
+        "CreateComparisonReport",
+        "ExecuteBuildSpec",
+        "MassCompile",
+        "RunUnitTests",
+        "RunVI",
+        "RunVIAnalyzer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- embed a providers catalog specification alongside the operations manifest
- expose a new `providers` command in `comparevi-cli` that returns provider details or ids
- cover the provider catalog formatter with focused unit tests

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68f12ffa5cb8832dbb04814f445b1db1