### PR TITLE
Backport auto-approve skip signalling

### DIFF
--- a/.github/workflows/pr-auto-approve-label.yml
+++ b/.github/workflows/pr-auto-approve-label.yml
@@ -1,0 +1,156 @@
+name: PR Auto-approve Label
+
+on:
+  workflow_run:
+    workflows:
+      - Validate
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  manage-label:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      AUTO_APPROVE_LABEL: ${{ secrets.AUTO_APPROVE_LABEL || 'auto-approve' }}
+    steps:
+      - name: Ensure auto-approve label state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          AUTO_APPROVE_ALLOWED: ${{ secrets.AUTO_APPROVE_ALLOWED || '' }}
+        run: |
+          set -euo pipefail
+
+          pull_number=$(jq -r '.workflow_run.pull_requests[0].number' "$GITHUB_EVENT_PATH")
+          if [ -z "$pull_number" ] || [ "$pull_number" = "null" ]; then
+            echo "No pull request associated with workflow run; exiting."
+            exit 0
+          fi
+
+          pr_json=$(gh pr view "$pull_number" --json number,state,isDraft,isCrossRepository,baseRefName,author,labels,mergeStateStatus,mergeable,statusCheckRollup --jq '.')
+          state=$(echo "$pr_json" | jq -r '.state')
+          is_draft=$(echo "$pr_json" | jq -r '.isDraft')
+          is_cross=$(echo "$pr_json" | jq -r '.isCrossRepository')
+          base=$(echo "$pr_json" | jq -r '.baseRefName')
+          merge_state=$(echo "$pr_json" | jq -r '.mergeStateStatus // empty')
+          mergeable=$(echo "$pr_json" | jq -r '.mergeable // empty')
+          pr_author=$(echo "$pr_json" | jq -r '.author.login // empty')
+          status_rollup=$(echo "$pr_json" | jq -c '.statusCheckRollup // []')
+          if [ -z "$status_rollup" ]; then
+            status_rollup='[]'
+          fi
+
+          fail_checks=$(echo "$status_rollup" | jq -c '[.[] | select((.status == "COMPLETED") and (.conclusion != null) and (.conclusion != "SUCCESS") and (.conclusion != "NEUTRAL")) | {name: .name, conclusion: (.conclusion // "UNKNOWN"), url: (.detailsUrl // ""), workflow: (.workflowName // "")}]')
+          if [ -z "$fail_checks" ]; then
+            fail_checks='[]'
+          fi
+          fail_check_names=$(echo "$fail_checks" | jq -r '[.[].name] | join(", ")')
+
+          label_present=$(echo "$pr_json" | jq --arg label "$AUTO_APPROVE_LABEL" '[.labels[].name == $label] | any')
+
+          should_label=true
+          blocked_reasons=""
+          blocked_messages=""
+
+          if [ "$AUTO_APPROVE_LABEL" = "none" ]; then
+            should_label=false
+          fi
+          if [ "$state" != "OPEN" ]; then
+            should_label=false
+          fi
+          if [ "$is_draft" = "true" ] || [ "$is_cross" = "true" ]; then
+            should_label=false
+          fi
+          if [ "$base" != "develop" ]; then
+            should_label=false
+          fi
+          if [ -n "$merge_state" ] && [ "$merge_state" != "CLEAN" ]; then
+            should_label=false
+            if [ -z "$blocked_reasons" ]; then
+              blocked_reasons="merge-conflict"
+            else
+              blocked_reasons="$blocked_reasons,merge-conflict"
+            fi
+            message="PR has merge conflicts (mergeStateStatus=$merge_state); rebase onto '$base' to proceed."
+            blocked_messages="${blocked_messages}${message}\n"
+            echo "::notice::auto-approve skipped: ${message}"
+          elif [ "$mergeable" = "CONFLICTING" ]; then
+            should_label=false
+            if [[ ",$blocked_reasons," != *,merge-conflict,* ]]; then
+              if [ -z "$blocked_reasons" ]; then
+                blocked_reasons="merge-conflict"
+              else
+                blocked_reasons="$blocked_reasons,merge-conflict"
+              fi
+            fi
+            message="PR mergeability reported as CONFLICTING; resolve conflicts before auto-approval."
+            blocked_messages="${blocked_messages}${message}\n"
+            echo "::notice::auto-approve skipped: ${message}"
+          fi
+          if [ "$fail_checks" != "[]" ]; then
+            should_label=false
+            if [ -z "$blocked_reasons" ]; then
+              blocked_reasons="checks-failing"
+            else
+              blocked_reasons="$blocked_reasons,checks-failing"
+            fi
+            if [ -n "$fail_check_names" ]; then
+              message="Failing checks detected: $fail_check_names"
+            else
+              message="Failing checks detected (details unavailable)."
+            fi
+            blocked_messages="${blocked_messages}${message}\n"
+            echo "::notice::auto-approve skipped: ${message}"
+          fi
+
+          if [ -n "$AUTO_APPROVE_ALLOWED" ] && [ -n "$pr_author" ]; then
+            allowed_match=0
+            IFS=',' read -r -a allowed_array <<< "$AUTO_APPROVE_ALLOWED"
+            for entry in "${allowed_array[@]}"; do
+              trimmed=$(echo "$entry" | xargs)
+              if [ -n "$trimmed" ] && [ "$trimmed" = "$pr_author" ]; then
+                allowed_match=1
+                break
+              fi
+            done
+            if [ $allowed_match -ne 1 ]; then
+              should_label=false
+            fi
+          fi
+
+          if [ "$should_label" = false ] && [ -z "$blocked_reasons" ]; then
+            blocked_reasons="criteria-not-met"
+          fi
+
+          if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            {
+              if [ "$should_label" = true ]; then
+                echo "autoapprove_should_label=true"
+              else
+                echo "autoapprove_should_label=false"
+              fi
+              echo "autoapprove_checks=$fail_checks"
+              if [ -n "$blocked_reasons" ]; then
+                echo "autoapprove_reason=$blocked_reasons"
+              fi
+              if [ -n "$blocked_messages" ]; then
+                printf 'autoapprove_detail<<EOF\n%sEOF\n' "$blocked_messages"
+              fi
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$should_label" = true ] && [ "$label_present" != "true" ]; then
+            gh pr edit "$pull_number" --add-label "$AUTO_APPROVE_LABEL"
+            echo "Applied label '$AUTO_APPROVE_LABEL' to PR #$pull_number."
+          fi
+
+          if [ "$should_label" = false ] && [ "$label_present" = "true" ]; then
+            gh pr edit "$pull_number" --remove-label "$AUTO_APPROVE_LABEL"
+            echo "Removed label '$AUTO_APPROVE_LABEL' from PR #$pull_number."
+          fi

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -51,7 +51,7 @@ Quick reference for building, testing, and releasing the LVCompare composite act
       | `control-rename`| Stage `fixtures/vi-stage/control-rename/{Base,Head}.vi` (control rename)     | diff |
       | `fp-window`     | Stage `fixtures/vi-stage/fp-window/{Base,Head}.vi` (window sizing change)    | diff |
 
-      Treat these fixtures as read-only baselines—update them only when you intend
+      Treat these fixtures as read-only baselinesΓÇöupdate them only when you intend
       to change the smoke matrix. The `/vi-stage` PR comment includes this table
       (via `tools/Summarize-VIStaging.ps1`) so reviewers can immediately see which
       categories (front panel, block diagram functional/cosmetic, VI attributes)
@@ -130,6 +130,10 @@ node tools/npm/run-script.mjs lint            # markdownlint + custom checks
 - `develop` is the integration branch. All standing-priority work lands here via squash merges (linear history).
 - `main` reflects the latest release. Use release branches to promote changes from `develop` to `main`.
 - For standing-priority work, create `issue/<number>-<slug>` and merge back with squash once checks are green.
+- When the standing-priority issue changes mid-flight, realign the branch name and PR head with  
+  `npm run priority:branch:rename -- --issue <number>`. The helper derives the slug from the issue title, renames the
+  local branch, pushes the new name to any remotes that carried the old branch, retargets the matching PR, and (unless
+  you pass `--keep-remote`) deletes the stale remote ref.
 - Use short-lived `feature/<slug>` branches when parallel threads are needed. Rebase on `develop` frequently and
   open PRs with `npm run priority:pr`.
 - When preparing a release:
@@ -210,8 +214,8 @@ node tools/npm/run-script.mjs lint            # markdownlint + custom checks
 - On shared runners the canonical installs sit under `C:\Program Files`, but
   local setups may vary. Copy `configs/labview-paths.sample.json` to
   `configs/labview-paths.json` and list overrides under:
-  - `lvcompare` array â€“ explicit `LVCompare.exe` locations; first match wins.
-  - `labview` array â€“ candidate `LabVIEW.exe` paths (per version/bitness).
+  - `lvcompare` array ├óΓé¼ΓÇ£ explicit `LVCompare.exe` locations; first match wins.
+  - `labview` array ├óΓé¼ΓÇ£ candidate `LabVIEW.exe` paths (per version/bitness).
 - Environment variables (`LVCOMPARE_PATH`, `LABVIEW_PATH`, etc.) still win, and
   the provider now writes verbose logs enumerating every candidate so you can
   troubleshoot missing installs quickly (`pwsh -v 5` to surface messages).
@@ -261,3 +265,13 @@ pwsh -File scripts/CompareVI.ps1 -Base VI1.vi -Head VI2.vi -LvCompareArgs "-nobd
 - [`docs/SCHEMA_HELPER.md`](./SCHEMA_HELPER.md)
 - [`docs/TROUBLESHOOTING.md`](./TROUBLESHOOTING.md)
 
+
+
+### Fork pull request automation
+
+- Fork PRs targeting develop automatically run the **VI Compare (Fork PR)** workflow. The job checks out the head commit using the shared etch-pr-head helper, stages the affected VIs, runs LVCompare on the self-hosted runner, and uploads artifacts identical to /vi-stage.
+- /vi-stage and /vi-history commands remain available for both upstream and fork contributions. Those workflows now also use the fetch helper so they can operate on fork heads safely.
+- The new **PR Auto-approve Label** workflow runs after Validate. When a PR targets develop, is not a fork/draft, its checks are green, and (optionally) the author is allowed, the workflow adds the auto-approve label automatically. If any condition fails, the label is removed.
+- When the workflow skips a PR, it now emits structured outputs (`autoapprove_reason`, `autoapprove_checks`, `autoapprove_detail`) and `::notice::` messages (for example, merge conflicts or failing checks). Downstream automation can inspect those outputs to surface richer status or trigger follow-up actions.
+- Auto-approve still requires AUTO_APPROVE_TOKEN, optional AUTO_APPROVE_LABEL (default uto-approve), and optional AUTO_APPROVE_ALLOWED. The label lifecycle is now fully automated so contributors donΓÇÖt need to toggle it manually.
+- When testing fork scenarios locally, use the composite ./.github/actions/fetch-pr-head to simulate pull/<id>/head checkouts before invoking staging/history helpers.


### PR DESCRIPTION
## Summary
- port the updated auto-approve workflow onto develop so Validate-triggered runs emit skip reasons and structured outputs
- refresh the developer guide to mention the new workflow outputs

## Testing
- git cherry-pick 0c910f3 on develop