### PR TITLE
fix(#9): stabilize mobile preview evidence and compare plumbing

### DIFF
--- a/.github/workflows/pr-vi-history.yml
+++ b/.github/workflows/pr-vi-history.yml
@@ -23,6 +23,14 @@ on:
         description: 'History job timeout in minutes (default 10)'
         required: false
         default: '10'
+      compare_timeout_seconds:
+        description: 'Per-compare timeout in seconds passed to history compare (default 900)'
+        required: false
+        default: '900'
+      labview_path:
+        description: 'LabVIEW.exe path used by headless compare operations'
+        required: false
+        default: 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe'
 
 permissions:
   contents: read
@@ -48,6 +56,8 @@ jobs:
       NOTE: ${{ inputs.note }}
       MAX_PAIRS: ${{ inputs.max_pairs || '6' }}
       FETCH_DEPTH: ${{ github.event.inputs.fetch_depth || '20' }}
+      COMPARE_TIMEOUT_SECONDS: ${{ github.event.inputs.compare_timeout_seconds || '900' }}
+      LABVIEW_PATH: ${{ github.event.inputs.labview_path || 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe' }}
     steps:
       - name: Resolve pull request metadata
         id: pr
@@ -185,6 +195,10 @@ jobs:
           if ($env:MAX_PAIRS) {
             $args += '-MaxPairs'
             $args += $env:MAX_PAIRS
+          }
+          if ($env:COMPARE_TIMEOUT_SECONDS) {
+            $args += '-CompareTimeoutSeconds'
+            $args += $env:COMPARE_TIMEOUT_SECONDS
           }
 
           pwsh -NoLogo -NoProfile @args

--- a/tests/Invoke-PRVIHistory.Tests.ps1
+++ b/tests/Invoke-PRVIHistory.Tests.ps1
@@ -205,6 +205,90 @@ Describe 'Invoke-PRVIHistory.ps1' {
         Test-Path -LiteralPath $result.targets[0].manifest -PathType Leaf | Should -BeTrue
     }
 
+    It 'forwards compare timeout to Compare-VIHistory via explicit parameter and env fallback' {
+        $tempDir = Join-Path $TestDrive 'history-fixtures-timeout'
+        New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+        $headPath = Join-Path $tempDir 'Head.vi'
+        Set-Content -LiteralPath $headPath -Value 'vi-bytes'
+
+        $manifestPath = Join-Path $TestDrive 'vi-diff-manifest-timeout.json'
+        $manifest = [ordered]@{
+            schema      = 'vi-diff-manifest@v1'
+            generatedAt = (Get-Date).ToString('o')
+            baseRef     = 'base'
+            headRef     = 'head'
+            pairs       = @(
+                [ordered]@{
+                    changeType = 'modified'
+                    basePath   = 'Base.vi'
+                    headPath   = $headPath
+                }
+            )
+        }
+        $manifest | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+        $resultsRoot = Join-Path $TestDrive 'history-results-timeout'
+        $invocations = [System.Collections.Generic.List[hashtable]]::new()
+        $compareStub = {
+            param([hashtable]$Arguments)
+            $invocations.Add($Arguments) | Out-Null
+
+            New-Item -ItemType Directory -Path $Arguments.ResultsDir -Force | Out-Null
+            $summaryManifest = [ordered]@{
+                schema      = 'vi-compare/history-suite@v1'
+                targetPath  = $Arguments.TargetPath
+                stats       = [ordered]@{
+                    processed = 1
+                    diffs     = 0
+                    missing   = 0
+                }
+                modes       = @(
+                    [ordered]@{
+                        name = 'default'
+                        stats = [ordered]@{
+                            processed = 1
+                            diffs     = 0
+                            missing   = 0
+                        }
+                        comparisons = @()
+                    }
+                )
+            }
+            $manifestOut = Join-Path $Arguments.ResultsDir 'manifest.json'
+            $summaryManifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $manifestOut -Encoding utf8
+            Set-Content -LiteralPath (Join-Path $Arguments.ResultsDir 'history-report.md') -Value '# history' -Encoding utf8
+        }.GetNewClosure()
+
+        Push-Location $repoRoot
+        try {
+            & $scriptPath `
+                -ManifestPath $manifestPath `
+                -ResultsRoot $resultsRoot `
+                -CompareInvoker $compareStub `
+                -CompareTimeoutSeconds 777 `
+                -SkipRenderReport | Out-Null
+
+            $invocations.Count | Should -Be 1
+            $invocations[0].CompareTimeoutSeconds | Should -Be 777
+
+            $invocations.Clear()
+            $env:PR_VI_HISTORY_COMPARE_TIMEOUT_SECONDS = '666'
+            & $scriptPath `
+                -ManifestPath $manifestPath `
+                -ResultsRoot (Join-Path $TestDrive 'history-results-timeout-env') `
+                -CompareInvoker $compareStub `
+                -SkipRenderReport | Out-Null
+        }
+        finally {
+            Remove-Item Env:PR_VI_HISTORY_COMPARE_TIMEOUT_SECONDS -ErrorAction SilentlyContinue
+            Pop-Location
+        }
+
+        $invocations.Count | Should -Be 1
+        $invocations[0].CompareTimeoutSeconds | Should -Be 666
+    }
+
     It 'collects commit-pair timeline rows and timing aggregates from mode manifests' {
         $tempDir = Join-Path $TestDrive 'history-fixtures-timeline'
         New-Item -ItemType Directory -Path $tempDir | Out-Null

--- a/tools/Compare-RefsToTemp.ps1
+++ b/tools/Compare-RefsToTemp.ps1
@@ -18,6 +18,7 @@ param(
   [switch]$LeakCheck,
   [double]$LeakGraceSeconds = 1.5,
   [string]$LeakJsonPath,
+  [Nullable[int]]$TimeoutSeconds,
   [switch]$FailOnDiff
 )
 
@@ -65,6 +66,19 @@ function Normalize-ExistingPath {
   param([string]$Candidate)
   if ([string]::IsNullOrWhiteSpace($Candidate)) { return $null }
   try { return (Resolve-Path -LiteralPath $Candidate -ErrorAction Stop).Path } catch { return $Candidate }
+}
+
+function Get-PositiveIntFromEnv {
+  param([string[]]$Names)
+  foreach ($name in @($Names | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })) {
+    $raw = [System.Environment]::GetEnvironmentVariable($name, 'Process')
+    if ([string]::IsNullOrWhiteSpace($raw)) { continue }
+    $parsed = 0
+    if ([int]::TryParse($raw.Trim(), [ref]$parsed) -and $parsed -gt 0) {
+      return [int]$parsed
+    }
+  }
+  return $null
 }
 
 function Get-IncludedAttributesFromReport {
@@ -241,7 +255,21 @@ if ($RenderReport.IsPresent -and $reportFormatEffective -ne 'html') {
 }
 $renderReportRequested = ($reportFormatEffective -eq 'html')
 $detailRequested = $Detailed.IsPresent -or $renderReportRequested -or ($reportFormatEffective -ne 'html')
-Write-Host ("[Debug] detailRequested={0} renderReportRequested={1} reportFormat={2}" -f $detailRequested, $renderReportRequested, $reportFormatEffective)
+$timeoutSecondsEffective = $null
+if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -gt 0) {
+  $timeoutSecondsEffective = [int]$TimeoutSeconds
+} else {
+  $timeoutSecondsEffective = Get-PositiveIntFromEnv -Names @(
+    'PR_VI_HISTORY_COMPARE_TIMEOUT_SECONDS',
+    'VI_HISTORY_COMPARE_TIMEOUT_SECONDS',
+    'COMPAREVI_TIMEOUT_SECONDS'
+  )
+}
+if (($timeoutSecondsEffective -eq $null -or $timeoutSecondsEffective -le 0) -and $detailRequested) {
+  # Report generation can exceed the default 300s under real fixture load.
+  $timeoutSecondsEffective = 900
+}
+Write-Host ("[Debug] detailRequested={0} renderReportRequested={1} reportFormat={2} timeoutSeconds={3}" -f $detailRequested, $renderReportRequested, $reportFormatEffective, ($timeoutSecondsEffective ?? 'default'))
 $scriptsRoot = Resolve-CompareVIScriptsRoot -PrimaryRoot $repoRoot
 $flagTokens = Split-ArgString -Value $LvCompareArgs
 $customInvokeProvided = -not [string]::IsNullOrWhiteSpace($InvokeScriptPath)
@@ -313,6 +341,8 @@ $cliCommand = $null
 $cliPath = $null
 $cliDurationSeconds = $null
 $cliDurationNanoseconds = $null
+$cliArtifactImageCount = 0
+$cliArtifactReportSizeBytes = 0
 $cliArgsRecorded = @()
 $cliArtifacts = $null
 $cliHighlights = @()
@@ -323,6 +353,10 @@ $includedAttributes = @()
 if ($detailRequested) {
   $invokeArgs = @('-NoLogo','-NoProfile','-File', $invokeScriptResolved, '-BaseVi', $base, '-HeadVi', $head, '-OutputDir', $artifactDir, '-NoiseProfile', 'full', '-Quiet')
   if ($renderReportRequested) { $invokeArgs += '-RenderReport' }
+  if ($timeoutSecondsEffective -and $timeoutSecondsEffective -gt 0) {
+    $invokeArgs += '-TimeoutSeconds'
+    $invokeArgs += [string]$timeoutSecondsEffective
+  }
   if ($lvComparePathResolved) { $invokeArgs += '-LVComparePath'; $invokeArgs += $lvComparePathResolved }
   if ($labviewExeResolved) { $invokeArgs += '-LabVIEWExePath'; $invokeArgs += $labviewExeResolved }
   if ($customInvokeProvided -and $invokeFlagTokens -and $invokeFlagTokens.Length -gt 0) {
@@ -373,6 +407,9 @@ if ($detailRequested) {
 
   $cliExit = if ($capture.exitCode -ne $null) { [int]$capture.exitCode } else { [int]$invokeResult.ExitCode }
   $cliDiff = ($cliExit -eq 1)
+  if (-not $cliDiff -and $capture.PSObject.Properties['diff']) {
+    try { $cliDiff = [bool]$capture.diff } catch {}
+  }
   $cliCommand = if ($capture.command) { [string]$capture.command } else { $null }
   $cliPath = if ($capture.cliPath) { [string]$capture.cliPath } else { $lvComparePathResolved }
   if ($capture.seconds -ne $null) {
@@ -390,16 +427,39 @@ if ($detailRequested) {
     if ($cliNode.PSObject.Properties['artifacts'] -and $cliNode.artifacts) {
       $artifactSummary = [ordered]@{}
       foreach ($prop in $cliNode.artifacts.PSObject.Properties) {
+        if ($prop.Name -eq 'imageCount' -and $prop.Value -ne $null) {
+          try { $cliArtifactImageCount = [Math]::Max([int]$prop.Value, 0) } catch {}
+        } elseif ($prop.Name -eq 'reportSizeBytes' -and $prop.Value -ne $null) {
+          try { $cliArtifactReportSizeBytes = [Math]::Max([int64]$prop.Value, 0) } catch {}
+        }
         if ($prop.Name -eq 'images' -and $prop.Value) {
           $images = @()
           foreach ($img in @($prop.Value)) {
             if (-not $img) { continue }
-            $images += [ordered]@{
-              index      = $img.index
-              mimeType   = $img.mimeType
-              byteLength = $img.byteLength
-              savedPath  = $img.savedPath
+            $imgIndex = $null
+            $imgMimeType = $null
+            $imgByteLength = $null
+            $imgSavedPath = $null
+            if ($img -is [string]) {
+              $imgSavedPath = [string]$img
+            } elseif ($img.PSObject) {
+              if ($img.PSObject.Properties['index']) { $imgIndex = $img.index }
+              if ($img.PSObject.Properties['mimeType']) { $imgMimeType = $img.mimeType }
+              elseif ($img.PSObject.Properties['mime']) { $imgMimeType = $img.mime }
+              if ($img.PSObject.Properties['byteLength']) { $imgByteLength = $img.byteLength }
+              elseif ($img.PSObject.Properties['bytes']) { $imgByteLength = $img.bytes }
+              if ($img.PSObject.Properties['savedPath']) { $imgSavedPath = $img.savedPath }
+              elseif ($img.PSObject.Properties['path']) { $imgSavedPath = $img.path }
             }
+            $images += [ordered]@{
+              index      = $imgIndex
+              mimeType   = $imgMimeType
+              byteLength = $imgByteLength
+              savedPath  = $imgSavedPath
+            }
+          }
+          if ($images.Count -gt $cliArtifactImageCount) {
+            $cliArtifactImageCount = $images.Count
           }
           if ($images.Count -gt 0) { $artifactSummary.images = $images }
         } else {
@@ -407,6 +467,16 @@ if ($detailRequested) {
         }
       }
       if ($artifactSummary.Count -gt 0) { $cliArtifacts = [pscustomobject]$artifactSummary }
+    }
+  }
+
+  if (-not $cliDiff -and $expectDiff) {
+    if ($cliArtifactImageCount -gt 0) {
+      $cliDiff = $true
+      Write-Verbose ("Treating compare as diff based on artifact image evidence (imageCount={0})." -f $cliArtifactImageCount)
+    } elseif ($cliArtifactReportSizeBytes -gt 0) {
+      $cliDiff = $true
+      Write-Verbose ("Treating compare as diff based on non-empty report artifact (reportSizeBytes={0})." -f $cliArtifactReportSizeBytes)
     }
   }
 
@@ -498,6 +568,7 @@ if ($detailRequested) {
     cwd         = $repoRoot
     duration_s  = $cliDurationSeconds
     duration_ns = $cliDurationNanoseconds
+    timeoutSeconds = $timeoutSecondsEffective
     base        = $capture.base
     head        = $capture.head
   }

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -34,6 +34,7 @@ param(
   [string]$ReportFormat = 'html',
   [switch]$KeepArtifactsOnNoDiff,
   [string]$InvokeScriptPath,
+  [Nullable[int]]$CompareTimeoutSeconds,
 
   [string]$GitHubOutputPath,
   [string]$StepSummaryPath,
@@ -1401,6 +1402,10 @@ foreach ($modeSpec in $modeSpecs) {
         if ($modeFlags -and $modeFlags.Count -gt 0) {
           $compareArgs += "-LvCompareArgs"
           $compareArgs += ($modeFlags -join ' ')
+        }
+        if ($PSBoundParameters.ContainsKey('CompareTimeoutSeconds') -and $CompareTimeoutSeconds -gt 0) {
+          $compareArgs += "-TimeoutSeconds"
+          $compareArgs += [string][int]$CompareTimeoutSeconds
         }
         if (-not [string]::IsNullOrWhiteSpace($InvokeScriptPath)) {
           $compareArgs += "-InvokeScriptPath"

--- a/tools/Invoke-PRVIHistory.ps1
+++ b/tools/Invoke-PRVIHistory.ps1
@@ -53,6 +53,7 @@ param(
     [string]$ResultsRoot = 'tests/results/pr-vi-history',
 
     [Nullable[int]]$MaxPairs,
+    [Nullable[int]]$CompareTimeoutSeconds,
 
     [string[]]$Mode,
 
@@ -76,6 +77,23 @@ $ErrorActionPreference = 'Stop'
 
 $maxPairsValue = if ($PSBoundParameters.ContainsKey('MaxPairs')) { $MaxPairs } else { $null }
 $maxPairsRequested = ($null -ne $maxPairsValue) -and ($maxPairsValue -gt 0)
+$compareTimeoutValue = if ($PSBoundParameters.ContainsKey('CompareTimeoutSeconds')) { $CompareTimeoutSeconds } else { $null }
+if ($null -eq $compareTimeoutValue -or $compareTimeoutValue -le 0) {
+    $timeoutSources = @(
+        [System.Environment]::GetEnvironmentVariable('PR_VI_HISTORY_COMPARE_TIMEOUT_SECONDS', 'Process'),
+        [System.Environment]::GetEnvironmentVariable('VI_HISTORY_COMPARE_TIMEOUT_SECONDS', 'Process'),
+        [System.Environment]::GetEnvironmentVariable('COMPAREVI_TIMEOUT_SECONDS', 'Process')
+    )
+    foreach ($rawTimeout in $timeoutSources) {
+        if ([string]::IsNullOrWhiteSpace($rawTimeout)) { continue }
+        $parsedTimeout = 0
+        if ([int]::TryParse($rawTimeout.Trim(), [ref]$parsedTimeout) -and $parsedTimeout -gt 0) {
+            $compareTimeoutValue = [int]$parsedTimeout
+            break
+        }
+    }
+}
+$compareTimeoutRequested = ($null -ne $compareTimeoutValue) -and ($compareTimeoutValue -gt 0)
 
 function Resolve-ExistingFile {
     param(
@@ -885,6 +903,7 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
     }
     Write-Verbose ("[{0}/{1}] Target '{2}' (origin: {3}) -> compare path '{4}'" -f ($i + 1), $targets.Count, $repoPath, $target.origin, $effectiveTargetPath)
     if ($maxPairsRequested) { $compareArgs.MaxPairs = $maxPairsValue }
+    if ($compareTimeoutRequested) { $compareArgs.CompareTimeoutSeconds = [int]$compareTimeoutValue }
     if ($Mode) { $compareArgs.Mode = $Mode }
     if (-not [string]::IsNullOrWhiteSpace($StartRef)) { $compareArgs.StartRef = $StartRef }
     if (-not [string]::IsNullOrWhiteSpace($EndRef)) { $compareArgs.EndRef = $EndRef }
@@ -1037,6 +1056,76 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
                 $reportImages.error = $_.Exception.Message
                 $reportImageExtractionErrors++
                 Write-Warning ("Failed to extract report images for '{0}': {1}" -f $repoPath, $_.Exception.Message)
+            }
+        }
+
+        if ($reportImages.status -eq 'completed' -and [int]$reportImages.exportedImageCount -le 0) {
+            try {
+                $cliImageCandidates = @(Get-ChildItem -LiteralPath $targetResultsDir -Recurse -File -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -like 'cli-image-*' -and $_.FullName -match '[\\/]+cli-images[\\/]' } |
+                    Sort-Object FullName)
+                Write-Host ("[report-images] fallback scan for '{0}' found {1} CLI image candidate(s)." -f $repoPath, $cliImageCandidates.Count)
+                if ($cliImageCandidates.Count -gt 0) {
+                    $imageOutputDir = Join-Path $targetResultsDir 'previews'
+                    $imageIndexPath = Join-Path $targetResultsDir 'vi-history-image-index.json'
+                    New-Item -ItemType Directory -Path $imageOutputDir -Force | Out-Null
+
+                    $fallbackImages = New-Object System.Collections.Generic.List[object]
+                    $copiedCount = 0
+                    foreach ($candidate in $cliImageCandidates) {
+                        if (-not $candidate) { continue }
+                        $extension = $candidate.Extension
+                        if ([string]::IsNullOrWhiteSpace($extension)) {
+                            $extension = '.png'
+                        }
+                        $extension = $extension.Trim().TrimStart('.').ToLowerInvariant()
+                        if ([string]::IsNullOrWhiteSpace($extension)) {
+                            $extension = 'png'
+                        }
+
+                        $fileName = ('history-image-{0:D3}.{1}' -f $copiedCount, $extension)
+                        $destinationPath = Join-Path $imageOutputDir $fileName
+                        Copy-Item -LiteralPath $candidate.FullName -Destination $destinationPath -Force
+                        $resolvedSavedPath = (Resolve-Path -LiteralPath $destinationPath).Path
+                        $fallbackImages.Add([pscustomobject]@{
+                            index      = $copiedCount
+                            source     = $candidate.FullName
+                            sourceType = 'cli-images'
+                            alt        = 'VI diff preview'
+                            fileName   = $fileName
+                            savedPath  = $resolvedSavedPath
+                            byteLength = [int64]$candidate.Length
+                            status     = 'saved'
+                        }) | Out-Null
+                        $copiedCount++
+                    }
+
+                    $resolvedOutputDir = (Resolve-Path -LiteralPath $imageOutputDir).Path
+                    $fallbackIndex = [pscustomobject]@{
+                        schema             = 'pr-vi-history-image-index@v1'
+                        generatedAt        = (Get-Date).ToString('o')
+                        reportPath         = $reportHtml
+                        outputDir          = $resolvedOutputDir
+                        sourceImageCount   = $cliImageCandidates.Count
+                        exportedImageCount = $copiedCount
+                        images             = @($fallbackImages.ToArray())
+                    }
+                    $fallbackIndex | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $imageIndexPath -Encoding utf8
+
+                    $reportImages.sourceImageCount = [int]$cliImageCandidates.Count
+                    $reportImages.exportedImageCount = [int]$copiedCount
+                    $reportImages.indexPath = (Resolve-Path -LiteralPath $imageIndexPath).Path
+                    $reportImages.outputDir = $resolvedOutputDir
+                    $reportImages.source = 'cli-images-fallback'
+
+                    $reportImageExportedCount += [int]$copiedCount
+                    if ($copiedCount -gt 0) {
+                        $reportImageTargetCount++
+                    }
+                    Write-Host ("[report-images] fallback exported {0} preview image(s) for '{1}'." -f $copiedCount, $repoPath)
+                }
+            } catch {
+                Write-Warning ("Failed CLI-image fallback extraction for '{0}': {1}" -f $repoPath, $_.Exception.Message)
             }
         }
     }

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -31,6 +31,10 @@ Optional override for the `max_pairs` workflow input. Defaults to `6`.
 .PARAMETER WorkflowTimeoutMinutes
 Optional override for the `history_timeout_minutes` workflow input used by
 `pr-vi-history.yml`. Defaults to `25` for smoke evidence runs.
+
+.PARAMETER CompareTimeoutSeconds
+Optional override for the `compare_timeout_seconds` workflow input used by
+`pr-vi-history.yml`. Defaults to `900` for smoke evidence runs.
 #>
 [CmdletBinding()]
 param(
@@ -40,7 +44,8 @@ param(
     [ValidateSet('attribute', 'sequential', 'mixed-same-commit')]
     [string]$Scenario = 'attribute',
     [int]$MaxPairs = 6,
-    [int]$WorkflowTimeoutMinutes = 25
+    [int]$WorkflowTimeoutMinutes = 25,
+    [int]$CompareTimeoutSeconds = 900
 )
 
 Set-StrictMode -Version Latest
@@ -48,6 +53,9 @@ $ErrorActionPreference = 'Stop'
 
 if ($WorkflowTimeoutMinutes -lt 1) {
     throw 'WorkflowTimeoutMinutes must be greater than zero.'
+}
+if ($CompareTimeoutSeconds -lt 1) {
+    throw 'CompareTimeoutSeconds must be greater than zero.'
 }
 
 function Invoke-Git {
@@ -167,15 +175,39 @@ function Wait-WorkflowRunCompletion {
     $auth = Get-GitHubAuth
     $uri = "https://api.github.com/repos/$($Repo.Slug)/actions/runs/$RunId"
     $deadline = (Get-Date).ToUniversalTime().AddMinutes([Math]::Max(1, $TimeoutMinutes))
+    $lastPollError = $null
     do {
-        $run = Invoke-RestMethod -Uri $uri -Headers $auth.Headers -Method Get -ErrorAction Stop
-        if ($run.status -eq 'completed') {
-            return $run
+        try {
+            $run = Invoke-RestMethod -Uri $uri -Headers $auth.Headers -Method Get -ErrorAction Stop
+            $lastPollError = $null
+            if ($run.status -eq 'completed') {
+                return $run
+            }
+        } catch {
+            $lastPollError = $_
+            $errorText = if ($_.Exception -and $_.Exception.Message) { $_.Exception.Message } else { [string]$_ }
+            $compactError = ($errorText -replace '\s+', ' ').Trim()
+            $isTransient = $compactError -match '(?i)(unicorn|issues producing the response|502|503|504|gateway|temporar|timeout|timed out)'
+            if (-not $isTransient) {
+                throw
+            }
+            if ($compactError.Length -gt 220) {
+                $compactError = $compactError.Substring(0, 220) + '...'
+            }
+            Write-Warning ("Transient workflow polling error for run {0}; retrying: {1}" -f $RunId, $compactError)
         }
         Start-Sleep -Seconds ([Math]::Max(1, $PollSeconds))
     } while ((Get-Date).ToUniversalTime() -lt $deadline)
 
-    throw ("Timed out waiting for workflow run {0} to complete after {1} minute(s)." -f $RunId, $TimeoutMinutes)
+    $timeoutMessage = "Timed out waiting for workflow run $RunId to complete after $TimeoutMinutes minute(s)."
+    if ($lastPollError -and $lastPollError.Exception -and $lastPollError.Exception.Message) {
+        $lastMessage = ($lastPollError.Exception.Message -replace '\s+', ' ').Trim()
+        if ($lastMessage.Length -gt 220) {
+            $lastMessage = $lastMessage.Substring(0, 220) + '...'
+        }
+        $timeoutMessage = "$timeoutMessage Last polling error: $lastMessage"
+    }
+    throw $timeoutMessage
 }
 
 function Ensure-CleanWorkingTree {
@@ -690,7 +722,7 @@ $planSteps.Add("- Fetch origin/$BaseBranch") | Out-Null
 $planSteps.Add("- Create branch $branchName from origin/$BaseBranch") | Out-Null
 $planSteps.Add($scenarioPlanHint) | Out-Null
 $planSteps.Add("- Push scratch branch and create draft PR") | Out-Null
-$planSteps.Add("- Dispatch pr-vi-history.yml with PR input (max_pairs=$effectiveMaxPairs, history_timeout_minutes=$WorkflowTimeoutMinutes)") | Out-Null
+$planSteps.Add("- Dispatch pr-vi-history.yml with PR input (max_pairs=$effectiveMaxPairs, history_timeout_minutes=$WorkflowTimeoutMinutes, compare_timeout_seconds=$CompareTimeoutSeconds)") | Out-Null
 $planSteps.Add("- Wait for workflow completion and verify PR comment") | Out-Null
 if ($scenarioNeedsArtifactValidation) {
     $planSteps.Add("- Download workflow artifact and validate diff/comparison counts") | Out-Null
@@ -736,6 +768,7 @@ $scratchContext = [ordered]@{
     MaxPairsRequested = $MaxPairs
     MaxPairsEffective = $effectiveMaxPairs
     WorkflowTimeoutMinutes = $WorkflowTimeoutMinutes
+    CompareTimeoutSeconds = $CompareTimeoutSeconds
     MobilePreviewRequired = $scenarioRequiresMobilePreview
 }
 
@@ -869,6 +902,7 @@ try {
             pr                      = $scratchContext.PrNumber.ToString()
             max_pairs               = $effectiveMaxPairs.ToString()
             history_timeout_minutes = $WorkflowTimeoutMinutes.ToString()
+            compare_timeout_seconds = $CompareTimeoutSeconds.ToString()
         }
     } | ConvertTo-Json -Depth 4
     $dispatchStartedAtUtc = (Get-Date).ToUniversalTime()
@@ -992,12 +1026,16 @@ try {
 
     if ($scenarioNeedsArtifactValidation) {
         if ($scenarioKey -eq 'sequential') {
+            $expectedSequentialComparisons = [Math]::Max(1, $commitSummaries.Count)
+            if ($effectiveMaxPairs -gt 0) {
+                $expectedSequentialComparisons = [Math]::Max(1, [Math]::Min($expectedSequentialComparisons, $effectiveMaxPairs))
+            }
             $sequentialTarget = $targetValidations | Where-Object { $_.repoPath -eq 'fixtures/vi-attr/Head.vi' } | Select-Object -First 1
             if (-not $sequentialTarget) {
                 $sequentialTarget = $targetValidations | Select-Object -First 1
             }
-            if ($sequentialTarget.comparisons -lt [Math]::Max(1, $commitSummaries.Count)) {
-                throw ("Expected at least {0} comparisons for sequential scenario, but comment reported {1}." -f [Math]::Max(1, $commitSummaries.Count), $sequentialTarget.comparisons)
+            if ($sequentialTarget.comparisons -lt $expectedSequentialComparisons) {
+                throw ("Expected at least {0} comparisons for sequential scenario, but comment reported {1}." -f $expectedSequentialComparisons, $sequentialTarget.comparisons)
             }
         }
         $artifactDir = Join-Path $summaryDir ("artifact-$timestamp")
@@ -1034,13 +1072,19 @@ try {
             if ([bool]$expectedTarget.requireDiff -and $artifactDiffs -lt $requiredDiffs) {
                 throw ("Summary JSON target '{0}' expected at least {1} diff(s) but saw {2}." -f $expectedTarget.repoPath, $requiredDiffs, $artifactDiffs)
             }
-            if ($scenarioKey -eq 'sequential' -and $summaryTarget.repoPath -eq 'fixtures/vi-attr/Head.vi' -and $artifactComparisons -lt [Math]::Max(1, $commitSummaries.Count)) {
-                throw ("Summary JSON reported {0} comparisons for sequential target; expected at least {1}." -f $artifactComparisons, [Math]::Max(1, $commitSummaries.Count))
+            if ($scenarioKey -eq 'sequential' -and $summaryTarget.repoPath -eq 'fixtures/vi-attr/Head.vi') {
+                $expectedSequentialComparisons = [Math]::Max(1, $commitSummaries.Count)
+                if ($effectiveMaxPairs -gt 0) {
+                    $expectedSequentialComparisons = [Math]::Max(1, [Math]::Min($expectedSequentialComparisons, $effectiveMaxPairs))
+                }
+                if ($artifactComparisons -lt $expectedSequentialComparisons) {
+                    throw ("Summary JSON reported {0} comparisons for sequential target; expected at least {1}." -f $artifactComparisons, $expectedSequentialComparisons)
+                }
             }
         }
 
-        $imageIndexFiles = Get-ChildItem -LiteralPath $artifactDir -Recurse -Filter 'vi-history-image-index.json' -File
-        if (-not $imageIndexFiles -or $imageIndexFiles.Count -lt 1) {
+        $imageIndexFiles = @(Get-ChildItem -LiteralPath $artifactDir -Recurse -Filter 'vi-history-image-index.json' -File)
+        if ($imageIndexFiles.Count -lt 1) {
             throw 'vi-history-image-index.json not found in downloaded artifact.'
         }
         $previewImageFiles = Get-ChildItem -LiteralPath $artifactDir -Recurse -File |


### PR DESCRIPTION
## Summary
Mirror of fork PR #77 (`fix(#9): stabilize mobile preview evidence and compare plumbing`) into upstream `develop`.

Includes:
- compare timeout plumbing through PR history workflow and smoke harness
- transient workflow polling retry hardening
- compare capture parsing tolerance for sparse artifact image metadata
- diff inference from CLI artifact evidence
- mobile preview fallback extraction from `cli-images`
- workflow default LabVIEW path to 2026 executable

## Evidence
- Live sequential smoke with mobile preview validated:
  - https://github.com/svelderrainruiz/compare-vi-cli-action/actions/runs/22583156565