### PR TITLE
Mirror #152 hook-parity pre-push env compatibility to upstream

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -150,6 +150,7 @@ jobs:
     - name: PrePush local gates (includes watcher schema validation)
       shell: pwsh
       env:
+        PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS: '1'
         PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: '1'
       run: |
         pwsh -File tools/PrePush-Checks.ps1
@@ -489,6 +490,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
+      PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS: '1'
       PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: '1'
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- mirror origin #152 compatibility fix into upstream validate hook parity path
- export both pre-push fixture skip env vars so parity jobs remain deterministic across script revisions

## Change
In `.github/workflows/validate.yml`, set both vars in `lint` and `hook-parity` jobs:
- `PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS=1`
- `PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS=1`

## Why
Upstream can still run script revisions that only honor the icon-editor skip name. Exporting both avoids unexpected fixture-check execution in hook parity and removes false failures.

Refs: #154
