### PR TITLE
Prune unused dispatcher helper functions (#127)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -2,7 +2,7 @@
   "number": 134,
   "title": "Standing priority: evolve CompareVI helper into N-provider CLI companion",
   "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/134",
-  "cachedAtUtc": "2025-10-16T20:17:09.741Z",
+  "cachedAtUtc": "2025-10-16T21:11:04.820Z",
   "state": "OPEN",
   "lastSeenUpdatedAt": "2025-10-15T18:04:17Z",
   "issueDigest": "310ba3b99f6a2a5f9797def48303864d1859c7d1e77011fbe5bdf7cb233b1611",
@@ -12,5 +12,5 @@
   "commentCount": null,
   "bodyDigest": null,
   "lastFetchSource": "cache",
-  "lastFetchError": "Failed to fetch issue #134 via gh CLI (HTTP 401: Bad credentials (https://api.github.com/graphql)\nTry authenticating with:  gh auth login)"
+  "lastFetchError": "Failed to fetch issue #134 via gh CLI (gh CLI not found)"
 }

--- a/tests/Invoke-PesterTests.Patterns.Tests.ps1
+++ b/tests/Invoke-PesterTests.Patterns.Tests.ps1
@@ -1,31 +1,59 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
 Describe 'Invoke-PesterTests Include/Exclude patterns' -Tag 'Unit' {
   BeforeAll {
     $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
     $script:dispatcher = Join-Path $repoRoot 'Invoke-PesterTests.ps1'
+    $script:fixtureTestsRoot = Join-Path $TestDrive 'fixture-tests'
+    New-Item -ItemType Directory -Force -Path $script:fixtureTestsRoot | Out-Null
+
+    Import-Module (Join-Path $repoRoot 'tests' '_helpers' 'DispatcherTestHelper.psm1') -Force
+
+    $testTemplate = @'
+Describe "{0}" {{
+  It "passes" {{
+    1 | Should -Be 1
+  }}
+}}
+'@
+
+    foreach ($name in @('Alpha.Unit.Tests.ps1', 'Beta.Unit.Tests.ps1', 'Gamma.Helper.ps1')) {
+      $content = [string]::Format($testTemplate, $name)
+      Set-Content -LiteralPath (Join-Path $script:fixtureTestsRoot $name) -Value $content -Encoding utf8
+    }
   }
 
   It 'honors IncludePatterns for a single file' {
     $resultsDir = Join-Path $TestDrive 'results-inc'
-    $inc = @('Invoke-PesterTests.*.ps1')
-    pwsh -File $script:dispatcher -TestsPath (Join-Path $repoRoot 'tests') -ResultsPath $resultsDir -IncludePatterns $inc -IntegrationMode exclude | Out-Null
+    $inc = 'Alpha*.ps1'
+    $res = Invoke-DispatcherSafe -DispatcherPath $script:dispatcher -ResultsPath $resultsDir -IncludePatterns $inc -TestsPath $script:fixtureTestsRoot -AdditionalArgs @('-IntegrationMode', 'exclude')
+    $res.TimedOut | Should -BeFalse
+    $res.ExitCode | Should -Be 0
+    $res.StdErr.Trim() | Should -BeNullOrEmpty
     $sel = Join-Path $resultsDir 'pester-selected-files.txt'
     Test-Path $sel | Should -BeTrue
     $lines = @(Get-Content -LiteralPath $sel)
-    ($lines.Count -ge 1) | Should -BeTrue
-    $allMatch = $true
-    foreach ($l in $lines) { if (-not ($l -like '*Invoke-PesterTests.*.ps1')) { $allMatch = $false; break } }
-    $allMatch | Should -BeTrue
+    $lines.Count | Should -Be 1
+    $leafs = $lines | ForEach-Object { Split-Path -Leaf $_ }
+    $leafs | Should -Be @('Alpha.Unit.Tests.ps1')
+    $res.StdOut | Should -Match ([regex]::Escape($script:fixtureTestsRoot))
   }
 
   It 'honors ExcludePatterns to remove files' {
     $resultsDir = Join-Path $TestDrive 'results-exc'
-    $exc = @('PesterSummary.*.ps1')
-    pwsh -File $script:dispatcher -TestsPath (Join-Path $repoRoot 'tests') -ResultsPath $resultsDir -ExcludePatterns $exc -IntegrationMode exclude | Out-Null
+    $exc = '*Helper.ps1'
+    $res = Invoke-DispatcherSafe -DispatcherPath $script:dispatcher -ResultsPath $resultsDir -TestsPath $script:fixtureTestsRoot -AdditionalArgs @('-ExcludePatterns', $exc, '-IntegrationMode', 'exclude')
+    $res.TimedOut | Should -BeFalse
+    $res.ExitCode | Should -Be 0
+    $res.StdErr.Trim() | Should -BeNullOrEmpty
     $sel = Join-Path $resultsDir 'pester-selected-files.txt'
     Test-Path $sel | Should -BeTrue
     $lines = @(Get-Content -LiteralPath $sel)
-    $noneExcluded = $true
-    foreach ($l in $lines) { if ($l -like '*PesterSummary.*.ps1') { $noneExcluded = $false; break } }
-    $noneExcluded | Should -BeTrue
+    $lines.Count | Should -Be 2
+    $leafs = $lines | ForEach-Object { Split-Path -Leaf $_ }
+    $leafs | Should -Not -Contain 'Gamma.Helper.ps1'
+    ($leafs | Sort-Object) | Should -Be @('Alpha.Unit.Tests.ps1', 'Beta.Unit.Tests.ps1')
+    $res.StdOut | Should -Match ([regex]::Escape($script:fixtureTestsRoot))
   }
 }


### PR DESCRIPTION
## Summary
- remove the unused pwsh baseline helper functions now that Invoke-DispatcherSafe performs targeted child cleanup

## Testing
- pwsh -NoLogo -Command "Import-Module Pester; Invoke-Pester -Script tests/Invoke-PesterTests.Patterns.Tests.ps1 -Output Detailed" *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_b_68f15bf3f11c832d9f4cb5e76424710c