### PR TITLE
(#127) Guard fixture summary against missing arrays

### DIFF
--- a/tests/FixtureSummary.Tests.ps1
+++ b/tests/FixtureSummary.Tests.ps1
@@ -172,6 +172,50 @@ Describe 'Fixture summary script' -Tag 'Unit' {
     $out | Should -Match '\*\*Will Fail:\*\* True'
   }
 
+  It 'derives structural issues from changes when the array is empty' {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..') | Select-Object -ExpandProperty Path
+    $summary = Join-Path $repoRoot 'tools' 'Write-FixtureValidationSummary.ps1'
+
+    $validationPath = Join-Path $TestDrive 'validation.json'
+    $validation = @{
+      ok = $true
+      summaryCounts = @{
+        missing = 0
+        untracked = 0
+        tooSmall = 0
+        sizeMismatch = 0
+        hashMismatch = 0
+        manifestError = 0
+        duplicate = 0
+        schema = 0
+      }
+    } | ConvertTo-Json -Depth 3
+    Set-Content -LiteralPath $validationPath -Value $validation -Encoding utf8
+
+    $deltaPath = Join-Path $TestDrive 'delta.json'
+    $delta = @{
+      schema = 'fixture-validation-delta-v1'
+      baselinePath = 'baseline.json'
+      currentPath = 'current.json'
+      generatedAt = '2025-10-17T00:00:00Z'
+      baselineOk = $true
+      currentOk = $true
+      deltaCounts = @{ manifestError = 1 }
+      changes = @(
+        @{ category = 'manifestError'; baseline = 0; current = 1; delta = 1 }
+      )
+      newStructuralIssues = @()
+      failOnNewStructuralIssue = $true
+      # Intentionally omit willFail so the fallback uses failOnNewStructuralIssue and the inferred issues.
+    } | ConvertTo-Json -Depth 4
+    Set-Content -LiteralPath $deltaPath -Value $delta -Encoding utf8
+
+    Remove-Item Env:SUMMARY_VERBOSE -ErrorAction SilentlyContinue
+    $out = (pwsh -NoLogo -NoProfile -File $summary -ValidationJson $validationPath -DeltaJson $deltaPath -SummaryPath '' | Out-String)
+    $out | Should -Match '\*\*New Structural Issues:\*\* 1'
+    $out | Should -Match '\*\*Will Fail:\*\* True'
+  }
+
   It 'infers new structural issues when the array property is null' {
     $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..') | Select-Object -ExpandProperty Path
     $summary = Join-Path $repoRoot 'tools' 'Write-FixtureValidationSummary.ps1'


### PR DESCRIPTION
## Summary
- ensure `Write-FixtureValidationSummary.ps1` materialises JSON arrays before enumerating them
- avoid null dereferences when fixture delta properties are absent

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "./Invoke-PesterTests.ps1 -IncludePatterns 'Fixture summary script'"` *(fails: `pwsh` not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f275314bf4832d81a67328a07f275e