### PR TITLE
sync: mirror #30 pair timeline metadata into upstream

### DIFF
--- a/fixtures/vi-history/README.md
+++ b/fixtures/vi-history/README.md
@@ -60,6 +60,8 @@ Extend the `steps` list when new scenarios are required; tests ensure every refe
   least two VI targets are updated in one commit.
 - Consumed by `tools/Test-PRVIHistorySmoke.ps1` when
   `-Scenario sequential-masscompile` is selected.
+- Harness summary output records pair-level timeline/timing metadata under
+  `PairTimeline`, `PairClassification`, and `PairTiming`.
 
 ## Policy Gate Semantics
 

--- a/tests/Get-VIHistoryPairTimeline.Tests.ps1
+++ b/tests/Get-VIHistoryPairTimeline.Tests.ps1
@@ -1,0 +1,70 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Get-VIHistoryPairTimeline' -Tag 'Unit' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        . (Join-Path $repoRoot 'tools' 'Get-VIHistoryPairTimeline.ps1')
+    }
+
+    It 'extracts rows from pairTimeline and computes classification/timing stats' {
+        $summary = [pscustomobject]@{
+            pairTimeline = @(
+                [pscustomobject]@{
+                    targetPath = 'fixtures/vi-attr/Head.vi'
+                    mode = 'default'
+                    pairIndex = 1
+                    baseRef = 'abc'
+                    headRef = 'def'
+                    diff = $true
+                    classification = 'signal'
+                    durationSeconds = 12.5
+                },
+                [pscustomobject]@{
+                    targetPath = 'fixtures/vi-attr/Base.vi'
+                    mode = 'default'
+                    pairIndex = 2
+                    baseRef = 'def'
+                    headRef = 'ghi'
+                    diff = $false
+                    classification = 'noise-masscompile'
+                    durationSeconds = 4.0
+                }
+            )
+        }
+
+        $result = Get-VIHistoryPairTimeline -Summary $summary
+        $result.rows.Count | Should -Be 2
+        $result.classificationCounts.signal | Should -Be 1
+        $result.classificationCounts.'noise-masscompile' | Should -Be 1
+        $result.timing.comparisonCount | Should -Be 2
+        $result.timing.totalSeconds | Should -Be 16.5
+        $result.timing.p50Seconds | Should -Be 4.0
+        $result.timing.p95Seconds | Should -Be 12.5
+    }
+
+    It 'falls back to targets.commitPairs when pairTimeline is absent' {
+        $summary = [pscustomobject]@{
+            targets = @(
+                [pscustomobject]@{
+                    repoPath = 'fixtures/vi-attr/Head.vi'
+                    commitPairs = @(
+                        [pscustomobject]@{
+                            pairIndex = 1
+                            diff = $true
+                            classification = 'signal'
+                            durationSeconds = 7
+                        }
+                    )
+                }
+            )
+        }
+
+        $result = Get-VIHistoryPairTimeline -Summary $summary
+        $result.rows.Count | Should -Be 1
+        $result.rows[0].targetPath | Should -Be 'fixtures/vi-attr/Head.vi'
+        $result.classificationCounts.signal | Should -Be 1
+        $result.timing.totalSeconds | Should -Be 7.0
+    }
+}
+

