### PR TITLE
Redirect punycode loads to userland implementation (#127)

### DIFF
--- a/dist/src/env/derive-env.js
+++ b/dist/src/env/derive-env.js
@@ -1,3 +1,4 @@
+import '../../tools/bootstrap/node-deprecations.js';
 import { randomUUID } from 'node:crypto';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';

--- a/dist/src/session-index/cli.js
+++ b/dist/src/session-index/cli.js
@@ -1,3 +1,4 @@
+import '../../tools/bootstrap/node-deprecations.js';
 import { ArgumentParser } from 'argparse';
 import { writeFileSync } from 'node:fs';
 import { createSessionIndexBuilder } from './builder.js';

--- a/dist/tools/actions/normalize-command.js
+++ b/dist/tools/actions/normalize-command.js
@@ -1,4 +1,4 @@
-"use strict";
+import '../bootstrap/node-deprecations.js';
 // Minimal JS/TS action without external deps.
 // Reads INPUT_BODY, writes multi-line 'comment' and single-line 'target' to GITHUB_OUTPUT.
 function getEnv(name) {

--- a/dist/tools/actions/parse-orchestrated.js
+++ b/dist/tools/actions/parse-orchestrated.js
@@ -1,3 +1,4 @@
+import '../bootstrap/node-deprecations.js';
 function getEnv(name) {
     return process.env[name];
 }
@@ -139,4 +140,3 @@ catch (err) {
     process.stderr.write(`parse-orchestrated error: ${msg}\n`);
     process.exit(1);
 }
-export {};

--- a/dist/tools/bootstrap/node-deprecations.js
+++ b/dist/tools/bootstrap/node-deprecations.js
@@ -1,0 +1,34 @@
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+const globalKey = Symbol.for('comparevi.node.punycodePatched');
+if (!globalThis[globalKey]) {
+    const moduleWithLoad = Module;
+    const originalLoad = moduleWithLoad._load;
+    if (typeof originalLoad === 'function') {
+        const require = createRequire(import.meta.url);
+        let replacement = null;
+        try {
+            // Prefer the package that mirrors Node's legacy API while avoiding the builtin.
+            require.resolve('punycode/');
+            replacement = 'punycode/';
+        }
+        catch {
+            try {
+                require.resolve('punycode.js');
+                replacement = 'punycode.js';
+            }
+            catch {
+                replacement = null;
+            }
+        }
+        if (replacement) {
+            moduleWithLoad._load = function patchedLoad(request, parent, isMain) {
+                if (request === 'punycode') {
+                    request = replacement;
+                }
+                return originalLoad.call(this, request, parent, isMain);
+            };
+        }
+    }
+    globalThis[globalKey] = true;
+}

--- a/dist/tools/cli/validate-cli.js
+++ b/dist/tools/cli/validate-cli.js
@@ -1,3 +1,4 @@
+import '../bootstrap/node-deprecations.js';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/dist/tools/generate-action-outputs.js
+++ b/dist/tools/generate-action-outputs.js
@@ -1,3 +1,4 @@
+import './bootstrap/node-deprecations.js';
 import { readFileSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import yaml from 'js-yaml';

--- a/dist/tools/schemas/generate-schemas.js
+++ b/dist/tools/schemas/generate-schemas.js
@@ -1,3 +1,4 @@
+import '../bootstrap/node-deprecations.js';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { zodToJsonSchema } from 'zod-to-json-schema';

--- a/dist/tools/schemas/validate-json.js
+++ b/dist/tools/schemas/validate-json.js
@@ -1,3 +1,4 @@
+import '../bootstrap/node-deprecations.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ArgumentParser } from 'argparse';

--- a/dist/tools/test-discovery.js
+++ b/dist/tools/test-discovery.js
@@ -4,6 +4,7 @@
   - Marks a file as Integration if it contains -Tag 'Integration' (loose match)
   - Emits a manifest JSON used by the dispatcher to pre-exclude Integration tests
 */
+import './bootstrap/node-deprecations.js';
 import fs from 'fs';
 import path from 'path';
 function walk(dir, acc = []) {

--- a/dist/tools/watchers/orchestrated-watch.js
+++ b/dist/tools/watchers/orchestrated-watch.js
@@ -1,3 +1,4 @@
+import '../bootstrap/node-deprecations.js';
 import { execSync } from 'node:child_process';
 import { ArgumentParser } from 'argparse';
 import { setTimeout as sleep } from 'node:timers/promises';

--- a/src/env/derive-env.ts
+++ b/src/env/derive-env.ts
@@ -1,3 +1,5 @@
+import '../../tools/bootstrap/node-deprecations.js';
+
 import { randomUUID } from 'node:crypto';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';

--- a/src/session-index/cli.ts
+++ b/src/session-index/cli.ts
@@ -1,3 +1,5 @@
+import '../../tools/bootstrap/node-deprecations.js';
+
 import { ArgumentParser } from 'argparse';
 import { writeFileSync } from 'node:fs';
 import { createSessionIndexBuilder } from './builder.js';

--- a/tools/actions/normalize-command.ts
+++ b/tools/actions/normalize-command.ts
@@ -1,3 +1,5 @@
+import '../bootstrap/node-deprecations.js';
+
 // Minimal JS/TS action without external deps.
 // Reads INPUT_BODY, writes multi-line 'comment' and single-line 'target' to GITHUB_OUTPUT.
 

--- a/tools/actions/parse-orchestrated.ts
+++ b/tools/actions/parse-orchestrated.ts
@@ -1,3 +1,5 @@
+import '../bootstrap/node-deprecations.js';
+
 export {}
 
 function getEnv(name: string): string | undefined {

--- a/tools/bootstrap/node-deprecations.ts
+++ b/tools/bootstrap/node-deprecations.ts
@@ -1,0 +1,46 @@
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+
+type ModuleLoader = (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+
+type ModuleWithLoad = typeof Module & {
+  _load?: ModuleLoader;
+};
+
+declare const globalThis: typeof global & {
+  [key: symbol]: unknown;
+};
+
+const globalKey = Symbol.for('comparevi.node.punycodePatched');
+
+if (!globalThis[globalKey]) {
+  const moduleWithLoad = Module as ModuleWithLoad;
+  const originalLoad = moduleWithLoad._load;
+  if (typeof originalLoad === 'function') {
+    const require = createRequire(import.meta.url);
+    let replacement: string | null = null;
+    try {
+      // Prefer the package that mirrors Node's legacy API while avoiding the builtin.
+      require.resolve('punycode/');
+      replacement = 'punycode/';
+    } catch {
+      try {
+        require.resolve('punycode.js');
+        replacement = 'punycode.js';
+      } catch {
+        replacement = null;
+      }
+    }
+
+    if (replacement) {
+      moduleWithLoad._load = function patchedLoad(request, parent, isMain) {
+        if (request === 'punycode') {
+          request = replacement;
+        }
+        return originalLoad.call(this, request, parent, isMain);
+      };
+    }
+  }
+
+  globalThis[globalKey] = true;
+}

--- a/tools/cli/validate-cli.ts
+++ b/tools/cli/validate-cli.ts
@@ -1,3 +1,5 @@
+import '../bootstrap/node-deprecations.js';
+
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/tools/generate-action-outputs.ts
+++ b/tools/generate-action-outputs.ts
@@ -1,3 +1,5 @@
+import './bootstrap/node-deprecations.js';
+
 import { readFileSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import yaml from 'js-yaml';

--- a/tools/schemas/generate-schemas.ts
+++ b/tools/schemas/generate-schemas.ts
@@ -1,3 +1,5 @@
+import '../bootstrap/node-deprecations.js';
+
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { zodToJsonSchema } from 'zod-to-json-schema';

--- a/tools/schemas/validate-json.ts
+++ b/tools/schemas/validate-json.ts
@@ -1,3 +1,5 @@
+import '../bootstrap/node-deprecations.js';
+
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ArgumentParser } from 'argparse';

--- a/tools/test-discovery.ts
+++ b/tools/test-discovery.ts
@@ -5,6 +5,8 @@
   - Emits a manifest JSON used by the dispatcher to pre-exclude Integration tests
 */
 
+import './bootstrap/node-deprecations.js';
+
 import fs from 'fs';
 import path from 'path';
 

--- a/tools/watchers/orchestrated-watch.ts
+++ b/tools/watchers/orchestrated-watch.ts
@@ -1,3 +1,5 @@
+import '../bootstrap/node-deprecations.js';
+
 import { execSync } from 'node:child_process';
 import { ArgumentParser } from 'argparse';
 import { setTimeout as sleep } from 'node:timers/promises';


### PR DESCRIPTION
## Summary
- add a bootstrap shim that redirects `require('punycode')` to the packaged replacement
- load the shim from each Node-based entry point so the deprecated core module is never used

## Testing
- node tools/npm/run-script.mjs build
- NODE_OPTIONS=--trace-deprecation node -e "import('./dist/tools/bootstrap/node-deprecations.js').then(() => { require('punycode'); console.log('patched'); })"


------
https://chatgpt.com/codex/tasks/task_b_68f18b558738832dab256ddd930e7103