### PR TITLE
Add release readiness investigation summary (#127)

### DIFF
--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -28,6 +28,8 @@
    should be cleared or relocated before the next dispatcher attempt.
 4. Issue/PR #134 still needs an update summarising the restored toolchain, rogue sweep, and the
    dispatcher recursion findings.
+5. Release readiness status remains uncertain; see `docs/RELEASE_READINESS_v0.5.0.md` for a consolidated
+   view of failing/blocked gates (dispatcher failures, CLI provider errors, unchecked Validate items).
 
 ## Suggested Next Actions
 1. Authenticate GitHub CLI (`gh auth login` or export `GH_TOKEN`) and rerun `priority:sync` so the standing
@@ -41,6 +43,8 @@
    dispatcher recursion investigation.
 5. Continue the rogue LVCompare sweep cadence with `tools/Detect-RogueLV.ps1` now that PowerShell/Pester are
    available locally.
+6. Work through the follow-ups captured in `docs/RELEASE_READINESS_v0.5.0.md` once the dispatcher recursion
+   is resolved to bring the release checklist back to green.
 
 ## First Actions for the Next Agent
 1. Provide GitHub credentials and ensure `node tools/npm/run-script.mjs priority:sync` succeeds against live

--- a/docs/RELEASE_READINESS_v0.5.0.md
+++ b/docs/RELEASE_READINESS_v0.5.0.md
@@ -1,0 +1,28 @@
+# Release Readiness Investigation (v0.5.0)
+
+## Checklist status
+
+| Checklist item | Status | Notes |
+| --- | --- | --- |
+| Pester (windows-latest) | ⚠️ At risk | Latest Windows XML shows the targeted Run-AutonomousIntegrationLoop tests passing, but the full dispatcher log from a broader run reports two failures in the same suite, so the unit surface still needs attention before release. |
+| Pester self-hosted (IntegrationMode include) | ❌ Blocked | Dispatcher attempt recurses endlessly through the IncludePatterns tests, preventing completion and leaving no artifacts to verify. |
+| Fixture Drift (Windows/Ubuntu) | ✅ Passing | Current and baseline fixture validation JSON reports show no missing/untracked fixtures or size mismatches. |
+| Validate workflow (actionlint, docs links) | ⚠️ Not verified | Release checklist items for Validate remain unchecked, so the status is still unconfirmed. |
+| LabVIEW/LVCompare guard | ❌ Blocked | Latest TestStand session index records a CLI compare failure because no provider can service `CreateComparisonReport`, so no clean guard confirmation exists. |
+
+## Key findings
+
+- The hosted Windows NUnit export indicates the Run-AutonomousIntegrationLoop tests pass in isolation, but the more comprehensive dispatcher run still fails two guard scenarios (`retains shadow effectiveness...`, `flags discovery failure...`), keeping the suite red overall. 
+- Self-hosted dispatcher runs with `-IntegrationMode exclude` remain unstable; IncludePatterns recursion spins up child dispatchers indefinitely, so the release gate cannot be exercised. 
+- Fixture validation remains green with identical `summaryCounts`, suggesting fixture drift is not blocking the release. 
+- The TestStand CLI sample session logs stop with a `CreateComparisonReport` provider error, meaning LVCompare automation is not verified for this build. 
+- Quantile polling loop telemetry stays healthy (no diffs or errors), indicating the instrumentation path is stable even while other gates fail. 
+- The standing-priority sync still operates on cached metadata because the GitHub CLI is unauthenticated, so automated release status dashboards are stale.
+
+## Recommended next steps
+
+1. Stabilize the dispatcher failures reported in `full-run.log`, then rerun the full suite to capture clean NUnit and summary artifacts.
+2. Address the IncludePatterns recursion in the self-hosted dispatcher so integration mode exits normally; once fixed, rerun with `-IntegrationMode include` to populate the release checklist evidence.
+3. Reconfigure LVCompare/TestStand automation so the CLI provider can satisfy `CreateComparisonReport`, then regenerate the session index.
+4. Authenticate `gh` (or provide `GH_TOKEN`) so `priority:sync` refreshes the standing issue data before the next release audit.
+5. Once the gates above are green, execute the Validate workflow (actionlint + docs links) and record its results alongside this readiness report.


### PR DESCRIPTION
## Summary
- document the current release readiness gaps and evidence in `docs/RELEASE_READINESS_v0.5.0.md`
- update `AGENT_HANDOFF.txt` to point future agents to the new readiness summary

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68f19dd48408832daf63acd2a3c87c11