### PR TITLE
Guard pattern self-test when dispatcher reruns itself (#127)

### DIFF
--- a/Invoke-PesterTests.ps1
+++ b/Invoke-PesterTests.ps1
@@ -1351,6 +1351,10 @@ if ($limitToSingle) {
   $maxTestFilesApplied = ($MaxTestFiles -gt 0 -and $originalTestFileCount -gt $selectedTestFileCount)
 }
 
+if (-not (Get-Variable -Name maxTestFilesApplied -ErrorAction SilentlyContinue)) {
+  $maxTestFilesApplied = $false
+}
+
 if (-not (Get-Variable -Name originalTestFileCount -Scope Script -ErrorAction SilentlyContinue)) {
   $originalTestFileCount = $testFiles.Count
 }

--- a/tests/Invoke-PesterTests.Patterns.Tests.ps1
+++ b/tests/Invoke-PesterTests.Patterns.Tests.ps1
@@ -1,8 +1,17 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Set-Variable -Name skipSelfTest -Scope Script -Value $false -Force
+Set-Variable -Name skipReason -Scope Script -Value 'Pattern self-test suppressed in nested dispatcher context' -Force
+
 Describe 'Invoke-PesterTests Include/Exclude patterns' -Tag 'Unit' {
   BeforeAll {
+    if ($env:SUPPRESS_PATTERN_SELFTEST -eq '1') {
+      $script:skipSelfTest = $true
+      $script:skipReason = 'Pattern self-test suppressed in nested dispatcher context'
+      return
+    }
+
     $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
     $script:dispatcher = Join-Path $repoRoot 'Invoke-PesterTests.ps1'
     $fixtureTestsRootPs = Join-Path $TestDrive 'fixture-tests'
@@ -39,8 +48,20 @@ Describe "{0}" {{
   }
 
   It 'honors IncludePatterns for a single file' {
+    $skipFlag = $false
+    $skipVar = Get-Variable -Name skipSelfTest -Scope Script -ErrorAction SilentlyContinue
+    if ($skipVar) { $skipFlag = [bool]$skipVar.Value }
+    if ($skipFlag) {
+      $reasonVar = Get-Variable -Name skipReason -Scope Script -ErrorAction SilentlyContinue
+      $reason = if ($reasonVar) { [string]$reasonVar.Value } else { 'Pattern self-test suppressed in nested dispatcher context' }
+      Set-ItResult -Skipped -Because $reason
+      return
+    }
+
     if (-not $script:pwshAvailable) {
-      Set-ItResult -Skipped -Because $script:skipReason
+      $reasonVar = Get-Variable -Name skipReason -Scope Script -ErrorAction SilentlyContinue
+      $reason = if ($reasonVar) { [string]$reasonVar.Value } else { 'pwsh executable not available on PATH' }
+      Set-ItResult -Skipped -Because $reason
       return
     }
 
@@ -75,8 +96,20 @@ Describe "{0}" {{
   }
 
   It 'honors ExcludePatterns to remove files' {
+    $skipFlag = $false
+    $skipVar = Get-Variable -Name skipSelfTest -Scope Script -ErrorAction SilentlyContinue
+    if ($skipVar) { $skipFlag = [bool]$skipVar.Value }
+    if ($skipFlag) {
+      $reasonVar = Get-Variable -Name skipReason -Scope Script -ErrorAction SilentlyContinue
+      $reason = if ($reasonVar) { [string]$reasonVar.Value } else { 'Pattern self-test suppressed in nested dispatcher context' }
+      Set-ItResult -Skipped -Because $reason
+      return
+    }
+
     if (-not $script:pwshAvailable) {
-      Set-ItResult -Skipped -Because $script:skipReason
+      $reasonVar = Get-Variable -Name skipReason -Scope Script -ErrorAction SilentlyContinue
+      $reason = if ($reasonVar) { [string]$reasonVar.Value } else { 'pwsh executable not available on PATH' }
+      Set-ItResult -Skipped -Because $reason
       return
     }
 

--- a/tests/_helpers/DispatcherTestHelper.psm1
+++ b/tests/_helpers/DispatcherTestHelper.psm1
@@ -87,6 +87,7 @@ function Invoke-DispatcherSafe {
   $psi.EnvironmentVariables['SUPPRESS_NESTED_DISCOVERY'] = '1'
   $psi.EnvironmentVariables['STUCK_GUARD']          = '0'
   $psi.EnvironmentVariables['DISABLE_SINGLE_INVOKER'] = '1'
+  $psi.EnvironmentVariables['SUPPRESS_PATTERN_SELFTEST'] = '1'
 
   $baseline  = Get-PwshProcessIds
   $startedAt = Get-Date


### PR DESCRIPTION
## Summary
- add a safe default for `maxTestFilesApplied` so single-file dispatcher runs no longer throw under strict mode (#127)
- set `SUPPRESS_PATTERN_SELFTEST` when launching nested dispatchers and skip the pattern self-test when the guard is present
- harden the pattern self-test skip handling so strict mode never faults while checking the guard

## Testing
- pwsh -NoLogo -NoProfile -Command "Import-Module Pester -MinimumVersion 5.5.0; Invoke-Pester -Script tests/Invoke-PesterTests.Patterns.Tests.ps1 -Output Detailed"
- pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -IntegrationMode exclude -TestsPath tests/Invoke-PesterTests.Patterns.Tests.ps1 -ResultsPath /tmp/patterns-only > /tmp/patterns-only.log

------
https://chatgpt.com/codex/tasks/task_b_68f1a062399c832db931f8f1e92a7bfb