### PR TITLE
Add backbone helper and harden compare history (#254)

### DIFF
--- a/PR_NOTES.md
+++ b/PR_NOTES.md
@@ -57,14 +57,22 @@ Release v0.5.1 focuses on four pillars:
 
 ## 7. Validation Snapshot (goal = all checked before merge/tag)
 
-- [ ] Validate workflow (actionlint, markdownlint, docs links) – rerun until clean.
-- [ ] `./Invoke-PesterTests.ps1` (non-integration) – expect PASS, session index uploaded.
-- [ ] Self-hosted integration run (`./Invoke-PesterTests.ps1 -IntegrationMode include`) – ensure guard/integration path
+- [ ] Validate workflow (actionlint, markdownlint, docs links) - rerun until clean.
+- [ ] `./Invoke-PesterTests.ps1` (non-integration) - expect PASS, session index uploaded.
+- [ ] Self-hosted integration run (`./Invoke-PesterTests.ps1 -IntegrationMode include`) - ensure guard/integration path
       exits cleanly.
-- [ ] Fixture drift jobs (Windows + Ubuntu) – confirm size/bytes alignment.
+- [ ] Fixture drift jobs (Windows + Ubuntu) - confirm size/bytes alignment.
 - [ ] LabVIEW CLI provider smoke: `tools/TestStand-CompareHarness.ps1` should complete without `CreateComparisonReport`
       errors.
 - [ ] `node tools/npm/run-script.mjs priority:release` succeeds, writing `tests/results/_agent/handoff/release-summary.json`.
+
+## 7a. Compare History Artifact Sanity
+
+- Confirm `tests/results/ref-compare-history/history-summary.json` exists, schema=`vi-history-compare/v1`, and `pairs` matches the commit window inspected.
+- For each pair, open the matching `*-summary.json`; ensure `cli.diff`, `exitCode`, and `reportHtml` align with expectations (diffs have `exitCode = 1`, identical runs stay at `0`).
+- Spot-check the rendered report (`cli-report.html`) for at least the first diff, verifying highlighted sections reflect the regression under review.
+- Ensure highlights captured in the summary (`cli.highlights`) mirror the report and that the artifact directory holds stdout/stderr captures for triage.
+- If `IncludeIdenticalPairs` was enabled, verify identical entries are flagged (`skippedIdentical=true`) and excluded from markdown rows when not requested.
 
 ## 8. Risks & Mitigations
 

--- a/tests/CompareVI.Integration.Tests.ps1
+++ b/tests/CompareVI.Integration.Tests.ps1
@@ -183,7 +183,7 @@ Describe 'Invoke-CompareVI (real CLI on self-hosted)' -Tag Integration {
 
     # Verify flags are in the command
     foreach ($flag in @('-noattr','-nofp','-nofppos','-nobd','-nobdcosm')) {
-      $res.Command | Should -Match [regex]::Escape($flag)
+      ($res.Command.IndexOf($flag, [System.StringComparison]::OrdinalIgnoreCase)) | Should -BeGreaterThan -1 -Because $flag
     }
   }
 
@@ -218,7 +218,7 @@ Describe 'Invoke-CompareVI (real CLI on self-hosted)' -Tag Integration {
     # Verify all flags are in the command
     $res.Command | Should -Match '-lvpath'
     foreach ($flag in @('-noattr','-nofp','-nofppos','-nobd','-nobdcosm')) {
-      $res.Command | Should -Match [regex]::Escape($flag)
+      ($res.Command.IndexOf($flag, [System.StringComparison]::OrdinalIgnoreCase)) | Should -BeGreaterThan -1 -Because $flag
     }
   }
 }

