### PR TITLE
Handle GitHub rate limits in REST watcher (#127)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,8 @@ Use `tools/workflows/update_workflows.py` for mechanical updates (comment-preser
   if
   the run fails. Passing `--branch <name>` auto-selects the latest run. The VS Code task “CI Watch (REST)” prompts for a run id.
 - The watcher now aborts with `conclusion: watcher-error` after repeated 404s or other API failures (90s / 120s grace by default), still
-  writing `watcher-rest.json` so session-index telemetry isn’t lost.
+  writing `watcher-rest.json` so session-index telemetry isn’t lost. Explicit rate-limit responses short-circuit with instructions to
+  supply `GH_TOKEN`/`GITHUB_TOKEN` (or wait for the reset) instead of waiting out the error window.
 - Use the Docker watcher (`tools/Watch-InDocker.ps1`) when you need dispatcher logs or artifact download mirrors. Both watchers honor
   `GH_TOKEN`/`GITHUB_TOKEN` and fall back to `C:\github_token.txt` on Windows.
 - Keep watcher summaries in `tests/results/_agent/` up to date so downstream agents inherit telemetry context.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Tips:
 - Prefer the REST watcher for GitHub status: `node tools/npm/run-script.mjs ci:watch:rest -- --run-id <id>` streams job conclusions without relying on the
   `gh` CLI. Passing `--branch <name>` auto-selects the latest run. A VS Code task named “CI Watch (REST)” prompts for the run id.
 - Repeated 404s or other API errors cause the watcher to exit with `conclusion: watcher-error` after the built-in grace window
-  (90s for “run not found”, 120s for other failures) while still writing `watcher-rest.json` to keep telemetry flowing.
+  (90s for “run not found”, 120s for other failures) while still writing `watcher-rest.json` to keep telemetry flowing. Direct
+  rate-limit responses abort immediately with guidance to authenticate via `GH_TOKEN`/`GITHUB_TOKEN` or wait for the reset window.
 - The REST watcher writes `watcher-rest.json` into the job’s results directory; `tools/Update-SessionIndexWatcher.ps1` merges the data
   into `session-index.json` so CI telemetry reflects the final GitHub status alongside Pester results.
 - The watcher prunes old run directories (`.tmp/watch-run`) automatically and warns if


### PR DESCRIPTION
## Summary
- detect GitHub rate limit responses in the REST watcher and abort immediately with guidance for supplying GH_TOKEN (#127)
- document the rate-limit handling in AGENTS.md and README.md so future agents know about the shortcut (#127)

## Testing
- node tools/npm/run-script.mjs build


------
https://chatgpt.com/codex/tasks/task_b_68f1e154b074832d99a06e099cd4bab3