### PR TITLE
Ensure IncludePatterns restricts dispatcher run path (#127)

### DIFF
--- a/tests/Invoke-PesterTests.Patterns.Tests.ps1
+++ b/tests/Invoke-PesterTests.Patterns.Tests.ps1
@@ -66,6 +66,12 @@ Describe "{0}" {{
     $leafs | Should -Be @('Alpha.Unit.Tests.ps1')
     $res.StdOut | Should -Not -Match 'Single-invoker mode'
     $res.StdOut | Should -Match ([regex]::Escape($script:fixtureTestsRoot))
+    $xmlPath = Join-Path $resultsDir 'pester-results.xml'
+    Test-Path $xmlPath | Should -BeTrue
+    $xmlText = Get-Content -LiteralPath $xmlPath -Raw
+    $xmlText | Should -Match 'Alpha\.Unit\.Tests\.ps1'
+    $xmlText | Should -Not -Match 'Beta\.Unit\.Tests\.ps1'
+    $xmlText | Should -Not -Match 'Gamma\.Helper\.ps1'
   }
 
   It 'honors ExcludePatterns to remove files' {
@@ -98,5 +104,11 @@ Describe "{0}" {{
     ($leafs | Sort-Object) | Should -Be @('Alpha.Unit.Tests.ps1', 'Beta.Unit.Tests.ps1')
     $res.StdOut | Should -Not -Match 'Single-invoker mode'
     $res.StdOut | Should -Match ([regex]::Escape($script:fixtureTestsRoot))
+    $xmlPath = Join-Path $resultsDir 'pester-results.xml'
+    Test-Path $xmlPath | Should -BeTrue
+    $xmlText = Get-Content -LiteralPath $xmlPath -Raw
+    $xmlText | Should -Match 'Alpha\.Unit\.Tests\.ps1'
+    $xmlText | Should -Match 'Beta\.Unit\.Tests\.ps1'
+    $xmlText | Should -Not -Match 'Gamma\.Helper\.ps1'
   }
 }


### PR DESCRIPTION
## Summary
- ensure Invoke-PesterTests.ps1 switches to an explicit test file list whenever IncludePatterns/ExcludePatterns filtering or MaxTestFiles trimming changes the discovered set so nested dispatcher runs no longer recurse through the full suite
- extend Invoke-PesterTests.Patterns unit coverage to verify the emitted NUnit results only contain the files kept by include/exclude filtering

## Testing
- not run (pwsh is unavailable in this container)


------
https://chatgpt.com/codex/tasks/task_b_68f1974c53cc832da66dc860ead9a93b