### PR TITLE
feat: streamline manual compare workflow (#312)

### DIFF
--- a/.github/workflows/vi-compare-refs.yml
+++ b/.github/workflows/vi-compare-refs.yml
@@ -3,57 +3,52 @@ name: Manual VI Compare (refs)
 on:
   workflow_dispatch:
     inputs:
-      sample_id:
-        description: 'Optional sample id for concurrency grouping'
-        required: false
-        type: string
-      target_path:
-        description: 'Repository-relative VI path (e.g. path/to/VI1.vi)'
+      vi_path:
+        description: 'Repository-relative VI path (e.g. Fixtures/Loop.vi)'
         required: true
         default: 'VI1.vi'
         type: string
-      start_ref:
-        description: 'Starting commit/ref (defaults to HEAD)'
+      compare_ref:
+        description: 'Branch, tag, or commit to walk history from (defaults to HEAD)'
         required: false
         default: ''
         type: string
-      end_ref:
-        description: 'Optional commit/ref to stop at (exclusive)'
-        required: false
-        default: ''
-        type: string
-      max_pairs:
+      compare_depth:
         description: 'Maximum commit pairs to evaluate (0 = no limit)'
         required: false
         default: '10'
         type: string
-      fail_fast:
+      compare_modes:
+        description: 'Comma/semicolon separated modes to evaluate (default,attributes,front-panel,block-diagram,all)'
+        required: false
+        default: 'default'
+        type: string
+      compare_ignore_flags:
+        description: 'LVCompare ignore toggles (default, none, or comma-separated flags such as noattr,nofp)'
+        required: false
+        default: 'default'
+        type: string
+      compare_additional_flags:
+        description: 'Extra LVCompare flags (optional, space-delimited)'
+        required: false
+        default: ''
+        type: string
+      compare_fail_fast:
         description: 'Stop after the first detected diff'
         required: false
         default: 'false'
         type: choice
         options: ['true','false']
-      ignore_flags:
-        description: 'Comma-separated ignore toggles (e.g., noattr,nofp,nofppos,nobdcosm or none)'
-        required: false
-        default: 'noattr,nofp,nofppos,nobdcosm'
-        type: string
-      modes:
-        description: 'Comma-separated compare modes (default, attributes, front-panel, block-diagram, all)'
-        required: false
-        default: 'default'
-        type: string
-      additional_flags:
-        description: 'Extra LVCompare flags (optional, space-delimited)'
-        required: false
-        default: ''
-        type: string
-      fail_on_diff:
+      compare_fail_on_diff:
         description: 'Fail the job when any compare diff is detected'
         required: false
         default: 'false'
         type: choice
         options: ['true','false']
+      sample_id:
+        description: 'Optional sample id for concurrency grouping'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || github.ref }}
@@ -100,15 +95,14 @@ jobs:
         id: history
         shell: pwsh
         env:
-          TARGET_PATH: ${{ inputs.target_path }}
-          START_REF: ${{ inputs.start_ref }}
-          END_REF: ${{ inputs.end_ref }}
-          MAX_PAIRS: ${{ inputs.max_pairs }}
-          IGNORE_FLAGS: ${{ inputs.ignore_flags }}
-          MODES: ${{ inputs.modes }}
-          EXTRA_FLAGS: ${{ inputs.additional_flags }}
-          FAIL_FAST: ${{ inputs.fail_fast }}
-          FAIL_ON_DIFF: ${{ inputs.fail_on_diff }}
+          TARGET_PATH: ${{ inputs.vi_path }}
+          START_REF: ${{ inputs.compare_ref }}
+          MAX_PAIRS: ${{ inputs.compare_depth }}
+          IGNORE_FLAGS: ${{ inputs.compare_ignore_flags }}
+          MODES: ${{ inputs.compare_modes }}
+          EXTRA_FLAGS: ${{ inputs.compare_additional_flags }}
+          FAIL_FAST: ${{ inputs.compare_fail_fast }}
+          FAIL_ON_DIFF: ${{ inputs.compare_fail_on_diff }}
         run: |
           $ErrorActionPreference = 'Stop'
           function Convert-ToBoolean([string]$value, [bool]$default = $false) {
@@ -153,7 +147,7 @@ jobs:
           $modeTokens = @($modeTokens | Select-Object -Unique)
 
           $startRef = if ([string]::IsNullOrWhiteSpace($env:START_REF)) { $null } else { $env:START_REF.Trim() }
-          $endRef = if ([string]::IsNullOrWhiteSpace($env:END_REF)) { $null } else { $env:END_REF.Trim() }
+          $endRef = $null
 
           $parsedMaxPairs = $null
           if (-not [string]::IsNullOrWhiteSpace($env:MAX_PAIRS)) {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,79 @@
-<!-- markdownlint-disable-next-line MD041 -->
 # Compare VI CLI Action
 
-Placeholder README for the Compare VI CLI action workspace. Update this file with
-project documentation once the standing-priority roadmap lands.
+## Overview
+
+This repository hosts the reusable workflows and helper scripts that drive manual
+LVCompare runs against commits in a LabVIEW project. The primary entrypoint is the
+`Manual VI Compare (refs)` workflow, which walks a branch/ref history, extracts the
+target VI at each commit→parent pair, and invokes LVCompare in headless mode.
+
+The latest rev streamlines the workflow inputs so SMEs only need to provide:
+
+1. The branch/tag/commit to inspect (`compare_ref`, defaults to `HEAD`)
+2. The repository-relative VI path (`vi_path`)
+
+Additional knobs remain available but defaulted so most runs require no extra
+tuning.
+
+## Quick start
+
+### GitHub UI
+
+1. Navigate to **Actions → Manual VI Compare (refs)**.
+2. Click **Run workflow**.
+3. Supply `vi_path` (for example `Fixtures/Loop.vi`) and, optionally,
+   `compare_ref` if you want something other than the workflow branch tip.
+4. Run the workflow. Results appear under the job summary with links to
+   the generated manifests and any LVCompare diff artifacts.
+
+### CLI (gh)
+
+```powershell
+gh workflow run vi-compare-refs.yml `
+  -f vi_path='Fixtures/Loop.vi' `
+  -f compare_ref='develop'
+```
+
+Use `gh run watch <run-id>` or the rendered summary to follow progress. The
+workflow uploads two artifacts:
+
+- `vi-compare-manifests` – aggregate suite manifest and per-mode summaries
+- `vi-compare-diff-artifacts` – only present when LVCompare detects differences
+
+## Optional inputs
+
+| Input name               | Default   | Description                                                                 |
+| ------------------------ | --------- | --------------------------------------------------------------------------- |
+| `compare_depth`          | `10`      | Maximum commit pairs to evaluate (`0` = no limit)                           |
+| `compare_modes`          | `default` | Comma/semicolon list of compare modes (`default,attributes,front-panel` …) |
+| `compare_ignore_flags`   | `default` | LVCompare ignore toggles (`default`, `none`, or comma-separated flags)      |
+| `compare_additional_flags` | ` `   | Extra LVCompare switches (space-delimited)                                  |
+| `compare_fail_fast`      | `false`   | Stop after the first diff                                                   |
+| `compare_fail_on_diff`   | `false`   | Fail the workflow when any diff is detected                                 |
+| `sample_id`              | _(empty)_ | Optional concurrency key (advanced use)                                     |
+
+These inputs map directly onto the parameters in `tools/Compare-VIHistory.ps1`,
+so advanced behaviour remains available without cluttering the default UX.
+
+## Local helper
+
+You can run the same compare logic locally:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Compare-VIHistory.ps1 `
+  -TargetPath Fixtures/Loop.vi `
+  -StartRef develop `
+  -MaxPairs 5 `
+  -Detailed `
+  -RenderReport
+```
+
+Artifacts are written under `tests/results/ref-compare/history/` using the same
+schema as the workflow outputs.
+
+## Release and compatibility
+
+Renaming the workflow inputs breaks compatibility with previous revisions, so the
+next release should cut a new major tag (for example `v1.0.0`). Update downstream
+automation or scheduled triggers to use the new `vi_path` / `compare_ref` inputs
+before adopting the release.


### PR DESCRIPTION
## Summary
- collapse vi-compare workflow inputs to branch + VI path
- map simplified inputs to the existing helper flags and optional overrides
- refresh README/knowledge base with Quickstart instructions

## Testing
- node tools/npm/run-script.mjs hooks:pre-commit
- node tools/npm/run-script.mjs hooks:multi
- node tools/npm/run-script.mjs hooks:schema
- pwsh -File tools/PrePush-Checks.ps1
- node tools/npm/run-script.mjs lint:md
- node tools/npm/run-script.mjs priority:validate -- --ref issue/312-streamlined-compare --push-missing (run 18797838568)
