### PR TITLE
feat: guard Validate dispatch for forks (#283)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -1,18 +1,18 @@
 {
-  "number": 277,
-  "title": "Release candidate: v0.5.2",
-  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/277",
+  "number": 283,
+  "title": "Prevent fork dispatch of Validate",
+  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/283",
   "state": "OPEN",
   "labels": [
     "standing-priority"
   ],
   "assignees": [],
   "milestone": null,
-  "commentCount": 4,
-  "lastSeenUpdatedAt": "2025-10-22T06:15:22Z",
-  "issueDigest": "21f3f15d7ba63e9cdb35579d5508f4aba5e531a4de63c188f057e215b69880ab",
-  "bodyDigest": "ec03651863c4b6602e232e7845a533482856cd76604f56b516a8ee8103c65a99",
-  "cachedAtUtc": "2025-10-22T06:36:16.782Z",
+  "commentCount": 0,
+  "lastSeenUpdatedAt": "2025-10-22T14:34:41Z",
+  "issueDigest": "d7a2bf7bca447b0227d93feae7b01af12f288c791d7740989830d7aba24fa543",
+  "bodyDigest": "3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112",
+  "cachedAtUtc": "2025-10-22T14:49:27.914Z",
   "lastFetchSource": "live",
   "lastFetchError": null
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,9 @@ Use `tools/workflows/update_workflows.py` for mechanical updates (comment-preser
 ## Re-run with same inputs
 
 - Summaries include a copy/pastable `gh workflow run` command.
+- Use `node tools/npm/run-script.mjs priority:validate -- --ref <branch>` to dispatch
+  Validate from upstream; the helper blocks fork refs unless you pass `--allow-fork`
+  (or `VALIDATE_DISPATCH_ALLOW_FORK=1`).
 - Comment snippets documented in `.github/PR_COMMENT_SNIPPETS.md`.
 
 ## Watching orchestrated runs

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -19,7 +19,7 @@
 6. Workflow labels enforcement fix merged in PR #280; Validate still needs a fresh run on `main` now that the workflow change is available.
 
 ## Suggested Next Actions
-1. Trigger `Validate` on `main` (or wait for the next push) to confirm the labels enforcement step passes with PR #280 applied.
+1. Trigger `Validate` on `main` via `node tools/npm/run-script.mjs priority:validate -- --ref main` (or wait for the next push) to confirm the labels enforcement step passes with PR #280 applied.
 2. Check the status of PR #279 (release candidate finalize) and trigger CI reruns if any required checks are missing or stale.
 3. Exercise the updated VS Code tasks on another plane (macOS/Linux) to flush out shell-specific issues before documenting them.
 4. Run `pwsh -File tools/PrePush-Checks.ps1` and `node tools/npm/run-script.mjs hooks:multi` once new changes are staged for #277 to keep router priorities green.
@@ -28,7 +28,7 @@
 ## First Actions for the Next Agent
 1. Run `node tools/npm/run-script.mjs priority:sync` to refresh issue #277 metadata and router artifacts.
 2. Review release artifacts under `tests/results/_agent/release/` and sync with PR #279 status before making edits.
-3. Re-run `Validate` on `main` if it has not already picked up the workflow fix; confirm the labels enforcement job reports success.
+3. Re-run `Validate` on `main` with `node tools/npm/run-script.mjs priority:validate -- --ref main` if it has not already picked up the workflow fix; confirm the labels enforcement job reports success.
 4. Check `tests/results/_agent/issue/router.json` for the active validation order (hooks and PrePush) and schedule the relevant runs as changes land.
 
 ## Notes for Next Agent

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "release:branch": "node tools/priority/create-release-branch.mjs",
     "release:branch:dry": "node tools/priority/create-release-branch.dryrun.mjs",
     "release:finalize": "node tools/priority/finalize-release.mjs",
+    "priority:validate": "node tools/priority/dispatch-validate.mjs",
     "release:finalize:dry": "node tools/priority/finalize-release.dryrun.mjs",
     "feature:branch:dry": "node tools/priority/create-feature-branch.dryrun.mjs",
     "feature:finalize:dry": "node tools/priority/finalize-feature.dryrun.mjs",

--- a/tools/priority/__tests__/dispatch-validate.test.mjs
+++ b/tools/priority/__tests__/dispatch-validate.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { dispatchValidate, parseCliOptions } from '../dispatch-validate.mjs';
+
+test('parseCliOptions respects env override', () => {
+  const opts = parseCliOptions(['node', 'script'], { VALIDATE_DISPATCH_ALLOW_FORK: '1' });
+  assert.equal(opts.allowFork, true);
+  assert.equal(opts.ref, null);
+});
+
+test('dispatchValidate blocks fork by default', () => {
+  assert.throws(
+    () =>
+      dispatchValidate({
+        argv: ['node', 'script'],
+        env: {},
+        getRepoRootFn: () => 'repo',
+        resolveContextFn: () => ({
+          upstream: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' },
+          isFork: true
+        }),
+        getCurrentBranchFn: () => 'feature/x',
+        ensureRemoteHasRefFn: () => {},
+        runFn: () => '',
+        ensureGhCliFn: () => {}
+      }),
+    /blocked: working copy points to a fork/i
+  );
+});
+
+test('dispatchValidate allows fork when override set', () => {
+  const calls = [];
+  const result = dispatchValidate({
+    argv: ['node', 'script', '--allow-fork', '--ref', 'feature/x'],
+    env: {},
+    getRepoRootFn: () => 'repo',
+    resolveContextFn: () => ({
+      upstream: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' },
+      isFork: true
+    }),
+    getCurrentBranchFn: () => 'feature/x',
+    ensureRemoteHasRefFn: () => {},
+    runFn: (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === 'run' && args[1] === 'list') {
+        return '[]';
+      }
+      return '';
+    },
+    ensureGhCliFn: () => {}
+  });
+
+  assert.equal(result.dispatched, true);
+  assert.ok(
+    calls.some(
+      (call) =>
+        call.cmd === 'gh' &&
+        call.args[0] === 'workflow' &&
+        call.args[1] === 'run' &&
+        call.args.includes('validate.yml')
+    ),
+    'should dispatch validate workflow via gh'
+  );
+});
+
+test('dispatchValidate fails when ref missing on remote', () => {
+  assert.throws(
+    () =>
+      dispatchValidate({
+        argv: ['node', 'script', '--ref', 'missing'],
+        env: { VALIDATE_DISPATCH_ALLOW_FORK: '1' },
+        getRepoRootFn: () => 'repo',
+        resolveContextFn: () => ({
+          upstream: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' },
+          isFork: false
+        }),
+        getCurrentBranchFn: () => 'missing',
+        ensureRemoteHasRefFn: () => {
+          throw new Error('Ref missing');
+        },
+        runFn: () => '',
+        ensureGhCliFn: () => {}
+      }),
+    /Ref missing/i
+  );
+});
+

--- a/tools/priority/__tests__/snapshot.test.mjs
+++ b/tools/priority/__tests__/snapshot.test.mjs
@@ -57,6 +57,7 @@ test('buildRouter honours policy map and default actions', () => {
   assert.ok(keys.includes('hooks:multi'));
   assert.ok(keys.includes('docs:lint'));
   assert.ok(keys.includes('ci:parity'));
+  assert.ok(keys.includes('validate:dispatch'));
 
   const priorities = router.actions.map((a) => a.priority);
   assert.deepEqual([...priorities].sort((a, b) => a - b), priorities, 'actions sorted by priority');
@@ -77,5 +78,6 @@ test('buildRouter adds fallback validation action when needed', () => {
   const router = buildRouter(snapshot, null);
   const keys = router.actions.map((a) => a.key);
   assert.ok(keys.includes('validate:lint'));
+  assert.ok(keys.includes('validate:dispatch'));
 });
 

--- a/tools/priority/dispatch-validate.mjs
+++ b/tools/priority/dispatch-validate.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { run, getRepoRoot, getCurrentBranch } from './lib/branch-utils.mjs';
+import { resolveRepoContext } from './lib/git-context.mjs';
+import { ensureGhCli } from './lib/remote-utils.mjs';
+
+const USAGE = [
+  'Usage: node tools/priority/dispatch-validate.mjs [--ref <branch>] [--allow-fork]',
+  '',
+  'Dispatches the Validate workflow on the upstream repository after ensuring the',
+  'target ref exists on that remote. Fails fast when executed from a fork clone,',
+  'unless --allow-fork (or VALIDATE_DISPATCH_ALLOW_FORK=1) is provided.'
+];
+
+function printUsage() {
+  for (const line of USAGE) {
+    console.log(line);
+  }
+}
+
+export function parseCliOptions(argv = process.argv, env = process.env) {
+  const args = Array.isArray(argv) ? argv.slice(2) : [];
+  let ref = null;
+  let allowFork = env.VALIDATE_DISPATCH_ALLOW_FORK === '1';
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      return { help: true, ref, allowFork };
+    }
+    if (arg === '--ref') {
+      if (i + 1 >= args.length) {
+        throw new Error('--ref requires a value');
+      }
+      ref = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === '--allow-fork') {
+      allowFork = true;
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return { help: false, ref, allowFork };
+}
+
+export function ensureRemoteHasRef(repoRoot, remoteName, ref) {
+  const patterns = [ref];
+  if (!ref.startsWith('refs/')) {
+    patterns.push(`refs/heads/${ref}`);
+    patterns.push(`refs/tags/${ref}`);
+  }
+
+  for (const pattern of patterns) {
+    const probe = spawnSync(
+      'git',
+      ['ls-remote', '--exit-code', remoteName, pattern],
+      { cwd: repoRoot, stdio: 'ignore', encoding: 'utf8' }
+    );
+    if (probe.status === 0) {
+      return pattern;
+    }
+  }
+
+  throw new Error(
+    `Ref '${ref}' not found on remote '${remoteName}'. Push it first (git push ${remoteName} ${ref}).`
+  );
+}
+
+export function dispatchValidate({
+  argv = process.argv,
+  env = process.env,
+  runFn = run,
+  ensureGhCliFn = ensureGhCli,
+  resolveContextFn = resolveRepoContext,
+  getRepoRootFn = getRepoRoot,
+  getCurrentBranchFn = getCurrentBranch,
+  ensureRemoteHasRefFn = ensureRemoteHasRef,
+  remoteName = 'upstream'
+} = {}) {
+  const { help, ref: refArg, allowFork } = parseCliOptions(argv, env);
+  if (help) {
+    printUsage();
+    return { dispatched: false, help: true };
+  }
+
+  const repoRoot = getRepoRootFn();
+  ensureGhCliFn();
+  const context = resolveContextFn(repoRoot);
+  if (!context?.upstream?.owner || !context?.upstream?.repo) {
+    throw new Error('Unable to resolve upstream repository. Configure an upstream remote.');
+  }
+
+  if (context.isFork && !allowFork) {
+    throw new Error(
+      'Validate dispatch blocked: working copy points to a fork. Push your branch to upstream and rerun, or pass --allow-fork.'
+    );
+  }
+
+  let ref = refArg;
+  if (!ref) {
+    ref = getCurrentBranchFn();
+  }
+  if (!ref || ref === 'HEAD') {
+    throw new Error('Unable to determine ref. Pass --ref <branch> explicitly.');
+  }
+
+  ensureRemoteHasRefFn(repoRoot, remoteName, ref);
+
+  const slug = `${context.upstream.owner}/${context.upstream.repo}`;
+  runFn(
+    'gh',
+    ['workflow', 'run', 'validate.yml', '--repo', slug, '--ref', ref],
+    { cwd: repoRoot }
+  );
+
+  let runSummary = null;
+  try {
+    const json = runFn(
+      'gh',
+      [
+        'run',
+        'list',
+        '--repo',
+        slug,
+        '--workflow',
+        'Validate',
+        '--branch',
+        ref,
+        '--json',
+        'databaseId,headSha,status,conclusion,createdAt',
+        '-L',
+        '1'
+      ],
+      { cwd: repoRoot }
+    );
+    if (json) {
+      const parsed = JSON.parse(json);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        runSummary = parsed[0];
+      }
+    }
+  } catch (err) {
+    console.warn(`[validate] Warning: unable to query latest Validate run: ${err.message}`);
+  }
+
+  const message = `[validate] Dispatched Validate on ${slug} @ ${ref}` + (runSummary?.databaseId ? ` (run ${runSummary.databaseId})` : '');
+  console.log(message);
+
+  return {
+    dispatched: true,
+    repo: slug,
+    ref,
+    run: runSummary
+  };
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  try {
+    dispatchValidate();
+  } catch (err) {
+    console.error(`[validate] ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/tools/priority/lib/git-context.mjs
+++ b/tools/priority/lib/git-context.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+import { resolveUpstream, tryResolveRemote } from './remote-utils.mjs';
+
+function parseEnvRepository(env) {
+  const slug = env.GITHUB_REPOSITORY ?? '';
+  if (slug.includes('/')) {
+    const [owner, repo] = slug.split('/', 2);
+    if (owner && repo) {
+      return { owner, repo };
+    }
+  }
+
+  const owner = env.GITHUB_REPOSITORY_OWNER ?? '';
+  const repo = env.GITHUB_REPOSITORY_NAME ?? env.GITHUB_REPOSITORY?.split('/')?.[1] ?? null;
+  if (owner && repo) {
+    return { owner, repo };
+  }
+
+  return null;
+}
+
+export function resolveRepoContext(repoRoot, options = {}) {
+  const {
+    resolveUpstreamFn = resolveUpstream,
+    resolveRemoteFn = tryResolveRemote,
+    env = process.env
+  } = options;
+
+  const upstream = resolveUpstreamFn(repoRoot);
+  const upstreamRemote = resolveRemoteFn(repoRoot, 'upstream');
+  const originRemote = resolveRemoteFn(repoRoot, 'origin');
+  const envRepo = parseEnvRepository(env);
+
+  const origin = originRemote?.parsed ?? null;
+  const upstreamSlug = upstreamRemote?.parsed ?? upstream ?? null;
+
+  const working = origin ?? envRepo ?? upstreamSlug;
+
+  const isFork =
+    Boolean(working?.owner) &&
+    Boolean(upstream?.owner) &&
+    working.owner.toLowerCase() !== upstream.owner.toLowerCase();
+
+  return {
+    upstream,
+    upstreamRemote: upstreamRemote?.parsed ?? null,
+    origin,
+    working,
+    isFork
+  };
+}
+

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -334,6 +334,7 @@ export function buildRouter(issue, policy) {
 
   addAction({ key: 'hooks:pre-commit', priority: 10, scripts: ['node tools/npm/run-script.mjs hooks:pre-commit'], rationale: 'baseline hook gate' });
   addAction({ key: 'hooks:multi', priority: 11, scripts: ['node tools/npm/run-script.mjs hooks:multi', 'node tools/npm/run-script.mjs hooks:schema'], rationale: 'ensure parity across planes' });
+  addAction({ key: 'validate:dispatch', priority: 95, scripts: ['node tools/npm/run-script.mjs priority:validate'], rationale: 'dispatch Validate via upstream guard' });
 
   const labelSet = new Set((issue.labels || []).map((l) => (l || '').toLowerCase()));
   const policyEntries = Array.isArray(policy?.labels) ? policy.labels : [];
@@ -388,9 +389,7 @@ export function buildRouter(issue, policy) {
     }
   }
 
-  if (actionsMap.size < 3) {
-    addAction({ key: 'validate:lint', priority: 90, scripts: ['pwsh -File tools/PrePush-Checks.ps1'], rationale: 'baseline validation' });
-  }
+  addAction({ key: 'validate:lint', priority: 90, scripts: ['pwsh -File tools/PrePush-Checks.ps1'], rationale: 'baseline validation' });
 
   const actions = Array.from(actionsMap.values()).sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50) || a.key.localeCompare(b.key));
   return {


### PR DESCRIPTION
## Summary
- add a guarded Validate dispatcher that blocks fork refs unless explicitly overridden
- surface a priority router action (validate:dispatch) and npm script (priority:validate)
- document the helper in agent guidance and add regression coverage

## Testing
- node tools/npm/run-script.mjs priority:test
- node tools/npm/run-script.mjs hooks:test
- node tools/npm/run-script.mjs hooks:pre-commit
- node tools/npm/run-script.mjs hooks:multi
- pwsh -File tools/PrePush-Checks.ps1
- node tools/npm/run-script.mjs priority:validate -- --ref issue/283-validate-guard --allow-fork
- Validate run: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/18720509028

Fixes #283