### PR TITLE
Auto-detect history depth (#528)

### DIFF
--- a/.github/workflows/vi-compare-refs.yml
+++ b/.github/workflows/vi-compare-refs.yml
@@ -16,7 +16,7 @@ on:
       compare_depth:
         description: 'Maximum commit pairs to evaluate (0 = no limit)'
         required: false
-        default: '10'
+        default: '0'
         type: string
       compare_modes:
         description: 'Comma/semicolon separated modes to evaluate (default,attributes,front-panel,block-diagram,all,full)'
@@ -192,7 +192,7 @@ jobs:
           }
           if ($startRef) { $invokeParams.StartRef = $startRef }
           if ($endRef) { $invokeParams.EndRef = $endRef }
-          if ($null -ne $parsedMaxPairs) {
+          if ($null -ne $parsedMaxPairs -and $parsedMaxPairs -gt 0) {
             $invokeParams.MaxPairs = [int]$parsedMaxPairs
           }
           if (-not [string]::IsNullOrWhiteSpace($env:EXTRA_FLAGS)) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Changed
+
+- `tools/Compare-VIHistory.ps1` now walks every reachable commit pair by default. Wrapper scripts and workflows only cap
+  history when `-MaxPairs`/`max_pairs` is explicitly supplied, keeping manifests and reports complete without extra flags.
+
+### Documentation
+
+- Updated README, developer guide, and workflow notes to describe the optional `-MaxPairs` cap and refreshed examples to
+  highlight the new default behaviour.
 
 ## [v0.5.4] - 2025-10-31
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ the same summary table to a GitHub issue for stakeholders.
 
 | Input name                 | Default   | Description                                                                 |
 | -------------------------- | --------- | --------------------------------------------------------------------------- |
-| `compare_depth`            | `10`      | Maximum commit pairs to evaluate (`0` = no limit)                           |
+| `compare_depth`            | `0`       | Maximum commit pairs to evaluate (`0` = no limit)                           |
 | `compare_modes`            | `default` | Comma/semicolon list of compare modes (`default,attributes,front-panel`) |
 | `compare_ignore_flags`     | `none`    | LVCompare ignore toggles (`none`, `default`, or comma-separated flags)      |
 | `compare_additional_flags` | ` `       | Extra LVCompare switches (space-delimited)                                  |
@@ -106,10 +106,12 @@ You can run the same compare logic locally:
 pwsh -NoLogo -NoProfile -File tools/Compare-VIHistory.ps1 `
   -TargetPath Fixtures/Loop.vi `
   -StartRef develop `
-  -MaxPairs 5 `
   -Detailed `
   -RenderReport
 ```
+
+The helper now processes every reachable commit pair by default. Supply
+`-MaxPairs <n>` when you need to cap the history for large or exploratory runs.
 
 Artifacts are written under `tests/results/ref-compare/history/` using the same
 schema as the workflow outputs.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -96,8 +96,10 @@ Quick reference for building, testing, and releasing the LVCompare composite act
       1. `tools/Get-PRVIDiffManifest.ps1` enumerates VI changes between the PR base/head commits.
       2. `tools/Invoke-PRVIHistory.ps1` resolves the history helper once
          (works with repo-relative targets) and runs the compare suite per VI.
-         Use the default `-MaxPairs 6`; artifacts land under `tests/results/pr-vi-history/` (aggregate manifest plus
-         `history-report.{md,html}` per target). Enable `-Verbose` locally to see the resolved helper path and origin
+        The helper now walks every reachable commit pair by default; pass `-MaxPairs <n>` only when you need
+        a deliberate cap (for example the history smoke script still uses `-MaxPairs 6` to keep the loop fast).
+        Artifacts land under `tests/results/pr-vi-history/` (aggregate manifest plus `history-report.{md,html}` per
+        target). Enable `-Verbose` locally to see the resolved helper path and origin
          (base/head) for each target.
       3. `tools/Summarize-PRVIHistory.ps1` renders the PR table with change types, comparison/diff counts, and
          relative report paths so reviewers can triage without downloading the artifact bundle.
@@ -200,7 +202,8 @@ node tools/npm/run-script.mjs lint            # markdownlint + custom checks
 - `scripts/Run-VIHistory.ps1` - regenerates the manual compare suite locally,
   verifies the target VI exists at the selected ref, and prints the Markdown
   summary (attribute coverage included) for issue comments. You can also call it
-  via `npm run history:run -- -ViPath Fixtures/Loop.vi -StartRef HEAD -MaxPairs 3`.
+  via `npm run history:run -- -ViPath Fixtures/Loop.vi -StartRef HEAD`. Add `-MaxPairs <n>`
+  when you intentionally need a cap.
 - `scripts/Dispatch-VIHistoryWorkflow.ps1` - wraps `gh workflow run` for
   `vi-compare-refs.yml`, echoes the latest run id/link, and records dispatch
   metadata under `tests/results/_agent/handoff/vi-history-run.json` for

--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -35,13 +35,13 @@ standing issue #527).
 
    ```powershell
    Set-Location labview-icon-editor
-   Invoke-CompareVIHistory `
-     -TargetPath "resource/plugins/NIIconEditor/Miscellaneous/Settings Init.vi" `
-     -MaxPairs 6 `
-     -RenderReport `
-     -FailOnDiff:$false `
-     -InvokeScriptPath ..\compare-vi-cli-action\tools\Invoke-LVCompare.ps1
-   ```
+Invoke-CompareVIHistory `
+  -TargetPath "resource/plugins/NIIconEditor/Miscellaneous/Settings Init.vi" `
+  -RenderReport `
+  -FailOnDiff:$false `
+  -InvokeScriptPath ..\compare-vi-cli-action\tools\Invoke-LVCompare.ps1
+```
+Add `-MaxPairs <n>` when you need to cap the number of commit pairs in the cross-repo run.
 
    - Outputs land in `tests/results/ref-compare/history/` inside the cloned
      repo (`history-report.md`, `history-report.html`, manifest JSON, etc.).

--- a/tests/RunVIHistory.Guidance.Tests.ps1
+++ b/tests/RunVIHistory.Guidance.Tests.ps1
@@ -94,6 +94,12 @@ Describe 'Run-VIHistory guidance helper' {
       $result | Should -Match 'git log --follow -- VI1\.vi'
     }
 
+    It 'labels the current MaxPairs as unlimited when no cap is provided' {
+      $msg = 'No commits found for VI1.vi reachable from HEAD'
+      $result = Get-CompareHistoryGuidance -ErrorMessage $msg -RepoRelativePath 'VI1.vi' -StartRef 'HEAD' -MaxPairs $null -ResultsDir 'outDir'
+      $result | Should -Match 'current: unlimited'
+    }
+
     It 'advises verifying prior revisions when no comparison modes execute' {
       $msg = 'No comparison modes executed.'
       $result = Get-CompareHistoryGuidance -ErrorMessage $msg -RepoRelativePath 'VI1.vi' -StartRef 'HEAD' -MaxPairs 3 -ResultsDir 'outDir'

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -41,6 +41,8 @@ $ErrorActionPreference = 'Stop'
 
 Set-Variable -Name repoRoot -Scope Script -Value $null
 
+$maxPairsRequested = $PSBoundParameters.ContainsKey('MaxPairs') -and $MaxPairs -gt 0
+
 try {
   $vendorModule = Join-Path (Split-Path -Parent $PSCommandPath) 'VendorTools.psm1'
   if (Test-Path -LiteralPath $vendorModule -PathType Leaf) {
@@ -557,7 +559,7 @@ Ensure-FileExistsAtRef -Ref $startRef -Path $targetRel
 if ($endRef) { Ensure-FileExistsAtRef -Ref $endRef -Path $targetRel }
 
 $revArgs = @('rev-list','--first-parent',$startRef)
-if ($MaxPairs -gt 0) {
+if ($maxPairsRequested) {
   $revArgs += ("--max-count={0}" -f ([int]($MaxPairs + 5)))
 }
 $revArgs += '--'
@@ -625,7 +627,7 @@ $aggregate = [ordered]@{
   requestedStartRef = $requestedStartRef
   startRef    = $startRef
   endRef      = $endRef
-  maxPairs    = $MaxPairs
+  maxPairs    = if ($maxPairsRequested) { $MaxPairs } else { $null }
   failFast    = [bool]$FailFast.IsPresent
   failOnDiff  = [bool]$FailOnDiff.IsPresent
   reportFormat = $reportFormatEffective
@@ -713,7 +715,7 @@ foreach ($modeSpec in $modeSpecs) {
     requestedStartRef = $requestedStartRef
     startRef    = $startRef
     endRef      = $endRef
-    maxPairs    = $MaxPairs
+    maxPairs    = if ($maxPairsRequested) { $MaxPairs } else { $null }
     failFast    = [bool]$FailFast.IsPresent
     failOnDiff  = [bool]$FailOnDiff.IsPresent
     mode        = $modeName
@@ -771,7 +773,7 @@ foreach ($modeSpec in $modeSpecs) {
     }
 
     $index = $processed + 1
-    if ($MaxPairs -gt 0 -and $index -gt $MaxPairs) {
+    if ($maxPairsRequested -and $index -gt $MaxPairs) {
       $stopReason = 'max-pairs'
       break
     }

--- a/tools/Run-LocalBackbone.ps1
+++ b/tools/Run-LocalBackbone.ps1
@@ -2,7 +2,7 @@ param(
   [switch]$SkipPrioritySync,
   [string[]]$CompareViName,
   [string]$CompareBranch = 'HEAD',
-  [int]$CompareMaxPairs = 1,
+  [Nullable[int]]$CompareMaxPairs,
   [switch]$CompareIncludeIdenticalPairs,
   [switch]$CompareFailOnDiff,
   [string]$CompareLvCompareArgs,
@@ -153,9 +153,11 @@ try {
           '-NoLogo', '-NoProfile',
           '-File', (Join-Path $repoRoot 'tools' 'Compare-VIHistory.ps1'),
           '-ViName', $vi,
-          '-Branch', $CompareBranch,
-          '-MaxPairs', [Math]::Max(1, $CompareMaxPairs)
+          '-Branch', $CompareBranch
         )
+        if ($CompareMaxPairs -and $CompareMaxPairs -gt 0) {
+          $args += @('-MaxPairs', $CompareMaxPairs)
+        }
         if ($CompareIncludeIdenticalPairs) { $args += '-IncludeIdenticalPairs' }
         if ($CompareFailOnDiff) { $args += '-FailOnDiff' }
         if ($CompareLvCompareArgs) {


### PR DESCRIPTION
## Summary
- default Compare-VIHistory runs no longer require -MaxPairs; manifests record null when uncapped
- wrappers, docs, and workflow input defaults updated to reflect optional capping
- expanded tests + workflow runs (develop + labview-icon-editor) prove uncapped and capped behaviour

## Testing
- Invoke-PesterTests.ps1
- gh run view 18978319799
- gh run view 18978589328
- pwsh -NoLogo -NoProfile -File tools/Compare-VIHistory.ps1 ... (labview-icon-editor)