### PR TITLE
Fix docs link checker node_modules exclusion (#127)

### DIFF
--- a/tools/Check-DocsLinks.ps1
+++ b/tools/Check-DocsLinks.ps1
@@ -53,8 +53,9 @@ function Write-Info($msg){ if (-not $Quiet) { Write-Host $msg -ForegroundColor D
 
 $checkHttp = $External -or $Http
 $root = Resolve-Path -LiteralPath $Path
+$skipPattern = '(?:[\\/]\.git[\\/]|[\\/]node_modules[\\/]|[\\/]\.venv[\\/]|[\\/]dist[\\/]|[\\/]build[\\/]|[\\/]coverage[\\/])'
 $md = Get-ChildItem -LiteralPath $root -Recurse -File -Include *.md -ErrorAction SilentlyContinue |
-  Where-Object { $_.FullName -notmatch "\\\.git\\|\\node_modules\\|\\.venv\\|\\dist\\|\\build\\|\\coverage\\" }
+  Where-Object { $_.FullName -notmatch $skipPattern }
 $autoIgnore = @(
   '*/bin/*','*\\bin\\*',
   '*/vendor/*','*\\vendor\\*',


### PR DESCRIPTION
## Summary
- adjust the docs link checker to skip common dependency folders using a cross-platform pattern
- avoid scanning packaged dependencies so intra-repo link validation ignores vendored markdown

## Testing
- not run (pwsh missing in container)


------
https://chatgpt.com/codex/tasks/task_b_68f1d5eec718832dafe5593c90f4bc6f