### PR TITLE
ci: add branch policy guard to validate #289

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -1,7 +1,7 @@
 {
-  "number": 285,
-  "title": "Document feature branch enforcement policy",
-  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/285",
+  "number": 289,
+  "title": "Enforce branch protection policy in CI (policy guard)",
+  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/289",
   "state": "OPEN",
   "labels": [
     "standing-priority"
@@ -9,10 +9,10 @@
   "assignees": [],
   "milestone": null,
   "commentCount": 0,
-  "lastSeenUpdatedAt": "2025-10-22T15:48:53Z",
-  "issueDigest": "d4ca445a1f89c2f8882ed4c7bcb7855fbed60f5e369fa9ba15c399b6b47c9c36",
-  "bodyDigest": "3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112",
-  "cachedAtUtc": "2025-10-22T18:25:17.425Z",
+  "lastSeenUpdatedAt": "2025-10-22T19:30:39Z",
+  "issueDigest": "c7a39232d09d424b38723869e458ec3777c2b4badfec461ddaa0b3a5d06641f7",
+  "bodyDigest": "68bae82cd7375951745eb3413bc8617b85eca640415082f45edf2f3414836279",
+  "cachedAtUtc": "2025-10-22T19:30:50.558Z",
   "lastFetchSource": "live",
   "lastFetchError": null
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,6 +113,13 @@ jobs:
       run: |
         pwsh -File tools/PrePush-Checks.ps1
 
+    - name: Policy guard (branch protection)
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        node tools/npm/run-script.mjs priority:policy
+
     - name: Lint unanchored dot-sourcing (non-blocking)
       shell: pwsh
       continue-on-error: true

--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -2,39 +2,39 @@
 
 ## Context Snapshot
 - Running on the Windows runner; PowerShell 7.5.3 is available at `C:\Program Files\PowerShell\7\pwsh.exe`.
-- Pester 5.7.1 is preinstalled and still on the PSModulePath.
-- GitHub CLI 2.81.0 resides at `C:\Program Files\GitHub CLI\gh.exe` with valid `repo`, `workflow`, `gist`, `read:org` scopes.
-- `node tools/npm/run-script.mjs priority:sync` ran at 2025-10-22T18:25Z; `.agent_priority_cache.json` now tracks standing issue #285 (`lastFetchSource = "live"`, digest aligned with `tests/results/_agent/issue/285.json`).
-- Latest `tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim` execution (2025-10-22T18:39Z) confirmed the watcher is idle, reapplied LabVIEW safety toggles, and wrote session capsule `tests/results/_agent/sessions/session-20251022T183930471Z-8dd088cf59d9.json`.
-- `pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900 -AppendToStepSummary` executed at 2025-10-22T18:26Z; no rogue LVCompare/LabVIEW processes detected (JSON emitted to console only).
+- Pester 5.7.1 remains on the PSModulePath.
+- GitHub CLI 2.81.0 is available with `repo`, `workflow`, `gist`, and `read:org` scopes.
+- `node tools/npm/run-script.mjs priority:sync` ran at 2025-10-22T19:30Z; `.agent_priority_cache.json` now tracks standing issue #289 (`lastFetchSource = "live"`, digest aligned with `tests/results/_agent/issue/289.json`).
+- Latest `tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim` execution (2025-10-22T19:43Z) confirmed the watcher is idle, re-applied LabVIEW safety toggles, and wrote session capsule `tests/results/_agent/sessions/session-20251022T194354048Z-058a25d675fd.json`.
+- `pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900 -AppendToStepSummary` executed at 2025-10-22T19:32Z; no rogue LVCompare/LabVIEW processes detected.
 - `node tools/npm/run-script.mjs priority:handoff-tests` last ran 2025-10-22T03:23Z; cached results remain under `tests/results/_agent/handoff/test-summary.json`.
-- Working tree on `issue/285-feature-branch-policy` (tracking origin); only documentation edits staged so far.
+- Working tree on `issue/289-policy-guard` (tracking upstream); workflow + docs edits staged but not yet committed to main.
 
 ## Status & Known Gaps
-1. Drafted `docs/knowledgebase/FEATURE_BRANCH_POLICY.md` and linked it from the Developer Guide; the write-up still needs SME review plus a sanity check that the recorded merge queue parameters match GitHub’s current ruleset.
-2. `docs/documentation-manifest.json` now lists the new knowledge base article. `node tools/npm/run-script.mjs lint:md` passed on 2025-10-22; rerun after any follow-up edits.
-3. `tools/priority/policy.json` now tracks the `main` merge-queue ruleset; keep it in sync if GitHub updates queue parameters.
-4. Cached release artifacts (`tests/results/_agent/release/release-v0.5.2-rc1-*.json`) are unchanged but still reference PR #279; keep them in mind if the release thread reopens.
+1. Validate workflow now includes a `Policy guard (branch protection)` step that runs `node tools/npm/run-script.mjs priority:policy` with `GITHUB_TOKEN`; monitor the next CI run to confirm it passes on PRs targeting `develop`.
+2. `docs/knowledgebase/FEATURE_BRANCH_POLICY.md` references the new guard, but SME review is still pending.
+3. `tools/priority/check-policy.mjs` already supports `--apply`; CI remains verify-only. Keep admin workflows aligned with the manifest.
+4. Cached release artifacts (`tests/results/_agent/release/release-v0.5.2-rc1-*.json`) still reference PR #279; no action required unless the release thread reopens.
 
 ## Suggested Next Actions
-1. Re-run `node tools/npm/run-script.mjs lint:md` (and optionally `hooks:multi`) after making additional documentation edits.
-2. Verify the merge queue parameters by requerying `gh api repos/LabVIEW-Community-CI-CD/compare-vi-cli-action/rulesets/8614140` and update the doc if GitHub adjusts defaults.
-3. Re-run `node tools/npm/run-script.mjs priority:policy` after any policy tweaks to confirm the merge-queue expectations remain aligned.
+1. Open PR for #289 once tests finish; ensure Validate shows the new policy guard step green.
+2. If the guard fails, realign GitHub protections or update `tools/priority/policy.json` before re-running CI.
+3. Kick off `tools/PrePush-Checks.ps1` and `node tools/npm/run-script.mjs hooks:multi` before pushing additional workflow changes to keep hook telemetry current.
 
 ## First Actions for the Next Agent
-1. Run `node tools/npm/run-script.mjs priority:sync` to refresh the standing-priority snapshot for #285.
-2. Review `docs/knowledgebase/FEATURE_BRANCH_POLICY.md` for accuracy and tighten wording if SME feedback arrives.
-3. Execute `node tools/npm/run-script.mjs lint:md` before pushing to ensure markdownlint stays green.
-4. Check `tests/results/_agent/issue/router.json` to keep the priority router aligned once additional tasks queue up.
+1. Run `node tools/npm/run-script.mjs priority:sync` to refresh the standing-priority snapshot (issue #289).
+2. Execute `node tools/npm/run-script.mjs lint:md` and `npm run priority:test` after any follow-up edits to keep the policy guard doc and helper covered.
+3. Dispatch Validate via `node tools/npm/run-script.mjs priority:validate -- --ref issue/289-policy-guard` if a manual CI run is needed to observe the guard.
+4. Check `tests/results/_agent/issue/router.json` for updated priority actions once the router refreshes.
 
 ## Notes for Next Agent
 - `SUPPRESS_PATTERN_SELFTEST` remains enforced via `tests/_helpers/DispatcherTestHelper.psm1`; leave it enabled to avoid recursion loops.
 - Pester artifacts live under `tests/results/` (`pester-summary.json`, `pester-results.xml`, `pester-artifacts.json`, `pester-summary.txt`).
-- Rogue LV notices: most recent is `tests/results/_lvcompare_notice/notice-20251021-0521137873.json`; earlier notices from 2025-10-20 remain for history.
-- Latest session capsule: `tests/results/_agent/sessions/session-20251022T183930471Z-8dd088cf59d9.json`.
+- Rogue LV notices: most recent is `tests/results/_lvcompare_notice/notice-20251021-0521137873.json`; earlier notices (2025-10-20) retained for history.
+- Latest session capsule: `tests/results/_agent/sessions/session-20251022T194354048Z-058a25d675fd.json`.
 
 ## Manual LabVIEW Recovery (when LV refuses to exit)
 1. Run `pwsh -File tools/Detect-RogueLV.ps1 -ResultsDir tests/results -LookBackSeconds 900` to list live LVCompare/LabVIEW PIDs.
 2. Attempt graceful shutdown: `pwsh -File tools/Close-LabVIEW.ps1`.
-3. If PIDs remain, issue `Stop-Process -Id <pid> -Force` for each rogue entry (LVCompare first, then LabVIEW). Capture the console log for the issue thread.
-4. Re-run `tools/Detect-RogueLV.ps1 -FailOnRogue` to confirm cleanup; escalate in #285 if the second sweep still reports live processes.
+3. If PIDs remain, issue `Stop-Process -Id <pid> -Force` for each rogue entry (LVCompare first, then LabVIEW). Capture the console output for the issue thread.
+4. Re-run `tools/Detect-RogueLV.ps1 -FailOnRogue` to confirm cleanup; escalate in #289 if rogues persist.

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -54,6 +54,8 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 - `node tools/npm/run-script.mjs priority:policy` – verify only (fails on drift).
 - `node tools/npm/run-script.mjs priority:policy -- --apply` – pushes the manifest configuration back to GitHub (branch
   protections + rulesets); rerun without `--apply` afterward to confirm parity.
+- The Validate workflow runs the verify-only command on every PR targeting `develop`; fix GitHub settings or update
+  `tools/priority/policy.json` before re-running CI when it fails.
 
 ### `develop`
 - **Merge strategy**: squash only (enforce linear history, disable merge commits).


### PR DESCRIPTION
## Summary
- add a policy guard step to the Validate workflow that runs the standing priority policy check with GITHUB_TOKEN
- document the new CI guard in the feature-branch policy guide so contributors know why failures happen and how to fix them
- refresh AGENT_HANDOFF with the current standing priority context (#289)

## Testing
- node tools/npm/run-script.mjs lint:md
- node tools/npm/run-script.mjs priority:test