### PR TITLE
feat: harden fork compare paths (#496)

### DIFF
--- a/.github/workflows/pr-vi-history.yml
+++ b/.github/workflows/pr-vi-history.yml
@@ -9,6 +9,10 @@ on:
       pr:
         description: 'Pull request number'
         required: true
+      fetch_depth:
+        description: 'Depth used when fetching the PR head (default 20)'
+        required: false
+        default: '20'
       note:
         description: 'Optional note echoed in the PR comment'
         required: false
@@ -38,6 +42,7 @@ jobs:
     env:
       NOTE: ${{ inputs.note }}
       MAX_PAIRS: ${{ inputs.max_pairs || '6' }}
+      FETCH_DEPTH: ${{ github.event.inputs.fetch_depth || '20' }}
     steps:
       - name: Resolve pull request metadata
         id: pr
@@ -100,6 +105,7 @@ jobs:
         shell: pwsh
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          FETCH_DEPTH: ${{ env.FETCH_DEPTH }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
@@ -107,7 +113,7 @@ jobs:
             throw 'PR number unavailable; cannot fetch head commit.'
           }
 
-          $fetchDepth = 1
+          $fetchDepth = if ($env:FETCH_DEPTH) { [int]$env:FETCH_DEPTH } else { 20 }
           git fetch --no-tags --depth=$fetchDepth origin ("pull/{0}/head:pr-{0}-head" -f $env:PR_NUMBER)
           git checkout --detach ("pr-{0}-head" -f $env:PR_NUMBER)
           git branch -D ("pr-{0}-head" -f $env:PR_NUMBER) 2>$null | Out-Null

--- a/.github/workflows/pr-vi-staging.yml
+++ b/.github/workflows/pr-vi-staging.yml
@@ -9,6 +9,10 @@ on:
       pr:
         description: 'Pull request number'
         required: true
+      fetch_depth:
+        description: 'Depth used when fetching the PR head (default 20)'
+        required: false
+        default: '20'
       note:
         description: 'Optional note that will be echoed in the run summary'
         required: false
@@ -38,6 +42,7 @@ jobs:
     env:
       NOTE: ${{ inputs.note }}
       STAGING_LABEL: ${{ inputs.label_name || 'vi-staging-ready' }}
+      FETCH_DEPTH: ${{ github.event.inputs.fetch_depth || '20' }}
     steps:
       - name: Resolve pull request metadata
         id: pr
@@ -113,6 +118,7 @@ jobs:
         shell: pwsh
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          FETCH_DEPTH: ${{ env.FETCH_DEPTH }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
@@ -120,7 +126,7 @@ jobs:
             throw 'PR number unavailable; cannot fetch head commit.'
           }
 
-          $fetchDepth = 1
+          $fetchDepth = if ($env:FETCH_DEPTH) { [int]$env:FETCH_DEPTH } else { 20 }
           git fetch --no-tags --depth=$fetchDepth origin ("pull/{0}/head:pr-{0}-head" -f $env:PR_NUMBER)
           git checkout --detach ("pr-{0}-head" -f $env:PR_NUMBER)
           git branch -D ("pr-{0}-head" -f $env:PR_NUMBER) 2>$null | Out-Null

--- a/.github/workflows/vi-compare-fork.yml
+++ b/.github/workflows/vi-compare-fork.yml
@@ -17,6 +17,7 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      FETCH_DEPTH: 20
     steps:
       - name: Checkout base (parent repository)
         uses: actions/checkout@v4
@@ -35,7 +36,7 @@ jobs:
             throw 'PR number unavailable; cannot fetch head commit.'
           }
 
-          $fetchDepth = 1
+          $fetchDepth = if ($env:FETCH_DEPTH) { [int]$env:FETCH_DEPTH } else { 20 }
           git fetch --no-tags --depth=$fetchDepth origin ("pull/{0}/head:pr-{0}-head" -f $env:PR_NUMBER)
           git checkout --detach ("pr-{0}-head" -f $env:PR_NUMBER)
           git branch -D ("pr-{0}-head" -f $env:PR_NUMBER) 2>$null | Out-Null

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ the same summary table to a GitHub issue for stakeholders.
 - The job is read-only (no pushes or release writes) and produces the same artifact layout as `/vi-stage`, giving
   reviewers deterministic bundles without manual staging. The workflow executes on the trusted self-hosted Windows
   runner (`self-hosted, Windows, X64`) so the same LVCompare install used in CI handles fork PRs.