--- a/tools/Get-VIHistoryPairTimeline.ps1
+++ b/tools/Get-VIHistoryPairTimeline.ps1
@@ -1,0 +1,110 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-VIHistoryPairTimeline {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object]$Summary
+    )
+
+    $rows = New-Object System.Collections.Generic.List[pscustomobject]
+    $classificationCounts = @{}
+    $durations = New-Object System.Collections.Generic.List[double]
+
+    $addPair = {
+        param(
+            [AllowNull()]
+            [object]$Pair,
+            [string]$FallbackTargetPath
+        )
+        if (-not $Pair) { return }
+
+        $targetPath = if ($Pair.PSObject.Properties['targetPath'] -and $Pair.targetPath) {
+            [string]$Pair.targetPath
+        } else {
+            $FallbackTargetPath
+        }
+        $classification = if ($Pair.PSObject.Properties['classification'] -and $Pair.classification) {
+            [string]$Pair.classification
+        } else {
+            'unknown'
+        }
+        $durationSeconds = $null
+        if ($Pair.PSObject.Properties['durationSeconds']) {
+            try {
+                $durationSeconds = [double]$Pair.durationSeconds
+            } catch {
+                $durationSeconds = $null
+            }
+        }
+
+        $key = $classification.ToLowerInvariant()
+        if (-not $classificationCounts.ContainsKey($key)) {
+            $classificationCounts[$key] = 0
+        }
+        $classificationCounts[$key] = [int]$classificationCounts[$key] + 1
+
+        if ($durationSeconds -ne $null -and $durationSeconds -ge 0) {
+            $durations.Add($durationSeconds) | Out-Null
+        }
+
+        $rows.Add([pscustomobject]@{
+            targetPath      = $targetPath
+            mode            = if ($Pair.PSObject.Properties['mode']) { [string]$Pair.mode } else { 'default' }
+            pairIndex       = if ($Pair.PSObject.Properties['pairIndex']) { [int]$Pair.pairIndex } else { $null }
+            baseRef         = if ($Pair.PSObject.Properties['baseRef']) { [string]$Pair.baseRef } else { $null }
+            headRef         = if ($Pair.PSObject.Properties['headRef']) { [string]$Pair.headRef } else { $null }
+            diff            = if ($Pair.PSObject.Properties['diff']) { [bool]$Pair.diff } else { $false }
+            classification  = $classification
+            durationSeconds = $durationSeconds
+        }) | Out-Null
+    }
+
+    if ($Summary -and $Summary.PSObject.Properties['pairTimeline'] -and $Summary.pairTimeline -is [System.Collections.IEnumerable]) {
+        foreach ($pair in @($Summary.pairTimeline)) {
+            & $addPair -Pair $pair -FallbackTargetPath $null
+        }
+    } elseif ($Summary -and $Summary.PSObject.Properties['targets'] -and $Summary.targets -is [System.Collections.IEnumerable]) {
+        foreach ($target in @($Summary.targets)) {
+            if (-not $target) { continue }
+            $fallbackTargetPath = if ($target.PSObject.Properties['repoPath']) { [string]$target.repoPath } else { $null }
+            if (-not ($target.PSObject.Properties['commitPairs'] -and $target.commitPairs -is [System.Collections.IEnumerable])) {
+                continue
+            }
+            foreach ($pair in @($target.commitPairs)) {
+                & $addPair -Pair $pair -FallbackTargetPath $fallbackTargetPath
+            }
+        }
+    }
+
+    $sortedDurations = @($durations | Sort-Object)
+    $durationCount = $sortedDurations.Count
+    $totalSeconds = 0.0
+    foreach ($duration in $sortedDurations) {
+        $totalSeconds += [double]$duration
+    }
+
+    $p50 = $null
+    $p95 = $null
+    if ($durationCount -gt 0) {
+        $midIndex = [Math]::Floor(($durationCount - 1) / 2)
+        $p50 = [double]$sortedDurations[$midIndex]
+        $p95Index = [Math]::Ceiling(($durationCount * 0.95) - 1)
+        $p95Index = [Math]::Max(0, [Math]::Min($durationCount - 1, [int]$p95Index))
+        $p95 = [double]$sortedDurations[$p95Index]
+    }
+
+    [pscustomobject]@{
+        rows = @($rows)
+        classificationCounts = [pscustomobject]$classificationCounts
+        timing = [pscustomobject]@{
+            comparisonCount = $durationCount
+            totalSeconds = [Math]::Round($totalSeconds, 6)
+            p50Seconds = if ($p50 -ne $null) { [Math]::Round([double]$p50, 6) } else { $null }
+            p95Seconds = if ($p95 -ne $null) { [Math]::Round([double]$p95, 6) } else { $null }
+        }
+    }
+}
+

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -58,6 +58,12 @@ if (-not (Test-Path -LiteralPath $policyHelperPath -PathType Leaf)) {
 }
 . $policyHelperPath
 
