### PR TITLE
Skip dependency docs during intra-repo link check (#127)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -219,7 +219,11 @@ jobs:
       run: |
         # Simple intra-repo link checker: scans markdown for (./...) links and verifies files exist.
         $ErrorActionPreference = 'Stop'
-        $mdFiles = Get-ChildItem -Path . -Recurse -Include *.md
+        $mdFiles = Get-ChildItem -Path . -Recurse -Include *.md -File |
+          Where-Object {
+            $path = $_.FullName -replace '\\','/'
+            return $path -notmatch '/node_modules/'
+          }
         $errors = @()
         foreach ($file in $mdFiles) {
           $text = Get-Content -LiteralPath $file.FullName -Raw


### PR DESCRIPTION
## Summary
- skip Markdown files under node_modules during the validate workflow's intra-repo link check to avoid dependency readme false positives

## Testing
- not run (pwsh unavailable in container)

Resolves #127.

------
https://chatgpt.com/codex/tasks/task_b_68f1dc4f6b18832db805e023c44b6b02