### PR TITLE
Fix punycode deprecation in Ajv tooling (#127)

### DIFF
--- a/dist/tools/cli/validate-cli.js
+++ b/dist/tools/cli/validate-cli.js
@@ -1,3 +1,4 @@
+import '../shims/punycode-userland.js';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/dist/tools/schemas/validate-json.js
+++ b/dist/tools/schemas/validate-json.js
@@ -1,3 +1,4 @@
+import '../shims/punycode-userland.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ArgumentParser } from 'argparse';

--- a/dist/tools/shims/punycode-userland.js
+++ b/dist/tools/shims/punycode-userland.js
@@ -1,0 +1,15 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const Module = require('module');
+const marker = Symbol.for('compare-vi-cli-action.punycode-userland');
+const globalRegistry = globalThis;
+if (!globalRegistry[marker]) {
+    const originalLoad = Module._load;
+    Module._load = function patchedLoad(request, parent, isMain) {
+        if (request === 'punycode') {
+            request = 'punycode/';
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+    globalRegistry[marker] = true;
+}

--- a/tools/cli/validate-cli.ts
+++ b/tools/cli/validate-cli.ts
@@ -1,3 +1,4 @@
+import '../shims/punycode-userland.js';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/tools/hooks/core/validate-summaries.mjs
+++ b/tools/hooks/core/validate-summaries.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import '../../shims/punycode-userland.mjs';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import Ajv from 'ajv';

--- a/tools/priority/__tests__/handoff-schema.test.mjs
+++ b/tools/priority/__tests__/handoff-schema.test.mjs
@@ -1,3 +1,4 @@
+import '../../shims/punycode-userland.mjs';
 import test from 'node:test';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/tools/schemas/validate-json.ts
+++ b/tools/schemas/validate-json.ts
@@ -1,3 +1,4 @@
+import '../shims/punycode-userland.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ArgumentParser } from 'argparse';

--- a/tools/shims/punycode-userland.mjs
+++ b/tools/shims/punycode-userland.mjs
@@ -1,0 +1,18 @@
+import Module from 'node:module';
+
+const marker = Symbol.for('compare-vi-cli-action.punycode-userland');
+const registry = /** @type {Record<symbol, boolean>} */ (globalThis);
+
+if (!registry[marker]) {
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'punycode') {
+      request = 'punycode/';
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  registry[marker] = true;
+}

--- a/tools/shims/punycode-userland.ts
+++ b/tools/shims/punycode-userland.ts
@@ -1,0 +1,25 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+type LoadFunction = (request: string, parent: NodeModule | null | undefined, isMain: boolean) => unknown;
+
+const Module = require('module') as typeof import('module') & { _load: LoadFunction };
+const marker = Symbol.for('compare-vi-cli-action.punycode-userland');
+
+const globalRegistry = globalThis as Record<symbol, unknown>;
+
+if (!globalRegistry[marker]) {
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request: string, parent: NodeModule | null | undefined, isMain: boolean) {
+    if (request === 'punycode') {
+      request = 'punycode/';
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  globalRegistry[marker] = true;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a loader shim that redirects `punycode` requests to the userland package so Ajv avoids Node's deprecation warning
- import the shim across the schema validation utilities and tests that rely on Ajv formats

## Testing
- node --trace-deprecation --test tools/priority/__tests__/handoff-schema.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68f18b558738832dab256ddd930e7103