### PR TITLE
Avoid orchestrated lint deadlock (#127)

### DIFF
--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -156,6 +156,9 @@ jobs:
           $params += '-FailOnWorkflowDrift'
         }
         $params += '-SkipDotnetCliBuild'
+        # Skip linting this workflow while it is executing to avoid orchestration deadlocks.
+        $params += '-ExcludeWorkflowPaths'
+        $params += '.github/workflows/ci-orchestrated.yml'
         pwsh -File ./tools/Run-NonLVChecksInDocker.ps1 @params
     - name: Publish comparevi-cli (SDK container)
       if: ${{ hashFiles('src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj') != '' }}


### PR DESCRIPTION
## Summary
- allow `Run-NonLVChecksInDocker.ps1` to exclude specific workflow files from drift enforcement
- skip `.github/workflows/ci-orchestrated.yml` when the orchestrated lint job runs to avoid the self-referential deadlock

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68f251053e8c832db85600fde0482e7f