### PR TITLE
Clarify fixture summary markdown structure (#127)

### DIFF
--- a/fixture-summary.md
+++ b/fixture-summary.md
@@ -2,11 +2,18 @@
 
 ## Current Snapshot
 
-Status: OK
-Counts: missing=0 untracked=0 tooSmall=0 hashMismatch=0 manifestError=0 duplicate=0 schema=0
+- **Status:** OK
+- **Counts:**
+  - missing: 0
+  - untracked: 0
+  - tooSmall: 0
+  - hashMismatch: 0
+  - manifestError: 0
+  - duplicate: 0
+  - schema: 0
 
 ## Delta
 
-Changed Categories:
-New Structural Issues: 0
-Will Fail: False
+- **Changed Categories:** _(none)_
+- **New Structural Issues:** 0
+- **Will Fail:** False


### PR DESCRIPTION
## Summary
- restyled the fixture summary snapshot counts as a structured list for readability
- kept the delta section in list form to satisfy markdownlint's first-line heading check

## Testing
- not run (doc-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f2621a27e8832d8404afb8e1a3c1f4