### PR TITLE
Add provider catalog schemas and CLI validation (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,4 +374,7 @@ publish helper to build per-RID archives and checksums for distribution.
 - `./comparevi-cli procs`
 - `./comparevi-cli operations`
 - `./comparevi-cli operations --names-only`
+- `./comparevi-cli providers`
+- `./comparevi-cli providers --names-only`
+- `./comparevi-cli providers --name labviewcli`
 

--- a/dist/tools/cli/validate-cli.js
+++ b/dist/tools/cli/validate-cli.js
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { cliArtifactMetaSchema, cliOperationNamesSchema, cliOperationsSchema, cliQuoteSchema, cliProcsSchema, cliTokenizeSchema, cliVersionSchema, } from '../schemas/definitions.js';
+import { cliArtifactMetaSchema, cliOperationNamesSchema, cliOperationsSchema, cliProviderNamesSchema, cliProviderSchema, cliProvidersSchema, cliQuoteSchema, cliProcsSchema, cliTokenizeSchema, cliVersionSchema, } from '../schemas/definitions.js';
 function resolveCliDll() {
     const override = process.env.CLI_DLL;
     if (override) {
@@ -69,6 +69,9 @@ function main() {
     const procsValidator = compileValidator('cli-procs', zodToJsonSchema(cliProcsSchema, { target: 'jsonSchema7', name: 'cli-procs' }));
     const operationsValidator = compileValidator('cli-operations', zodToJsonSchema(cliOperationsSchema, { target: 'jsonSchema7', name: 'cli-operations' }));
     const operationNamesValidator = compileValidator('cli-operation-names', zodToJsonSchema(cliOperationNamesSchema, { target: 'jsonSchema7', name: 'cli-operation-names' }));
+    const providersValidator = compileValidator('cli-providers', zodToJsonSchema(cliProvidersSchema, { target: 'jsonSchema7', name: 'cli-providers' }));
+    const providerValidator = compileValidator('cli-provider', zodToJsonSchema(cliProviderSchema, { target: 'jsonSchema7', name: 'cli-provider' }));
+    const providerNamesValidator = compileValidator('cli-provider-names', zodToJsonSchema(cliProviderNamesSchema, { target: 'jsonSchema7', name: 'cli-provider-names' }));
     const versionData = runCli(dll, ['version']);
     validate('comparevi-cli version', versionData, versionValidator);
     const tokenizeData = runCli(dll, ['tokenize', '--input', 'foo -x=1 "bar baz"']);
@@ -81,6 +84,30 @@ function main() {
     validate('comparevi-cli operations', operationsData, operationsValidator);
     const operationsNamesData = runCli(dll, ['operations', '--names-only']);
     validate('comparevi-cli operations --names-only', operationsNamesData, operationNamesValidator);
+    const providersData = runCli(dll, ['providers']);
+    validate('comparevi-cli providers', providersData, providersValidator);
+    const providerNamesData = runCli(dll, ['providers', '--names-only']);
+    validate('comparevi-cli providers --names-only', providerNamesData, providerNamesValidator);
+    const providerNames = providerNamesData &&
+        typeof providerNamesData === 'object' &&
+        Array.isArray(providerNamesData.names)
+        ? providerNamesData.names
+        : [];
+    let providerId = providerNames.find((name) => typeof name === 'string' && name.length > 0);
+    if (!providerId &&
+        providersData &&
+        typeof providersData === 'object' &&
+        Array.isArray(providersData.providers)) {
+        const firstProvider = providersData.providers?.[0];
+        if (firstProvider && typeof firstProvider === 'object' && typeof firstProvider.id === 'string') {
+            providerId = firstProvider.id;
+        }
+    }
+    if (!providerId) {
+        throw new Error('comparevi-cli providers did not return any provider identifiers to validate.');
+    }
+    const providerData = runCli(dll, ['providers', '--name', providerId]);
+    validate(`comparevi-cli providers --name ${providerId}`, providerData, providerValidator);
     const metaData = readArtifactMeta();
     if (metaData) {
         const metaValidator = compileValidator('cli-artifact-meta', zodToJsonSchema(cliArtifactMetaSchema, { target: 'jsonSchema7', name: 'cli-artifact-meta' }));

--- a/docs/schema/generated/cli-provider-names.schema.json
+++ b/docs/schema/generated/cli-provider-names.schema.json
@@ -1,0 +1,35 @@
+{
+  "$ref": "#/definitions/cli-provider-names",
+  "definitions": {
+    "cli-provider-names": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "comparevi-cli/provider-names@v1"
+        },
+        "providerCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "names": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "schema",
+        "providerCount",
+        "names"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Sorted provider identifiers exposed by comparevi-cli providers --names-only.",
+  "$id": "urn:compare-vi-cli-action:schema:cli-provider-names"
+}

--- a/docs/schema/generated/cli-provider.schema.json
+++ b/docs/schema/generated/cli-provider.schema.json
@@ -1,0 +1,68 @@
+{
+  "$ref": "#/definitions/cli-provider",
+  "definitions": {
+    "cli-provider": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "comparevi-cli/provider@v1"
+        },
+        "providerId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "displayName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
+            "binary": {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "additionalProperties": true
+            },
+            "operations": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "schema",
+        "providerId",
+        "provider"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Single provider payload emitted by comparevi-cli providers --name <provider>.",
+  "$id": "urn:compare-vi-cli-action:schema:cli-provider"
+}

--- a/docs/schema/generated/cli-providers.schema.json
+++ b/docs/schema/generated/cli-providers.schema.json
@@ -1,0 +1,72 @@
+{
+  "$ref": "#/definitions/cli-providers",
+  "definitions": {
+    "cli-providers": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "comparevi-cli/providers@v1"
+        },
+        "providerCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "displayName": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "binary": {
+                "type": "object",
+                "properties": {
+                  "env": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "additionalProperties": true
+              },
+              "operations": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": true
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "schema",
+        "providerCount",
+        "providers"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Providers catalog exposed by comparevi-cli providers.",
+  "$id": "urn:compare-vi-cli-action:schema:cli-providers"
+}

--- a/tools/cli/validate-cli.ts
+++ b/tools/cli/validate-cli.ts
@@ -10,6 +10,9 @@ import {
   cliArtifactMetaSchema,
   cliOperationNamesSchema,
   cliOperationsSchema,
+  cliProviderNamesSchema,
+  cliProviderSchema,
+  cliProvidersSchema,
   cliQuoteSchema,
   cliProcsSchema,
   cliTokenizeSchema,
@@ -116,6 +119,21 @@ function main() {
     zodToJsonSchema(cliOperationNamesSchema, { target: 'jsonSchema7', name: 'cli-operation-names' }) as Record<string, unknown>,
   );
 
+  const providersValidator = compileValidator(
+    'cli-providers',
+    zodToJsonSchema(cliProvidersSchema, { target: 'jsonSchema7', name: 'cli-providers' }) as Record<string, unknown>,
+  );
+
+  const providerValidator = compileValidator(
+    'cli-provider',
+    zodToJsonSchema(cliProviderSchema, { target: 'jsonSchema7', name: 'cli-provider' }) as Record<string, unknown>,
+  );
+
+  const providerNamesValidator = compileValidator(
+    'cli-provider-names',
+    zodToJsonSchema(cliProviderNamesSchema, { target: 'jsonSchema7', name: 'cli-provider-names' }) as Record<string, unknown>,
+  );
+
   const versionData = runCli(dll, ['version']);
   validate('comparevi-cli version', versionData, versionValidator);
 
@@ -133,6 +151,38 @@ function main() {
 
   const operationsNamesData = runCli(dll, ['operations', '--names-only']);
   validate('comparevi-cli operations --names-only', operationsNamesData, operationNamesValidator);
+
+  const providersData = runCli(dll, ['providers']);
+  validate('comparevi-cli providers', providersData, providersValidator);
+
+  const providerNamesData = runCli(dll, ['providers', '--names-only']);
+  validate('comparevi-cli providers --names-only', providerNamesData, providerNamesValidator);
+
+  const providerNames =
+    providerNamesData &&
+    typeof providerNamesData === 'object' &&
+    Array.isArray((providerNamesData as { names?: unknown }).names)
+      ? ((providerNamesData as { names?: unknown[] }).names as unknown[])
+      : [];
+
+  let providerId = providerNames.find((name): name is string => typeof name === 'string' && name.length > 0);
+
+  if (!providerId &&
+      providersData &&
+      typeof providersData === 'object' &&
+      Array.isArray((providersData as { providers?: unknown }).providers)) {
+    const firstProvider = (providersData as { providers?: unknown[] }).providers?.[0];
+    if (firstProvider && typeof firstProvider === 'object' && typeof (firstProvider as { id?: unknown }).id === 'string') {
+      providerId = (firstProvider as { id: string }).id;
+    }
+  }
+
+  if (!providerId) {
+    throw new Error('comparevi-cli providers did not return any provider identifiers to validate.');
+  }
+
+  const providerData = runCli(dll, ['providers', '--name', providerId]);
+  validate(`comparevi-cli providers --name ${providerId}`, providerData, providerValidator);
 
   const metaData = readArtifactMeta();
   if (metaData) {

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -440,6 +440,67 @@ export const cliOperationNamesSchema = z
     }
   });
 
+const cliProviderBinarySchema = z
+  .object({
+    env: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
+
+const cliProviderSpecSchema = z
+  .object({
+    id: z.string().min(1),
+    displayName: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    binary: cliProviderBinarySchema.optional(),
+    operations: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
+
+export const cliProvidersSchema = z
+  .object({
+    schema: z.literal('comparevi-cli/providers@v1'),
+    providerCount: nonNegativeInteger,
+    providers: z.array(cliProviderSpecSchema).min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (value.providerCount !== value.providers.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'providerCount must equal providers.length',
+      });
+    }
+  });
+
+export const cliProviderSchema = z
+  .object({
+    schema: z.literal('comparevi-cli/provider@v1'),
+    providerId: z.string().min(1),
+    provider: cliProviderSpecSchema,
+  })
+  .superRefine((value, ctx) => {
+    if (value.providerId.localeCompare(value.provider.id, undefined, { sensitivity: 'accent' }) !== 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'providerId must match provider.id (case-insensitive)',
+      });
+    }
+  });
+
+export const cliProviderNamesSchema = z
+  .object({
+    schema: z.literal('comparevi-cli/provider-names@v1'),
+    providerCount: nonNegativeInteger,
+    names: z.array(z.string().min(1)).min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (value.providerCount !== value.names.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'providerCount must equal names.length',
+      });
+    }
+  });
+
 const cliArtifactFileSchema = z.object({
   path: z.string().min(1),
   sha256: hexSha256,
@@ -571,6 +632,24 @@ export const schemas = [
     fileName: 'cli-operation-names.schema.json',
     description: 'Sorted operation names exposed by comparevi-cli operations --names-only.',
     schema: cliOperationNamesSchema,
+  },
+  {
+    id: 'cli-providers',
+    fileName: 'cli-providers.schema.json',
+    description: 'Providers catalog exposed by comparevi-cli providers.',
+    schema: cliProvidersSchema,
+  },
+  {
+    id: 'cli-provider',
+    fileName: 'cli-provider.schema.json',
+    description: 'Single provider payload emitted by comparevi-cli providers --name <provider>.',
+    schema: cliProviderSchema,
+  },
+  {
+    id: 'cli-provider-names',
+    fileName: 'cli-provider-names.schema.json',
+    description: 'Sorted provider identifiers exposed by comparevi-cli providers --names-only.',
+    schema: cliProviderNamesSchema,
   },
   {
     id: 'cli-artifact-meta',


### PR DESCRIPTION
## Summary
- add Zod schemas for the CLI provider catalog payloads and publish JSON schema artifacts
- extend the CLI validation harness to cover `providers`, `providers --names-only`, and `providers --name`
- document the new CLI commands in the README

## Testing
- node tools/npm/run-script.mjs schemas:generate

------
https://chatgpt.com/codex/tasks/task_b_68f13707ed00832daf5803843099352e