--- a/tests/CompareVIHistory.Tests.ps1
+++ b/tests/CompareVIHistory.Tests.ps1
@@ -1,13 +1,12 @@
 Describe 'Compare-VIHistory.ps1' {
-  It 'produces history summary artifacts using stub LVCompare' {
-    $ErrorActionPreference = 'Stop'
+  $repoRoot = (Get-Location).Path
+  $scriptPath = Join-Path $repoRoot 'tools' 'Compare-VIHistory.ps1'
+  Test-Path -LiteralPath $scriptPath -PathType Leaf | Should -BeTrue
 
-    $repoRoot = (Get-Location).Path
-    $scriptPath = Join-Path $repoRoot 'tools' 'Compare-VIHistory.ps1'
-    Test-Path -LiteralPath $scriptPath -PathType Leaf | Should -BeTrue
-
-    $stubPath = Join-Path $TestDrive 'Invoke-LVCompare.stub.ps1'
-    @'
+  Context 'artifact handling' {
+    It 'falls back to cli-report.html when compare report is renamed' {
+      $scriptPath = Join-Path (Get-Location).Path 'tools' 'Compare-VIHistory.ps1'
+      $stubTemplate = @'
 param(
   [string]$BaseVi,
   [string]$HeadVi,
@@ -17,75 +16,266 @@ param(
 $ErrorActionPreference = 'Stop'
 if (-not $OutputDir) { $OutputDir = Join-Path $env:TEMP ([guid]::NewGuid().ToString()) }
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$exitCodeValue = 0
+if ($env:STUB_COMPARE_EXITCODE) {
+  $parsed = 0
+  if ([int]::TryParse($env:STUB_COMPARE_EXITCODE, [ref]$parsed)) {
+    $exitCodeValue = $parsed
+  }
+}
+
+function Get-StubBool([string]$value) {
+  if ([string]::IsNullOrWhiteSpace($value)) { return $false }
+  switch -Regex ($value.ToLowerInvariant()) {
+    '^(1|true|yes|on)$' { return $true }
+    default { return $false }
+  }
+}
+
+$diffFlag     = Get-StubBool $env:STUB_COMPARE_DIFF
+$renameReport = Get-StubBool $env:STUB_COMPARE_RENAME_REPORT
+
 $stdoutPath = Join-Path $OutputDir 'lvcompare-stdout.txt'
 $stderrPath = Join-Path $OutputDir 'lvcompare-stderr.txt'
 $exitPath   = Join-Path $OutputDir 'lvcompare-exitcode.txt'
 $reportPath = Join-Path $OutputDir 'compare-report.html'
+$cliReport  = Join-Path $OutputDir 'cli-report.html'
 $capPath    = Join-Path $OutputDir 'lvcompare-capture.json'
+
 "Stub compare for $BaseVi -> $HeadVi (flags: $($Flags -join ' '))" | Out-File -LiteralPath $stdoutPath -Encoding utf8
 '' | Out-File -LiteralPath $stderrPath -Encoding utf8
-'0' | Out-File -LiteralPath $exitPath -Encoding utf8
+$exitCodeValue.ToString() | Out-File -LiteralPath $exitPath -Encoding utf8
 '<html><body><h1>Stub Report</h1></body></html>' | Out-File -LiteralPath $reportPath -Encoding utf8
-$cap = [pscustomobject]@{
+
+if (Test-Path -LiteralPath $cliReport) { Remove-Item -LiteralPath $cliReport -Force }
+
+if ($renameReport) {
+  Rename-Item -LiteralPath $reportPath -NewName (Split-Path $cliReport -Leaf)
+} else {
+  Copy-Item -LiteralPath $reportPath -Destination $cliReport -Force
+}
+
+$cap = [ordered]@{
   schema   = 'lvcompare-capture-v1'
-  exitCode = 0
-  seconds  = 0.01
+  exitCode = $exitCodeValue
+  seconds  = 0.02
   command  = 'stub'
   cliPath  = 'stub'
   base     = $BaseVi
   head     = $HeadVi
+  diff     = $diffFlag
   args     = $Flags
   environment = [ordered]@{
     flags  = $Flags
     policy = 'default'
   }
-  cli = [ordered]@{
-    artifacts = [ordered]@{
-      reportSizeBytes = 128
-      imageCount      = 0
-    }
+  cli      = [ordered]@{
+    exitCode   = $exitCodeValue
+    diff       = $diffFlag
+    highlights = @("stub: $HeadVi")
   }
 }
 $cap | ConvertTo-Json -Depth 6 | Out-File -LiteralPath $capPath -Encoding utf8
-'@ | Set-Content -LiteralPath $stubPath -Encoding utf8
+'@
+      $stubPath = Join-Path $TestDrive 'Invoke-LVCompare.stub.ps1'
+      Set-Content -LiteralPath $stubPath -Value $stubTemplate -Encoding utf8
 
-    $resultsDir = Join-Path $TestDrive 'history'
-    $args = @(
-      '-File', $scriptPath,
-      '-ViName', 'VI1.vi',
-      '-Branch', 'HEAD',
-      '-MaxPairs', 2,
-      '-ResultsDir', $resultsDir,
-      '-LvCompareArgs', '-nobdcosm',
-      '-InvokeScriptPath', $stubPath,
-      '-Quiet'
-    )
+      $resultsDir = Join-Path $TestDrive 'history-fallback'
+      $env:STUB_COMPARE_RENAME_REPORT = '1'
+      try {
+        $invokeHistory = {
+          param([string[]]$ExtraArgs)
+          $baseArgs = @(
+            '-NoLogo', '-NoProfile',
+            '-File', $scriptPath,
+            '-ViName', 'VI1.vi',
+            '-Branch', 'HEAD',
+            '-MaxPairs', 2,
+            '-ResultsDir', $resultsDir,
+            '-InvokeScriptPath', $stubPath,
+            '-Quiet'
+          )
+          if ($ExtraArgs) { $baseArgs += $ExtraArgs }
+          $proc = Start-Process -FilePath 'pwsh' -ArgumentList $baseArgs -Wait -PassThru -WindowStyle Hidden
+          return $proc.ExitCode
+        }
 
-    pwsh @args
+        $exit = & $invokeHistory @()
+        $exit | Should -Be 0
 
-    $summaryPath = Join-Path $resultsDir 'history-summary.json'
-    if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
-      Set-ItResult -Skipped -Because "history summary not produced for branch window (likely no commits with VI present)"
-      return
-    }
-    $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 10
-    $summary.schema | Should -Be 'vi-history-compare/v1'
-    ($summary.commitWindow | Measure-Object).Count | Should -BeGreaterThan 0
-    $summary.missingStrategy | Should -Be 'skip'
-    $summary.missingSegments | Should -Not -Be $null
-    ($summary.pairs | Measure-Object).Count | Should -BeGreaterThanOrEqual 0
+        $summaryPath = Join-Path $resultsDir 'history-summary.json'
+        if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+          Set-ItResult -Skipped -Because "history summary not produced for branch window (likely no commits with VI present)"
+          return
+        }
 
-    $executedPairs = @($summary.pairs | Where-Object { -not $_.skippedIdentical -and -not $_.skippedMissing })
-    if ($executedPairs.Count -gt 0) {
-      foreach ($pair in $executedPairs) {
-        $pair.pathA | Should -Not -BeNullOrEmpty
-        $pair.pathB | Should -Not -BeNullOrEmpty
-        $pair.summaryJson | Should -Not -BeNullOrEmpty
+        $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 10
+        $summary.schema | Should -Be 'vi-history-compare/v1'
+        $executedPairs = @($summary.pairs | Where-Object { -not $_.skippedIdentical -and -not $_.skippedMissing })
+        if ($executedPairs.Count -eq 0) {
+          Set-ItResult -Skipped -Because "no executed pairs were generated for VI1.vi on this branch"
+          return
+        }
+
+        $pair = $executedPairs | Select-Object -First 1
         $pair.reportHtml | Should -Not -BeNullOrEmpty
-        $pair.lvcompare | Should -Not -Be $null
+        $pair.reportHtml | Should -Match 'cli-report\.html$'
+        Test-Path -LiteralPath $pair.reportHtml -PathType Leaf | Should -BeTrue
       }
-    } else {
-      ($summary.missingSegments | Measure-Object).Count | Should -BeGreaterThan 0
+      finally {
+        Remove-Item Env:STUB_COMPARE_RENAME_REPORT -ErrorAction SilentlyContinue
+        Remove-Item Env:STUB_COMPARE_EXITCODE -ErrorAction SilentlyContinue
+        Remove-Item Env:STUB_COMPARE_DIFF -ErrorAction SilentlyContinue
+      }
+    }
+  }
+
+  Context 'diff exit handling' {
+    It 'treats exit code 1 with diff as success unless FailOnDiff is set' {
+      $scriptPath = Join-Path (Get-Location).Path 'tools' 'Compare-VIHistory.ps1'
+      $stubTemplate = @'
+param(
+  [string]$BaseVi,
+  [string]$HeadVi,
+  [string]$OutputDir,
+  [string[]]$Flags
+)
+$ErrorActionPreference = 'Stop'
+if (-not $OutputDir) { $OutputDir = Join-Path $env:TEMP ([guid]::NewGuid().ToString()) }
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$exitCodeValue = 0
+if ($env:STUB_COMPARE_EXITCODE) {
+  $parsed = 0
+  if ([int]::TryParse($env:STUB_COMPARE_EXITCODE, [ref]$parsed)) {
+    $exitCodeValue = $parsed
+  }
+}
+
+function Get-StubBool([string]$value) {
+  if ([string]::IsNullOrWhiteSpace($value)) { return $false }
+  switch -Regex ($value.ToLowerInvariant()) {
+    '^(1|true|yes|on)$' { return $true }
+    default { return $false }
+  }
+}
+
+$diffFlag     = Get-StubBool $env:STUB_COMPARE_DIFF
+$renameReport = Get-StubBool $env:STUB_COMPARE_RENAME_REPORT
+
+$stdoutPath = Join-Path $OutputDir 'lvcompare-stdout.txt'
+$stderrPath = Join-Path $OutputDir 'lvcompare-stderr.txt'
+$exitPath   = Join-Path $OutputDir 'lvcompare-exitcode.txt'
+$reportPath = Join-Path $OutputDir 'compare-report.html'
+$cliReport  = Join-Path $OutputDir 'cli-report.html'
+$capPath    = Join-Path $OutputDir 'lvcompare-capture.json'
+
+"Stub compare for $BaseVi -> $HeadVi (flags: $($Flags -join ' '))" | Out-File -LiteralPath $stdoutPath -Encoding utf8
+'' | Out-File -LiteralPath $stderrPath -Encoding utf8
+$exitCodeValue.ToString() | Out-File -LiteralPath $exitPath -Encoding utf8
+'<html><body><h1>Stub Report</h1></body></html>' | Out-File -LiteralPath $reportPath -Encoding utf8
+
+if (Test-Path -LiteralPath $cliReport) { Remove-Item -LiteralPath $cliReport -Force }
+
+if ($renameReport) {
+  Rename-Item -LiteralPath $reportPath -NewName (Split-Path $cliReport -Leaf)
+} else {
+  Copy-Item -LiteralPath $reportPath -Destination $cliReport -Force
+}
+
+$cap = [ordered]@{
+  schema   = 'lvcompare-capture-v1'
+  exitCode = $exitCodeValue
+  seconds  = 0.02
+  command  = 'stub'
+  cliPath  = 'stub'
+  base     = $BaseVi
+  head     = $HeadVi
+  diff     = $diffFlag
+  args     = $Flags
+  environment = [ordered]@{
+    flags  = $Flags
+    policy = 'default'
+  }
+  cli      = [ordered]@{
+    exitCode   = $exitCodeValue
+    diff       = $diffFlag
+    highlights = @("stub: $HeadVi")
+  }
+}
+$cap | ConvertTo-Json -Depth 6 | Out-File -LiteralPath $capPath -Encoding utf8
+'@
+      $stubPath = Join-Path $TestDrive 'Invoke-LVCompare.diffstub.ps1'
+      Set-Content -LiteralPath $stubPath -Value $stubTemplate -Encoding utf8
+
+      $resultsDir = Join-Path $TestDrive 'history-diff'
+      $env:STUB_COMPARE_EXITCODE = '1'
+      $env:STUB_COMPARE_DIFF = '1'
+      try {
+        $invokeHistory = {
+          param([string[]]$ExtraArgs)
+          $baseArgs = @(
+            '-NoLogo', '-NoProfile',
+            '-File', $scriptPath,
+            '-ViName', 'VI1.vi',
+            '-Branch', 'HEAD',
+            '-MaxPairs', 1,
+            '-ResultsDir', $resultsDir,
+            '-InvokeScriptPath', $stubPath,
+            '-Quiet'
+          )
+          if ($ExtraArgs) { $baseArgs += $ExtraArgs }
+          $proc = Start-Process -FilePath 'pwsh' -ArgumentList $baseArgs -Wait -PassThru -WindowStyle Hidden
+          return $proc.ExitCode
+        }
+
+        $exit = & $invokeHistory @()
+        $exit | Should -Be 0
+
+        $summaryPath = Join-Path $resultsDir 'history-summary.json'
+        if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+          Set-ItResult -Skipped -Because "history summary not produced for branch window (likely no commits with VI present)"
+          return
+        }
+
+        $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 10
+        $pair = @($summary.pairs | Where-Object { -not $_.skippedIdentical -and -not $_.skippedMissing }) | Select-Object -First 1
+        if (-not $pair) {
+          Set-ItResult -Skipped -Because "no executed pairs were generated for VI1.vi on this branch"
+          return
+        }
+
+        $pair.exitCode | Should -Be 0
+        $pair.diff | Should -BeTrue
+        if ($pair.lvcompare) {
+          $pair.lvcompare.exitCode | Should -Be 1
+          $pair.lvcompare.diff | Should -BeTrue
+        }
+
+        if (-not $pair.diff) {
+          Set-ItResult -Skipped -Because "no diff detected for VI1.vi on this branch"
+          return
+        }
+
+        $null = pwsh @(
+          '-NoLogo','-NoProfile',
+          '-File', $scriptPath,
+          '-ViName','VI1.vi',
+          '-Branch','HEAD',
+          '-MaxPairs','1',
+          '-ResultsDir', $resultsDir,
+          '-InvokeScriptPath', $stubPath,
+          '-Quiet',
+          '-FailOnDiff'
+        )
+        $LASTEXITCODE | Should -Be 1
+      }
+      finally {
+        Remove-Item Env:STUB_COMPARE_RENAME_REPORT -ErrorAction SilentlyContinue
+        Remove-Item Env:STUB_COMPARE_EXITCODE -ErrorAction SilentlyContinue
+        Remove-Item Env:STUB_COMPARE_DIFF -ErrorAction SilentlyContinue
+      }
     }
   }
 }

--- a/tools/Run-LocalBackbone.ps1
+++ b/tools/Run-LocalBackbone.ps1
@@ -1,0 +1,168 @@
+param(
+  [switch]$SkipPrioritySync,
+  [string[]]$CompareViName,
+  [string]$CompareBranch = 'HEAD',
+  [int]$CompareMaxPairs = 1,
+  [switch]$CompareIncludeIdenticalPairs,
+  [switch]$CompareFailOnDiff,
+  [string]$CompareLvCompareArgs,
+  [string]$CompareResultsDir,
+  [switch]$SkipCompareHistory,
+  [string]$AdditionalScriptPath,
+  [string[]]$AdditionalScriptArguments,
+  [switch]$IncludeIntegration,
+  [switch]$SkipPester,
+  [switch]$UseLocalRunTests,
+  [switch]$SkipPrePushChecks,
+  [switch]$RunWatcherUpdate,
+  [string]$WatcherJson,
+  [string]$WatcherResultsDir = 'tests/results',
+  [switch]$CheckLvEnv,
+  [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $PSCommandPath
+$repoRoot = Resolve-Path (Join-Path $scriptRoot '..') | Select-Object -ExpandProperty Path
+
+function Invoke-BackboneStep {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][scriptblock]$Action,
+    [switch]$SkipWhenDryRun
+  )
+
+  Write-Host ""
+  Write-Host ("=== {0} ===" -f $Name) -ForegroundColor Cyan
+  if ($DryRun -and $SkipWhenDryRun) {
+    Write-Host "[dry-run] Step skipped by request." -ForegroundColor Yellow
+    return
+  }
+
+  if ($DryRun) {
+    Write-Host "[dry-run] Step would execute; skipping actual invocation." -ForegroundColor Yellow
+    return
+  }
+
+  & $Action
+  $exit = $LASTEXITCODE
+  if ($exit -ne 0) {
+    throw ("Step '{0}' failed with exit code {1}." -f $Name, $exit)
+  }
+}
+
+Push-Location $repoRoot
+try {
+  Write-Host "Repository root: $repoRoot" -ForegroundColor Gray
+
+  if (-not $SkipPrioritySync) {
+    Invoke-BackboneStep -Name 'priority:sync' -Action {
+      & node tools/npm/run-script.mjs priority:sync
+    }
+  } else {
+    Write-Host "Skipping priority sync as requested." -ForegroundColor Yellow
+  }
+
+  if (-not $SkipCompareHistory -and $CompareViName -and $CompareViName.Count -gt 0) {
+    $viNames = $CompareViName | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    foreach ($vi in $viNames) {
+      $label = "compare-history ($vi)"
+      Invoke-BackboneStep -Name $label -Action {
+        $args = @(
+          '-NoLogo', '-NoProfile',
+          '-File', (Join-Path $repoRoot 'tools' 'Compare-VIHistory.ps1'),
+          '-ViName', $vi,
+          '-Branch', $CompareBranch,
+          '-MaxPairs', [Math]::Max(1, $CompareMaxPairs)
+        )
+        if ($CompareIncludeIdenticalPairs) { $args += '-IncludeIdenticalPairs' }
+        if ($CompareFailOnDiff) { $args += '-FailOnDiff' }
+        if ($CompareLvCompareArgs) {
+          $args += '-LvCompareArgs'
+          $args += $CompareLvCompareArgs
+        }
+        if ($CompareResultsDir) {
+          $args += '-ResultsDir'
+          $args += $CompareResultsDir
+        }
+        & pwsh @args
+      }
+    }
+  } elseif (-not $SkipCompareHistory) {
+    Write-Host "Compare history step requested but no VI names supplied; skipping." -ForegroundColor Yellow
+  } else {
+    Write-Host "Skipping compare-history step as requested." -ForegroundColor Yellow
+  }
+
+  if ($AdditionalScriptPath) {
+    $resolvedScript = Resolve-Path -LiteralPath (Join-Path $repoRoot $AdditionalScriptPath) -ErrorAction Stop
+    Invoke-BackboneStep -Name ("custom-script ({0})" -f (Split-Path $resolvedScript -Leaf)) -Action {
+      $args = @('-NoLogo', '-NoProfile', '-File', $resolvedScript)
+      if ($AdditionalScriptArguments) {
+        $args += $AdditionalScriptArguments
+      }
+      & pwsh @args
+    }
+  }
+
+  if (-not $SkipPester) {
+    if ($UseLocalRunTests) {
+      Invoke-BackboneStep -Name 'Local-RunTests.ps1' -Action {
+        $args = @('-NoLogo', '-NoProfile', '-File', (Join-Path $repoRoot 'tools' 'Local-RunTests.ps1'))
+        if ($IncludeIntegration) { $args += '-IncludeIntegration' }
+        & pwsh @args
+      }
+    } else {
+      Invoke-BackboneStep -Name 'Invoke-PesterTests.ps1' -Action {
+        $args = @('-NoLogo', '-NoProfile', '-File', (Join-Path $repoRoot 'Invoke-PesterTests.ps1'))
+        $args += '-IntegrationMode'
+        $args += (if ($IncludeIntegration) { 'include' } else { 'exclude' })
+        & pwsh @args
+      }
+    }
+  } else {
+    Write-Host "Skipping Pester run as requested." -ForegroundColor Yellow
+  }
+
+  if ($RunWatcherUpdate) {
+    if (-not $WatcherJson) {
+      throw "Watcher update requested but -WatcherJson was not provided."
+    }
+    Invoke-BackboneStep -Name 'Update watcher telemetry' -Action {
+      $args = @(
+        '-NoLogo', '-NoProfile',
+        '-File', (Join-Path $repoRoot 'tools' 'Update-SessionIndexWatcher.ps1'),
+        '-ResultsDir', $WatcherResultsDir,
+        '-WatcherJson', $WatcherJson
+      )
+      & pwsh @args
+    }
+  }
+
+  if ($CheckLvEnv) {
+    Invoke-BackboneStep -Name 'Test integration environment' -Action {
+      $scriptPath = Join-Path $repoRoot 'scripts' 'Test-IntegrationEnvironment.ps1'
+      & pwsh '-NoLogo' '-NoProfile' '-File' $scriptPath
+    }
+  }
+
+  if (-not $SkipPrePushChecks) {
+    Invoke-BackboneStep -Name 'PrePush-Checks.ps1' -Action {
+      & pwsh '-NoLogo' '-NoProfile' '-File' (Join-Path $repoRoot 'tools' 'PrePush-Checks.ps1')
+    }
+  } else {
+    Write-Host "Skipping PrePush-Checks as requested." -ForegroundColor Yellow
+  }
+
+  Write-Host ""
+  Write-Host "Local backbone completed successfully." -ForegroundColor Green
+}
+catch {
+  Write-Error $_
+  exit 1
+}
+finally {
+  Pop-Location
+}


### PR DESCRIPTION
## Summary
- add tools/Run-LocalBackbone.ps1 to orchestrate priority sync -> compare-history -> Pester/testing with optional flags
- harden tools/Compare-VIHistory.ps1 to safely read summary JSON, fall back to cli-report.html, and tolerate diff exit codes
- extend tests/CompareVIHistory.Tests.ps1 with stub coverage and relax compare integration flag assertions

## Testing
- ./Invoke-PesterTests.ps1
- ./Invoke-PesterTests.ps1 -IntegrationMode include
- tools/PrePush-Checks.ps1
