### PR TITLE
fix: respect default branch for workflow drift gate (#127)

### DIFF
--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -150,9 +150,11 @@ jobs:
 
     - name: Non-LabVIEW checks (Docker)
       shell: pwsh
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch || github.event.pull_request.base.repo.default_branch || github.event.workflow_run.repository.default_branch || '' }}
       run: |
         $params = @()
-        $defaultBranch = '${{ github.event.repository.default_branch || github.repository_default_branch }}'
+        $defaultBranch = $env:DEFAULT_BRANCH
         if ('${{ github.ref_name }}' -eq $defaultBranch -or '${{ github.base_ref }}' -eq $defaultBranch) {
           $params += '-FailOnWorkflowDrift'
         }


### PR DESCRIPTION
## Summary
- teach the orchestrated workflow to reference the repository default branch when deciding whether to enforce workflow drift failures
- update the workflow updater helper to call the sanitized npm wrapper when rebuilding the markdownlint install step so future syncs preserve the wrapper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f288802bd4832d88364c6fb727866f