### PR TITLE
Ensure Watch run (REST sanity) uses GH_TOKEN (#127)

### DIFF
--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -113,6 +113,7 @@ jobs:
     env:
       RESULTS_DIR: tests/results/lint
       ACTIONLINT_VERSION: '${{ vars.ACTIONLINT_VERSION || ''1.7.7'' }}'
+      GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
     steps:
     - uses: actions/checkout@v5
     - name: Wire Probe (J1)


### PR DESCRIPTION
## Summary
- export `GH_TOKEN` for the lint job so the REST watcher authenticates with the PAT fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f2495f9ddc832d9198b2f3c71ea72c