### PR TITLE
chore(#127): modernize orchestrated watcher URL handling

### DIFF
--- a/dist/tools/watchers/orchestrated-watch.js
+++ b/dist/tools/watchers/orchestrated-watch.js
@@ -55,16 +55,50 @@ function buildSummary(params) {
         })),
     };
 }
+function parseGitRemoteUrl(remoteUrl) {
+    if (!remoteUrl) {
+        return null;
+    }
+    const trimmed = remoteUrl.trim();
+    if (!trimmed) {
+        return null;
+    }
+    const sanitized = trimmed.replace(/^git\+/i, '');
+    const stripGitSuffix = (slug) => slug.replace(/\.git$/i, '');
+    const sshMatch = sanitized.match(/^git@[^:]+:(.+)$/i);
+    if (sshMatch) {
+        return stripGitSuffix(sshMatch[1]);
+    }
+    try {
+        const parsed = new URL(sanitized);
+        if (parsed.hostname && parsed.pathname) {
+            const slug = parsed.pathname.replace(/^\/+/, '');
+            if (slug) {
+                return stripGitSuffix(slug);
+            }
+        }
+    }
+    catch {
+        // Ignore invalid URLs and fall back to heuristic handling below.
+    }
+    if (/^[^/]+\/[\w.-]+$/i.test(trimmed)) {
+        return stripGitSuffix(trimmed);
+    }
+    return null;
+}
 function resolveRepo() {
     const fromEnv = process.env.GITHUB_REPOSITORY;
     if (fromEnv) {
-        return fromEnv;
+        const cleaned = fromEnv.trim();
+        if (cleaned) {
+            return cleaned;
+        }
     }
     try {
         const remote = execSync('git config --get remote.origin.url', { encoding: 'utf8' }).trim();
-        if (remote.endsWith('.git')) {
-            const clean = remote.slice(0, -4);
-            return clean.split(':').pop()?.split('/github.com/').pop() ?? clean;
+        const parsed = parseGitRemoteUrl(remote);
+        if (parsed) {
+            return parsed;
         }
         return remote.split(':').pop() ?? remote;
     }
@@ -154,8 +188,10 @@ async function fetchJson(url, token) {
     return parsed;
 }
 async function findLatestRun(repo, workflow, branch, token) {
-    const url = `https://api.github.com/repos/${repo}/actions/workflows/${encodeURIComponent(workflow)}/runs?branch=${encodeURIComponent(branch)}&per_page=5`;
-    const data = await fetchJson(url, token);
+    const url = new URL(`https://api.github.com/repos/${repo}/actions/workflows/${encodeURIComponent(workflow)}/runs`);
+    url.searchParams.set('branch', branch);
+    url.searchParams.set('per_page', '5');
+    const data = await fetchJson(url.toString(), token);
     return data.workflow_runs?.[0];
 }
 function formatJob(job) {
@@ -174,8 +210,8 @@ async function watchRun(repo, runId, token, pollMs = 15000, errorGraceMs = DEFAU
     let notFoundStart;
     while (true) {
         try {
-            const runUrl = `https://api.github.com/repos/${repo}/actions/runs/${runId}`;
-            latestRun = await fetchJson(runUrl, token);
+            const runUrl = new URL(`https://api.github.com/repos/${repo}/actions/runs/${runId}`);
+            latestRun = await fetchJson(runUrl.toString(), token);
             const title = latestRun.display_title ?? `Run ${latestRun.id}`;
             const status = latestRun.status ?? 'unknown';
             const conclusion = latestRun.conclusion ?? '';
@@ -193,8 +229,9 @@ async function watchRun(repo, runId, token, pollMs = 15000, errorGraceMs = DEFAU
                 // eslint-disable-next-line no-console
                 console.log(`URL: ${latestRun.html_url}`);
             }
-            const jobsUrl = `https://api.github.com/repos/${repo}/actions/runs/${runId}/jobs?per_page=100`;
-            const jobsResp = await fetchJson(jobsUrl, token);
+            const jobsUrl = new URL(`https://api.github.com/repos/${repo}/actions/runs/${runId}/jobs`);
+            jobsUrl.searchParams.set('per_page', '100');
+            const jobsResp = await fetchJson(jobsUrl.toString(), token);
             latestJobs = jobsResp.jobs ?? [];
             if (latestJobs.length) {
                 // eslint-disable-next-line no-console
@@ -316,7 +353,8 @@ async function main() {
         const branch = process.env.GITHUB_REF_NAME ?? process.env.GITHUB_HEAD_REF ?? process.env.GITHUB_REF ?? undefined;
         const sha = process.env.GITHUB_SHA ?? undefined;
         const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
-        const htmlUrl = `${serverUrl.replace(/\/$/, '')}/${repo}/actions/runs/${runId}`;
+        const baseUrl = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
+        const htmlUrl = new URL(`${repo}/actions/runs/${runId}`, baseUrl).toString();
         const summary = buildSummary({
             repo,
             runId,


### PR DESCRIPTION
## Summary
- replace ad-hoc remote parsing in the orchestrated watcher with a helper based on the WHATWG URL API so git remotes are handled consistently
- build GitHub API requests and self-run links with URL objects to avoid the legacy `url.parse` path

## Testing
- node dist/tools/watchers/orchestrated-watch.js --help
- NODE_OPTIONS=--trace-deprecation node dist/tools/watchers/orchestrated-watch.js --help

------
https://chatgpt.com/codex/tasks/task_b_68f28fb1bbe0832d941a7891e6100236