+- Manual `/vi-stage` and `/vi-history` dispatches accept a `fetch_depth` input (default `20`) if you need to pull a deeper history when testing locally.
+- To rehearse the fork flow locally, run `pwsh -File tools/Test-ForkSimulation.ps1` in three passes: `-DryRun` shows the
+  steps, the default run opens a draft PR and validates the automatic compare job, and `-KeepBranch` preserves the
+  scratch branch while the staging/history dispatches finish so you can inspect the artifacts.
 
 ## Optional inputs
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -273,5 +273,9 @@ pwsh -File scripts/CompareVI.ps1 -Base VI1.vi -Head VI2.vi -LvCompareArgs "-nobd
 - /vi-stage and /vi-history commands remain available for both upstream and fork contributions. Those workflows now also use the fetch helper so they can operate on fork heads safely.
 - The new **PR Auto-approve Label** workflow runs after Validate. When a PR targets develop, is not a fork/draft, its checks are green, and (optionally) the author is allowed, the workflow adds the auto-approve label automatically. If any condition fails, the label is removed.
 - When the workflow skips a PR, it now emits structured outputs (`autoapprove_reason`, `autoapprove_checks`, `autoapprove_detail`) and `::notice::` messages (for example, merge conflicts or failing checks). Downstream automation can inspect those outputs to surface richer status or trigger follow-up actions.
-- Auto-approve still requires AUTO_APPROVE_TOKEN, optional AUTO_APPROVE_LABEL (default uto-approve), and optional AUTO_APPROVE_ALLOWED. The label lifecycle is now fully automated so contributors don’t need to toggle it manually.
+- Auto-approve still requires AUTO_APPROVE_TOKEN, optional AUTO_APPROVE_LABEL (default uto-approve), and optional AUTO_APPROVE_ALLOWED. The label lifecycle is now fully automated so contributors don't need to toggle it manually.
+- Manual `/vi-stage` and `/vi-history` workflows accept an optional `fetch_depth` input (default `20`). Increase it when you need additional commit history before running compares.
+- Use `tools/Test-ForkSimulation.ps1` when validating fork automation. Run it in three passes: `-DryRun` prints the
+  plan, the default run pushes a scratch branch, opens a draft PR, and waits for the fork compare workflow, and adding
+  `-KeepBranch` preserves the branch/PR after the staging and history dispatches complete for manual inspection.
 - When testing fork scenarios locally, use the composite ./.github/actions/fetch-pr-head to simulate pull/<id>/head checkouts before invoking staging/history helpers.

--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -75,6 +75,9 @@
   `tools/Summarize-VIStaging.ps1`, and uploads the compare artifacts. It executes on the trusted self-hosted Windows
   runner (`self-hosted, Windows, X64`) and keeps the job read-only (no pushes/releases), so reviewers get deterministic
   LVCompare bundles at the start of every fork PR without manual staging.
+- Rehearse the fork path with `tools/Test-ForkSimulation.ps1`: start with `-DryRun` to review the plan, run the helper
+  normally to open a draft PR and validate the automatic compare job, then repeat with `-KeepBranch` when you want the
+  scratch branch preserved while the `/vi-stage` and `/vi-history` dispatches finish.
 - Comment `/vi-history` when you want the automation to walk commit history for every VI in the PR. The companion
   workflow (`pr-vi-history.yml`) generates the diff manifest, runs `tools/Invoke-PRVIHistory.ps1` (default `-MaxPairs 6`;
   add `-Verbose` locally to see the resolved helper and whether we lifted the path from the base or head tree),
