### PR TITLE
fix(lint): bootstrap and markdown updates (#303)

### DIFF
--- a/.github/PR_COMMENT_SNIPPETS.md
+++ b/.github/PR_COMMENT_SNIPPETS.md
@@ -9,11 +9,12 @@ brackets.
   values).
 - Paste this as a new PR comment:
 
-```
+```text
 /run orchestrated strategy=<single|matrix> include_integration=<true|false> sample_id=<same-or-new-id>
 ```
 
 Notes:
+
 - Prefer `strategy=single` under typical load; use `matrix` when runners are idle.
 - Re-using the same `sample_id` links runs for easier comparison and can help idempotency.
 - If you omit `sample_id`, the dispatcher will generate one automatically.
@@ -21,11 +22,14 @@ Notes:
 ## Quick Variants
 
 - Single (deterministic chain):
-```
+
+```text
 /run orchestrated strategy=single include_integration=true sample_id=<id>
 ```
+
 - Matrix (parallel categories):
-```
+
+```text
 /run orchestrated strategy=matrix include_integration=true sample_id=<id>
 ```
 

--- a/docs/test-requirements/vi-history-reporting.md
+++ b/docs/test-requirements/vi-history-reporting.md
@@ -31,7 +31,7 @@ This document tracks the atomic test requirements for `tools/Compare-VIHistory.p
 real LVCompare artifacts are captured in CI. Current tests verify flag wiring via the stub driver.*
 
 ## Workflow (`.github/workflows/vi-compare-refs.yml`)
-
+<!-- markdownlint-disable MD029 -->
 16. `modes` input shall accept comma/semicolon separated tokens (case-insensitive) and default to `default`.
 17. Workflow shall invoke the helper once per mode, writing outputs to `tests/results/ref-compare/history/<mode>`.
 18. `steps.history.outputs['manifest-path']` shall resolve to the aggregate history suite manifest.
@@ -50,4 +50,6 @@ real LVCompare artifacts are captured in CI. Current tests verify flag wiring vi
 26. Documentation shall explain helper usage with `-Mode` and how manifest fields map to modes and flag bundles.
 27. Documentation shall note that artifacts are partitioned per mode and that report-format tests will be enriched with
    real LVCompare outputs.
+
+<!-- markdownlint-enable MD029 -->
 


### PR DESCRIPTION
## Summary
- call `tools/priority/bootstrap.ps1` during session kickoff so hook preflight runs and the workspace starts on `develop`
- resolve markdownlint MD029/MD040 issues so Validate lint no longer fails on run 18765849456
- clean up the agent handbook to document the bootstrap-first workflow

## Testing
- markdownlint (strict)
- pwsh -File tools/PrePush-Checks.ps1
- pwsh -File tools/priority/bootstrap.ps1 -PreflightOnly
