### PR TITLE
Add TestStand harness loop option (#127)

### DIFF
--- a/docs/TESTSTAND_INTEGRATION_PLAN.md
+++ b/docs/TESTSTAND_INTEGRATION_PLAN.md
@@ -58,6 +58,7 @@ outputs change.
 | `node tools/npm/run-script.mjs tests:discover` | Ensure the TypeScript manifest is current before mapping tests to harness inputs. |
 | `pwsh -File tools/TestStand-CompareHarness.ps1 ...` | Baseline manual smoke. |
 | `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude -UseTestStandHarness -UseDiscoveryManifest` | End-to-end local run that mirrors CI. |
+| `pwsh -File scripts/Run-AutonomousIntegrationLoop.ps1 -UseTestStandHarness -TestStandHarnessPath ./tools/TestStand-CompareHarness.ps1 -TestStandOutputRoot tests/results/teststand-loop` | Start a continuous integration loop that reuses the TestStand harness for each iteration (producing per-iteration session folders and loop telemetry). |
 | `pwsh -File tools/Quick-DispatcherSmoke.ps1 -Keep` | Verify workflow helpers accept the harness outputs. |
 
 ### 1.5 Acceptance delta guardrails

--- a/tests/Run-AutonomousIntegrationLoop.Tests.ps1
+++ b/tests/Run-AutonomousIntegrationLoop.Tests.ps1
@@ -67,3 +67,88 @@ exit `$LASTEXITCODE
     $json.succeeded | Should -BeTrue
   }
 }
+
+Describe 'Run-AutonomousIntegrationLoop TestStand harness mode' -Tag 'Unit' {
+  It 'invokes the TestStand harness for each iteration with expected parameters' {
+    $here = Split-Path -Parent $PSCommandPath
+    $repoRoot = Resolve-Path (Join-Path $here '..')
+    $scriptPath = Join-Path $repoRoot 'scripts' 'Run-AutonomousIntegrationLoop.ps1'
+    $outDir = Join-Path $TestDrive 'loop-harness'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+    $base = Join-Path $outDir 'BaseHarness.vi'
+    $head = Join-Path $outDir 'HeadHarness.vi'
+    New-Item -ItemType File -Path $base -Force | Out-Null
+    New-Item -ItemType File -Path $head -Force | Out-Null
+
+    $harnessStub = Join-Path $outDir 'TestStand-CompareHarness.ps1'
+    $logPath = Join-Path $outDir 'harness-log.ndjson'
+    $outputRoot = Join-Path $outDir 'outputs'
+    $stubContent = @"
+param(
+  [string]`$BaseVi,
+  [string]`$HeadVi,
+  [Alias('LabVIEWPath')][string]`$LabVIEWExePath,
+  [Alias('LVCompareExePath')][string]`$LVComparePath,
+  [string]`$OutputRoot,
+  [ValidateSet('detect','spawn','skip')][string]`$Warmup,
+  [string[]]`$Flags,
+  [switch]`$RenderReport,
+  [switch]`$CloseLabVIEW,
+  [switch]`$CloseLVCompare,
+  [int]`$TimeoutSeconds,
+  [switch]`$DisableTimeout,
+  [switch]`$ReplaceFlags
+)
+$log = `$env:HARNESS_LOG
+if (-not $log) { $log = Join-Path (Split-Path `$OutputRoot -Parent) 'harness-log.ndjson' }
+$logDir = Split-Path -Parent $log
+if ($logDir -and -not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+$payload = [ordered]@{
+  base = `$BaseVi
+  head = `$HeadVi
+  output = `$OutputRoot
+  warmup = `$Warmup
+  flags = @($Flags)
+  renderReport = `$RenderReport.IsPresent
+  closeLabVIEW = `$CloseLabVIEW.IsPresent
+  closeLVCompare = `$CloseLVCompare.IsPresent
+  timeout = `$TimeoutSeconds
+  disableTimeout = `$DisableTimeout.IsPresent
+  replaceFlags = `$ReplaceFlags.IsPresent
+}
+($payload | ConvertTo-Json -Compress) | Add-Content -Path $log
+if ($env:HARNESS_EXIT_CODE) { exit [int]$env:HARNESS_EXIT_CODE }
+exit 0
+"@
+    Set-Content -LiteralPath $harnessStub -Encoding UTF8 -Value $stubContent
+
+    $env:HARNESS_LOG = $logPath
+    try {
+      $runner = Join-Path $outDir 'runner-harness.ps1'
+      $runnerContent = @"
+& '$scriptPath' -Base '$base' -Head '$head' -MaxIterations 2 -IntervalSeconds 0 -LogVerbosity Quiet -LvCompareArgs '-foo 1 -bar' -UseTestStandHarness -TestStandHarnessPath '$harnessStub' -TestStandOutputRoot '$outputRoot' -TestStandWarmup detect -TestStandRenderReport -TestStandCloseLabVIEW -TestStandCloseLVCompare -TestStandTimeoutSeconds 45 -TestStandReplaceFlags -FinalStatusJsonPath '$outDir/final.json'
+exit `$LASTEXITCODE
+"@
+      Set-Content -LiteralPath $runner -Encoding UTF8 -Value $runnerContent
+
+      pwsh -NoLogo -NoProfile -File $runner | Out-Null
+      $LASTEXITCODE | Should -Be 0
+
+      Test-Path -LiteralPath $logPath | Should -BeTrue
+      $entries = Get-Content -LiteralPath $logPath | ForEach-Object { $_ | ConvertFrom-Json }
+      $entries.Count | Should -Be 2
+      $entries[0].output | Should -Match 'iteration-0001$'
+      $entries[1].output | Should -Match 'iteration-0002$'
+      $entries | ForEach-Object { $_.warmup } | Sort-Object -Unique | Should -Be @('detect')
+      $entries | ForEach-Object { $_.renderReport } | Sort-Object -Unique | Should -Be @($true)
+      $entries | ForEach-Object { $_.closeLabVIEW } | Sort-Object -Unique | Should -Be @($true)
+      $entries | ForEach-Object { $_.closeLVCompare } | Sort-Object -Unique | Should -Be @($true)
+      $entries | ForEach-Object { [int]$_.timeout } | Sort-Object -Unique | Should -Be @(45)
+      $entries | ForEach-Object { $_.replaceFlags } | Sort-Object -Unique | Should -Be @($true)
+      $entries | ForEach-Object { $_.flags } | ForEach-Object { $_ } | Sort-Object -Unique | Should -Be @('-bar','-foo','1')
+    }
+    finally {
+      Remove-Item Env:HARNESS_LOG -ErrorAction SilentlyContinue
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend `Run-AutonomousIntegrationLoop.ps1` with a TestStand harness execution mode and supporting parameters so the loop can reuse the TestStand compare harness each iteration
- add a stub-backed Pester test that verifies the loop forwards parameters to the harness and emits iteration-specific outputs
- document the new harness-driven loop entry point in the TestStand integration plan

## Testing
- `pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/Run-AutonomousIntegrationLoop.Tests.ps1 -ResultsPath tests/results` *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f1911f23ec832d9c69214ac588d6c0