### PR TITLE
Guard provider restore when saved provider unavailable (#127)

### DIFF
--- a/vscode/comparevi-helper/lib/providerSelection.js
+++ b/vscode/comparevi-helper/lib/providerSelection.js
@@ -1,0 +1,30 @@
+function pickInitialProviderId(savedProviderId, providersMeta, fallbackId) {
+  const defaultId = (typeof fallbackId === 'string' && fallbackId.trim().length)
+    ? fallbackId
+    : 'comparevi';
+  if (!savedProviderId || savedProviderId === defaultId) {
+    return { id: defaultId, fallbackReason: null };
+  }
+
+  const list = Array.isArray(providersMeta) ? providersMeta : [];
+  const match = list.find((meta) => meta && meta.id === savedProviderId);
+  if (!match) {
+    return { id: defaultId, fallbackReason: 'Provider not registered.' };
+  }
+
+  const disabled = !!match.disabled;
+  const status = match.status || {};
+  const statusOk = typeof status.ok === 'boolean' ? status.ok : !disabled;
+  if (disabled || statusOk === false) {
+    const message = (typeof status.message === 'string' && status.message.trim().length)
+      ? status.message.trim()
+      : (disabled ? 'Provider marked unavailable.' : 'Provider health check failed.');
+    return { id: defaultId, fallbackReason: message };
+  }
+
+  return { id: savedProviderId, fallbackReason: null };
+}
+
+module.exports = {
+  pickInitialProviderId
+};

--- a/vscode/comparevi-helper/test/unit/initial-provider.test.js
+++ b/vscode/comparevi-helper/test/unit/initial-provider.test.js
@@ -1,0 +1,35 @@
+const { pickInitialProviderId } = require('../../lib/providerSelection');
+
+describe('pickInitialProviderId', () => {
+  it('prefers saved provider when metadata reports availability', () => {
+    const meta = [
+      { id: 'comparevi', disabled: false },
+      { id: 'gcli', disabled: false, status: { ok: true } }
+    ];
+
+    const result = pickInitialProviderId('gcli', meta, 'comparevi');
+
+    expect(result).toEqual({ id: 'gcli', fallbackReason: null });
+  });
+
+  it('falls back to fallback provider when saved provider is disabled', () => {
+    const meta = [
+      { id: 'comparevi', disabled: false },
+      { id: 'gcli', disabled: true, status: { ok: false, message: 'missing binary' } }
+    ];
+
+    const result = pickInitialProviderId('gcli', meta, 'comparevi');
+
+    expect(result.id).toBe('comparevi');
+    expect(result.fallbackReason).toContain('missing binary');
+  });
+
+  it('falls back when saved provider is unknown', () => {
+    const meta = [{ id: 'comparevi', disabled: false }];
+
+    const result = pickInitialProviderId('ghost', meta, 'comparevi');
+
+    expect(result.id).toBe('comparevi');
+    expect(result.fallbackReason).toMatch(/not registered/i);
+  });
+});


### PR DESCRIPTION
## Summary
- fall back to the CompareVI provider during activation when the previously saved provider is unavailable
- reuse a shared helper for choosing the initial provider so availability checks stay centralized
- add unit coverage for the provider selection helper to prevent regressions

## Testing
- node tools/npm/run-script.mjs --prefix vscode/comparevi-helper test:unit

------
https://chatgpt.com/codex/tasks/task_b_68f1445a81b0832d991595c634d467ff