### PR TITLE
Fix CLI TypeScript build errors (#127)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- update the TypeScript compiler options to resolve Node built-ins and include Node types
- tighten the CLI validator code to use typed Ajv helpers and improved error formatting
- refactor schema refinements so Zod callbacks respect strict TypeScript typing rules

## Testing
- node node_modules/typescript/lib/tsc.js -p tsconfig.cli.json
- node tools/npm/run-script.mjs cli:validate *(fails: comparevi-cli.dll not present)*

------
https://chatgpt.com/codex/tasks/task_b_68f1c9a47a50832d9e5bf3c95349fa39