### PR TITLE
Add bucket coverage to staging/history reports (#523)

### DIFF
--- a/tests/Render-VIHistoryReport.Tests.ps1
+++ b/tests/Render-VIHistoryReport.Tests.ps1
@@ -1,0 +1,158 @@
+Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+        $script:scriptPath = Join-Path $script:repoRoot 'tools' 'Render-VIHistoryReport.ps1'
+        $script:originalLocation = Get-Location
+        Set-Location $script:repoRoot
+    }
+
+    AfterAll {
+        if ($script:originalLocation) {
+            Set-Location $script:originalLocation
+        }
+    }
+
+    It 'renders bucket summaries into Markdown and HTML outputs' {
+        $resultsRoot = Join-Path $TestDrive 'history-results'
+        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+        $reportDir = Join-Path $resultsRoot 'default/pair-01'
+        New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+        $reportPath = Join-Path $reportDir 'compare-report.html'
+        '<html></html>' | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+        $aggregateManifest = [ordered]@{
+            schema            = 'vi-compare/history-suite@v1'
+            generatedAt       = (Get-Date).ToString('o')
+            targetPath        = 'fixtures/vi-attr/Base.vi'
+            requestedStartRef = 'HEAD^'
+            startRef          = 'HEAD'
+            maxPairs          = 2
+            resultsDir        = $resultsRoot
+            status            = 'ok'
+            modes             = @(
+                [ordered]@{
+                    name         = 'default'
+                    slug         = 'default'
+                    reportFormat = 'html'
+                    flags        = @('-nobd')
+                    manifestPath = Join-Path $resultsRoot 'default' 'manifest.json'
+                    resultsDir   = Join-Path $resultsRoot 'default'
+                    status       = 'ok'
+                    stats        = [ordered]@{
+                        processed     = 2
+                        diffs         = 1
+                        missing       = 0
+                        categoryCounts= [ordered]@{ 'block-diagram' = 1 }
+                        bucketCounts  = [ordered]@{ 'functional-behavior' = 1 }
+                    }
+                }
+            )
+            stats = [ordered]@{
+                modes          = 1
+                processed      = 2
+                diffs          = 1
+                missing        = 0
+                errors         = 0
+                categoryCounts = [ordered]@{
+                    'block-diagram' = 1
+                    'attributes'    = 1
+                }
+                bucketCounts   = [ordered]@{
+                    'functional-behavior' = 1
+                    'metadata'            = 1
+                }
+            }
+        }
+
+        $modeDir = Join-Path $resultsRoot 'default'
+        New-Item -ItemType Directory -Path $modeDir -Force | Out-Null
+        $modeManifestPath = Join-Path $modeDir 'manifest.json'
+        [ordered]@{
+            schema      = 'vi-compare/history@v1'
+            generatedAt = $aggregateManifest.generatedAt
+            targetPath  = $aggregateManifest.targetPath
+            mode        = 'default'
+            slug        = 'default'
+            stats       = $aggregateManifest.modes[0].stats
+            comparisons = @()
+        } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
+
+        $context = [ordered]@{
+            schema            = 'vi-compare/history-context@v1'
+            generatedAt       = $aggregateManifest.generatedAt
+            targetPath        = $aggregateManifest.targetPath
+            requestedStartRef = $aggregateManifest.requestedStartRef
+            startRef          = $aggregateManifest.startRef
+            maxPairs          = 2
+            comparisons       = @(
+                [ordered]@{
+                    mode  = 'default'
+                    index = 1
+                    base  = @{
+                        full   = 'abc123456789'
+                        short  = 'abc1234'
+                        subject= 'Base commit'
+                    }
+                    head  = @{
+                        full   = 'def987654321'
+                        short  = 'def9876'
+                        subject= 'Head commit'
+                    }
+                    result = [ordered]@{
+                        diff                   = $true
+                        duration_s             = 1.23
+                        status                 = 'completed'
+                        reportPath             = $reportPath
+                        categories             = @('Block Diagram Functional', 'VI Attribute')
+                        categoryDetails        = @(
+                            @{ slug = 'block-diagram'; label = 'Block diagram'; classification = 'signal' },
+                            @{ slug = 'attributes'; label = 'Attributes'; classification = 'neutral' }
+                        )
+                        categoryBuckets        = @('functional-behavior', 'metadata')
+                        categoryBucketDetails  = @(
+                            @{ slug = 'functional-behavior'; label = 'Functional behavior'; classification = 'signal' },
+                            @{ slug = 'metadata'; label = 'Metadata'; classification = 'neutral' }
+                        )
+                    }
+                    highlights = @('Block diagram change', 'Attributes: VI Attribute')
+                }
+            )
+        }
+
+        $manifestPath = Join-Path $TestDrive 'aggregate-manifest.json'
+        $contextPath = Join-Path $TestDrive 'history-context.json'
+        $aggregateManifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $context | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $contextPath -Encoding utf8
+
+        $markdownPath = Join-Path $resultsRoot 'history-report.md'
+        $htmlPath = Join-Path $resultsRoot 'history-report.html'
+        $githubOutputPath = Join-Path $TestDrive 'github-output.txt'
+
+        & $script:scriptPath `
+            -ManifestPath $manifestPath `
+            -HistoryContextPath $contextPath `
+            -OutputDir $resultsRoot `
+            -MarkdownPath $markdownPath `
+            -EmitHtml `
+            -HtmlPath $htmlPath `
+            -GitHubOutputPath $githubOutputPath | Out-Null
+
+        Test-Path -LiteralPath $markdownPath | Should -BeTrue
+        Test-Path -LiteralPath $htmlPath | Should -BeTrue
+
+        $markdown = Get-Content -LiteralPath $markdownPath -Raw
+        $markdown | Should -Match '\| Metric \| Value \|'
+        $markdown | Should -Match '\| Buckets \|'
+        $markdown | Should -Match 'Functional behavior'
+        $markdown | Should -Match 'Metadata'
+        $markdown | Should -Match '\| Mode \| Pair \| Base \| Head \| Diff \| Duration \(s\) \| Categories \| Buckets \| Report \| Highlights \|'
+
+        $html = Get-Content -LiteralPath $htmlPath -Raw
+        $html | Should -Match '<th>Categories</th>'
+        $html | Should -Match '<th>Buckets</th>'
+        $html | Should -Match 'data-buckets='
+
+        $outputLines = Get-Content -LiteralPath $githubOutputPath
+    }
+}

--- a/tests/ReportFixtureHelpers.ps1
+++ b/tests/ReportFixtureHelpers.ps1
@@ -18,7 +18,7 @@ function Get-ReportFixtureCases {
                 'VI Attribute - Miscellaneous'
             )
             Expected    = @(
-                [pscustomobject]@{ slug = 'attributes'; classification = 'signal' }
+                [pscustomobject]@{ slug = 'vi-attribute'; classification = 'neutral' }
             )
         }
         [ordered]@{
@@ -30,7 +30,7 @@ function Get-ReportFixtureCases {
             )
             Expected    = @(
                 [pscustomobject]@{ slug = 'block-diagram'; classification = 'signal' }
-                [pscustomobject]@{ slug = 'cosmetic'; classification = 'noise' }
+                [pscustomobject]@{ slug = 'block-diagram-cosmetic'; classification = 'noise' }
             )
         }
         [ordered]@{

--- a/tests/Summarize-VIStaging.Tests.ps1
+++ b/tests/Summarize-VIStaging.Tests.ps1
@@ -72,8 +72,12 @@ Describe 'Summarize-VIStaging.ps1' -Tag 'Unit' {
         $result.pairs[0].diffCategories | Should -Contain 'VI Attribute'
         $result.pairs[0].diffCategories | Should -Contain 'Block Diagram Functional'
         $result.pairs[0].diffCategoryDetails | Should -Not -BeNullOrEmpty
-        ($result.pairs[0].diffCategoryDetails | Where-Object { $_.slug -eq 'attributes' }).Count | Should -Be 1
-        ($result.pairs[0].diffCategoryDetails | Where-Object { $_.slug -eq 'block-diagram' }).Count | Should -Be 1
+        ($result.pairs[0].diffCategoryDetails | Where-Object { $_.slug -eq 'vi-attribute' }).Count | Should -Be 1
+        ($result.pairs[0].diffCategoryDetails | Where-Object { $_.slug -eq 'block-diagram-functional' }).Count | Should -Be 1
+        $result.pairs[0].diffBuckets | Should -Contain 'metadata'
+        $result.pairs[0].diffBuckets | Should -Contain 'functional-behavior'
+        ($result.pairs[0].diffBucketDetails | Where-Object { $_.slug -eq 'metadata' }).Count | Should -Be 1
+        ($result.pairs[0].diffBucketDetails | Where-Object { $_.slug -eq 'functional-behavior' }).Count | Should -Be 1
         $result.pairs[0].includedAttributes.Count | Should -BeGreaterThan 0
         ($result.pairs[0].includedAttributes | Where-Object { $_.name -eq 'VI Attribute' }).value | Should -BeTrue
         (@($result.pairs[0].diffDetailPreview | Where-Object { $_ -match 'Difference Type: VI icon' })).Count | Should -BeGreaterThan 0
@@ -84,14 +88,19 @@ Describe 'Summarize-VIStaging.ps1' -Tag 'Unit' {
         $markdown = Get-Content -LiteralPath $mdPath -Raw
         $markdown | Should -Match 'VI Attribute'
         $markdown | Should -Match 'Difference Type: VI icon'
+        $markdown | Should -Match 'Buckets:'
+        $markdown | Should -Match 'Functional behavior'
+        $markdown | Should -Match 'Metadata'
 
         Test-Path -LiteralPath $jsonPath | Should -BeTrue
         $jsonPayload = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 6
         $jsonPayload.totals.diff | Should -Be 1
         (@($jsonPayload.pairs[0].diffDetailPreview | Where-Object { $_ -match 'Difference Type: VI icon' })).Count | Should -BeGreaterThan 0
         $jsonPayload.pairs[0].diffCategoryDetails | Should -Not -BeNullOrEmpty
-        $jsonPayload.totals.categoryCounts.attributes | Should -Be 1
-        $jsonPayload.totals.categoryCounts.'block-diagram' | Should -Be 1
+        $jsonPayload.totals.categoryCounts.'vi-attribute' | Should -Be 1
+        $jsonPayload.totals.categoryCounts.'block-diagram-functional' | Should -Be 1
+        $jsonPayload.totals.bucketCounts.'metadata' | Should -Be 1
+        $jsonPayload.totals.bucketCounts.'functional-behavior' | Should -Be 1
     }
 
     It 'handles missing report gracefully' {
@@ -116,6 +125,8 @@ Describe 'Summarize-VIStaging.ps1' -Tag 'Unit' {
         $result.pairs[0].status | Should -Be 'skipped'
         $result.pairs[0].diffCategories.Count | Should -Be 0
         $result.pairs[0].diffCategoryDetails.Count | Should -Be 0
+        $result.pairs[0].diffBuckets.Count | Should -Be 0
+        $result.pairs[0].diffBucketDetails.Count | Should -Be 0
         $result.markdown | Should -Match 'Totals'
     }
 

--- a/tests/VICategoryBuckets.Tests.ps1
+++ b/tests/VICategoryBuckets.Tests.ps1
@@ -1,0 +1,36 @@
+Describe 'VICategoryBuckets module' -Tag 'Unit' {
+    BeforeAll {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+        $modulePath = Join-Path $repoRoot 'tools' 'VICategoryBuckets.psm1'
+        Import-Module $modulePath -Force
+    }
+
+    It 'maps VI Attribute to metadata bucket' {
+        $meta = Get-VICategoryMetadata -Name 'VI Attribute'
+        $meta | Should -Not -BeNullOrEmpty
+        $meta.slug | Should -Be 'vi-attribute'
+        $meta.bucketSlug | Should -Be 'metadata'
+        $meta.bucketLabel | Should -Be 'Metadata'
+        $meta.bucketClassification | Should -Be 'neutral'
+    }
+
+    It 'collects bucket details for multiple categories' {
+        $inputCategories = @(
+            'Block Diagram Functional',
+            'Front Panel Position/Size',
+            'Documentation'
+        )
+
+        $info = Get-VICategoryBuckets -Names $inputCategories
+        $info | Should -Not -BeNullOrEmpty
+        $info.Details.Count | Should -Be 3
+        $info.BucketSlugs | Should -Contain 'functional-behavior'
+        $info.BucketSlugs | Should -Contain 'ui-visual'
+        $info.BucketSlugs | Should -Contain 'metadata'
+
+        $functionalBucket = $info.BucketDetails | Where-Object { $_.slug -eq 'functional-behavior' }
+        $functionalBucket | Should -Not -BeNullOrEmpty
+        $functionalBucket.label | Should -Be 'Functional behavior'
+        $functionalBucket.classification | Should -Be 'signal'
+    }
+}

--- a/tools/VICategoryBuckets.psm1
+++ b/tools/VICategoryBuckets.psm1
@@ -1,0 +1,214 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:BucketDefinitions = @{
+    'functional-behavior' = @{
+        label          = 'Functional behavior'
+        classification = 'signal'
+    }
+    'ui-visual' = @{
+        label          = 'UI / visual'
+        classification = 'noise'
+    }
+    'metadata' = @{
+        label          = 'Metadata'
+        classification = 'neutral'
+    }
+    'uncategorized' = @{
+        label          = 'Uncategorized'
+        classification = 'neutral'
+    }
+}
+
+$script:CategoryDefinitions = @{
+    'block-diagram' = @{
+        label          = 'Block diagram'
+        classification = 'signal'
+        bucket         = 'functional-behavior'
+    }
+    'block-diagram-functional' = @{
+        label          = 'Block diagram (functional)'
+        classification = 'signal'
+        bucket         = 'functional-behavior'
+    }
+    'block-diagram-cosmetic' = @{
+        label          = 'Block diagram (cosmetic)'
+        classification = 'noise'
+        bucket         = 'ui-visual'
+    }
+    'connector-pane' = @{
+        label          = 'Connector pane'
+        classification = 'signal'
+        bucket         = 'functional-behavior'
+    }
+    'front-panel' = @{
+        label          = 'Front panel'
+        classification = 'signal'
+        bucket         = 'ui-visual'
+    }
+    'front-panel-position-size' = @{
+        label          = 'Front panel position/size'
+        classification = 'noise'
+        bucket         = 'ui-visual'
+    }
+    'control-changes' = @{
+        label          = 'Front panel controls'
+        classification = 'signal'
+        bucket         = 'ui-visual'
+    }
+    'window' = @{
+        label          = 'Window properties'
+        classification = 'neutral'
+        bucket         = 'ui-visual'
+    }
+    'icon' = @{
+        label          = 'Icon'
+        classification = 'noise'
+        bucket         = 'ui-visual'
+    }
+    'attributes' = @{
+        label          = 'Attributes'
+        classification = 'neutral'
+        bucket         = 'metadata'
+    }
+    'vi-attribute' = @{
+        label          = 'VI attribute'
+        classification = 'neutral'
+        bucket         = 'metadata'
+    }
+    'documentation' = @{
+        label          = 'Documentation'
+        classification = 'neutral'
+        bucket         = 'metadata'
+    }
+    'execution' = @{
+        label          = 'Execution settings'
+        classification = 'signal'
+        bucket         = 'functional-behavior'
+    }
+    'unspecified' = @{
+        label          = 'Unspecified'
+        classification = 'neutral'
+        bucket         = 'uncategorized'
+    }
+    'cosmetic' = @{
+        label          = 'Cosmetic'
+        classification = 'noise'
+        bucket         = 'ui-visual'
+    }
+}
+
+function Resolve-VICategorySlug {
+    param([string]$Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name)) { return $null }
+
+    $token = $Name.Trim().ToLowerInvariant()
+
+    if ($token -match 'block diagram' -and $token -match 'cosmetic') { return 'block-diagram-cosmetic' }
+    if ($token -match 'block diagram' -and $token -match 'functional') { return 'block-diagram-functional' }
+    if ($token -match 'block diagram') { return 'block-diagram' }
+    if ($token -match 'connector') { return 'connector-pane' }
+    if ($token -match 'vi attribute' -or $token -match 'attributes') { return 'vi-attribute' }
+    if ($token -match 'front panel position') { return 'front-panel-position-size' }
+    if ($token -match 'front panel' -or $token -match 'control changes') { return 'front-panel' }
+    if ($token -match 'cosmetic') { return 'cosmetic' }
+    if ($token -match 'window') { return 'window' }
+    if ($token -match 'icon') { return 'icon' }
+    if ($token -match 'documentation') { return 'documentation' }
+    if ($token -match 'execution') { return 'execution' }
+
+    return ($token -replace '[^a-z0-9]+', '-').Trim('-')
+}
+
+function Get-VIBucketMetadata {
+    param([string]$BucketSlug)
+
+    $slug = if ([string]::IsNullOrWhiteSpace($BucketSlug)) { 'uncategorized' } else { $BucketSlug.Trim().ToLowerInvariant() }
+    if (-not $script:BucketDefinitions.ContainsKey($slug)) {
+        $slug = 'uncategorized'
+    }
+    $definition = $script:BucketDefinitions[$slug]
+    return [pscustomobject]@{
+        slug           = $slug
+        label          = $definition.label
+        classification = $definition.classification
+    }
+}
+
+function Get-VICategoryMetadata {
+    param([string]$Name)
+
+    $slug = Resolve-VICategorySlug -Name $Name
+    if (-not $slug) { return $null }
+
+    $definition = $script:CategoryDefinitions[$slug]
+    $label = $null
+    $classification = 'signal'
+    $bucketSlug = 'uncategorized'
+    if ($definition) {
+        $label = $definition.label
+        $classification = $definition.classification
+        $bucketSlug = $definition.bucket
+    } else {
+        $spaced = ($slug -replace '[-_]', ' ')
+        $label = [System.Globalization.CultureInfo]::InvariantCulture.TextInfo.ToTitleCase($spaced)
+    }
+
+    $bucket = Get-VIBucketMetadata -BucketSlug $bucketSlug
+
+    return [pscustomobject]@{
+        slug                = $slug
+        label               = $label
+        classification      = $classification
+        bucketSlug          = $bucket.slug
+        bucketLabel         = $bucket.label
+        bucketClassification= $bucket.classification
+    }
+}
+
+function ConvertTo-VICategoryDetails {
+    param([System.Collections.IEnumerable]$Names)
+
+    $details = [System.Collections.Generic.List[object]]::new()
+    if (-not $Names) { return @() }
+
+    $seen = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in $Names) {
+        if ([string]::IsNullOrWhiteSpace($name)) { continue }
+        $meta = Get-VICategoryMetadata -Name $name
+        if (-not $meta) { continue }
+        if ($seen.Add($meta.slug)) {
+            $details.Add($meta) | Out-Null
+        }
+    }
+
+    return @($details)
+}
+
+function Get-VICategoryBuckets {
+    param([System.Collections.IEnumerable]$Names)
+
+    $details = ConvertTo-VICategoryDetails -Names $Names
+    $bucketSet = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+    $bucketDetails = [System.Collections.Generic.List[object]]::new()
+    foreach ($detail in $details) {
+        if (-not $detail) { continue }
+        if (-not [string]::IsNullOrWhiteSpace($detail.bucketSlug)) {
+            $bucketSet.Add($detail.bucketSlug) | Out-Null
+            $bucketMeta = Get-VIBucketMetadata -BucketSlug $detail.bucketSlug
+            if ($bucketMeta -and -not ($bucketDetails | Where-Object { $_.slug -eq $bucketMeta.slug })) {
+                $bucketDetails.Add($bucketMeta) | Out-Null
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        Details       = $details
+        BucketSlugs   = @($bucketSet)
+        BucketDetails = @($bucketDetails)
+    }
+}
+
+Export-ModuleMember -Function Resolve-VICategorySlug, Get-VIBucketMetadata, Get-VICategoryMetadata, ConvertTo-VICategoryDetails, Get-VICategoryBuckets


### PR DESCRIPTION
## Summary
- add shared VI bucket metadata module and wire it through staging/history helpers
- surface bucket totals in Markdown/HTML output and document the new acceptance checks

## Testing
- Invoke-Pester -Path tests/VICategoryBuckets.Tests.ps1,tests/Summarize-VIStaging.Tests.ps1,tests/Render-VIHistoryReport.Tests.ps1
- Invoke-Pester -Path tests/Run-StagedLVCompare.Tests.ps1
- Invoke-Pester -Path tests/CompareVI.History.Tests.ps1
- ./Invoke-PesterTests.ps1 -IntegrationMode include

Resolves #523