### PR TITLE
Compare-VIHistory: add signal budget and noise collapse (#544)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -1,18 +1,19 @@
 {
-  "number": 536,
-  "title": "Revisit VI compare default flags and clarify summary",
-  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/536",
+  "number": 544,
+  "title": "Compare-VIHistory: add noise collapse and signal budget",
+  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/544",
   "state": "OPEN",
   "labels": [
+    "enhancement",
     "standing-priority"
   ],
   "assignees": [],
   "milestone": null,
   "commentCount": 0,
-  "lastSeenUpdatedAt": "2025-11-01T05:27:49Z",
-  "issueDigest": "c6886392c08bd086292b8eaf4852c236b626bb138daf8e7680b58c955eb27393",
-  "bodyDigest": "23678748190bb6762eda47f04df4fd80c6cbe48e6e612a5db07b13ef209bcd3d",
-  "cachedAtUtc": "2025-11-01T05:48:49.909Z",
+  "lastSeenUpdatedAt": "2025-11-01T17:29:09Z",
+  "issueDigest": "313c1b802c9153f134956ac0ba8a6a85746f501c037f4e966b3ee1d9297991c5",
+  "bodyDigest": "21794e33f61d86d88ead0fc44bab263c168b18e3f07ed8813646dea831d2ed10",
+  "cachedAtUtc": "2025-11-01T17:32:15.761Z",
   "lastFetchSource": "live",
   "lastFetchError": null
 }

--- a/README.md
+++ b/README.md
@@ -113,11 +113,39 @@ pwsh -NoLogo -NoProfile -File tools/Compare-VIHistory.ps1 `
   -RenderReport
 ```
 
+If LabVIEW/LVCompare is not available locally, point the helper at the bundled stub:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Compare-VIHistory.ps1 `
+  -TargetPath fixtures/vi-stage/bd-cosmetic/Head.vi `
+  -StartRef develop `
+  -MaxSignalPairs 1 `
+  -NoisePolicy collapse `
+  -InvokeScriptPath tests/stubs/Invoke-LVCompare.stub.ps1 `
+  -Detailed -RenderReport -KeepArtifactsOnNoDiff
+```
+
+For a quick summary without digging through JSON, run:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Inspect-HistorySignalStats.ps1 -Verbose
+```
+
+Before running with the real LabVIEW CLI, verify your setup:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Verify-LVCompareSetup.ps1 -ProbeCli
+```
+
 The helper now processes every reachable commit pair by default. Supply
 `-MaxPairs <n>` when you need to cap the history for large or exploratory runs.
 Pass `-IncludeMergeParents` to audit merge parents alongside the mainline; the
 extra comparisons surface lineage metadata (parent index, branch head, depth)
 so reports and manifests call out where each revision originated.
+Signal-first helpers are built in: use `-MaxSignalPairs <n>` (default `2`) to
+limit the number of surfaced signal diffs and `-NoisePolicy include|collapse|skip`
+(default `collapse`) to decide whether cosmetic-only changes are emitted,
+aggregated, or skipped entirely.
 
 Artifacts are written under `tests/results/ref-compare/history/` using the same
 schema as the workflow outputs.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -101,12 +101,17 @@ Quick reference for building, testing, and releasing the LVCompare composite act
     - `/vi-history` PR comments (or the `pr-vi-history.yml` workflow) reuse the same pattern for history diffs:
       1. `tools/Get-PRVIDiffManifest.ps1` enumerates VI changes between the PR base/head commits.
       2. `tools/Invoke-PRVIHistory.ps1` resolves the history helper once
-         (works with repo-relative targets) and runs the compare suite per VI.
+        (works with repo-relative targets) and runs the compare suite per VI.
         The helper now walks every reachable commit pair by default; pass `-MaxPairs <n>` only when you need
         a deliberate cap (for example the history smoke script still uses `-MaxPairs 6` to keep the loop fast).
+        Use `-MaxSignalPairs <n>` (default `2`) to limit how many signal diffs surface in a run and tune
+        cosmetic churn via `-NoisePolicy include|collapse|skip` (default `collapse`).
         Artifacts land under `tests/results/pr-vi-history/` (aggregate manifest plus `history-report.{md,html}` per
         target). Enable `-Verbose` locally to see the resolved helper path and origin
          (base/head) for each target.
+        When LabVIEW/LVCompare is unavailable, run the helper with
+        `-InvokeScriptPath tests/stubs/Invoke-LVCompare.stub.ps1` to exercise the flow using the stubbed CLI.
+        `tools/Inspect-HistorySignalStats.ps1` wraps the helper + stub and prints the signal/noise counts directly.
       3. `tools/Summarize-PRVIHistory.ps1` renders the PR table with change types, comparison/diff counts, and
          relative report paths so reviewers can triage without downloading the artifact bundle.
     - Override the history depth via the workflow_dispatch input `max_pairs` when you need a longer runway; otherwise

--- a/tests/results/_agent/issue/router.json
+++ b/tests/results/_agent/issue/router.json
@@ -1,7 +1,7 @@
 {
   "schema": "agent/priority-router@v1",
-  "issue": 536,
-  "updatedAt": "2025-11-01T05:27:49Z",
+  "issue": 544,
+  "updatedAt": "2025-11-01T17:29:09Z",
   "actions": [
     {
       "key": "hooks:pre-commit",

--- a/tests/stubs/Invoke-LVCompare.stub.ps1
+++ b/tests/stubs/Invoke-LVCompare.stub.ps1
@@ -1,0 +1,63 @@
+param(
+    [string]$BaseVi,
+    [string]$HeadVi,
+    [string]$OutputDir,
+    [string[]]$Flags,
+    [switch]$RenderReport,
+    [string]$ReportFormat = 'html'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $OutputDir) {
+    $OutputDir = Join-Path $env:TEMP ("lvcompare-stub-" + [guid]::NewGuid().ToString('N'))
+}
+
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+$imagesDir = Join-Path $OutputDir 'cli-images'
+New-Item -ItemType Directory -Path $imagesDir -Force | Out-Null
+
+$stdoutPath = Join-Path $OutputDir 'lvcompare-stdout.txt'
+$stderrPath = Join-Path $OutputDir 'lvcompare-stderr.txt'
+$capturePath = Join-Path $OutputDir 'lvcompare-capture.json'
+
+"Stub LVCompare run for $BaseVi -> $HeadVi" | Set-Content -LiteralPath $stdoutPath -Encoding utf8
+"" | Set-Content -LiteralPath $stderrPath -Encoding utf8
+[System.IO.File]::WriteAllBytes((Join-Path $imagesDir 'cli-image-00.png'), @(0xCA,0xFE,0xBA,0xBE))
+
+$exitCode = 1
+
+$capture = [ordered]@{
+    schema    = 'lvcompare-capture-v1'
+    timestamp = (Get-Date).ToString('o')
+    base      = $BaseVi
+    head      = $HeadVi
+    cliPath   = 'Stub LVCompare'
+    args      = $Flags
+    exitCode  = $exitCode
+    seconds   = 0.05
+    command   = "Stub LVCompare ""$BaseVi"" ""$HeadVi"""
+    environment = @{
+        cli = @{
+            artifacts = @{
+                images = @(
+                    @{
+                        index      = 0
+                        mimeType   = 'image/png'
+                        byteLength = 4
+                        savedPath  = (Join-Path $imagesDir 'cli-image-00.png')
+                    }
+                )
+            }
+        }
+    }
+}
+$capture | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $capturePath -Encoding utf8
+
+if ($RenderReport.IsPresent -or $ReportFormat.ToLowerInvariant() -eq 'html') {
+    "<html><body><h1>Stub Report (diff=True)</h1></body></html>" |
+        Set-Content -LiteralPath (Join-Path $OutputDir 'compare-report.html') -Encoding utf8
+}
+
+exit $exitCode

--- a/tools/Inspect-HistorySignalStats.ps1
+++ b/tools/Inspect-HistorySignalStats.ps1
@@ -1,0 +1,120 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string]$TargetPath = 'fixtures/vi-stage/bd-cosmetic/Head.vi',
+    [string]$StartRef = 'HEAD',
+    [int]$MaxPairs = 6,
+    [int]$MaxSignalPairs = 2,
+    [ValidateSet('include','collapse','skip')]
+    [string]$NoisePolicy = 'collapse',
+    [string]$ResultsDir,
+    [switch]$RenderReport,
+    [switch]$KeepArtifacts,
+    [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+if (-not $scriptDir) { throw 'Unable to locate script directory.' }
+$repoRoot = Split-Path -Parent $scriptDir
+if (-not $repoRoot) { throw 'Unable to determine repository root.' }
+
+$stubPath = Join-Path $repoRoot 'tests/stubs/Invoke-LVCompare.stub.ps1'
+if (-not (Test-Path -LiteralPath $stubPath -PathType Leaf)) {
+    throw "Stub LVCompare script not found at $stubPath"
+}
+
+$resultsRoot = if ($ResultsDir) {
+    if ([System.IO.Path]::IsPathRooted($ResultsDir)) { $ResultsDir } else { Join-Path $repoRoot $ResultsDir }
+} else {
+    Join-Path $repoRoot 'tests/results/_agent/history-stub'
+}
+
+if (Test-Path -LiteralPath $resultsRoot) {
+    Remove-Item -LiteralPath $resultsRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+$historyScript = Join-Path $repoRoot 'tools/Compare-VIHistory.ps1'
+if (-not (Test-Path -LiteralPath $historyScript -PathType Leaf)) {
+    throw "Compare-VIHistory.ps1 not found at $historyScript"
+}
+
+$arguments = @(
+    '-NoLogo','-NoProfile','-File', $historyScript,
+    '-TargetPath', $TargetPath,
+    '-StartRef', $StartRef,
+    '-MaxPairs', $MaxPairs,
+    '-MaxSignalPairs', $MaxSignalPairs,
+    '-NoisePolicy', $NoisePolicy,
+    '-ResultsDir', $resultsRoot,
+    '-InvokeScriptPath', $stubPath,
+    '-Detailed'
+)
+
+if ($RenderReport.IsPresent) { $arguments += '-RenderReport' }
+if ($KeepArtifacts.IsPresent) { $arguments += '-KeepArtifactsOnNoDiff' }
+if ($Quiet.IsPresent) { $arguments += '-Quiet' }
+
+Write-Verbose ("Running Compare-VIHistory with arguments:`n{0}" -f ($arguments -join ' '))
+
+$proc = Start-Process -FilePath 'pwsh' -ArgumentList $arguments -WorkingDirectory $repoRoot -NoNewWindow -Wait -PassThru
+if ($proc.ExitCode -ne 0) {
+    throw "Compare-VIHistory.ps1 exited with code $($proc.ExitCode)"
+}
+
+$manifestPath = Join-Path $resultsRoot 'manifest.json'
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw "Aggregate manifest not found at $manifestPath"
+}
+$aggregate = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 8
+
+$summary = [ordered]@{
+    manifestPath    = $manifestPath
+    targetPath      = $aggregate.targetPath
+    startRef        = $aggregate.startRef
+    maxSignalPairs  = $aggregate.maxSignalPairs
+    noisePolicy     = $aggregate.noisePolicy
+    totalProcessed  = $aggregate.stats.processed
+    totalDiffs      = $aggregate.stats.diffs
+    signalDiffs     = $aggregate.stats.signalDiffs
+    noiseCollapsed  = $aggregate.stats.noiseCollapsed
+    modes           = @()
+}
+
+foreach ($mode in $aggregate.modes) {
+    $modeInfo = [ordered]@{
+        name           = $mode.name
+        processed      = $mode.stats.processed
+        diffs          = $mode.stats.diffs
+        signalDiffs    = $mode.stats.signalDiffs
+        noiseCollapsed = $mode.stats.noiseCollapsed
+        stopReason     = $mode.stats.stopReason
+        manifestPath   = $mode.manifestPath
+    }
+    $summary.modes += [pscustomobject]$modeInfo
+}
+
+Write-Host ''
+Write-Host '=== History Signal/Noise Summary ===' -ForegroundColor Cyan
+Write-Host ("Target Path     : {0}" -f $summary.targetPath)
+Write-Host ("Start Ref       : {0}" -f $summary.startRef)
+Write-Host ("Max SignalPairs : {0}" -f $summary.maxSignalPairs)
+Write-Host ("Noise Policy    : {0}" -f $summary.noisePolicy)
+Write-Host ("Total processed : {0}" -f $summary.totalProcessed)
+Write-Host ("Signal diffs    : {0}" -f $summary.signalDiffs)
+Write-Host ("Noise collapsed : {0}" -f $summary.noiseCollapsed)
+Write-Host ("Aggregate manifest: {0}" -f $summary.manifestPath)
+Write-Host ''
+foreach ($mode in $summary.modes) {
+    Write-Host ("Mode '{0}': processed={1}, diffs={2}, signal={3}, collapsedNoise={4}, stopReason={5}" -f `
+        $mode.name, $mode.processed, $mode.diffs, $mode.signalDiffs, $mode.noiseCollapsed, $mode.stopReason)
+    Write-Host ("    manifest: {0}" -f $mode.manifestPath)
+}
+
+Write-Host ''
+Write-Host ("Results directory: {0}" -f $resultsRoot)
+
+return [pscustomobject]$summary

--- a/tools/Verify-LVCompareSetup.ps1
+++ b/tools/Verify-LVCompareSetup.ps1
@@ -1,0 +1,147 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [switch]$ProbeCli
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows) {
+    throw 'This helper is intended for Windows hosts only.'
+}
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+if (-not $scriptDir) { throw 'Unable to determine script directory.' }
+$repoRoot = Split-Path -Parent $scriptDir
+if (-not $repoRoot) { throw 'Unable to determine repository root.' }
+
+$configPath = Join-Path $repoRoot 'configs\labview-paths.json'
+$config = $null
+if (Test-Path -LiteralPath $configPath -PathType Leaf) {
+    try {
+        $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+    } catch {
+        throw "Failed to parse labview-paths.json at $configPath: $($_.Exception.Message)"
+    }
+}
+
+function Resolve-CandidatePath {
+    param(
+        [string]$PathValue
+    )
+    if ([string]::IsNullOrWhiteSpace($PathValue)) { return $null }
+    $expanded = [Environment]::ExpandEnvironmentVariables($PathValue.Trim())
+    try {
+        $resolved = (Resolve-Path -LiteralPath $expanded -ErrorAction Stop).Path
+        return $resolved
+    } catch {
+        return $expanded
+    }
+}
+
+$paths = [ordered]@{
+    LabVIEWExePath  = $null
+    LVComparePath   = $null
+    LabVIEWCLIPath  = $null
+    ConfigSource    = if ($config) { $configPath } else { $null }
+}
+
+if ($config) {
+    if ($config.PSObject.Properties['LabVIEWExePath'])  { $paths.LabVIEWExePath = Resolve-CandidatePath $config.LabVIEWExePath }
+    if ($config.PSObject.Properties['LVComparePath'])   { $paths.LVComparePath  = Resolve-CandidatePath $config.LVComparePath }
+    if ($config.PSObject.Properties['LabVIEWCLIPath'])  { $paths.LabVIEWCLIPath = Resolve-CandidatePath $config.LabVIEWCLIPath }
+}
+
+$defaultRoots = @(
+    'C:\Program Files\National Instruments\LabVIEW 2025',
+    'C:\Program Files\National Instruments\LabVIEW 2024',
+    'C:\Program Files\National Instruments\LabVIEW 2023'
+)
+
+function Ensure-Path {
+    param(
+        [string]$Key,
+        [string]$Candidate
+    )
+    if (-not [string]::IsNullOrWhiteSpace($paths[$Key])) { return }
+    if ([string]::IsNullOrWhiteSpace($Candidate)) { return }
+    $resolved = Resolve-CandidatePath $Candidate
+    $paths[$Key] = $resolved
+}
+
+foreach ($root in $defaultRoots) {
+    if (-not (Test-Path -LiteralPath $root -PathType Container)) { continue }
+    Ensure-Path -Key 'LabVIEWExePath' -Candidate (Join-Path $root 'LabVIEW.exe')
+    Ensure-Path -Key 'LVComparePath'  -Candidate (Join-Path $root 'Shared\LabVIEW Compare\LVCompare.exe')
+    Ensure-Path -Key 'LabVIEWCLIPath' -Candidate (Join-Path $root 'Shared\LabVIEW CLI\LabVIEWCLI.exe')
+}
+
+if (-not $paths.LabVIEWCLIPath) {
+    $cmd = Get-Command LabVIEWCLI.exe -ErrorAction SilentlyContinue
+    if ($cmd) {
+        $paths.LabVIEWCLIPath = $cmd.Source
+    }
+}
+
+$missing = @()
+foreach ($key in @('LabVIEWExePath','LVComparePath','LabVIEWCLIPath')) {
+    $candidate = $paths[$key]
+    if (-not $candidate) {
+        $missing += $key
+        continue
+    }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+        $missing += $key
+    }
+}
+
+if ($missing.Count -gt 0) {
+    Write-Warning "The following required paths are missing or invalid:"
+    foreach ($key in $missing) {
+        Write-Warning ("  {0}: {1}" -f $key, ($paths[$key] ?? '(not set)'))
+    }
+    Write-Warning "Update configs\labview-paths.json or install the LabVIEW CLI components, then re-run this check."
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'LabVIEW/LVCompare configuration:' -ForegroundColor Cyan
+Write-Host ("  LabVIEWExePath : {0}" -f $paths.LabVIEWExePath)
+Write-Host ("  LVComparePath  : {0}" -f $paths.LVComparePath)
+Write-Host ("  LabVIEWCLIPath : {0}" -f $paths.LabVIEWCLIPath)
+if ($paths.ConfigSource) {
+    Write-Host ("  Config file    : {0}" -f $paths.ConfigSource)
+}
+Write-Host ''
+
+if ($ProbeCli.IsPresent) {
+    Write-Host 'Probing LabVIEW CLI...'
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $paths.LabVIEWCLIPath
+    $psi.ArgumentList.Add('--help')
+    $psi.WorkingDirectory = $repoRoot
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    if ($proc.ExitCode -ne 0) {
+        Write-Host $stdout
+        Write-Host $stderr
+        throw "LabVIEW CLI probe (--help) exited with code $($proc.ExitCode). Inspect output above."
+    }
+    Write-Host 'LabVIEW CLI responded to --help successfully.' -ForegroundColor Green
+}
+
+Write-Host 'LVCompare setup verified.' -ForegroundColor Green
+
+[pscustomobject]@{
+    LabVIEWExePath = $paths.LabVIEWExePath
+    LVComparePath  = $paths.LVComparePath
+    LabVIEWCLIPath = $paths.LabVIEWCLIPath
+    ConfigSource   = $paths.ConfigSource
+}


### PR DESCRIPTION
This PR implements #544 (signal-first history compare):

- Add `-MaxSignalPairs` and `-NoisePolicy include|collapse|skip` to history helper.
- Classify compare categories, collapse cosmetic-only changes, and track per-mode/aggregate signal vs noise counts.
- Add LVCompare stub + inspector helper to exercise the flow without LabVIEW.
- Update tests and docs.

Highlights
- Mode stats: processed, diffs, signalDiffs, noiseCollapsed, stopReason.
- Aggregate manifest surfaces collapsed noise category/bucket counts.
- README/dev guide updated with examples and helper usage.

Validation
- Stubbed run via `tools/Inspect-HistorySignalStats.ps1 -Verbose` confirms signal/noise rollup.
- Pester integration focused on history compares; broader gates will run in CI.

Closes #544 once CI is green.