### PR TITLE
Replace LabVIEWPidTracker functions with approved verbs (#127)

### DIFF
--- a/Invoke-PesterTests.ps1
+++ b/Invoke-PesterTests.ps1
@@ -842,7 +842,7 @@ if ($labviewPidTrackerLoaded) {
   $trackerPath = Join-Path $resultsDir '_agent' 'labview-pid.json'
   $script:labviewPidTrackerPath = $trackerPath
   try {
-    $script:labviewPidTrackerState = Initialize-LabVIEWPidTracker -TrackerPath $trackerPath -Source 'dispatcher:init'
+    $script:labviewPidTrackerState = Start-LabVIEWPidTracker -TrackerPath $trackerPath -Source 'dispatcher:init'
     if ($script:labviewPidTrackerState) {
       if ($script:labviewPidTrackerState.Pid) {
         $modeText = if ($script:labviewPidTrackerState.Reused) { 'Reusing existing' } else { 'Tracking detected' }
@@ -859,7 +859,7 @@ if ($labviewPidTrackerLoaded) {
       $script:labviewPidTrackerFinalizer = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Action {
         if ($script:labviewPidTrackerPath) {
           try {
-            $finalTracker = Finalize-LabVIEWPidTracker -TrackerPath $script:labviewPidTrackerPath -Source 'dispatcher:final'
+            $finalTracker = Stop-LabVIEWPidTracker -TrackerPath $script:labviewPidTrackerPath -Source 'dispatcher:final'
             if ($finalTracker -and $finalTracker.Pid) {
               if ($finalTracker.Running) {
                 Write-Host ("[labview-pid] LabVIEW.exe PID {0} still running at dispatcher exit." -f $finalTracker.Pid) -ForegroundColor DarkGray

--- a/tests/LabVIEWPidTracker.Tests.ps1
+++ b/tests/LabVIEWPidTracker.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'LabVIEWPidTracker module' -Tag 'Unit' {
     Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @() }
     Mock -CommandName Get-Process -ParameterFilter { $Id } -MockWith { throw "process not found" }
 
-    $result = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+    $result = Start-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
 
     Test-Path -LiteralPath $tracker | Should -BeTrue
     $result.Pid | Should -BeNullOrEmpty
@@ -42,7 +42,7 @@ Describe 'LabVIEWPidTracker module' -Tag 'Unit' {
     Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @($procObj) }
     Mock -CommandName Get-Process -ParameterFilter { $Id -eq 4242 } -MockWith { $procObj }
 
-    $result = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+    $result = Start-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
 
     $result.Pid | Should -Be 4242
     $result.Reused | Should -BeTrue
@@ -67,7 +67,7 @@ Describe 'LabVIEWPidTracker module' -Tag 'Unit' {
     Mock -CommandName Get-Process -ParameterFilter { $Id -eq 100 } -MockWith { throw "process missing" }
     Mock -CommandName Get-Process -ParameterFilter { $Id -eq 5555 } -MockWith { $candidate }
 
-    $result = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+    $result = Start-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
 
     $result.Pid | Should -Be 5555
     $result.Reused | Should -BeFalse
@@ -81,10 +81,10 @@ Describe 'LabVIEWPidTracker module' -Tag 'Unit' {
     Mock -CommandName Get-Process -ParameterFilter { $Name -eq 'LabVIEW' } -MockWith { @($proc) }
     Mock -CommandName Get-Process -ParameterFilter { $Id -eq 3210 } -MockWith { $proc }
 
-    $init = Initialize-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
+    $init = Start-LabVIEWPidTracker -TrackerPath $tracker -Source 'test:init'
     $init.Pid | Should -Be 3210
 
-    $final = Finalize-LabVIEWPidTracker -TrackerPath $tracker -Pid $init.Pid -Source 'test:final'
+    $final = Stop-LabVIEWPidTracker -TrackerPath $tracker -Pid $init.Pid -Source 'test:final'
     $final.Pid | Should -Be 3210
     $final.Running | Should -BeTrue
 

--- a/tools/LabVIEWPidTracker.psm1
+++ b/tools/LabVIEWPidTracker.psm1
@@ -1,7 +1,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Initialize-LabVIEWPidTracker {
+function Start-LabVIEWPidTracker {
   [CmdletBinding()]
   param(
     [Parameter(Mandatory)][string]$TrackerPath,
@@ -126,7 +126,7 @@ function Initialize-LabVIEWPidTracker {
   }
 }
 
-function Finalize-LabVIEWPidTracker {
+function Stop-LabVIEWPidTracker {
   [CmdletBinding()]
   param(
     [Parameter(Mandatory)][string]$TrackerPath,
@@ -218,4 +218,4 @@ function Finalize-LabVIEWPidTracker {
   }
 }
 
-Export-ModuleMember -Function Initialize-LabVIEWPidTracker,Finalize-LabVIEWPidTracker
+Export-ModuleMember -Function Start-LabVIEWPidTracker,Stop-LabVIEWPidTracker


### PR DESCRIPTION
## Summary
- rename the LabVIEWPidTracker module's exported functions to Start-/Stop-LabVIEWPidTracker to follow approved verb guidance
- update dispatcher wiring and unit tests to consume the new function names

## Testing
- not run (pwsh unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68f2a5f766ec832da6325f4a6a04e517