### PR TITLE
sync: mirror #29 VI history KPI contract into upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ the same summary table to a GitHub issue for stakeholders.
   so reviewers can scan cosmetic changes on mobile without downloading artifacts first.
 - Comment-size safety guards cap preview/image payload and apply markdown truncation when needed; the summarizer writes
   this state to totals (`previewImages`, `markdownTruncated`) and emits an explicit truncation note in the PR comment.
+- `pr-vi-history-summary@v1` now carries additive per-pair rows under `pairTimeline[]`:
+  `targetPath`, `baseRef`, `headRef`, `classification`, `diff`, `durationSeconds`, `previewStatus`, `reportPath`,
+  `imageIndexPath`.
+- Run-level KPI envelope (`kpi`) is additive and includes:
+  `signalRecall`, `noisePrecisionMasscompile`, `previewCoverage`, `timingP50Seconds`, `timingP95Seconds`,
+  `commentTruncated`, `truncationReason`.
 - `tools/Test-PRVIHistorySmoke.ps1` now emits explicit hybrid gate policy metadata (`schema: vi-history-policy-gate@v1`):
   strict (`requireDiff=true`) violations are hard failures, while smoke (`requireDiff=false`) violations are recorded as
   non-blocking warnings for diagnostics.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -146,6 +146,17 @@ Quick reference for building, testing, and releasing the LVCompare composite act
         The summary contract now includes additive image metadata for report rendering:
         - target node `reportImages` (`enabled`, `indexPath`, `previewCount`, `previews[]`)
         - totals `previewImages` and `markdownTruncated` in `pr-vi-history-summary@v1`
+        - per-pair rows under `pairTimeline[]`:
+          `targetPath`, `baseRef`, `headRef`, `classification`, `diff`, `durationSeconds`,
+          `previewStatus`, `reportPath`, `imageIndexPath`
+        - run-level `kpi` envelope:
+          `signalRecall`, `noisePrecisionMasscompile`, `previewCoverage`,
+          `timingP50Seconds`, `timingP95Seconds`, `commentTruncated`, `truncationReason`
+        Classification enum contract for `pairTimeline[].classification`:
+        - `signal`
+        - `noise-masscompile`
+        - `noise-cosmetic`
+        - `unknown`
         The same helper emits a `### Mobile Preview` section in the PR comment/summary markdown when previews are
         available, and writes extracted files to `tests/results/pr-vi-history/<target>/previews/` with index contract
         `pr-vi-history-image-index@v1`.

