### PR TITLE
Ensure dispatcher finalizes LabVIEW PID tracker on every exit path (#127)

### DIFF
--- a/tests/LabVIEWPidTracker.Tests.ps1
+++ b/tests/LabVIEWPidTracker.Tests.ps1
@@ -1,0 +1,95 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'LabVIEWPidTracker module' -Tag 'Unit' {
+  BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' 'tools' 'LabVIEWPidTracker.psm1'
+    Import-Module $modulePath -Force
+  }
+
+  It 'writes tracker with null pid when no LabVIEW process is present' {
+    $tracker = Join-Path $TestDrive 'labview.json'
+    Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @() }
+    Mock -CommandName Get-Process -ParameterFilter { $Id } -MockWith { throw "process not found" }
+
+    $result = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+
+    Test-Path -LiteralPath $tracker | Should -BeTrue
+    $result.Pid | Should -BeNullOrEmpty
+    $result.Running | Should -BeFalse
+    $result.Reused | Should -BeFalse
+
+    $json = Get-Content -LiteralPath $tracker -Raw | ConvertFrom-Json -Depth 6
+    $json.schema | Should -Be 'labview-pid-tracker/v1'
+    $json.pid | Should -BeNullOrEmpty
+    $json.running | Should -BeFalse
+  }
+
+  It 'reuses existing pid when tracker file references a running LabVIEW.exe' {
+    $tracker = Join-Path $TestDrive 'labview.json'
+    $existing = [ordered]@{
+      schema       = 'labview-pid-tracker/v1'
+      updatedAt    = (Get-Date).ToString('o')
+      pid          = 4242
+      running      = $true
+      reused       = $false
+      source       = 'seed'
+      observations = @()
+    }
+    $existing | ConvertTo-Json -Depth 4 | Out-File -FilePath $tracker -Encoding utf8
+
+    $procObj = [pscustomobject]@{ Id = 4242; ProcessName = 'LabVIEW'; StartTime = (Get-Date).AddMinutes(-5) }
+    Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @($procObj) }
+    Mock -CommandName Get-Process -ParameterFilter { $Id -eq 4242 } -MockWith { $procObj }
+
+    $result = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+
+    $result.Pid | Should -Be 4242
+    $result.Reused | Should -BeTrue
+    $result.Running | Should -BeTrue
+  }
+
+  It 'selects a new pid when existing tracker entry is stale' {
+    $tracker = Join-Path $TestDrive 'labview.json'
+    $stale = [ordered]@{
+      schema       = 'labview-pid-tracker/v1'
+      updatedAt    = (Get-Date).ToString('o')
+      pid          = 100
+      running      = $false
+      reused       = $false
+      source       = 'seed'
+      observations = @()
+    }
+    $stale | ConvertTo-Json -Depth 4 | Out-File -FilePath $tracker -Encoding utf8
+
+    $candidate = [pscustomobject]@{ Id = 5555; ProcessName = 'LabVIEW'; StartTime = (Get-Date).AddMinutes(-1) }
+    Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @($candidate) }
+    Mock -CommandName Get-Process -ParameterFilter { $Id -eq 100 } -MockWith { throw "process missing" }
+    Mock -CommandName Get-Process -ParameterFilter { $Id -eq 5555 } -MockWith { $candidate }
+
+    $result = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+
+    $result.Pid | Should -Be 5555
+    $result.Reused | Should -BeFalse
+    $result.Running | Should -BeTrue
+  }
+
+  It 'finalizes tracker and records running state' {
+    $tracker = Join-Path $TestDrive 'labview.json'
+    $proc = [pscustomobject]@{ Id = 3210; ProcessName = 'LabVIEW'; StartTime = (Get-Date).AddMinutes(-2) }
+
+    Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @($proc) }
+    Mock -CommandName Get-Process -ParameterFilter { $Id -eq 3210 } -MockWith { $proc }
+
+    $init = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+    $init.Pid | Should -Be 3210
+
+    $final = Finalize-LabVIEWPidTracker -TrackerPath $tracker -Pid $init.Pid -Source 'test:final'
+    $final.Pid | Should -Be 3210
+    $final.Running | Should -BeTrue
+
+    $json = Get-Content -LiteralPath $tracker -Raw | ConvertFrom-Json -Depth 6
+    $json.running | Should -BeTrue
+    ($json.observations | Measure-Object).Count | Should -BeGreaterThan 0
+  }
+}

