### PR TITLE
Update handoff snapshot after dispatcher recursion (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T19:19:36.942Z",
+  "cachedAtUtc": "2025-10-16T20:17:09.741Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",
@@ -12,5 +12,5 @@
   "commentCount": null,
   "bodyDigest": null,
   "lastFetchSource": "cache",
-  "lastFetchError": "Failed to fetch issue #134 via gh CLI (To get started with GitHub CLI, please run:  gh auth login\nAlternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.)"
+  "lastFetchError": "Failed to fetch issue #134 via gh CLI (HTTP 401: Bad credentials (https://api.github.com/graphql)\nTry authenticating with:  gh auth login)"
 }

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -1,63 +1,63 @@
 # Agent Handoff - Compare VI CLI Action
 
 ## Context Snapshot
-- Reinstalled GitHub CLI 2.45.0 via apt; the binary is available but still unauthenticated (`gh auth
-  status` continues to report "not logged in" without a `GH_TOKEN`). Fresh
-  `node tools/npm/run-script.mjs priority:sync` attempts therefore fall back to cached metadata for
-  issue #134 and emit the `gh auth login` guidance.
-- Added Microsoft's package feed, installed PowerShell 7.5.3, and manually staged Pester 5.5.0 by
-  unpacking the PSGallery `.nupkg` into `~/.local/share/powershell/Modules/Pester/5.5.0`. Importing the
-  module now succeeds and `Get-Module Pester` reports version 5.5.0.
-- Ran `pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900
-  -AppendToStepSummary`; no rogue LabVIEW/LVCompare processes were detected and a fresh batch of
-  `tests/results/_lvcompare_notice/notice-*.json` files was emitted.
-- Kicked off `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude` (logging to `/tmp/pester.log`).
-  The dispatcher launched successfully, but after ~10 minutes it began spawning nested `pwsh`
-  processes without producing `pester-summary.json`; the guard dropped
-  `tests/results/_diagnostics/guard.json` complaining that the results path resolved to a file. The
-  process tree was terminated to keep the workspace responsive.
-- Ran `node tools/npm/run-script.mjs priority:handoff-tests`; the quick regression bundle completed and
-  updated `tests/results/_agent/handoff/test-summary.json`.
-- Working tree remains on branch `work`; no commits have been created this session.
+- Installed PowerShell 7.5.0 from the upstream GitHub tarball (`/opt/microsoft/powershell/7/pwsh`) and
+  symlinked `/usr/bin/pwsh`.
+- Installed Pester 5.5.0 into `~/.local/share/powershell/Modules/Pester/5.5.0`; `Get-Module Pester` now
+  reports 5.5.0.
+- Downloaded GitHub CLI 2.45.0 to `/usr/local/bin/gh` (still unauthenticated).
+- `node tools/npm/run-script.mjs priority:sync` still falls back to cached #134 metadata because the REST
+  fallback returns HTTP 401 without credentials.
+- `pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900 -AppendToStepSummary`
+  reported no rogue LVCompare/LabVIEW processes and refreshed
+  `tests/results/_lvcompare_notice/notice-*.json`.
+- Attempted `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude` (logs in `/tmp/pester.log`); after
+  ~8 minutes the dispatcher spawned a runaway `pwsh` chain inside the IncludePatterns tests
+  (`Invoke-PesterTests.Patterns.Tests.ps1` kept relaunching the dispatcher). Terminated PID 5349 to stop the
+  recursion.
+- The guard dropped `tests/results/_diagnostics/guard.json` pointing to a temporary
+  `/tmp/.../blocked-results.txt` during the recursion attempt.
+- Working tree remains on branch `work`; no commits created yet.
 
 ## Status & Known Gaps
-1. GitHub CLI is present but unauthenticated; priority syncs still fail without a token, leaving
-   `.agent_priority_cache.json` on cached data.
-2. `Invoke-PesterTests.ps1 -IntegrationMode exclude` did not finish cleanly. The guard recorded
-   `tests/results/_diagnostics/guard.json` and no `pester-summary.json`/NUnit output was produced before
-   the run was terminated.
-3. The dispatcher watchdog left several defunct `pwsh` processes behind when interrupted. Fresh runs
-   should start from a clean shell and may need the diagnostics guard cleared.
-4. Issue/PR #134 still needs an update describing the restored toolchain, rogue sweep, and dispatcher
-   findings.
+1. GitHub CLI is present but unauthenticated, so `priority:sync` continues to rely on cached #134 data.
+2. Dispatcher run (`Invoke-PesterTests.ps1 -IntegrationMode exclude`) still has no clean completion because
+   the IncludePatterns test recursively spawns new dispatcher instances. `pester-summary.json`/NUnit output
+   were not produced.
+3. `/tmp/pester.log` plus `tests/results/_diagnostics/guard.json` document the recursion/guard failure and
+   should be cleared or relocated before the next dispatcher attempt.
+4. Issue/PR #134 still needs an update summarising the restored toolchain, rogue sweep, and the
+   dispatcher recursion findings.
 
 ## Suggested Next Actions
