### PR TITLE
Fix lint job npm hangs (#127)

### DIFF
--- a/.github/actions/cli-lints/action.yml
+++ b/.github/actions/cli-lints/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Install markdownlint-cli
       shell: bash
-      run: npm install -g markdownlint-cli
+      run: node tools/npm/cli.mjs install -g markdownlint-cli
 
     - name: Run markdownlint (strict)
       shell: bash

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -219,16 +219,16 @@ jobs:
         node-version: "20"
         cache: "npm"
     - name: Install CLI validation deps
-      run: npm ci
+      run: node tools/npm/cli.mjs ci
     - name: Install markdownlint-cli (retry)
       shell: bash
       run: |
         set -euo pipefail
         for i in 1 2 3; do
-          if npm install -g markdownlint-cli; then
+          if node tools/npm/cli.mjs install -g markdownlint-cli; then
             break
           else
-            npm cache clean --force || true
+            node tools/npm/cli.mjs cache clean --force || true
             echo "retry $i"
             sleep 2
           fi

--- a/tmp_ci.yml
+++ b/tmp_ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install markdownlint-cli
         run: |
-          npm install -g markdownlint-cli
+          node tools/npm/cli.mjs install -g markdownlint-cli
 
       - name: Run markdownlint (non-blocking)
         continue-on-error: true


### PR DESCRIPTION
## Summary
- replace raw npm invocations in the orchestrated lint job with the repo's sanitized wrappers
- update the CLI lints composite action (and tmp_ci sample) to install markdownlint via the wrapper as well
- avoid proxy-inherited hangs that previously left the lint job stuck while fetching npm packages

## Testing
- none (logic change only)

------
https://chatgpt.com/codex/tasks/task_b_68f24c091d20832d951099e333d3c0e6