### PR TITLE
Add VI history compare harness (#254)

### DIFF
--- a/.github/workflows/vi-history-compare.yml
+++ b/.github/workflows/vi-history-compare.yml
@@ -1,0 +1,140 @@
+name: VI History Compare
+
+on:
+  workflow_dispatch:
+    inputs:
+      sample_id:
+        description: 'Optional sample id for concurrency grouping'
+        required: false
+        type: string
+      vi_name:
+        description: 'VI filename (e.g. VI1.vi)'
+        required: true
+        default: 'VI1.vi'
+        type: string
+      branch:
+        description: 'Branch or ref to analyze (default HEAD)'
+        required: false
+        default: 'HEAD'
+        type: string
+      max_pairs:
+        description: 'Maximum adjacent commit pairs to compare'
+        required: false
+        default: 20
+        type: number
+      flag_nobdcosm:
+        description: 'Include -nobdcosm (ignore block diagram cosmetic changes)'
+        required: false
+        default: true
+        type: boolean
+      flag_nofppos:
+        description: 'Include -nofppos (ignore front-panel position changes)'
+        required: false
+        default: true
+        type: boolean
+      flag_noattr:
+        description: 'Include -noattr (ignore VI attribute differences)'
+        required: false
+        default: true
+        type: boolean
+      additional_flags:
+        description: 'Extra LVCompare flags (optional, space-delimited)'
+        required: false
+        default: ''
+        type: string
+      fail_on_diff:
+        description: 'Fail workflow when LVCompare reports differences'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['true', 'false']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: [self-hosted, Windows, X64]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Verify LVCompare installation
+        shell: pwsh
+        run: |
+          $cli = 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompare.exe'
+          if (-not (Test-Path -LiteralPath $cli)) {
+            Write-Host "::error::LVCompare.exe not found at canonical path: $cli"; exit 1
+          }
+          $lv = Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue
+          if ($lv) { Write-Host "::error::LabVIEW.exe is running (PID(s): $($lv.Id -join ','))"; exit 1 }
+          Write-Host 'Preflight OK: LVCompare present; LabVIEW not running.'
+
+  compare-history:
+    runs-on: [self-hosted, Windows, X64]
+    needs: preflight
+    timeout-minutes: 60
+    env:
+      UNBLOCK_GUARD: '1'
+      VI_NAME: ${{ inputs.vi_name }}
+      TARGET_BRANCH: ${{ inputs.branch || 'HEAD' }}
+      MAX_PAIRS: ${{ inputs.max_pairs || 20 }}
+      FLAG_NOBDCOSM: ${{ inputs.flag_nobdcosm }}
+      FLAG_NOFPPOS: ${{ inputs.flag_nofppos }}
+      FLAG_NOATTR: ${{ inputs.flag_noattr }}
+      EXTRA_FLAGS: ${{ inputs.additional_flags }}
+      FAIL_ON_DIFF: ${{ inputs.fail_on_diff || 'false' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Ensure refs available
+        shell: pwsh
+        run: git fetch --all --prune --tags
+
+      - name: Run VI history compare
+        id: history
+        shell: pwsh
+        run: |
+          $flags = @()
+          if ($env:FLAG_NOBDCOSM -eq 'true') { $flags += '-nobdcosm' }
+          if ($env:FLAG_NOFPPOS -eq 'true') { $flags += '-nofppos' }
+          if ($env:FLAG_NOATTR -eq 'true') { $flags += '-noattr' }
+          if (-not [string]::IsNullOrWhiteSpace($env:EXTRA_FLAGS)) {
+            $extra = $env:EXTRA_FLAGS.Trim()
+            if ($extra) { $flags += $extra }
+          }
+          $args = @(
+            '-File', (Join-Path $env:GITHUB_WORKSPACE 'tools' 'Compare-VIHistory.ps1'),
+            '-ViName', $env:VI_NAME,
+            '-Branch', $env:TARGET_BRANCH,
+            '-MaxPairs', [int]$env:MAX_PAIRS,
+            '-ResultsDir', 'tests/results/ref-compare-history'
+          )
+          if ($flags.Count -gt 0) {
+            $args += '-LvCompareArgs'
+            $args += ($flags -join ' ')
+          }
+          if ($env:FAIL_ON_DIFF -eq 'true') { $args += '-FailOnDiff' }
+          pwsh @args
+          $summaryPath = Join-Path $env:GITHUB_WORKSPACE 'tests/results/ref-compare-history/history-summary.json'
+          if (Test-Path -LiteralPath $summaryPath) {
+            "historySummary=$summaryPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
+
+      - name: Upload history artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vi-history-compare
+          path: tests/results/ref-compare-history/**
+          if-no-files-found: warn
+
+      - name: Runner Unblock Guard
+        if: always()
+        uses: ./.github/actions/runner-unblock-guard
+        with:
+          snapshot-path: tests/results/runner-unblock-snapshot.json
+          cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
+          process-names: 'conhost,pwsh,LabVIEW,LVCompare'

--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ When the base and head VIs share the same filename (typical commit-to-commit com
 flows. The composite action does not support comparing two different files that share the same filename; LVCompare will
 reject that case.
 
+### VI history comparisons
+
+	ools/Compare-VIHistory.ps1 walks the git log for a VI, compares each adjacent commit pair with Compare-RefsToTemp.ps1 in detailed mode, and emits a consolidated history summary. The manual workflow .github/workflows/vi-history-compare.yml wraps the script for self-serve dispatch.
+
+- Always-on artifacts: every pair produces `lvcompare-capture.json`, `compare-exec.json`, stdout/stderr, and an HTML report (no suppression, even for identical VIs).
+- Aggregated metadata: `tests/results/ref-compare-history/history-summary.json` (`schema: vi-history-compare/v1`) captures LVCompare exit codes, highlights (for example, block-diagram vs. attribute-only changes), skip reasons, and report locations.
+- Step summary table: the workflow appends a Markdown grid showing each pair, diff status, exit code, and links to the generated reports.
+
+Workflow inputs mirror the script:
+
+- `vi_name` – target VI (default `VI1.vi`)
+- `branch` – branch/ref to analyse (`HEAD` by default)
+- `max_pairs` – adjacent commit pairs to evaluate (latest first)
+- LVCompare flags (`-nobdcosm`, `-nofppos`, `-noattr`) plus optional `additional_flags`
+- `fail_on_diff` – optionally fail the job when LVCompare detects a difference
+
+> Tip: leave `fail_on_diff` set to `false` for the first pass, review the history summary, and rerun with `true` once you are ready to gate on differences.
+
 CLI-only quick start (64-bit Windows):
 
 - On self-hosted runners with LabVIEW CLI installed, automation defaults the CLI path to `C:\Program Files

--- a/tests/CompareVIHistory.Tests.ps1
+++ b/tests/CompareVIHistory.Tests.ps1
@@ -1,0 +1,81 @@
+Describe 'Compare-VIHistory.ps1' {
+  It 'produces history summary artifacts using stub LVCompare' {
+    $ErrorActionPreference = 'Stop'
+
+    $repoRoot = (Get-Location).Path
+    $scriptPath = Join-Path $repoRoot 'tools' 'Compare-VIHistory.ps1'
+    Test-Path -LiteralPath $scriptPath -PathType Leaf | Should -BeTrue
+
+    $stubPath = Join-Path $TestDrive 'Invoke-LVCompare.stub.ps1'
+    @'
+param(
+  [string]$BaseVi,
+  [string]$HeadVi,
+  [string]$OutputDir,
+  [string[]]$Flags
+)
+$ErrorActionPreference = 'Stop'
+if (-not $OutputDir) { $OutputDir = Join-Path $env:TEMP ([guid]::NewGuid().ToString()) }
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$stdoutPath = Join-Path $OutputDir 'lvcompare-stdout.txt'
+$stderrPath = Join-Path $OutputDir 'lvcompare-stderr.txt'
+$exitPath   = Join-Path $OutputDir 'lvcompare-exitcode.txt'
+$reportPath = Join-Path $OutputDir 'compare-report.html'
+$capPath    = Join-Path $OutputDir 'lvcompare-capture.json'
+"Stub compare for $BaseVi -> $HeadVi (flags: $($Flags -join ' '))" | Out-File -LiteralPath $stdoutPath -Encoding utf8
+'' | Out-File -LiteralPath $stderrPath -Encoding utf8
+'0' | Out-File -LiteralPath $exitPath -Encoding utf8
+'<html><body><h1>Stub Report</h1></body></html>' | Out-File -LiteralPath $reportPath -Encoding utf8
+$cap = [pscustomobject]@{
+  schema   = 'lvcompare-capture-v1'
+  exitCode = 0
+  seconds  = 0.01
+  command  = 'stub'
+  cliPath  = 'stub'
+  base     = $BaseVi
+  head     = $HeadVi
+  args     = $Flags
+  environment = [ordered]@{
+    flags  = $Flags
+    policy = 'default'
+  }
+  cli = [ordered]@{
+    artifacts = [ordered]@{
+      reportSizeBytes = 128
+      imageCount      = 0
+    }
+  }
+}
+$cap | ConvertTo-Json -Depth 6 | Out-File -LiteralPath $capPath -Encoding utf8
+'@ | Set-Content -LiteralPath $stubPath -Encoding utf8
+
+    $resultsDir = Join-Path $TestDrive 'history'
+    $args = @(
+      '-File', $scriptPath,
+      '-ViName', 'VI1.vi',
+      '-Branch', 'HEAD',
+      '-MaxPairs', 2,
+      '-ResultsDir', $resultsDir,
+      '-LvCompareArgs', '-nobdcosm',
+      '-InvokeScriptPath', $stubPath,
+      '-Quiet'
+    )
+
+    pwsh @args
+
+    $summaryPath = Join-Path $resultsDir 'history-summary.json'
+    Test-Path -LiteralPath $summaryPath -PathType Leaf | Should -BeTrue
+    $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 10
+    $summary.schema | Should -Be 'vi-history-compare/v1'
+    ($summary.pairs | Measure-Object).Count | Should -BeGreaterThan 0
+
+    $executedPairs = @($summary.pairs | Where-Object { -not $_.skippedIdentical -and -not $_.skippedMissing })
+    if ($executedPairs.Count -gt 0) {
+      foreach ($pair in $executedPairs) {
+        Test-Path -LiteralPath $pair.summaryJson | Should -BeTrue
+        Test-Path -LiteralPath $pair.reportHtml | Should -BeTrue
+        $pair.lvcompare | Should -Not -Be $null
+      }
+    }
+  }
+}

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -1,0 +1,378 @@
+param(
+  [Parameter(Mandatory = $true)][string]$ViName,
+  [string]$Branch = 'HEAD',
+  [int]$MaxPairs = 20,
+  [string]$ResultsDir = 'tests/results/ref-compare-history',
+  [string]$LvCompareArgs,
+  [string]$InvokeScriptPath,
+  [switch]$FailOnDiff,
+  [switch]$IncludeIdenticalPairs,
+  [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$Arguments,
+    [switch]$IgnoreNonZero
+  )
+
+  $result = & git @Arguments 2>&1
+  $exitCode = $LASTEXITCODE
+  if (-not $IgnoreNonZero -and $exitCode -ne 0) {
+    throw "git $($Arguments -join ' ') failed: $result"
+  }
+  if ($result -is [System.Array]) {
+    $lines = @($result)
+  } else {
+    $lines = ($result -split "`r?`n")
+  }
+  return @($lines | Where-Object { $_ -ne $null })
+}
+
+function Split-ArgString {
+  param([string]$Value)
+  if ([string]::IsNullOrWhiteSpace($Value)) { return @() }
+  $errors = $null
+  $tokens = [System.Management.Automation.PSParser]::Tokenize($Value, [ref]$errors)
+  $accepted = @('CommandArgument', 'String', 'Number', 'CommandParameter')
+  $list = @()
+  foreach ($token in $tokens) {
+    if ($accepted -contains $token.Type) { $list += $token.Content }
+  }
+  return @($list | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Get-ItemCount {
+  param($Value)
+  if ($null -eq $Value) { return 0 }
+  if ($Value -is [System.Collections.IDictionary]) { return $Value.Count }
+  if ($Value -is [System.Collections.ICollection]) { return $Value.Count }
+  if ($Value -is [string]) { return ([string]::IsNullOrWhiteSpace($Value)) ? 0 : 1 }
+  return (@($Value) | Measure-Object).Count
+}
+
+function Resolve-ViRelativePath {
+  param(
+    [Parameter(Mandatory = $true)][string]$ViName,
+    [Parameter(Mandatory = $true)][string[]]$Refs
+  )
+
+  $viLeaf = $ViName.Trim()
+  if ([string]::IsNullOrWhiteSpace($viLeaf)) { throw "VI name cannot be empty." }
+  $viLeafLower = $viLeaf.ToLowerInvariant()
+  $refMatches = [ordered]@{}
+  $pathLookup = @{}
+
+  foreach ($ref in $Refs | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) {
+    $pathsForRef = @()
+    $ls = Invoke-Git -Arguments @('ls-tree', '-r', '--name-only', $ref)
+    foreach ($entry in @($ls)) {
+      if (-not $entry) { continue }
+      $leaf = (Split-Path $entry -Leaf)
+      if ($leaf -and $leaf.ToLowerInvariant() -eq $viLeafLower) {
+        $pathsForRef += $entry
+        $lower = $entry.ToLowerInvariant()
+        if (-not $pathLookup.ContainsKey($lower)) { $pathLookup[$lower] = $entry }
+      }
+    }
+    if ($pathsForRef.Count -gt 0) { $refMatches[$ref] = $pathsForRef }
+  }
+
+  if ($refMatches.Count -eq 0) {
+    throw "VI '$ViName' not found in refs: $($Refs -join ', ')"
+  }
+
+  $lowerLists = @()
+  foreach ($pair in $refMatches.GetEnumerator()) {
+    $lowerLists += ,(@($pair.Value | ForEach-Object { $_.ToLowerInvariant() }))
+  }
+
+  $commonLower = $lowerLists[0]
+  for ($i = 1; $i -lt $lowerLists.Count; $i++) {
+    $current = $lowerLists[$i]
+    $commonLower = @($commonLower | Where-Object { $current -contains $_ })
+  }
+
+  $commonLower = @($commonLower | Select-Object -Unique)
+  $commonPaths = @($commonLower | ForEach-Object { $pathLookup[$_] }) | Where-Object { $_ }
+  $allLower = @($pathLookup.Keys)
+  $allPaths = @($allLower | ForEach-Object { $pathLookup[$_] }) | Where-Object { $_ }
+
+  $pathScore = {
+    param([string]$PathValue)
+    $score = 0
+    if ($PathValue -match '^tmp-commit') { $score += 200 }
+    elseif ($PathValue -match '^tmp') { $score += 150 }
+    if ($PathValue -match '^tests/') { $score += 100 }
+    $depth = (($PathValue -split '/').Count - 1)
+    if ($depth -gt 0) { $score += ($depth * 25) }
+    $score += [Math]::Min([int]$PathValue.Length, 500) / 10
+    return $score
+  }
+
+  $candidates = @($commonPaths)
+  if ($candidates.Count -eq 0) { $candidates = @($allPaths) }
+  if ($candidates.Count -eq 0) {
+    throw "Unable to resolve VI path for '$ViName'."
+  }
+
+  $ordered = $candidates | Sort-Object @{ Expression = { & $pathScore $_ } }, @{ Expression = { $_ } }
+  $chosen = $ordered | Select-Object -First 1
+  if (-not $chosen) { throw "Unable to resolve VI path for '$ViName'." }
+  if ($candidates.Count -gt 1) {
+    Write-Verbose ("[Compare-VIHistory] Multiple candidates for '{0}'; selected '{1}'" -f $ViName, $chosen)
+  }
+  return $chosen
+}
+
+$repoRoot = (Get-Location).Path
+$compareScript = Join-Path $repoRoot 'tools' 'Compare-RefsToTemp.ps1'
+if (-not (Test-Path -LiteralPath $compareScript -PathType Leaf)) {
+  throw "Compare-RefsToTemp.ps1 not found at expected path: $compareScript"
+}
+
+Invoke-Git -Arguments @('rev-parse', '--is-inside-work-tree') > $null
+
+$resolvedPath = Resolve-ViRelativePath -ViName $ViName -Refs @($Branch)
+Write-Verbose "Resolved VI path: $resolvedPath"
+
+$logArgs = @('log', '--follow', '--format=%H', $Branch, '--', $resolvedPath)
+$commitList = @(Invoke-Git -Arguments $logArgs | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+Write-Verbose ("Commit hashes (newest first): {0}" -f ($commitList -join ', '))
+$commitCount = Get-ItemCount $commitList
+if (-not $Quiet) { Write-Host "Commit count detected: $commitCount" }
+if ($commitCount -lt 2) {
+  Write-Host "Only one commit touches $ViName; nothing to compare."
+  exit 0
+}
+
+if ($MaxPairs -lt 1) { $MaxPairs = 1 }
+$desiredCount = [Math]::Min((Get-ItemCount $commitList), $MaxPairs + 1)
+$commitTotal = Get-ItemCount $commitList
+if (-not $Quiet) {
+  Write-Host "Found $commitTotal commits touching $ViName (using last $desiredCount for history scan)."
+}
+$recentCommits = @($commitList | Select-Object -Last $desiredCount)
+[array]::Reverse($recentCommits)
+$pairs = @()
+$recentCommitCount = Get-ItemCount $recentCommits
+Write-Verbose ("Recent commit window (oldest->newest): {0}" -f ($recentCommits -join ', '))
+Write-Verbose ("Recent commit count: {0}" -f $recentCommitCount)
+for ($i = 0; $i -lt $recentCommitCount - 1; $i++) {
+  $pairs += [pscustomobject]@{
+    Index = $i
+    RefA  = $recentCommits[$i]
+    RefB  = $recentCommits[$i + 1]
+  }
+}
+
+$pairCount = Get-ItemCount $pairs
+if (-not $Quiet) { Write-Host "Generated pair count: $pairCount" }
+if ($pairCount -eq 0) {
+  Write-Host "No commit pairs found for $ViName."
+  exit 0
+}
+
+$resultsRoot = if ([System.IO.Path]::IsPathRooted($ResultsDir)) { $ResultsDir } else { Join-Path $repoRoot $ResultsDir }
+New-Item -ItemType Directory -Force -Path $resultsRoot | Out-Null
+
+$flagTokens = Split-ArgString -Value $LvCompareArgs
+$summaryItems = @()
+$hadFailure = $false
+$markdownRows = @()
+
+function Get-BlobIdForPath {
+  param(
+    [Parameter(Mandatory = $true)][string]$Ref,
+    [Parameter(Mandatory = $true)][string]$Path
+  )
+  $output = Invoke-Git -Arguments @('rev-parse', "$Ref`:$Path") -IgnoreNonZero
+  if (-not $output) { return $null }
+  $first = ($output | Select-Object -First 1)
+  if (-not $first) { return $null }
+  return $first.Trim()
+}
+
+foreach ($pair in $pairs) {
+  $refA = $pair.RefA
+  $refB = $pair.RefB
+  $index = $pair.Index
+  $pairLabel = "{0:D2}-{1:D2}" -f $index, ($index + 1)
+
+  $pathA = $null
+  $pathB = $null
+  $pathError = $null
+  try {
+    $pathA = Resolve-ViRelativePath -ViName $ViName -Refs @($refA)
+  } catch {
+    $pathError = "Ref $refA missing ${ViName}: $($_.Exception.Message)"
+  }
+  if (-not $pathError) {
+    try {
+      $pathB = Resolve-ViRelativePath -ViName $ViName -Refs @($refB)
+    } catch {
+      $pathError = "Ref $refB missing ${ViName}: $($_.Exception.Message)"
+    }
+  }
+  if ($pathError) {
+    $summaryItems += [ordered]@{
+      refA             = $refA
+      refB             = $refB
+      pair             = $pairLabel
+      skippedIdentical = $false
+      skippedMissing   = $true
+      skipReason       = $pathError
+      diff             = $false
+      exitCode         = $null
+      summaryJson      = $null
+      reportHtml       = $null
+      highlights       = @()
+      blobA            = $null
+      blobB            = $null
+      lvcompare        = $null
+    }
+    $markdownRows += "| $pairLabel | Skipped (missing VI) | - | $pathError |"
+    continue
+  }
+  $blobA = Get-BlobIdForPath -Ref $refA -Path $pathA
+  $blobB = Get-BlobIdForPath -Ref $refB -Path $pathB
+  $identical = ($blobA -ne $null -and $blobA -eq $blobB)
+
+  if ($identical -and -not $IncludeIdenticalPairs) {
+    $summaryItems += [ordered]@{
+      refA              = $refA
+      refB              = $refB
+      pair              = $pairLabel
+      skippedIdentical  = $true
+      skippedMissing    = $false
+      skipReason        = $null
+      diff              = $false
+      exitCode          = $null
+      summaryJson       = $null
+      reportHtml        = $null
+      highlights        = @()
+      blobA             = $blobA
+      blobB             = $blobB
+      lvcompare         = $null
+    }
+    $markdownRows += "| $pairLabel | Skipped (identical) | - | - |"
+    continue
+  }
+
+  $outName = ('{0}-{1}' -f ($ViName -replace '[^A-Za-z0-9._-]+', '_'), $pairLabel)
+  $args = @(
+    '-NoLogo', '-NoProfile', '-File', $compareScript,
+    '-ViName', $ViName,
+    '-RefA', $refA,
+    '-RefB', $refB,
+    '-ResultsDir', $resultsRoot,
+    '-OutName', $outName,
+    '-Detailed',
+    '-RenderReport',
+    '-Quiet:$false'
+  )
+  if ($InvokeScriptPath) {
+    $args += '-InvokeScriptPath'
+    $args += $InvokeScriptPath
+  }
+  if ($flagTokens -and $flagTokens.Length -gt 0) {
+    $args += '-LvCompareArgs'
+    $args += ($flagTokens -join ' ')
+  }
+  $args += (if ($FailOnDiff) { '-FailOnDiff:$true' } else { '-FailOnDiff:$false' })
+
+  if (-not $Quiet) {
+    Write-Host "Comparing $ViName for commits $refA -> $refB (pair $pairLabel)..."
+  }
+
+  $proc = Start-Process -FilePath 'pwsh' -ArgumentList $args -Wait -PassThru -WindowStyle Hidden
+  $exitCode = $proc.ExitCode
+
+  $compareSummaryPath = Join-Path $resultsRoot ("$outName-summary.json")
+  $compareReportPath = Join-Path $resultsRoot ("$outName-artifacts")
+  $summaryJson = $null
+  $cliInfo = $null
+  $diffResult = $null
+  $highlights = @()
+  $reportFile = $null
+
+  if (Test-Path -LiteralPath $compareSummaryPath) {
+    $summaryJson = Get-Content -LiteralPath $compareSummaryPath -Raw | ConvertFrom-Json -Depth 8
+    $diffResult = $summaryJson.cli.diff
+    $cliInfo = $summaryJson.cli
+    if ($summaryJson.out -and $summaryJson.out.reportHtml) {
+      $reportFile = $summaryJson.out.reportHtml
+    }
+    if ($summaryJson.cli -and $summaryJson.cli.highlights) {
+      $highlights = @($summaryJson.cli.highlights)
+    }
+  }
+
+  if ($exitCode -ne 0 -and -not ($FailOnDiff -and $diffResult)) {
+    $hadFailure = $true
+  }
+
+  $summaryItems += [ordered]@{
+    refA             = $refA
+    refB             = $refB
+    pair             = $pairLabel
+    skippedIdentical = $false
+    skippedMissing   = $false
+    skipReason       = $null
+    diff             = [bool]$diffResult
+    exitCode         = $exitCode
+    summaryJson      = $compareSummaryPath
+    reportHtml       = $reportFile
+    highlights       = $highlights
+    blobA            = $blobA
+    blobB            = $blobB
+    lvcompare        = $cliInfo
+  }
+
+  $status = if ($diffResult) { 'Diff' } elseif ($exitCode -eq 0) { 'No diff' } else { "Error ($exitCode)" }
+  $highlightText = if (Get-ItemCount $highlights -gt 0) { ($highlights | Select-Object -First 2) -join '; ' } else { '' }
+  $mkNotes = if ($highlightText) { $highlightText } elseif ($reportFile) { (Split-Path $reportFile -Leaf) } else { '' }
+  $markdownRows += "| $pairLabel | $status | $exitCode | $mkNotes |"
+}
+
+$historySummary = [ordered]@{
+  schema         = 'vi-history-compare/v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  viName         = $ViName
+  branch         = $Branch
+  resolvedPath   = $resolvedPath
+  maxPairs       = $MaxPairs
+  lvcompareArgs  = $flagTokens
+  includeIdentical = [bool]$IncludeIdenticalPairs
+  resultsDir     = $resultsRoot
+  pairs          = $summaryItems
+}
+
+$summaryPath = Join-Path $resultsRoot 'history-summary.json'
+$historySummary | ConvertTo-Json -Depth 10 | Out-File -LiteralPath $summaryPath -Encoding utf8
+
+if (-not $Quiet) {
+  Write-Host "History summary written to $summaryPath"
+}
+
+if ($env:GITHUB_STEP_SUMMARY) {
+  $lines = @(
+    '### VI History Compare',
+    '',
+    "| Pair | Outcome | Exit | Notes |",
+    "|------|---------|------|-------|"
+  )
+  if (Get-ItemCount $markdownRows -gt 0) {
+    $lines += $markdownRows
+  } else {
+    $lines += "| - | - | - | - |"
+  }
+  $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+
+if ($hadFailure) {
+  throw "One or more comparisons failed. See $resultsRoot for details."
+}


### PR DESCRIPTION
# Summary

Briefly describe the changes.

## Changes

- [ ] Updated action.yml logic
- [ ] Updated README/docs
- [ ] Updated workflows

## Testing

- [ ] Unit tests passed (Pester tests workflow)
- [ ] Ran Test (mock) on windows-latest and it passed
- [ ] Ran Smoke on self-hosted Windows and recorded exit codes
- [ ] Verified outputs (`diff`, `exitCode`, `cliPath`, `command`) and step summary

## Documentation

- [ ] README updated (usage, args, troubleshooting)
- [ ] CHANGELOG updated (user-facing changes)
- [ ] Copilot instructions updated if behavior changed

## Checklist

- [ ] CI green (Validate, Pester tests, Test (mock))
- [ ] Tag plan prepared (if releasing)

## Smoke test (optional guidance)

- If you have access to the self-hosted runner with LabVIEW, run `.github/workflows/smoke.yml`.
- Provide inputs, or ensure repo variables exist:
  - `LV_BASE_VI` (no-diff), `LV_HEAD_VI` (diff), `LVCOMPARE_PATH`
