### PR TITLE
Add runbook fallback for missing VI inputs (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - Validator flags: `tools/Validate-Fixtures.ps1 -Json -RequirePair -FailOnExpectedMismatch [-EvidencePath results/fixture-drift/compare-exec.json]`.
   - Evidence mapping: LVCompare exitCode `0→identical`, `1→diff` (or `diff` boolean when available). Validator searches default evidence locations when `-EvidencePath` is omitted.
 
+### Fixed
+
+- Integration runbook now falls back to the repository fixtures (`VI1.vi` / `VI2.vi`) when `LV_BASE_VI` / `LV_HEAD_VI` are unset,
+  ensuring the ViInputs phase succeeds in default environments.
+
 ## [v0.5.0] - 2025-10-05
 
 ### Breaking Changes

--- a/docs/INTEGRATION_RUNBOOK.md
+++ b/docs/INTEGRATION_RUNBOOK.md
@@ -41,6 +41,10 @@ Test-Path 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompar
 | `CLEAN_LV_BEFORE`, `CLEAN_LV_AFTER`, `CLEAN_LV_INCLUDE_COMPARE` | Runner unblock guard defaults |
 | `LOOP_ITERATIONS`, `LOOP_TIMEOUT_SECONDS` | Control autonomous loop runs |
 
+`Invoke-IntegrationRunbook.ps1` automatically falls back to the repository fixtures (`VI1.vi` / `VI2.vi`) when
+these environment variables are unset. Runners should still configure canonical locations for their preferred
+validation VIs, but the fallback keeps the runbook usable out of the box.
+
 ## Quick sequence
 
 ```powershell


### PR DESCRIPTION
## Summary
- allow the integration runbook to fall back to the repository VI fixtures when LV_BASE_VI/LV_HEAD_VI are unset
- record the selected source in ViInputs diagnostics and cover the fallback in unit tests
- document the behavior change in the runbook guide and changelog

## Testing
- not run (pwsh unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68f2a3d0fc58832d859640dc316e2082