@@ -232,4 +235,5 @@ gh workflow run vi-compare-refs.yml `
 
 - VI Compare (Fork PR) runs automatically on PRs targeting develop (including forks). The workflow fetches the fork head via the composite etch-pr-head helper, stages pairs, runs LVCompare on the self-hosted Windows runner, and uploads the same artifacts as /vi-stage.
 - The command-driven workflows (pr-vi-staging.yml, pr-vi-history.yml) now reuse the helper so they operate on fork commits safely without bespoke checkout logic.
+- Manual `/vi-stage` and `/vi-history` dispatches accept an optional `fetch_depth` input (default `20`) so you can deepen history when needed.
 - PR auto-approval depends on the standing label gate: the new auto-approve label workflow toggles the label automatically once Validate succeeds for eligible PRs.

--- a/tools/Test-ForkSimulation.ps1
+++ b/tools/Test-ForkSimulation.ps1
@@ -1,0 +1,471 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+Creates a fork-style pull request, runs the compare workflows, and optionally
+cleans everything up again.
+
+.DESCRIPTION
+This helper simulates a fork contributor by copying a deterministic VI fixture,
+committing the change on a scratch branch that lives on the fork remote
+(`origin`), opening a draft PR against `upstream/<BaseBranch>`, and exercising
+three compare passes:
+
+1. The automatic **VI Compare (Fork PR)** workflow that runs on every fork PR.
+2. The manual **PR VI Compare Staging** workflow (dispatched with the new PR).
+3. The manual **PR VI History** workflow (also dispatched with the PR).
+
+Each pass waits for the workflow to complete and fails fast if any job reports
+`conclusion != success`. When `-KeepBranch` is omitted the helper closes the
+draft PR, deletes the fork branch, and restores the working tree to its
+original state. Use `-DryRun` to print the planned steps without mutating the
+workspace or touching GitHub.
+
+.PARAMETER BaseBranch
+Upstream branch to branch from and target in the draft PR. Defaults to `develop`.
+
+.PARAMETER KeepBranch
+Skip cleanup so the scratch branch and draft PR remain available for inspection.
+
+.PARAMETER DryRun
+Emit the steps that would run without mutating git, GitHub, or the filesystem.
+#>
+[CmdletBinding()]
+param(
+    [string]$BaseBranch = 'develop',
+    [switch]$KeepBranch,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [switch]$IgnoreErrors
+    )
+
+    if ($DryRun) {
+        Write-Host "[dry-run] git $($Arguments -join ' ')"
+        return @()
+    }
+
+    $output = git @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0 -and -not $IgnoreErrors) {
+        throw "git $($Arguments -join ' ') failed:`n$output"
+    }
+
+    return @($output -split "`r?`n" | Where-Object { $_ -and $_.Trim() -ne '' })
+}
+
+function Invoke-Gh {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [switch]$ExpectJson,
+        [switch]$IgnoreErrors
+    )
+
+    if ($DryRun) {
+        Write-Host "[dry-run] gh $($Arguments -join ' ')"
+        return $null
+    }
+
+    $output = gh @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0 -and -not $IgnoreErrors) {
+        throw "gh $($Arguments -join ' ') failed:`n$output"
+    }
+
+    if ($ExpectJson) {
+        if (-not $output) {
+            return $null
+        }
+        return $output | ConvertFrom-Json
+    }
+
+    return @($output -split "`r?`n" | Where-Object { $_ -and $_.Trim() -ne '' })
+}
+
+function Ensure-GitClean {
+    $statusRaw = Invoke-Git -Arguments @('status', '--porcelain')
+    $status = @()
+    if ($statusRaw) {
+        if ($statusRaw -is [System.Array]) {
+            $status = $statusRaw
+        } else {
+            $status = @($statusRaw)
+        }
+    }
+    $status = @($status | Where-Object { $_ -and $_.Trim() -ne '' })
+    if ($status.Count -gt 0) {
+        throw "Working tree is not clean:`n$($status -join [Environment]::NewLine)"
+    }
+}
+
+function Get-RemoteInfo {
+    param(
+        [Parameter(Mandatory)]
+        [string]$RemoteName
+    )
+
+    if ($DryRun) {
+        switch ($RemoteName) {
+            'upstream' {
+                return [PSCustomObject]@{
+                    Owner      = 'LabVIEW-Community-CI-CD'
+                    Repository = 'compare-vi-cli-action'
+                    Slug       = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+                }
+            }
+            'origin' {
+                return [PSCustomObject]@{
+                    Owner      = 'fork-owner'
+                    Repository = 'compare-vi-cli-action'
+                    Slug       = 'fork-owner/compare-vi-cli-action'
+                }
+            }
+            default {
+                return [PSCustomObject]@{
+                    Owner      = "dry-run-$RemoteName"
+                    Repository = 'placeholder'
+                    Slug       = "dry-run-$RemoteName/placeholder"
+                }
+            }
+        }
+    }
+
+    $raw = Invoke-Git -Arguments @('remote', 'get-url', $RemoteName)
+    $url = if ($raw -is [System.Array]) { $raw | Select-Object -First 1 } else { $raw }
+    if (-not $url) {
+        throw "Unable to resolve remote '$RemoteName'."
+    }
+
+    $pattern = '(?<=github\.com[:/])(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$'
+    $match = [regex]::Match($url, $pattern)
+    if (-not $match.Success) {
+        throw "Remote '$RemoteName' does not appear to point at GitHub (value=$url)."
+    }
+
+    $owner = $match.Groups['owner'].Value
+    $repo = $match.Groups['repo'].Value
+
+    return [PSCustomObject]@{
+        Owner = $owner
+        Repository = $repo
+        Slug = "$owner/$repo"
+    }
+}
+
+function Copy-FixturePair {
+    param(
+        [Parameter(Mandatory)][string]$SourceBase,
+        [Parameter(Mandatory)][string]$SourceHead,
+        [Parameter(Mandatory)][string]$TargetBase,
+        [Parameter(Mandatory)][string]$TargetHead
+    )
+
+    if ($DryRun) {
+        Write-Host "[dry-run] Copy $SourceBase -> $TargetBase"
+        Write-Host "[dry-run] Copy $SourceHead -> $TargetHead"
+        return
+    }
+
+    [System.IO.File]::Copy($SourceBase, $TargetBase, $true)
+    [System.IO.File]::Copy($SourceHead, $TargetHead, $true)
+}
+
+function Wait-WorkflowCompletion {
+    param(
+        [Parameter(Mandatory)][string]$WorkflowSelector,
+        [string]$Branch,
+        [DateTime]$CreatedAfter,
+        [int]$TimeoutMinutes = 20,
+        [string]$EventName,
+        [long[]]$IgnoreRunIds = @()
+    )
+
+    if ($DryRun) {
+        Write-Host "[dry-run] Would wait for workflow '$WorkflowSelector' (branch='$Branch')"
+        return [PSCustomObject]@{
+            htmlUrl    = '(dry-run)'
+            status     = 'skipped'
+            conclusion = 'skipped'
+        }
+    }
+
+    $deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+    while ($true) {
+        if ((Get-Date) -gt $deadline) {
+            throw "Workflow '$WorkflowSelector' did not finish within $TimeoutMinutes minute(s)."
+        }
+
+        $args = @(
+            'run', 'list',
+            '--workflow', $WorkflowSelector,
+            '--json', 'databaseId,status,conclusion,headBranch,url,createdAt,event',
+            '--limit', '20'
+        )
+        if ($Branch) {
+            $args += @('--branch', $Branch)
+        }
+
+        $runs = Invoke-Gh -Arguments $args -ExpectJson
+        if (-not $runs) {
+            Start-Sleep -Seconds 5
+            continue
+        }
+
+        $candidates = $runs
+        if ($CreatedAfter) {
+            $cutoff = $CreatedAfter.ToUniversalTime()
+            $candidates = $candidates | Where-Object {
+                try {
+                    $created = [DateTime]::Parse($_.createdAt).ToUniversalTime()
+                    return $created -ge $cutoff
+                } catch {
+                    return $false
+                }
+            }
+        }
+
+        if ($Branch) {
+            $candidates = $candidates | Where-Object { $_.headBranch -eq $Branch }
+        }
+        if ($EventName) {
+            $candidates = $candidates | Where-Object { $_.event -eq $EventName }
+        }
+        if ($IgnoreRunIds) {
+            $candidates = $candidates | Where-Object { -not ($IgnoreRunIds -contains $_.databaseId) }
+        }
+
+        $match = $candidates | Sort-Object -Property createdAt -Descending | Select-Object -First 1
+        if (-not $match) {
+            Start-Sleep -Seconds 5
+            continue
+        }
+
+        if ($match.status -eq 'completed') {
+            if ($match.conclusion -ne 'success') {
+                throw "Workflow '$WorkflowSelector' failed (conclusion=$($match.conclusion)). See $($match.url)"
+            }
+            Write-Host "Workflow '$WorkflowSelector' succeeded. See: $($match.url)"
+            return $match
+        }
+
+        Start-Sleep -Seconds 10
+    }
+}
+
+function Invoke-WorkflowDispatch {
+    param(
+        [Parameter(Mandatory)][string]$WorkflowFile,
+        [hashtable]$Inputs,
+        [string]$Ref,
+        [string]$BranchForWait,
+        [string]$Note,
+        [int]$TimeoutMinutes = 20
+    )
+
+    $runNote = if ($Note) { $Note } else { "fork-sim $WorkflowFile" }
+    $startTime = Get-Date
+    $existingRuns = Invoke-Gh -ExpectJson -Arguments @(
+        'run', 'list',
+        '--workflow', $WorkflowFile,
+        '--json', 'databaseId',
+        '--limit', '20'
+    )
+    $existingIds = @()
+    if ($existingRuns) {
+        $existingIds = @($existingRuns | ForEach-Object { [long]$_.databaseId })
+    }
+
+    $args = @('workflow', 'run', $WorkflowFile)
+    if ($Ref) {
+        $args += @('--ref', $Ref)
+    }
+    $noteProvided = $false
+    if ($null -ne $Inputs) {
+        foreach ($key in $Inputs.Keys) {
+            $value = $Inputs[$key]
+            if ($null -ne $value) {
+                $args += @('--field', "$key=$value")
+            }
+            if ($key -eq 'note') {
+                $noteProvided = $true
+                $runNote = $value
+            }
+        }
+    }
+    if (-not $noteProvided) {
+        $args += @('--field', "note=$runNote")
+    }
+
+    Invoke-Gh -Arguments $args | Out-Null
+    Write-Host "Dispatched $WorkflowFile (note='$runNote')"
+
+    return Wait-WorkflowCompletion -WorkflowSelector $WorkflowFile -Branch $BranchForWait -CreatedAfter $startTime -TimeoutMinutes $TimeoutMinutes -EventName 'workflow_dispatch' -IgnoreRunIds $existingIds
+}
+
+Ensure-GitClean
+
+$repoRoot = if ($DryRun) { (Get-Location).Path } else {
+    $top = Invoke-Git -Arguments @('rev-parse', '--show-toplevel') | Select-Object -First 1
+    if (-not $top) {
+        throw 'Unable to resolve repository root.'
+    }
+    [System.IO.Path]::GetFullPath($top.Trim())
+}
+
+if (-not $DryRun) {
+    Set-Location -LiteralPath $repoRoot
+}
+
+$upstream = Get-RemoteInfo -RemoteName 'upstream'
+$fork = Get-RemoteInfo -RemoteName 'origin'
+Write-Host "Upstream: $($upstream.Slug); Fork: $($fork.Slug)"
+
+Invoke-Git -Arguments @('fetch', '--prune', 'upstream')
+Invoke-Git -Arguments @('fetch', '--prune', 'origin')
+Invoke-Git -Arguments @('checkout', $BaseBranch)
+Invoke-Git -Arguments @('reset', '--hard', "upstream/$BaseBranch")
+
+$timestamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmss')
+$scratchBranch = "fork-sim/$timestamp"
+$originalBranch = Invoke-Git -Arguments @('branch', '--show-current') | Select-Object -First 1
+
+Invoke-Git -Arguments @('checkout', '-B', $scratchBranch)
+
+$targetBaseVi = Join-Path 'fixtures' 'vi-attr' 'Base.vi'
+$targetHeadVi = Join-Path 'fixtures' 'vi-attr' 'Head.vi'
+$sourceBaseVi = Join-Path 'tmp-commit-236ffab' 'VI1.vi'
+$sourceHeadVi = Join-Path 'tmp-commit-236ffab' 'VI2.vi'
+
+Copy-FixturePair -SourceBase $sourceBaseVi -SourceHead $sourceHeadVi -TargetBase $targetBaseVi -TargetHead $targetHeadVi
+
+Invoke-Git -Arguments @('add', $targetBaseVi, $targetHeadVi)
+Invoke-Git -Arguments @('status', '--short')
+
+$commitMessage = "Fork simulation VI diff ($timestamp)"
+Invoke-Git -Arguments @('commit', '-m', $commitMessage)
+
+if (-not $DryRun) {
+    Invoke-Git -Arguments @('push', '--set-upstream', 'origin', $scratchBranch)
+}
+
+$prNumber = $null
+$prUrl = $null
+if (-not $DryRun) {
+    Invoke-Gh -Arguments @(
+        'pr', 'create',
+        '--repo', $upstream.Slug,
+        '--base', $BaseBranch,
+        '--head', "$($fork.Owner):$scratchBranch",
+        '--title', "[fork-sim] VI diff smoke ($timestamp)",
+        '--body', "Automated fork simulation to exercise compare workflows.",
+        '--draft'
+    ) | Out-Null
+
+    $prList = Invoke-Gh -ExpectJson -Arguments @(
+        'pr', 'list',
+        '--repo', $upstream.Slug,
+        '--head', $scratchBranch,
+        '--state', 'all',
+        '--json', 'number,url'
+    )
+    $prPayload = $prList | Select-Object -First 1
+    if (-not $prPayload) {
+        throw 'Failed to resolve draft pull request metadata.'
+    }
+    $prNumber = [int]$prPayload.number
+    $prUrl = $prPayload.url
+    Write-Host "Opened draft PR #$prNumber ($prUrl)"
+}
+
+$summary = @()
+$forkIgnoreIds = @()
+if (-not $DryRun) {
+    $existingForkRuns = Invoke-Gh -ExpectJson -Arguments @(
+        'run', 'list',
+        '--workflow', 'vi-compare-fork.yml',
+        '--json', 'databaseId',
+        '--limit', '20'
+    )
+    if ($existingForkRuns) {
+        $forkIgnoreIds = @($existingForkRuns | ForEach-Object { [long]$_.databaseId })
+    }
+}
+$autoRun = Wait-WorkflowCompletion -WorkflowSelector 'vi-compare-fork.yml' -Branch $scratchBranch -EventName 'pull_request' -IgnoreRunIds $forkIgnoreIds
+$summary += [PSCustomObject]@{
+    Pass       = 'fork-pr'
+    Workflow   = 'VI Compare (Fork PR)'
+    ResultUrl  = $autoRun.url
+    Conclusion = $autoRun.conclusion
+}
+
+if ($prNumber) {
+    $stagingNote = "fork-sim staging $timestamp"
+    $stagingRun = Invoke-WorkflowDispatch -WorkflowFile 'pr-vi-staging.yml' -Inputs @{
+        pr = $prNumber
+        note = $stagingNote
+    } -Ref $BaseBranch -BranchForWait $BaseBranch -TimeoutMinutes 25
+    $summary += [PSCustomObject]@{
+        Pass       = 'staging'
+        Workflow   = 'PR VI Compare Staging'
+        ResultUrl  = $stagingRun.url
+        Conclusion = $stagingRun.conclusion
+    }
+
+    $historyNote = "fork-sim history $timestamp"
+    $historyRun = Invoke-WorkflowDispatch -WorkflowFile 'pr-vi-history.yml' -Inputs @{
+        pr = $prNumber
+        note = $historyNote
+    } -Ref $BaseBranch -BranchForWait $BaseBranch -TimeoutMinutes 25
+    $summary += [PSCustomObject]@{
+        Pass       = 'history'
+        Workflow   = 'PR VI History'
+        ResultUrl  = $historyRun.url
+        Conclusion = $historyRun.conclusion
+    }
+} else {
+    $summary += [PSCustomObject]@{
+        Pass       = 'staging'
+        Workflow   = 'PR VI Compare Staging'
+        ResultUrl  = '(dry-run)'
+        Conclusion = 'skipped'
+    }
+    $summary += [PSCustomObject]@{
+        Pass       = 'history'
+        Workflow   = 'PR VI History'
+        ResultUrl  = '(dry-run)'
+        Conclusion = 'skipped'
+    }
+}
+
+if (-not $KeepBranch) {
+    Write-Host 'Cleaning up scratch branch and draft PR.'
+    if ($prNumber -and -not $DryRun) {
+        Invoke-Gh -Arguments @('pr', 'close', $prNumber.ToString(), '--comment', 'Closing fork simulation run.', '--delete-branch') -IgnoreErrors | Out-Null
+    }
+    Invoke-Git -Arguments @('checkout', $BaseBranch)
+    Invoke-Git -Arguments @('reset', '--hard', "upstream/$BaseBranch")
+    if (-not $DryRun) {
+        Invoke-Git -Arguments @('push', 'origin', '--delete', $scratchBranch) -IgnoreErrors | Out-Null
+    }
+    Invoke-Git -Arguments @('branch', '-D', $scratchBranch) -IgnoreErrors | Out-Null
+} else {
+    Write-Host "Keeping scratch branch '$scratchBranch' and draft PR for follow-up."
+    if ($originalBranch) {
+        Invoke-Git -Arguments @('checkout', $originalBranch)
+    }
+}
+
+Write-Host ""
+Write-Host "Fork simulation completed. Pass summary:"
+foreach ($entry in $summary) {
+    Write-Host (" - [{0}] {1} -> {2}" -f $entry.Conclusion, $entry.Workflow, $entry.ResultUrl)
+}
+
+if ($prUrl) {
+    Write-Host ("Draft PR: {0}" -f $prUrl)
+}


### PR DESCRIPTION
## Summary
- increase default fetch depth to 20 for fork compare workflows so history comparisons have parent commits
- add 	ools/Test-ForkSimulation.ps1 helper to exercise fork compare/staging/history in one script
- document the helper and new etch_depth input in README, Developer Guide, and knowledge base

## Testing
- pwsh -File tools/PrePush-Checks.ps1
- pwsh -File tools/Test-ForkSimulation.ps1 -DryRun