### PR TITLE
Export dispatcher helper Get-PwshExePath (#127)

### DIFF
--- a/tests/_helpers/DispatcherTestHelper.psm1
+++ b/tests/_helpers/DispatcherTestHelper.psm1
@@ -160,4 +160,4 @@ function Invoke-DispatcherSafe {
   }
 }
 
-Export-ModuleMember -Function Invoke-DispatcherSafe
+Export-ModuleMember -Function Get-PwshExePath, Invoke-DispatcherSafe


### PR DESCRIPTION
## Summary
- export `Get-PwshExePath` from `DispatcherTestHelper.psm1` so dispatcher-pattern tests can locate the pwsh executable during local runs

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/Invoke-PesterTests.Patterns.Tests.ps1' -Output Detailed"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/Invoke-PesterTests.ErrorHandling.FileGuard.Tests.ps1','tests/Invoke-PesterTests.ErrorHandling.DirectoryGuard.Tests.ps1' -Output Detailed"` *(fails on Linux because the directory-guard test exercises Windows-only principal APIs)*

------
https://chatgpt.com/codex/tasks/task_b_68f17aa4301c832d9090fa1c2a42f148