### PR TITLE
Fix fixture summary markdownlint compliance (#127)

### DIFF
--- a/fixture-summary.md
+++ b/fixture-summary.md
@@ -1,12 +1,21 @@
+<!-- markdownlint-disable-next-line MD041 -->
 # Fixture Validation Summary
 
 ## Current Snapshot
 
-Status: OK
-Counts: missing=0 untracked=0 tooSmall=0 hashMismatch=0 manifestError=0 duplicate=0 schema=0
+- **Status:** OK
+- **Counts:**
+  - missing: 0
+  - untracked: 0
+  - tooSmall: 0
+  - sizeMismatch: 0
+  - hashMismatch: 0
+  - manifestError: 0
+  - duplicate: 0
+  - schema: 0
 
 ## Delta
 
-Changed Categories:
-New Structural Issues: 0
-Will Fail: False
+- **Changed Categories:** _(none)_
+- **New Structural Issues:** 0
+- **Will Fail:** False


### PR DESCRIPTION
## Summary
- add the standard MD041 suppression comment to `fixture-summary.md` and record the size mismatch count so markdownlint passes
- update `tools/Write-FixtureValidationSummary.ps1` to emit the same markdown structure and counts, ensuring regenerated summaries stay compliant

## Testing
- ./node_modules/.bin/markdownlint-cli2 fixture-summary.md

------
https://chatgpt.com/codex/tasks/task_b_68f2621a27e8832d8404afb8e1a3c1f4