### PR TITLE
Auto-install npm deps for CLI validation (#127)

### DIFF
--- a/tools/npm/run-script.mjs
+++ b/tools/npm/run-script.mjs
@@ -1,7 +1,51 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { createSanitizedNpmEnv } from './sanitize-env.mjs';
 import { createNpmLaunchSpec } from './spawn.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const essentialPackages = [
+  'ajv',
+  'ajv-formats',
+  'argparse',
+  'fast-glob',
+  'typescript',
+  'zod',
+  'zod-to-json-schema',
+  '@types/argparse',
+  '@types/node',
+];
+
+function ensureNpmDependencies() {
+  const missingPackages = essentialPackages.filter((packageName) => {
+    const segments = packageName.split('/');
+    return !existsSync(join(repoRoot, 'node_modules', ...segments));
+  });
+
+  if (missingPackages.length === 0) {
+    return;
+  }
+
+  console.error(
+    `Missing npm dependencies detected: ${missingPackages.join(', ')}. Running sanitized npm install...`,
+  );
+
+  const installer = spawnSync(process.execPath, [join(repoRoot, 'tools', 'npm', 'cli.mjs'), 'install'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+
+  if (installer.status !== 0) {
+    const message =
+      installer.error?.message ??
+      `npm install exited with status ${installer.status ?? 'unknown'} while installing ${missingPackages.join(', ')}`;
+    throw new Error(message);
+  }
+}
 
 function printUsage() {
   console.error('Usage: run-script.mjs [npm-options] <script> [-- <script-args>]');
@@ -50,6 +94,8 @@ const npmArgs = ['run', ...npmOptions, scriptName];
 if (scriptArgs.length > 0) {
   npmArgs.push('--', ...scriptArgs);
 }
+
+ensureNpmDependencies();
 
 const env = createSanitizedNpmEnv();
 const launchSpec = createNpmLaunchSpec(npmArgs, env);


### PR DESCRIPTION
## Summary
- auto-detect missing CLI validation dependencies in the sanitized npm wrapper and invoke `npm install` before delegating to the requested script (#127)

## Testing
- rm -rf node_modules
- node tools/npm/run-script.mjs --silent priority:show


------
https://chatgpt.com/codex/tasks/task_b_68f1d155dcec832d83d6855c6e9edc7b