+$pairTimelineHelperPath = Join-Path $PSScriptRoot 'Get-VIHistoryPairTimeline.ps1'
+if (-not (Test-Path -LiteralPath $pairTimelineHelperPath -PathType Leaf)) {
+    throw "Pair timeline helper not found: $pairTimelineHelperPath"
+}
+. $pairTimelineHelperPath
+
 if ($WorkflowTimeoutMinutes -lt 1) {
     throw 'WorkflowTimeoutMinutes must be greater than zero.'
 }
@@ -986,6 +992,14 @@ $scratchContext = [ordered]@{
             warnings = @()
         }
     }
+    PairTimeline = @()
+    PairClassification = [ordered]@{}
+    PairTiming = [ordered]@{
+        comparisonCount = 0
+        totalSeconds = 0
+        p50Seconds = $null
+        p95Seconds = $null
+    }
     MaxPairsRequested = $MaxPairs
     MaxPairsEffective = $effectiveMaxPairs
     WorkflowTimeoutMinutes = $WorkflowTimeoutMinutes
@@ -1325,6 +1339,19 @@ try {
             throw 'Summary JSON not found in downloaded artifact.'
         }
         $summaryData = Get-Content -LiteralPath $summaryFile.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        $pairInsight = Get-VIHistoryPairTimeline -Summary $summaryData
+        $scratchContext.PairTimeline = @($pairInsight.rows)
+        $scratchContext.PairClassification = if ($pairInsight.classificationCounts) { $pairInsight.classificationCounts } else { [ordered]@{} }
+        $scratchContext.PairTiming = if ($pairInsight.timing) {
+            $pairInsight.timing
+        } else {
+            [ordered]@{
+                comparisonCount = 0
+                totalSeconds = 0
+                p50Seconds = $null
+                p95Seconds = $null
+            }
+        }
         $targetSummaries = @($summaryData.targets)
         if ($targetSummaries.Count -eq 0) {
             throw 'Summary JSON does not contain target entries.'
@@ -1335,7 +1362,15 @@ try {
             $artifactComparisons = if ($summaryTarget -and $summaryTarget.stats) { [int]$summaryTarget.stats.processed } else { 0 }
             $artifactDiffs = if ($summaryTarget -and $summaryTarget.stats) { [int]$summaryTarget.stats.diffs } else { 0 }
             $requiredDiffs = [Math]::Max(0, [int]$expectedTarget.minDiffs)
-            $artifactStatus = if ($summaryTarget -and $summaryTarget.PSObject.Properties['status']) { [string]$summaryTarget.status } else { 'missing' }
+            $artifactStatus = if (-not $summaryTarget) {
+                'missing'
+            } elseif ($artifactDiffs -gt 0) {
+                'diff'
+            } elseif ($artifactComparisons -gt 0) {
+                'match'
+            } else {
+                'missing'
+            }
             $artifactDecision = Resolve-VIHistoryPolicyDecision `
                 -TargetPath ([string]$expectedTarget.repoPath) `
                 -RequireDiff ([bool]$expectedTarget.requireDiff) `


### PR DESCRIPTION
## Summary
Mirror fork PR #84 into upstream `develop` to keep repos aligned for standing priority #30.

## Source
- Fork PR: https://github.com/svelderrainruiz/compare-vi-cli-action/pull/84
- Merge commit: `6a6b55b9a7e1a4a050219c31e3a7b493bb92acce`

## Changes mirrored
- add `tools/Get-VIHistoryPairTimeline.ps1`
- add `tests/Get-VIHistoryPairTimeline.Tests.ps1`
- enrich smoke summary timeline/classification/timing fields
- strict status derivation from diff/comparison artifacts