--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -201,9 +201,46 @@ gh workflow run vi-compare-refs.yml `
   rendering is skipped or fails, the Markdown path still points at the fallback report so consumers always have a
   summary to ingest. A compressed `category-counts-json` blob is also published so downstream automation can react to runs
   dominated by cosmetic noise without re-reading the manifests.
-- History summary JSON (`tests/results/pr-vi-history/vi-history-summary.json`) now adds `targets[].reportImages` and
-  totals `previewImages` / `markdownTruncated` so downstream checks can verify image extraction and comment-size
-  truncation deterministically.
+- History summary JSON (`tests/results/pr-vi-history/vi-history-summary.json`) now adds:
+  - `targets[].reportImages` for per-target extraction metadata.
+  - `pairTimeline[]` with additive per-pair contract fields:
+    `targetPath`, `baseRef`, `headRef`, `classification`, `diff`, `durationSeconds`,
+    `previewStatus`, `reportPath`, `imageIndexPath`.
+  - top-level `kpi` envelope:
+    `signalRecall`, `noisePrecisionMasscompile`, `previewCoverage`,
+    `timingP50Seconds`, `timingP95Seconds`, `commentTruncated`, `truncationReason`.
+  - classification enum for `pairTimeline[].classification`:
+    `signal | noise-masscompile | noise-cosmetic | unknown`.
+  - totals `previewImages` / `markdownTruncated` so downstream checks can verify image extraction and comment-size
+    truncation deterministically.
+- Minimal example (additive fields only):
+  ```json
+  {
+    "schema": "pr-vi-history-summary@v1",
+    "pairTimeline": [
+      {
+        "targetPath": "fixtures/vi-attr/Head.vi",
+        "baseRef": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "headRef": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "classification": "signal",
+        "diff": true,
+        "durationSeconds": 1.25,
+        "previewStatus": "present",
+        "reportPath": "tests/results/pr-vi-history/01.../history-report.html",
+        "imageIndexPath": "tests/results/pr-vi-history/01.../vi-history-image-index.json"
+      }
+    ],
+    "kpi": {
+      "signalRecall": 1.0,
+      "noisePrecisionMasscompile": null,
+      "previewCoverage": 1.0,
+      "timingP50Seconds": 1.25,
+      "timingP95Seconds": 1.25,
+      "commentTruncated": false,
+      "truncationReason": "none"
+    }
+  }
+  ```
 - Per-mode manifests live under `tests/results/ref-compare/history/<mode>/manifest.json`
   (`schema: vi-compare/history@v1`) and enumerate the commit pairs, summaries, and LVCompare outcomes.
 - Per-iteration summaries (`*-summary.json`) live beside the mode manifest

--- a/tests/Invoke-PRVIHistory.Tests.ps1
+++ b/tests/Invoke-PRVIHistory.Tests.ps1
@@ -106,6 +106,8 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $result.totals.completed | Should -Be 1
         $result.totals.diffTargets | Should -Be 1
         $result.targets.Count | Should -Be 1
+        $result.kpi.commentTruncated | Should -BeFalse
+        $result.kpi.truncationReason | Should -Be 'none'
 
         $target = $result.targets[0]
         $target.status | Should -Be 'completed'
@@ -406,6 +408,13 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $result.targets[0].timing.medianSeconds | Should -Be 2
         $result.totals.timing.totalSeconds | Should -Be 4
         $result.estimatedCompareTime.seconds | Should -Be 2
+        $result.kpi.signalRecall | Should -Be 0.5
+        $result.kpi.noisePrecisionMasscompile | Should -Be 1
+        $result.kpi.previewCoverage | Should -Be 0
+        $result.kpi.timingP50Seconds | Should -Be 1.25
+        $result.kpi.timingP95Seconds | Should -Be 2.75
+        $result.kpi.commentTruncated | Should -BeFalse
+        $result.kpi.truncationReason | Should -Be 'none'
     }
 
     It 'prefers repo-relative target paths when the VI resides in the repository' {

--- a/tests/Summarize-PRVIHistory.Tests.ps1
+++ b/tests/Summarize-PRVIHistory.Tests.ps1
@@ -125,6 +125,13 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.totals.previewImages | Should -Be 1
         $result.totals.markdownTruncated | Should -BeFalse
         $result.totals.timing.totalSeconds | Should -Be 3.75
+        $result.kpi.signalRecall | Should -Be 1
+        $result.kpi.noisePrecisionMasscompile | Should -BeNullOrEmpty
+        $result.kpi.previewCoverage | Should -Be 0.5
+        $result.kpi.timingP50Seconds | Should -Be 1.5
+        $result.kpi.timingP95Seconds | Should -Be 2.25
+        $result.kpi.commentTruncated | Should -BeFalse
+        $result.kpi.truncationReason | Should -Be 'none'
         $result.pairTimeline.Count | Should -Be 2
         $result.previews.Count | Should -Be 1
         $result.markdown | Should -Match 'fixtures/Example.vi'
@@ -227,6 +234,8 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.previews.Count | Should -Be 1
         $result.totals.previewImages | Should -Be 1
         $result.totals.markdownTruncated | Should -BeTrue
+        $result.kpi.commentTruncated | Should -BeTrue
+        $result.kpi.truncationReason | Should -Be 'max-markdown-length'
         $result.markdown.Length | Should -BeLessOrEqual 900
         $result.markdown | Should -Match 'Summary truncated for comment size safety'
     }

--- a/tools/Invoke-PRVIHistory.ps1
+++ b/tools/Invoke-PRVIHistory.ps1
@@ -399,6 +399,112 @@ function New-TimingSummary {
     }
 }
 
+function Get-PairKpiEnvelope {
+    param(
+        [AllowNull()]
+        [object[]]$Pairs,
+        [AllowNull()]
+        [object]$TimingSummary,
+        [bool]$CommentTruncated = $false,
+        [string]$TruncationReason = 'none'
+    )
+
+    $pairRows = @($Pairs)
+    $diffPairs = 0
+    $signalDiffPairs = 0
+    $noiseMasscompileDiffPairs = 0
+    $noiseCosmeticDiffPairs = 0
+    $previewPresentPairs = 0
+    $durations = New-Object System.Collections.Generic.List[double]
+
+    foreach ($pair in $pairRows) {
+        if (-not $pair) { continue }
+
+        $diffDetected = $false
+        if ($pair.PSObject.Properties['diff']) {
+            $diffDetected = [bool]$pair.diff
+        }
+
+        $classification = 'unknown'
+        if ($pair.PSObject.Properties['classification'] -and $pair.classification) {
+            $classification = [string]$pair.classification
+        }
+        $classificationKey = $classification.Trim().ToLowerInvariant()
+
+        if ($diffDetected) {
+            $diffPairs++
+            switch ($classificationKey) {
+                'signal'            { $signalDiffPairs++ }
+                'noise-masscompile' { $noiseMasscompileDiffPairs++ }
+                'noise-cosmetic'    { $noiseCosmeticDiffPairs++ }
+            }
+        }
+
+        $previewStatus = if ($pair.PSObject.Properties['previewStatus'] -and $pair.previewStatus) {
+            [string]$pair.previewStatus
+        } else {
+            'unknown'
+        }
+        if ($previewStatus.Trim().ToLowerInvariant() -eq 'present') {
+            $previewPresentPairs++
+        }
+
+        if ($pair.PSObject.Properties['durationSeconds']) {
+            $durationSeconds = Convert-ToNullableDouble -Value $pair.durationSeconds
+            if ($durationSeconds -ne $null -and $durationSeconds -ge 0) {
+                $durations.Add([double]$durationSeconds) | Out-Null
+            }
+        }
+    }
+
+    $signalRecall = $null
+    if ($diffPairs -gt 0) {
+        $signalRecall = [Math]::Round(($signalDiffPairs / [double]$diffPairs), 6)
+    }
+
+    $noisePrecisionMasscompile = $null
+    $noiseDiffPairs = $noiseMasscompileDiffPairs + $noiseCosmeticDiffPairs
+    if ($noiseDiffPairs -gt 0) {
+        $noisePrecisionMasscompile = [Math]::Round(($noiseMasscompileDiffPairs / [double]$noiseDiffPairs), 6)
+    }
+
+    $previewCoverage = $null
+    if ($pairRows.Count -gt 0) {
+        $previewCoverage = [Math]::Round(($previewPresentPairs / [double]$pairRows.Count), 6)
+    }
+
+    $timingP50Seconds = $null
+    $timingP95Seconds = $null
+    $sortedDurations = @($durations | Sort-Object)
+    if ($sortedDurations.Count -gt 0) {
+        $timingP50Seconds = Get-PercentileSeconds -SortedValues $sortedDurations -Percentile 0.5
+        $timingP95Seconds = Get-PercentileSeconds -SortedValues $sortedDurations -Percentile 0.95
+    } elseif ($TimingSummary) {
+        if ($TimingSummary.PSObject.Properties['medianSeconds']) {
+            $timingP50Seconds = Convert-ToNullableDouble -Value $TimingSummary.medianSeconds
+        }
+        if ($TimingSummary.PSObject.Properties['p95Seconds']) {
+            $timingP95Seconds = Convert-ToNullableDouble -Value $TimingSummary.p95Seconds
+        }
+    }
+
+    $normalizedReason = if ([string]::IsNullOrWhiteSpace($TruncationReason)) {
+        if ($CommentTruncated) { 'unspecified' } else { 'none' }
+    } else {
+        $TruncationReason
+    }
+
+    return [pscustomobject]@{
+        signalRecall             = $signalRecall
+        noisePrecisionMasscompile= $noisePrecisionMasscompile
+        previewCoverage          = $previewCoverage
+        timingP50Seconds         = $timingP50Seconds
+        timingP95Seconds         = $timingP95Seconds
+        commentTruncated         = [bool]$CommentTruncated
+        truncationReason         = $normalizedReason
+    }
+}
+
 function Resolve-PathBestEffort {
     param(
         [string]$PathValue,
@@ -1194,6 +1300,7 @@ foreach ($skipped in $skippedPairs) {
 
 $pairTimelineRows = @($summaryPairTimeline)
 $overallTiming = New-TimingSummary -DurationsSeconds @($pairDurations)
+$kpiEnvelope = Get-PairKpiEnvelope -Pairs $pairTimelineRows -TimingSummary $overallTiming -CommentTruncated:$false -TruncationReason 'none'
 
 $summary = [pscustomobject]@{
     schema      = 'pr-vi-history-summary@v1'
@@ -1222,6 +1329,7 @@ $summary = [pscustomobject]@{
     pairTimeline= $pairTimelineRows
     timing      = $overallTiming
     estimatedCompareTime = $overallTiming.estimatedCompareTime
+    kpi         = $kpiEnvelope
 }
 
 $summary | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $effectiveSummaryPath -Encoding utf8

--- a/tools/Summarize-PRVIHistory.ps1
+++ b/tools/Summarize-PRVIHistory.ps1
@@ -156,6 +156,131 @@ function Get-DurationDisplay {
     }
 }
 
+function Get-PercentileSeconds {
+    param(
+        [double[]]$SortedValues,
+        [ValidateRange(0.0, 1.0)][double]$Percentile
+    )
+
+    if (-not $SortedValues -or $SortedValues.Count -eq 0) {
+        return $null
+    }
+
+    $index = [Math]::Ceiling($SortedValues.Count * $Percentile) - 1
+    if ($index -lt 0) { $index = 0 }
+    if ($index -ge $SortedValues.Count) { $index = $SortedValues.Count - 1 }
+    return [Math]::Round([double]$SortedValues[$index], 3)
+}
+
+function Get-PairKpiEnvelope {
+    param(
+        [AllowNull()]
+        [object[]]$Pairs,
+        [AllowNull()]
+        [object]$TimingSummary,
+        [bool]$CommentTruncated = $false,
+        [string]$TruncationReason = 'none'
+    )
+
+    $pairRows = @($Pairs)
+    $diffPairs = 0
+    $signalDiffPairs = 0
+    $noiseMasscompileDiffPairs = 0
+    $noiseCosmeticDiffPairs = 0
+    $previewPresentPairs = 0
+    $durations = New-Object System.Collections.Generic.List[double]
+
+    foreach ($pair in $pairRows) {
+        if (-not $pair) { continue }
+
+        $diffDetected = $false
+        if ($pair.PSObject.Properties['diff']) {
+            $diffDetected = [bool]$pair.diff
+        }
+
+        $classification = 'unknown'
+        if ($pair.PSObject.Properties['classification'] -and $pair.classification) {
+            $classification = [string]$pair.classification
+        }
+        $classificationKey = $classification.Trim().ToLowerInvariant()
+
+        if ($diffDetected) {
+            $diffPairs++
+            switch ($classificationKey) {
+                'signal'            { $signalDiffPairs++ }
+                'noise-masscompile' { $noiseMasscompileDiffPairs++ }
+                'noise-cosmetic'    { $noiseCosmeticDiffPairs++ }
+            }
+        }
+
+        $previewStatus = if ($pair.PSObject.Properties['previewStatus'] -and $pair.previewStatus) {
+            [string]$pair.previewStatus
+        } else {
+            'unknown'
+        }
+        if ($previewStatus.Trim().ToLowerInvariant() -eq 'present') {
+            $previewPresentPairs++
+        }
+
+        if ($pair.PSObject.Properties['durationSeconds']) {
+            try {
+                $durationValue = [double]$pair.durationSeconds
+                if (-not [double]::IsNaN($durationValue) -and -not [double]::IsInfinity($durationValue) -and $durationValue -ge 0) {
+                    $durations.Add([double]$durationValue) | Out-Null
+                }
+            } catch {
+            }
+        }
+    }
+
+    $signalRecall = $null
+    if ($diffPairs -gt 0) {
+        $signalRecall = [Math]::Round(($signalDiffPairs / [double]$diffPairs), 6)
+    }
+
+    $noisePrecisionMasscompile = $null
+    $noiseDiffPairs = $noiseMasscompileDiffPairs + $noiseCosmeticDiffPairs
+    if ($noiseDiffPairs -gt 0) {
+        $noisePrecisionMasscompile = [Math]::Round(($noiseMasscompileDiffPairs / [double]$noiseDiffPairs), 6)
+    }
+
+    $previewCoverage = $null
+    if ($pairRows.Count -gt 0) {
+        $previewCoverage = [Math]::Round(($previewPresentPairs / [double]$pairRows.Count), 6)
+    }
+
+    $timingP50Seconds = $null
+    $timingP95Seconds = $null
+    $sortedDurations = @($durations | Sort-Object)
+    if ($sortedDurations.Count -gt 0) {
+        $timingP50Seconds = Get-PercentileSeconds -SortedValues $sortedDurations -Percentile 0.5
+        $timingP95Seconds = Get-PercentileSeconds -SortedValues $sortedDurations -Percentile 0.95
+    } elseif ($TimingSummary) {
+        if ($TimingSummary.PSObject.Properties['medianSeconds'] -and $null -ne $TimingSummary.medianSeconds) {
+            $timingP50Seconds = [double]$TimingSummary.medianSeconds
+        }
+        if ($TimingSummary.PSObject.Properties['p95Seconds'] -and $null -ne $TimingSummary.p95Seconds) {
+            $timingP95Seconds = [double]$TimingSummary.p95Seconds
+        }
+    }
+
+    $normalizedReason = if ([string]::IsNullOrWhiteSpace($TruncationReason)) {
+        if ($CommentTruncated) { 'unspecified' } else { 'none' }
+    } else {
+        $TruncationReason
+    }
+
+    [pscustomobject]@{
+        signalRecall              = $signalRecall
+        noisePrecisionMasscompile = $noisePrecisionMasscompile
+        previewCoverage           = $previewCoverage
+        timingP50Seconds          = $timingP50Seconds
+        timingP95Seconds          = $timingP95Seconds
+        commentTruncated          = [bool]$CommentTruncated
+        truncationReason          = $normalizedReason
+    }
+}
+
 function Get-CommitTimelineRows {
     param(
         [AllowNull()]$Summary,
@@ -480,6 +605,16 @@ if ($summary.PSObject.Properties['timing'] -and $summary.timing) {
     $timingSummary = $summary.totals.timing
 }
 
+$commentTruncated = ($markdownTruncated -or $timelineRowsDropped -gt 0)
+$truncationReason = if ($markdownTruncated) {
+    'max-markdown-length'
+} elseif ($timelineRowsDropped -gt 0) {
+    'timeline-row-drop'
+} else {
+    'none'
+}
+$kpiEnvelope = Get-PairKpiEnvelope -Pairs $activeTimelineRows -TimingSummary $timingSummary -CommentTruncated:$commentTruncated -TruncationReason $truncationReason
+
 $result = [pscustomobject]@{
     totals = [pscustomobject]@{
         targets     = $targets.Count
@@ -497,6 +632,7 @@ $result = [pscustomobject]@{
     targets  = $targets
     pairTimeline = $activeTimelineRows
     previews = $previewEntries
+    kpi      = $kpiEnvelope
     markdown = $markdown
 }
 


### PR DESCRIPTION
## Summary
Mirror fork PR #85 into upstream `develop` to keep repos aligned for standing priority #29.

## Source
- Fork PR: https://github.com/svelderrainruiz/compare-vi-cli-action/pull/85
- Merge commit: `d59cae28044eb3a8c15312939155edd5449b3219`

## Changes mirrored
- additive `kpi` envelope in `pr-vi-history-summary@v1`
- per-pair KPI classification/preview/timing assertions in tests
- docs updates with pair contract + KPI fields + concrete JSON example
