### PR TITLE
Fix dot-sourcing lint single-line handling (#127)

### DIFF
--- a/tools/Lint-DotSourcing.ps1
+++ b/tools/Lint-DotSourcing.ps1
@@ -46,7 +46,7 @@ $files = Get-ChildItem -LiteralPath $repoRoot -Recurse -File -Include $searchPat
 $violations = New-Object System.Collections.Generic.List[object]
 
 foreach ($file in $files) {
-  $lines = Get-Content -LiteralPath $file.FullName
+  $lines = @(Get-Content -LiteralPath $file.FullName)
   for ($index = 0; $index -lt $lines.Count; $index++) {
     $lineText = $lines[$index]
     $trimmed = $lineText.Trim()


### PR DESCRIPTION
## Summary
- ensure the dot-sourcing lint script always works with an array of lines
- prevent property access errors when linting single-line PowerShell files

## Testing
- ❌ `pwsh -File tools/Lint-DotSourcing.ps1 -WarnOnly` *(missing `pwsh` in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f1dd7d22fc832db0993d7c8a7c205c