### PR TITLE
Automate VI staging LVCompare leak checks (#351)

### DIFF
--- a/.github/workflows/pr-vi-staging.yml
+++ b/.github/workflows/pr-vi-staging.yml
@@ -305,10 +305,11 @@ jobs:
           }
 
           $compareTotals = @{
-            diff    = 0
-            match   = 0
-            error   = 0
-            skipped = 0
+            diff         = 0
+            match        = 0
+            error        = 0
+            skipped      = 0
+            leakWarnings = 0
           }
 
           $compareSummary = $null
@@ -322,7 +323,7 @@ jobs:
             $compareSummaryPath = Join-Path $env:ARTIFACTS_DIR 'vi-staging-compare-summary.json'
             $compareSummary = & $summarizePath -CompareJson $env:COMPARE_JSON -MarkdownPath $compareMarkdownPath -SummaryJsonPath $compareSummaryPath
             if ($compareSummary -and $compareSummary.totals) {
-              foreach ($key in @('diff','match','error','skipped')) {
+              foreach ($key in @('diff','match','error','skipped','leakWarnings')) {
                 if ($compareSummary.totals.PSObject.Properties[$key]) {
                   $rawValue = $compareSummary.totals.$key
                   $parsed = 0
@@ -355,12 +356,15 @@ jobs:
             if ($env:STAGE_SKIPPED) {
               $lines += ("Skipped bundles: {0}" -f $env:STAGE_SKIPPED)
             }
-            if ($env:STAGE_ALLOW_SAME_LEAF) {
-              $lines += ("AllowSameLeaf pairs: {0}" -f $env:STAGE_ALLOW_SAME_LEAF)
-            }
-            if ($env:STAGE_MODE_COUNTS) {
-              $lines += ("Staging modes: {0}" -f $env:STAGE_MODE_COUNTS.Replace(',', ', '))
-            }
+          if ($env:STAGE_ALLOW_SAME_LEAF) {
+            $lines += ("AllowSameLeaf pairs: {0}" -f $env:STAGE_ALLOW_SAME_LEAF)
+          }
+          if ($env:STAGE_MODE_COUNTS) {
+            $lines += ("Staging modes: {0}" -f $env:STAGE_MODE_COUNTS.Replace(',', ', '))
+          }
+          if ($compareTotals.leakWarnings -gt 0) {
+            $lines += ("Leak warnings: {0}" -f $compareTotals.leakWarnings)
+          }
           }
 
           if ($compareSummary -and $compareSummary.markdown) {
@@ -380,8 +384,8 @@ jobs:
             $lines += '### Staged bundle catalog'
             $lines += ''
             $table = @(
-              '| # | Change | Base | Head | Mode | AllowSameLeaf | Artifact | Compare |',
-              '| - | ------ | ---- | ---- | ---- | ------------- | -------- | ------- |'
+              '| # | Change | Base | Head | Mode | AllowSameLeaf | Artifact | Compare | Leak |',
+              '| - | ------ | ---- | ---- | ---- | ------------- | -------- | ------- | ---- |'
             )
 
             $useFallbackCounts = -not $compareSummary
@@ -484,6 +488,7 @@ jobs:
             "match_count=$($compareTotals.match)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
             "error_count=$($compareTotals.error)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
             "skip_count=$($compareTotals.skipped)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "leak_warning_count=$($compareTotals.leakWarnings)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
           }
 
       - name: Ensure staging label exists
@@ -754,4 +759,6 @@ jobs:
               $global:LASTEXITCODE = 0
             }
           }
+
+
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,8 @@ line buffers).
     -Branch (git branch --show-current)
   ```
 
-Staging smoke runs use the dedicated helper (`Test-PRVIStagingSmoke.ps1`) so staged VI bundles and LVCompare outputs are exercised end-to-end.
+Staging smoke runs use the dedicated helper (`Test-PRVIStagingSmoke.ps1`) so staged VI bundles and LVCompare outputs
+are exercised end-to-end.
 
 - Confirm `session-index.json` contains `branchProtection.result.status = "ok"`; mismatches should be logged in
   `branchProtection.notes`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Added
+
+- Staged LVCompare automation now records per-pair leak metadata (`compare-leak.json`) and exposes leak counts via
+  `tools/Run-StagedLVCompare.ps1`, `tools/Summarize-VIStaging.ps1`, and the `/vi-stage` PR summary table so reviewers can
+  see lingering LVCompare/LabVIEW processes without downloading artifacts.
+- Timeout overrides can be supplied end-to-end (`Run-StagedLVCompare.ps1`, `Invoke-LVCompare.ps1`,
+  `scripts/Capture-LVCompare.ps1`, `tools/LabVIEWCli.psm1`) allowing LVCompare runs to fail-fast during long captures.
+
+### Changed
+
+- Developer guide now documents the new leak/timeout environment toggles for staged comparisons and clarifies the
+  `/vi-history` table structure.
+- `pr-vi-staging.yml` surfaces leak totals in the workflow summary/PR comment for easier triage.
 
 ## [v0.5.2] - 2025-10-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,3 @@ If we later re-enable MD013:
 3. Avoid splitting code spans across lines solely for lint; prefer disabling for that line.
 
 Always ensure examples remain copy/paste friendly (avoid trailing spaces, stray prompts inside code blocks).
-
-
-

--- a/tests/Run-StagedLVCompare.Tests.ps1
+++ b/tests/Run-StagedLVCompare.Tests.ps1
@@ -17,6 +17,9 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
         Remove-Item Env:RUN_STAGED_LVCOMPARE_FLAGS -ErrorAction SilentlyContinue
         Remove-Item Env:RUN_STAGED_LVCOMPARE_FLAGS_MODE -ErrorAction SilentlyContinue
         Remove-Item Env:RUN_STAGED_LVCOMPARE_REPLACE_FLAGS -ErrorAction SilentlyContinue
+        Remove-Item Env:RUN_STAGED_LVCOMPARE_TIMEOUT_SECONDS -ErrorAction SilentlyContinue
+        Remove-Item Env:RUN_STAGED_LVCOMPARE_LEAK_CHECK -ErrorAction SilentlyContinue
+        Remove-Item Env:RUN_STAGED_LVCOMPARE_LEAK_GRACE_SECONDS -ErrorAction SilentlyContinue
         Remove-Item Env:VI_STAGE_COMPARE_FLAGS -ErrorAction SilentlyContinue
         Remove-Item Env:VI_STAGE_COMPARE_FLAGS_MODE -ErrorAction SilentlyContinue
     }
@@ -56,7 +59,10 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             $call = [pscustomobject]@{
                 Base         = $BaseVi
@@ -64,6 +70,9 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 OutputDir    = $OutputDir
                 AllowSameLeaf= $AllowSameLeaf.IsPresent
                 RenderReport = $RenderReport.IsPresent
+                LeakCheck    = $LeakCheck.IsPresent
+                TimeoutSeconds = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
             }
             $null = $invokeCalls.Add($call)
             New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
@@ -173,7 +182,10 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
             return [pscustomobject]@{
@@ -232,7 +244,10 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             return [pscustomobject]@{
                 ExitCode = 2
@@ -281,11 +296,17 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             $null = $invokeCalls.Add([pscustomobject]@{
                 Flags        = @($Flags)
                 ReplaceFlags = $ReplaceFlags.IsPresent
+                LeakCheck    = $LeakCheck.IsPresent
+                TimeoutSeconds = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
             })
             New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
             return [pscustomobject]@{
@@ -335,11 +356,17 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             $null = $invokeCalls.Add([pscustomobject]@{
                 Flags        = @($Flags)
                 ReplaceFlags = $ReplaceFlags.IsPresent
+                LeakCheck    = $LeakCheck.IsPresent
+                TimeoutSeconds = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
             })
             New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
             return [pscustomobject]@{
@@ -390,11 +417,17 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             $null = $invokeCalls.Add([pscustomobject]@{
                 Flags        = $Flags
                 ReplaceFlags = $ReplaceFlags.IsPresent
+                LeakCheck    = $LeakCheck.IsPresent
+                TimeoutSeconds = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
             })
             New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
             return [pscustomobject]@{
@@ -444,11 +477,17 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
                 [switch]$AllowSameLeaf,
                 [switch]$RenderReport,
                 [string[]]$Flags,
-                [switch]$ReplaceFlags
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
             )
             $null = $invokeCalls.Add([pscustomobject]@{
                 Flags        = @($Flags)
                 ReplaceFlags = $ReplaceFlags.IsPresent
+                LeakCheck    = $LeakCheck.IsPresent
+                TimeoutSeconds = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
             })
             New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
             return [pscustomobject]@{
@@ -461,6 +500,191 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
         $invokeCalls.Count | Should -Be 1
         $invokeCalls[0].ReplaceFlags | Should -BeFalse
         @($invokeCalls[0].Flags) | Should -Contain '-nobd'
+    }
+
+    It 'records leak warnings when leak summary present' {
+        $resultsPath = Join-Path $TestDrive 'leak-results.json'
+        $artifactsDir = Join-Path $TestDrive 'artifacts'
+        New-Item -ItemType Directory -Path $artifactsDir -Force | Out-Null
+
+        $stagedBase = Join-Path $TestDrive 'leak\Base.vi'
+        $stagedHead = Join-Path $TestDrive 'leak\Head.vi'
+        New-Item -ItemType Directory -Path (Split-Path $stagedBase -Parent) -Force | Out-Null
+        Set-Content -LiteralPath $stagedBase -Value 'base'
+        Set-Content -LiteralPath $stagedHead -Value 'head'
+
+        @(
+            [ordered]@{
+                changeType = 'modify'
+                basePath   = 'VI7.vi'
+                headPath   = 'VI7.vi'
+                staged     = [ordered]@{
+                    Base = $stagedBase
+                    Head = $stagedHead
+                }
+            }
+        ) | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $resultsPath -Encoding utf8
+
+        $invokeCalls = New-Object System.Collections.Generic.List[object]
+        $invoke = {
+            param(
+                [string]$BaseVi,
+                [string]$HeadVi,
+                [string]$OutputDir,
+                [switch]$AllowSameLeaf,
+                [switch]$RenderReport,
+                [string[]]$Flags,
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
+            )
+            $null = $invokeCalls.Add([pscustomobject]@{
+                LeakCheck    = $LeakCheck.IsPresent
+                TimeoutSeconds = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
+            })
+
+            New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+            $capturePath = Join-Path $OutputDir 'lvcompare-capture.json'
+            '{"capture":true}' | Set-Content -LiteralPath $capturePath -Encoding utf8
+            $reportPath = Join-Path $OutputDir 'compare-report.html'
+            '<html />' | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+            $leakPath = Join-Path $OutputDir 'compare-leak.json'
+            $leakPayload = [ordered]@{
+                schema    = 'prime-lvcompare-leak/v1'
+                at        = (Get-Date).ToString('o')
+                lvcompare = @{
+                    remaining = @(1234, 5678)
+                    count     = 2
+                }
+                labview   = @{
+                    remaining = @(4444)
+                    count     = 1
+                }
+            }
+            $leakPayload | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $leakPath -Encoding utf8
+
+            return [pscustomobject]@{
+                ExitCode    = 1
+                CapturePath = $capturePath
+                ReportPath  = $reportPath
+            }
+        }.GetNewClosure()
+
+        $outputFile = Join-Path $TestDrive 'outputs-leak.txt'
+        $env:GITHUB_OUTPUT = $outputFile
+
+        & $script:scriptPath -ResultsPath $resultsPath -ArtifactsDir $artifactsDir -RenderReport -InvokeLVCompare $invoke
+
+        $invokeCalls.Count | Should -Be 1
+        $invokeCalls[0].LeakCheck | Should -BeTrue
+
+        $updated = @(Get-Content -LiteralPath $resultsPath -Raw | ConvertFrom-Json)
+        $entry = $updated[0].compare
+        $entry.status | Should -Be 'diff'
+        $entry.leakWarning | Should -BeTrue
+        $entry.leak.lvcompare | Should -Be 2
+        $entry.leak.labview | Should -Be 1
+        $entry.leak.path | Should -Match 'compare-leak\.json$'
+
+        $summaryPath = Join-Path $artifactsDir 'vi-staging-compare.json'
+        Test-Path -LiteralPath $summaryPath | Should -BeTrue
+        $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json
+        $summary[0].leakWarning | Should -BeTrue
+        $summary[0].leakLvcompare | Should -Be 2
+        $summary[0].leakLabVIEW | Should -Be 1
+
+        $outputMap = @{}
+        foreach ($line in Get-Content -LiteralPath $outputFile) {
+            if ($line -match '=') {
+                $key, $value = $line.Split('=', 2)
+                $outputMap[$key] = $value
+            }
+        }
+        $outputMap['leak_warning_count'] | Should -Be '1'
+    }
+
+    It 'honors timeout and leak env overrides' {
+        $resultsPath = Join-Path $TestDrive 'timeout-results.json'
+        $artifactsDir = Join-Path $TestDrive 'artifacts'
+        New-Item -ItemType Directory -Path $artifactsDir -Force | Out-Null
+
+        $stagedBase = Join-Path $TestDrive 'timeout\Base.vi'
+        $stagedHead = Join-Path $TestDrive 'timeout\Head.vi'
+        New-Item -ItemType Directory -Path (Split-Path $stagedBase -Parent) -Force | Out-Null
+        Set-Content -LiteralPath $stagedBase -Value 'base'
+        Set-Content -LiteralPath $stagedHead -Value 'head'
+
+        @(
+            [ordered]@{
+                changeType = 'modify'
+                basePath   = 'VI8.vi'
+                headPath   = 'VI8.vi'
+                staged     = [ordered]@{
+                    Base = $stagedBase
+                    Head = $stagedHead
+                }
+            }
+        ) | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $resultsPath -Encoding utf8
+
+        $env:RUN_STAGED_LVCOMPARE_TIMEOUT_SECONDS = '45'
+        $env:RUN_STAGED_LVCOMPARE_LEAK_CHECK = 'false'
+        $env:RUN_STAGED_LVCOMPARE_LEAK_GRACE_SECONDS = '2.5'
+
+        $invokeCalls = New-Object System.Collections.Generic.List[object]
+        $invoke = {
+            param(
+                [string]$BaseVi,
+                [string]$HeadVi,
+                [string]$OutputDir,
+                [switch]$AllowSameLeaf,
+                [switch]$RenderReport,
+                [string[]]$Flags,
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds
+            )
+            $call = [pscustomobject]@{
+                LeakCheck        = $LeakCheck.IsPresent
+                TimeoutProvided  = $PSBoundParameters.ContainsKey('TimeoutSeconds')
+                TimeoutSeconds   = if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -ne $null) { [int]$TimeoutSeconds } else { $null }
+                LeakGraceProvided= $PSBoundParameters.ContainsKey('LeakGraceSeconds')
+                LeakGraceSeconds = if ($PSBoundParameters.ContainsKey('LeakGraceSeconds') -and $LeakGraceSeconds -ne $null) { [double]$LeakGraceSeconds } else { $null }
+            }
+            $null = $invokeCalls.Add($call)
+            New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+            return [pscustomobject]@{
+                ExitCode = 0
+            }
+        }.GetNewClosure()
+
+        $outputFile = Join-Path $TestDrive 'outputs-timeout.txt'
+        $env:GITHUB_OUTPUT = $outputFile
+
+        & $script:scriptPath -ResultsPath $resultsPath -ArtifactsDir $artifactsDir -InvokeLVCompare $invoke
+
+        $invokeCalls.Count | Should -Be 1
+        $invokeCalls[0].LeakCheck | Should -BeFalse
+        $invokeCalls[0].TimeoutProvided | Should -BeTrue
+        $invokeCalls[0].TimeoutSeconds | Should -Be 45
+        $invokeCalls[0].LeakGraceProvided | Should -BeFalse
+        $invokeCalls[0].LeakGraceSeconds | Should -Be $null
+
+        $updated = @(Get-Content -LiteralPath $resultsPath -Raw | ConvertFrom-Json)
+        $compareObject = $updated[0].compare
+        ($compareObject.PSObject.Properties.Name) | Should -Not -Contain 'leakWarning'
+
+        $outputMap = @{}
+        foreach ($line in Get-Content -LiteralPath $outputFile) {
+            if ($line -match '=') {
+                $key, $value = $line.Split('=', 2)
+                $outputMap[$key] = $value
+            }
+        }
+        $outputMap['leak_warning_count'] | Should -Be '0'
     }
 }
 

--- a/tools/LabVIEWCli.psm1
+++ b/tools/LabVIEWCli.psm1
@@ -779,7 +779,8 @@ function Invoke-LVCreateComparisonReport {
     [string]$ReportType,
     [string[]]$Flags,
     [string]$Provider = 'auto',
-    [switch]$Preview
+    [switch]$Preview,
+    [Nullable[int]]$TimeoutSeconds
   )
 
   $params = @{
@@ -795,7 +796,16 @@ function Invoke-LVCreateComparisonReport {
   if ($PSBoundParameters.ContainsKey('Flags') -and $Flags) {
     $params.flags = @($Flags)
   }
-  Invoke-LVOperation -Operation 'CreateComparisonReport' -Params $params -Provider $Provider -Preview:$Preview
+  $invokeArgs = @{
+    Operation = 'CreateComparisonReport'
+    Params    = $params
+    Provider  = $Provider
+    Preview   = $Preview.IsPresent
+  }
+  if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -gt 0) {
+    $invokeArgs.TimeoutSeconds = [int]$TimeoutSeconds
+  }
+  Invoke-LVOperation @invokeArgs
 }
 
 function Invoke-LVRunVI {


### PR DESCRIPTION
# Summary

- add leak/timeout controls to Run-StagedLVCompare.ps1 and forward new leak metrics through the PR staging workflow
- expose leak information in 	ools/Summarize-VIStaging.ps1, docs, and developer guide while documenting the new env toggles
- propagate -TimeoutSeconds support through Invoke-LVCompare, LabVIEWCli.psm1, and Capture-LVCompare.ps1 with new unit coverage

## Changes

- [ ] Updated action.yml logic
- [x] Updated README/docs
- [x] Updated workflows

## Testing

- [ ] Unit tests passed (Pester tests workflow)
- [ ] Ran Test (mock) on windows-latest and it passed
- [ ] Ran Smoke on self-hosted Windows and recorded exit codes
- [ ] Verified outputs (diff, ExitCode, cliPath, command) and step summary

### Manual verification
- pwsh -File Invoke-PesterTests.ps1 -TestsPath tests/Run-StagedLVCompare.Tests.ps1
- pwsh -File Invoke-PesterTests.ps1 -TestsPath tests/Summarize-VIStaging.Tests.ps1
- pwsh -File Invoke-PesterTests.ps1 -TestsPath tests/Invoke-LVCompare.Tests.ps1
- Validate workflow (run 18912980165)

## Documentation

- [x] README updated (usage, args, troubleshooting)
- [ ] CHANGELOG updated (user-facing changes)
- [ ] Copilot instructions updated if behavior changed

## Checklist

- [ ] CI green (Validate, Pester tests, Test (mock))
- [ ] Tag plan prepared (if releasing)

## Smoke test (optional guidance)

- If you have access to the self-hosted runner with LabVIEW, run .github/workflows/smoke.yml.
- Provide inputs, or ensure repo variables exist:
  - LV_BASE_VI (no-diff), LV_HEAD_VI (diff), LVCOMPARE_PATH

Fixes #351