### PR TITLE
Fix LVCompare canonical path resolution (#127)

### DIFF
--- a/scripts/Generate-PullRequestCompareReport.ps1
+++ b/scripts/Generate-PullRequestCompareReport.ps1
@@ -23,9 +23,9 @@
 )
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$canonical = 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompare.exe'
-if (-not (Test-Path -LiteralPath $canonical -PathType Leaf)) { throw "LVCompare not found at canonical path: $canonical" }
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+Import-Module (Join-Path $repoRoot 'scripts' 'CompareVI.psm1') -Force
+$canonical = Resolve-Cli
 
 # Resolve base/head input paths if provided, else default to repo-root VI1/VI2
 if ($BasePath) {
@@ -43,8 +43,6 @@ foreach ($p in @($baseVi,$headVi)) {
   $len = (Get-Item -LiteralPath $p).Length
   if ($len -lt 1024) { Write-Warning "VI file $p is unusually small ($len bytes) – ensure this is a real LabVIEW .vi binary." }
 }
-Import-Module (Join-Path $repoRoot 'scripts' 'CompareVI.psm1') -Force
-
 New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 
 if ($LoopMode) {

--- a/tools/RunnerInvoker/RunnerInvoker.psm1
+++ b/tools/RunnerInvoker/RunnerInvoker.psm1
@@ -1,5 +1,6 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+Import-Module (Join-Path (Split-Path -Parent $PSScriptRoot) 'VendorTools.psm1') -Force
 
 function Write-JsonFile([string]$Path, [object]$Obj) {
   $dir = Split-Path -Path $Path -Parent
@@ -267,7 +268,9 @@ function Start-InvokerLoop {
               $headPath = [string]$reqArgs['head']
               if ([string]::IsNullOrWhiteSpace($basePath) -or -not (Test-Path -LiteralPath $basePath)) { throw "preview base path not found: $basePath" }
               if ([string]::IsNullOrWhiteSpace($headPath) -or -not (Test-Path -LiteralPath $headPath)) { throw "preview head path not found: $headPath" }
-              $resolvedCli = 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompare.exe'
+              $resolvedCli = $null
+              try { $resolvedCli = Resolve-LVComparePath } catch {}
+              if (-not $resolvedCli) { $resolvedCli = 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompare.exe' }
               $resolvedBase = (Resolve-Path -LiteralPath $basePath).Path
               $resolvedHead = (Resolve-Path -LiteralPath $headPath).Path
               $command = '"{0}" "{1}" "{2}"' -f $resolvedCli,($resolvedBase -replace '"','\"'),($resolvedHead -replace '"','\"')


### PR DESCRIPTION
## Summary
- use the shared VendorTools resolver in CompareLoop and CompareVI so canonical LVCompare detection works for Program Files and Program Files (x86)
- update CompareVI entry points (PR report generator, runner invoker, integration environment check) to rely on the resolver output
- refresh the CompareVI unit tests to cover the new canonical candidate handling

## Testing
- not run (pwsh unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68f1817d76f4832d8d44628c1c2b8c8d