### PR TITLE
Update priority cache and handoff context after priority sync (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T18:09:53.110Z",
+  "cachedAtUtc": "2025-10-16T18:14:33.180Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",
@@ -12,5 +12,5 @@
   "commentCount": null,
   "bodyDigest": null,
   "lastFetchSource": "cache",
-  "lastFetchError": "Failed to fetch issue #134 via gh CLI (To get started with GitHub CLI, please run:  gh auth login\nAlternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.)"
+  "lastFetchError": "Failed to fetch issue #134 via gh CLI (gh CLI not found)"
 }

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -1,12 +1,13 @@
 # Agent Handoff - Compare VI CLI Action
 
 ## Context Snapshot
-- Ran `node tools/npm/run-script.mjs priority:sync` after installing GitHub CLI; authentication is
-  still missing so the script fell back to cached metadata for standing issue #134 and recorded the
-  failed unauthenticated attempt (see `.agent_priority_cache.json`).
-- Installed GitHub CLI 2.45.0 via `apt-get` so future sessions can authenticate without reinstalling.
-- `gh auth status` confirms no token is configured yet; REST fallback calls also fail without
-  credentials.
+- Ran `node tools/npm/run-script.mjs priority:sync`; the script fell back to cached metadata for
+  standing issue #134 because `gh` is currently unavailable in this container and unauthenticated
+  REST requests fail (see `.agent_priority_cache.json`).
+- GitHub CLI is not installed in the present environment, so authentication could not be attempted
+  and the script reported `gh CLI not found`.
+- `gh auth status` still cannot be checked because the executable is missing; REST fallback calls
+  also fail without credentials.
 - Attempted to install PowerShell (`pwsh`) with `apt-get install powershell`, but the package is not
   available in the default Ubuntu repositories configured here, so dispatcher and guard scripts
   remain blocked pending a manual installation path.
@@ -21,8 +22,8 @@
   described in issue #134.
 
 ## Status & Known Gaps
-1. GitHub CLI is now installed but unauthenticated, so standing-priority syncs still cannot reach
-   GitHub until credentials are configured (`gh auth login` or `GH_TOKEN`).
+1. GitHub CLI is absent, so standing-priority syncs still cannot reach GitHub until the binary is
+   installed and credentials are configured (`gh auth login` or `GH_TOKEN`).
 2. PowerShell 7+ (with Pester) remains absent because the Ubuntu repositories in this container do
    not offer the `powershell` package; dispatcher executions and guard sweeps remain blocked.
 3. Dispatcher coverage is still outstanding. No recent runs exist and the last guard diagnostics are
@@ -33,7 +34,7 @@
    provenance.
 
 ## Suggested Next Actions
-1. Authenticate GitHub CLI (`gh auth login` or set `GH_TOKEN`) and rerun
+1. Install GitHub CLI, authenticate (`gh auth login` or set `GH_TOKEN`), and rerun
    `node tools/npm/run-script.mjs priority:sync` to refresh `.agent_priority_cache.json` with live
    metadata.
 2. Restore PowerShell 7 (plus Pester) using the Microsoft package feed or manual install so
@@ -47,7 +48,7 @@
    provenance.
 
 ## First Actions for the Next Agent
-1. Authenticate GitHub CLI (now installed) and rerun `node tools/npm/run-script.mjs priority:sync` so the
+1. Install GitHub CLI, authenticate, and rerun `node tools/npm/run-script.mjs priority:sync` so the
    standing-priority cache reflects live metadata.
 2. Reinstall PowerShell 7 + Pester (or confirm availability via Microsoft feed) and rerun the dispatcher with guard
    diagnostics enabled to reproduce the prior loop and gather artifacts.
@@ -57,8 +58,8 @@
    with the refreshed context.
 
 ## Notes for Next Agent
-- GitHub CLI 2.45.0 is installed but unauthenticated; plan to configure credentials before attempting
-  dispatcher or guard commands that require API access.
+- GitHub CLI is currently missing; install it and authenticate before attempting dispatcher or guard
+  commands that require API access.
 - PowerShell is still missing; the default Ubuntu feeds here do not expose the `powershell` package so
   manual installation (Microsoft feed or direct package) is required.
 - `tests/results/_agent/handoff/test-summary.json` records the 2025-10-16T15:48Z


### PR DESCRIPTION
## Summary
- refresh the standing priority cache after running `priority:sync`
- document that GitHub CLI is currently missing in the handoff notes and adjust next steps

## Testing
- not run (environment lacks GitHub CLI authentication and PowerShell 7)

------
https://chatgpt.com/codex/tasks/task_b_68f135c0df60832dbad9d4aa268db923