--- a/tools/LabVIEWPidTracker.psm1
+++ b/tools/LabVIEWPidTracker.psm1
@@ -1,0 +1,221 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Initialize-LabVIEWPidTracker {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$TrackerPath,
+    [string]$Source = 'dispatcher'
+  )
+
+  $now = (Get-Date).ToUniversalTime()
+  $existingState = $null
+  $existingObservations = @()
+
+  if (Test-Path -LiteralPath $TrackerPath -PathType Leaf) {
+    try {
+      $existingState = Get-Content -LiteralPath $TrackerPath -Raw | ConvertFrom-Json -Depth 6
+      if ($existingState -and $existingState.PSObject.Properties['observations']) {
+        $existingObservations = @($existingState.observations | Where-Object { $_ -ne $null })
+      }
+    } catch {
+      $existingState = $null
+      $existingObservations = @()
+    }
+  }
+
+  $candidateProcesses = @()
+  try {
+    $candidateProcesses = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue)
+  } catch {
+    $candidateProcesses = @()
+  }
+
+  $trackedPid = $null
+  $reused = $false
+
+  if ($existingState -and $existingState.PSObject.Properties['pid']) {
+    $candidatePid = $null
+    try { $candidatePid = [int]$existingState.pid } catch { $candidatePid = $null }
+    if ($candidatePid -and $candidatePid -gt 0) {
+      try {
+        $proc = Get-Process -Id $candidatePid -ErrorAction Stop
+        if ($proc -and $proc.ProcessName -and $proc.ProcessName -eq 'LabVIEW') {
+          $trackedPid = [int]$proc.Id
+          $reused = $true
+        }
+      } catch {}
+    }
+  }
+
+  if (-not $trackedPid -and $candidateProcesses.Count -gt 0) {
+    $selected = $null
+    try {
+      $selected = $candidateProcesses | Sort-Object StartTime | Select-Object -First 1
+    } catch {
+      if ($candidateProcesses.Count -gt 0) { $selected = $candidateProcesses[0] }
+    }
+    if ($selected) {
+      try { $trackedPid = [int]$selected.Id } catch { $trackedPid = $null }
+    }
+  }
+
+  $running = $false
+  if ($trackedPid -and $trackedPid -gt 0) {
+    try {
+      $procCheck = Get-Process -Id $trackedPid -ErrorAction Stop
+      if ($procCheck -and $procCheck.ProcessName) { $running = $true }
+    } catch { $running = $false }
+  }
+
+  $candidateIds = @()
+  foreach ($proc in $candidateProcesses) {
+    try { $candidateIds += [int]$proc.Id } catch {}
+  }
+
+  $note = if ($trackedPid) {
+    if ($reused) { 'reused-existing' } else { 'selected-from-scan' }
+  } elseif ($candidateIds.Count -gt 0) {
+    'candidates-present'
+  } else {
+    'labview-not-running'
+  }
+
+  $observation = [ordered]@{
+    at         = $now.ToString('o')
+    action     = 'initialize'
+    pid        = if ($trackedPid) { [int]$trackedPid } else { $null }
+    running    = $running
+    reused     = $reused
+    source     = $Source
+    note       = $note
+    candidates = $candidateIds
+  }
+
+  $obsList = @()
+  if ($existingObservations -is [System.Collections.IEnumerable]) {
+    $obsList = @($existingObservations | Where-Object { $_ -ne $null })
+  }
+  $obsList += [pscustomobject]$observation
+  $obsList = @($obsList | Select-Object -Last 25)
+
+  $dir = Split-Path -Parent $TrackerPath
+  if ($dir -and -not (Test-Path -LiteralPath $dir -PathType Container)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  }
+
+  $record = [ordered]@{
+    schema       = 'labview-pid-tracker/v1'
+    updatedAt    = $now.ToString('o')
+    pid          = if ($trackedPid) { [int]$trackedPid } else { $null }
+    running      = $running
+    reused       = $reused
+    source       = $Source
+    observations = $obsList
+  }
+
+  $record | ConvertTo-Json -Depth 6 | Out-File -FilePath $TrackerPath -Encoding utf8
+
+  return [pscustomobject]@{
+    Path        = $TrackerPath
+    Pid         = $record.pid
+    Running     = $running
+    Reused      = $reused
+    Candidates  = $candidateIds
+    Observation = $observation
+  }
+}
+
+function Finalize-LabVIEWPidTracker {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$TrackerPath,
+    [Nullable[int]]$Pid,
+    [string]$Source = 'dispatcher'
+  )
+
+  $now = (Get-Date).ToUniversalTime()
+  $state = $null
+  $existingObservations = @()
+
+  if (Test-Path -LiteralPath $TrackerPath -PathType Leaf) {
+    try {
+      $state = Get-Content -LiteralPath $TrackerPath -Raw | ConvertFrom-Json -Depth 6
+      if ($state -and $state.PSObject.Properties['observations']) {
+        $existingObservations = @($state.observations | Where-Object { $_ -ne $null })
+      }
+    } catch {
+      $state = $null
+      $existingObservations = @()
+    }
+  }
+
+  $trackedPid = $null
+  if ($PSBoundParameters.ContainsKey('Pid') -and $null -ne $Pid) {
+    try { $trackedPid = [int]$Pid } catch { $trackedPid = $null }
+  }
+  if (-not $trackedPid -and $state -and $state.PSObject.Properties['pid']) {
+    try { $trackedPid = [int]$state.pid } catch { $trackedPid = $null }
+  }
+
+  $running = $false
+  if ($trackedPid -and $trackedPid -gt 0) {
+    try {
+      $procCheck = Get-Process -Id $trackedPid -ErrorAction Stop
+      if ($procCheck -and $procCheck.ProcessName) { $running = $true }
+    } catch { $running = $false }
+  }
+
+  $note = if ($trackedPid) {
+    if ($running) { 'still-running' } else { 'not-running' }
+  } else {
+    'no-tracked-pid'
+  }
+
+  $observation = [ordered]@{
+    at      = $now.ToString('o')
+    action  = 'finalize'
+    pid     = if ($trackedPid) { [int]$trackedPid } else { $null }
+    running = $running
+    source  = $Source
+    note    = $note
+  }
+
+  $obsList = @()
+  if ($existingObservations -is [System.Collections.IEnumerable]) {
+    $obsList = @($existingObservations | Where-Object { $_ -ne $null })
+  }
+  $obsList += [pscustomobject]$observation
+  $obsList = @($obsList | Select-Object -Last 25)
+
+  $reused = $false
+  if ($state -and $state.PSObject.Properties['reused']) {
+    try { $reused = [bool]$state.reused } catch { $reused = $false }
+  }
+
+  $record = [ordered]@{
+    schema       = 'labview-pid-tracker/v1'
+    updatedAt    = $now.ToString('o')
+    pid          = if ($trackedPid) { [int]$trackedPid } else { $null }
+    running      = $running
+    reused       = $reused
+    source       = $Source
+    observations = $obsList
+  }
+
+  $dir = Split-Path -Parent $TrackerPath
+  if ($dir -and -not (Test-Path -LiteralPath $dir -PathType Container)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  }
+
+  $record | ConvertTo-Json -Depth 6 | Out-File -FilePath $TrackerPath -Encoding utf8
+
+  return [pscustomobject]@{
+    Path        = $TrackerPath
+    Pid         = $record.pid
+    Running     = $running
+    Observation = $observation
+  }
+}
+
+Export-ModuleMember -Function Initialize-LabVIEWPidTracker,Finalize-LabVIEWPidTracker


### PR DESCRIPTION
## Summary
- add dispatcher helpers that capture the LabVIEW PID tracker finalization context and reuse it during cleanup
- replace raw dispatcher exits with Invoke-DispatcherExit so every failure and guard path triggers tracker persistence
- finalize the LabVIEW PID snapshot during the script's cleanup flow instead of relying on engine events

## Testing
- not run (PowerShell executable is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68f29820a64c832d889a09efb09ed038