-1. Authenticate GitHub CLI (or export `GH_TOKEN`) and rerun `priority:sync` so the standing-priority
-   cache refreshes against live data.
-2. Investigate the dispatcher guard (see `tests/results/_diagnostics/guard.json` and `/tmp/pester.log`),
-   clear any stale artifacts, and rerun `Invoke-PesterTests.ps1 -IntegrationMode exclude` to completion.
-3. Capture the rerun’s summaries (JSON, XML, leak reports, watcher telemetry) and share the findings—
-   along with the restored toolchain status—in issue/PR #134.
-4. Maintain the rogue LV sweep cadence with `tools/Detect-RogueLV.ps1` and continue sourcing
-   platform-specific artifacts as needed.
-
-## First Actions for the Next Agent
-1. Provide GitHub credentials (`gh auth login` or `GH_TOKEN`) and verify `priority:sync` succeeds.
-2. Reset the dispatcher guard state, launch `Invoke-PesterTests.ps1 -IntegrationMode exclude`, and let
-   it complete so `tests/results/pester-summary.json` and related artifacts materialise.
-3. Post an update to issue/PR #134 covering the toolchain restoration, rogue sweep outcome, and
-   dispatcher rerun status.
-4. Continue the rogue LV sweep cadence (`tools/Detect-RogueLV.ps1`) now that PowerShell and Pester are
+1. Authenticate GitHub CLI (`gh auth login` or export `GH_TOKEN`) and rerun `priority:sync` so the standing
+   priority cache refreshes from live data.
+2. Investigate and patch the IncludePatterns recursion (likely in `Invoke-PesterTests.Patterns.Tests.ps1` or
+   dispatcher selection logic) so `Invoke-PesterTests.ps1 -IntegrationMode exclude` can finish without
+   runaway child `pwsh` processes.
+3. Once the recursion fix lands, rerun the dispatcher to completion and collect the usual artifacts
+   (`pester-summary.json`, NUnit XML, watcher telemetry, leaks report).
+4. Post a status update to issue/PR #134 covering the toolchain installs, rogue sweep outcome, and the
+   dispatcher recursion investigation.
+5. Continue the rogue LVCompare sweep cadence with `tools/Detect-RogueLV.ps1` now that PowerShell/Pester are
    available locally.
 
+## First Actions for the Next Agent
+1. Provide GitHub credentials and ensure `node tools/npm/run-script.mjs priority:sync` succeeds against live
+   GitHub data.
+2. Reproduce and resolve the IncludePatterns-driven recursion so the dispatcher completes a normal run.
+3. After the fix, execute `Invoke-PesterTests.ps1 -IntegrationMode exclude` to completion and capture its
+   results artifacts.
+4. Update issue/PR #134 with the toolchain status, rogue sweep confirmation, and dispatcher progress.
+
 ## Notes for Next Agent
-- `gh --version` reports 2.45.0, but `gh auth status` still prompts for `gh auth login`; the latest
-  `priority:sync` attempt failed with the same guidance.
-- PowerShell 7.5.3 lives at `/opt/microsoft/powershell/7/pwsh`; Pester 5.5.0 is unpacked under
-  `~/.local/share/powershell/Modules/Pester/5.5.0` and loads successfully.
-- Rogue sweep notices were written under `tests/results/_lvcompare_notice/` after the
-  `tools/Detect-RogueLV.ps1` run; no LVCompare/LabVIEW processes were detected.
-- The dispatcher guard left `tests/results/_diagnostics/guard.json` referencing a temporary
-  `blocked-results.txt`. Inspect `/tmp/pester.log` and the guard file before retrying the dispatcher.
-- `tests/results/_agent/handoff/watcher-telemetry.json` now records the watcher state (`stopped`) from
-  this session’s telemetry sweep.
+- PowerShell 7.5.0: `/opt/microsoft/powershell/7/pwsh` (symlinked at `/usr/bin/pwsh`).
+- Pester 5.5.0: `~/.local/share/powershell/Modules/Pester/5.5.0`.
+- GitHub CLI 2.45.0: `/usr/local/bin/gh` (requires `gh auth login` or `GH_TOKEN`).
+- Latest `priority:sync` ended with `Failed to fetch issue #134 via gh CLI (HTTP 401: Bad credentials
+  (https://api.github.com/graphql)...)`.
+- `Invoke-PesterTests.ps1 -IntegrationMode exclude` currently spins up nested `pwsh` processes via the
+  IncludePatterns tests; see `/tmp/pester.log` and `ps -ef --forest` for context. Guard crumb at
+  `tests/results/_diagnostics/guard.json` captures the failure path.
+- Rogue sweep ran at `2025-10-16T20:17:16Z`; notices live under `tests/results/_lvcompare_notice/` and no
+  rogue processes were detected.


### PR DESCRIPTION
## Summary
- refresh the handoff log with the latest tooling status, rogue sweep results, and dispatcher recursion notes
- record the new cached error emitted by the unauthenticated standing-priority sync attempt

## Testing
- ❌ `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude` *(terminated after runaway nested pwsh processes triggered by the IncludePatterns tests)*

------
https://chatgpt.com/codex/tasks/task_b_68f1512ee37c832d92571c6e169d699a