### PR TITLE
Fix markdownlint warnings for watcher telemetry doc (#127)

### DIFF
--- a/docs/WATCHER_TELEMETRY_DX.md
+++ b/docs/WATCHER_TELEMETRY_DX.md
@@ -68,7 +68,8 @@ Optional additions:
      `LV_IDLE_WAIT_SECONDS=2`, `LV_IDLE_MAX_WAIT_SECONDS=5`.
 2. Run `tools/Detect-RogueLV.ps1` and report any rogue LabVIEW/LVCompare PIDs before taking
    action.
-3. Execute `node tools/npm/run-script.mjs dev:watcher:status` (or call `tools/Dev-WatcherManager.ps1 -Status` in-process), capturing output.
+3. Execute `node tools/npm/run-script.mjs dev:watcher:status` (or call `tools/Dev-WatcherManager.ps1 -Status`
+   in-process) and capture the output.
 4. Summarise the required fields in the reply (or step summary) using the template above.
 5. If `needsTrim=true`, call `node tools/npm/run-script.mjs dev:watcher:trim` (or `Print-AgentHandoff.ps1 -AutoTrim`) and
    mention the trim result; otherwise note that no trim was necessary.


### PR DESCRIPTION
## Summary
- wrap the watcher status step description so markdownlint's 120 character limit is respected
- references #127

## Testing
- node tools/npm/run-script.mjs lint:md:changed

------
https://chatgpt.com/codex/tasks/task_b_68f25f346a30832d9c40bdb9c6c5a07a