### PR TITLE
Alignment batch 1: fixture-drift runtime contracts from origin

### DIFF
--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -54,6 +54,44 @@ jobs:
         $lv = Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue
         if ($lv) { $pids = ($lv | ForEach-Object Id); $msg = '::notice::LabVIEW.exe is running (PID(s): {0}).' -f ([string]::Join(',', $pids)); Write-Host $msg } else { Write-Host 'LabVIEW not running.' }
         Write-Host 'Preflight check complete.'
+
+  docker-runtime-manager:
+    name: Docker Runtime Manager (Host)
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
+    needs:
+    - preflight-windows
+    timeout-minutes: 10
+    outputs:
+      manager_status: ${{ steps.manager.outputs.manager_status }}
+      manager_summary_path: ${{ steps.manager.outputs.manager_summary_path }}
+      windows_image_digest: ${{ steps.manager.outputs.windows_image_digest }}
+      linux_image_digest: ${{ steps.manager.outputs.linux_image_digest }}
+      start_context: ${{ steps.manager.outputs.start_context }}
+      final_context: ${{ steps.manager.outputs.final_context }}
+    env:
+      NI_WINDOWS_IMAGE: nationalinstruments/labview:2026q1-windows
+      NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
+    steps:
+    - uses: actions/checkout@v5
+    - name: Run Docker runtime manager
+      id: manager
+      shell: pwsh
+      run: |
+        pwsh -NoLogo -NoProfile -File tools/Invoke-DockerRuntimeManager.ps1 `
+          -WindowsImage $env:NI_WINDOWS_IMAGE `
+          -LinuxImage $env:NI_LINUX_IMAGE `
+          -BootstrapWindowsImage:$true `
+          -BootstrapLinuxImage:$true `
+          -OutputJsonPath 'results/fixture-drift/docker-runtime-manager.json' `
+          -GitHubOutputPath $env:GITHUB_OUTPUT `
+          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+    - name: Upload docker runtime manager artifact
+      if: always()
+      uses: actions/upload-artifact@v5
+      with:
+        name: fixture-drift-docker-runtime-manager
+        path: results/fixture-drift/docker-runtime-manager.json
+        if-no-files-found: warn
   validate-ubuntu:
     name: Fixture Drift (Ubuntu)
     runs-on: ubuntu-latest
@@ -126,12 +164,14 @@ jobs:
         soft-fail: ${{ github.event_name == 'pull_request' || steps.docs.outputs.docs_only }}
 
   validate-windows:
-    name: Fixture Drift (Windows)
-    runs-on: [self-hosted, Windows, X64]
+    name: Fixture Drift (Docker Desktop Host - LabVIEW 2026 q1 windows)
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
     concurrency:
       group: lv-fixture-win
       cancel-in-progress: false
-    needs: preflight-windows
+    needs:
+    - preflight-windows
+    - docker-runtime-manager
     timeout-minutes: 3
     env:
       INVOKER_REQUIRED: '1'
@@ -148,6 +188,12 @@ jobs:
       LV_CURSOR_RESTORE: ${{ vars.LV_CURSOR_RESTORE || '1' }}
       LV_IDLE_WAIT_SECONDS: ${{ vars.LV_IDLE_WAIT_SECONDS || '2' }}
       LV_IDLE_MAX_WAIT_SECONDS: ${{ vars.LV_IDLE_MAX_WAIT_SECONDS || '5' }}
+      DOCKER_MANAGER_STATUS: ${{ needs.docker-runtime-manager.outputs.manager_status }}
+      DOCKER_MANAGER_SUMMARY_PATH: ${{ needs.docker-runtime-manager.outputs.manager_summary_path }}
+      DOCKER_MANAGER_WINDOWS_IMAGE_DIGEST: ${{ needs.docker-runtime-manager.outputs.windows_image_digest }}
+      DOCKER_MANAGER_LINUX_IMAGE_DIGEST: ${{ needs.docker-runtime-manager.outputs.linux_image_digest }}
+      DOCKER_MANAGER_START_CONTEXT: ${{ needs.docker-runtime-manager.outputs.start_context }}
+      DOCKER_MANAGER_FINAL_CONTEXT: ${{ needs.docker-runtime-manager.outputs.final_context }}
     permissions:
       actions: read
       contents: read
@@ -167,6 +213,99 @@ jobs:
       with:
         phase: J2
         results-dir: results/fixture-drift
+    - name: Assert Docker runtime determinism (windows)
+      id: runtime_determinism
+      shell: pwsh
+      run: |
+        pwsh -NoLogo -NoProfile -File tools/Assert-DockerRuntimeDeterminism.ps1 `
+          -ExpectedOsType windows `
+          -ExpectedContext desktop-windows `
+          -AutoRepair:$true `
+          -ManageDockerEngine:$true `
+          -SnapshotPath 'results/fixture-drift/windows-runtime-determinism.json' `
+          -GitHubOutputPath $env:GITHUB_OUTPUT
+    - name: Assert self-hosted-docker runner label
+      id: runner_label_contract
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 `
+          -Repository '${{ github.repository }}' `
+          -RunId '${{ github.run_id }}' `
+          -RunnerName '${{ runner.name }}' `
+          -RequiredLabel 'self-hosted-docker' `
+          -OutputJsonPath 'results/fixture-drift/runner-label-contract.json' `
+          -GitHubOutputPath $env:GITHUB_OUTPUT `
+          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+
+    - name: Persist docker runtime manager context
+      id: docker_manager_context
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $dir = 'results/fixture-drift'
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        $path = Join-Path $dir 'docker-runtime-manager-context.json'
+        $labelsRaw = '${{ steps.runner_label_contract.outputs.labels }}'
+        $labels = if ([string]::IsNullOrWhiteSpace($labelsRaw)) { @() } else { @($labelsRaw -split ',' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) }
+        $payload = [ordered]@{
+          schema = 'fixture-drift/docker-runtime-manager-context@v1'
+          generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+          manager = [ordered]@{
+            status = [string]$env:DOCKER_MANAGER_STATUS
+            summaryPath = [string]$env:DOCKER_MANAGER_SUMMARY_PATH
+            windowsImageDigest = [string]$env:DOCKER_MANAGER_WINDOWS_IMAGE_DIGEST
+            linuxImageDigest = [string]$env:DOCKER_MANAGER_LINUX_IMAGE_DIGEST
+            startContext = [string]$env:DOCKER_MANAGER_START_CONTEXT
+            finalContext = [string]$env:DOCKER_MANAGER_FINAL_CONTEXT
+          }
+          runner = [ordered]@{
+            name = '${{ runner.name }}'
+            id = '${{ steps.runner_label_contract.outputs.runner_id }}'
+            requiredLabel = 'self-hosted-docker'
+            hasRequiredLabel = ('${{ steps.runner_label_contract.outputs.has_required_label }}' -eq 'true')
+            labels = $labels
+          }
+        }
+        ($payload | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $path -Encoding utf8
+        "context_path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Download docker runtime manager artifact
+      if: always()
+      uses: actions/download-artifact@v5
+      with:
+        name: fixture-drift-docker-runtime-manager
+        path: results/fixture-drift/_docker-runtime-manager
+
+    - name: Stage docker runtime manager artifact
+      if: always()
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $resultsDir = 'results/fixture-drift'
+        New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+        $dest = Join-Path $resultsDir 'docker-runtime-manager.json'
+        $source = Get-ChildItem -Path (Join-Path $resultsDir '_docker-runtime-manager') -Recurse -File -Filter 'docker-runtime-manager.json' -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($source) {
+          Copy-Item -LiteralPath $source.FullName -Destination $dest -Force
+          Write-Host "Staged docker runtime manager artifact: $dest"
+          exit 0
+        }
+
+        Write-Host '::warning::docker-runtime-manager artifact not found; writing fallback context file for evidence continuity.'
+        $fallback = [ordered]@{
+          schema = 'fixture-drift/docker-runtime-manager-fallback@v1'
+          generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+          status = [string]$env:DOCKER_MANAGER_STATUS
+          summaryPath = [string]$env:DOCKER_MANAGER_SUMMARY_PATH
+          windowsImageDigest = [string]$env:DOCKER_MANAGER_WINDOWS_IMAGE_DIGEST
+          linuxImageDigest = [string]$env:DOCKER_MANAGER_LINUX_IMAGE_DIGEST
+          startContext = [string]$env:DOCKER_MANAGER_START_CONTEXT
+          finalContext = [string]$env:DOCKER_MANAGER_FINAL_CONTEXT
+          note = 'Source artifact missing in downstream lane; values copied from docker-runtime-manager job outputs.'
+        }
+        ($fallback | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $dest -Encoding utf8
 
     - name: Detect docs-only change
       id: docs
@@ -362,6 +501,26 @@ jobs:
       shell: pwsh
       run: pwsh -File tools/Ensure-SessionIndex.ps1 -ResultsDir 'results/fixture-drift' -SummaryJson 'drift-summary.json'
 
+    - name: Attach docker manager metadata to session index
+      if: always()
+      shell: pwsh
+      run: |
+        $hasRequiredLabel = ('${{ steps.runner_label_contract.outputs.has_required_label }}' -eq 'true')
+        pwsh -NoLogo -NoProfile -File tools/Update-FixtureDriftSessionIndex.ps1 `
+          -ResultsDir 'results/fixture-drift' `
+          -ContextPath '${{ steps.docker_manager_context.outputs.context_path }}' `
+          -RuntimeSnapshotPath 'results/fixture-drift/windows-runtime-determinism.json' `
+          -RequiredLabel 'self-hosted-docker' `
+          -HasRequiredLabel:$hasRequiredLabel `
+          -RunnerLabelsCsv '${{ steps.runner_label_contract.outputs.labels }}' `
+          -ManagerStatus $env:DOCKER_MANAGER_STATUS `
+          -ManagerSummaryPath $env:DOCKER_MANAGER_SUMMARY_PATH `
+          -WindowsImageDigest $env:DOCKER_MANAGER_WINDOWS_IMAGE_DIGEST `
+          -LinuxImageDigest $env:DOCKER_MANAGER_LINUX_IMAGE_DIGEST `
+          -StartContext $env:DOCKER_MANAGER_START_CONTEXT `
+          -FinalContext $env:DOCKER_MANAGER_FINAL_CONTEXT `
+          -IgnoreMissingSessionIndex
+
     - name: Wire Session Index (S1)
       if: always()
       uses: ./.github/actions/wire-session-index
@@ -451,7 +610,7 @@ jobs:
       if: always()
       shell: pwsh
       run: |
-        $list = 'results/fixture-drift/drift-summary.json;results/fixture-drift/compare-report.html;results/fixture-drift/session-index.json'
+        $list = 'results/fixture-drift/drift-summary.json;results/fixture-drift/compare-report.html;results/fixture-drift/session-index.json;results/fixture-drift/docker-runtime-manager-context.json;results/fixture-drift/docker-runtime-manager.json;results/fixture-drift/runner-label-contract.json;results/fixture-drift/windows-runtime-determinism.json'
         pwsh -File tools/Write-ArtifactMap.ps1 -PathsList $list -Title 'Artifacts'
 
     - name: Re-run hint

--- a/tests/Assert-RunnerLabelContract.Tests.ps1
+++ b/tests/Assert-RunnerLabelContract.Tests.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Assert-RunnerLabelContract.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Assert-RunnerLabelContract.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'passes when required label is present in run-jobs payload' {
+    $work = Join-Path $TestDrive 'success'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      jobs = @(
+        [ordered]@{
+          runner_name = 'host-a'
+          runner_id = 42
+          status = 'in_progress'
+          started_at = '2026-03-02T00:00:00Z'
+          labels = @('self-hosted', 'windows', 'self-hosted-docker')
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+    $githubOutputPath = Join-Path $work 'github-output.txt'
+    $stepSummaryPath = Join-Path $work 'step-summary.md'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '100' `
+        -RunnerName 'host-a' `
+        -RequiredLabel 'self-hosted-docker' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath `
+        -GitHubOutputPath $githubOutputPath `
+        -StepSummaryPath $stepSummaryPath
+    } | Should -Not -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.schema | Should -Be 'runner-label-contract@v1'
+    $json.status | Should -Be 'success'
+    $json.failureClass | Should -Be 'none'
+    $json.hasRequiredLabel | Should -BeTrue
+    $json.runnerId | Should -Be '42'
+    @($json.labels) | Should -Contain 'self-hosted-docker'
+
+    $ghOutput = Get-Content -LiteralPath $githubOutputPath -Raw
+    $ghOutput | Should -Match 'has_required_label=true'
+    $ghOutput | Should -Match 'runner_label_contract_status=success'
+    $ghOutput | Should -Match 'runner_id=42'
+
+    $summary = Get-Content -LiteralPath $stepSummaryPath -Raw
+    $summary | Should -Match '### Runner Label Contract'
+    $summary | Should -Match 'status: `success`'
+  }
+
+  It 'fails with missing-label class when required label is absent' {
+    $work = Join-Path $TestDrive 'missing-label'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      jobs = @(
+        [ordered]@{
+          runner_name = 'host-b'
+          runner_id = 77
+          status = 'completed'
+          started_at = '2026-03-02T00:01:00Z'
+          labels = @('self-hosted', 'windows')
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '101' `
+        -RunnerName 'host-b' `
+        -RequiredLabel 'self-hosted-docker' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'missing-label'
+    $json.failureMessage | Should -Match 'missing required label'
+    $json.hasRequiredLabel | Should -BeFalse
+  }
+
+  It 'classifies 403 payload failures as api-permission' {
+    $work = Join-Path $TestDrive 'api-permission'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      status = 403
+      message = 'Resource not accessible by integration'
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '102' `
+        -RunnerName 'host-c' `
+        -RequiredLabel 'self-hosted-docker' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'api-permission'
+    $json.failureMessage | Should -Match 'Resource not accessible'
+  }
+}

--- a/tests/Invoke-DockerRuntimeManager.Tests.ps1
+++ b/tests/Invoke-DockerRuntimeManager.Tests.ps1
@@ -1,0 +1,404 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Invoke-DockerRuntimeManager.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ManagerScript = Join-Path $script:RepoRoot 'tools' 'Invoke-DockerRuntimeManager.ps1'
+    if (-not (Test-Path -LiteralPath $script:ManagerScript -PathType Leaf)) {
+      throw "Manager script not found: $script:ManagerScript"
+    }
+
+    $script:CreateDockerStub = {
+      param([Parameter(Mandatory)][string]$WorkRoot)
+
+      $binDir = Join-Path $WorkRoot 'bin'
+      New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+      $pwshPath = (Get-Command pwsh -ErrorAction Stop).Source
+
+      $dockerStub = @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+
+function Get-StatePath {
+  $path = [Environment]::GetEnvironmentVariable('DOCKER_STUB_STATE_PATH')
+  if ([string]::IsNullOrWhiteSpace($path)) {
+    $tmp = [System.IO.Path]::GetTempPath()
+    return (Join-Path $tmp 'docker-stub-state.json')
+  }
+  return $path
+}
+
+function New-SeedState {
+  $initial = [Environment]::GetEnvironmentVariable('DOCKER_STUB_INITIAL_CONTEXT')
+  if ([string]::IsNullOrWhiteSpace($initial)) { $initial = 'desktop-windows' }
+  return [ordered]@{
+    activeContext = $initial
+    pulledWindows = $false
+    pulledLinux = $false
+  }
+}
+
+function Get-State {
+  $statePath = Get-StatePath
+  if (Test-Path -LiteralPath $statePath -PathType Leaf) {
+    try {
+      return (Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json -ErrorAction Stop)
+    } catch {
+    }
+  }
+  $seed = New-SeedState
+  ($seed | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $statePath -Encoding utf8
+  return (Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json -ErrorAction Stop)
+}
+
+function Set-State([object]$State) {
+  $statePath = Get-StatePath
+  $parent = Split-Path -Parent $statePath
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  ($State | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $statePath -Encoding utf8
+}
+
+function Is-WindowsImage([string]$Image) {
+  return ($Image -match '(?i)windows')
+}
+
+function Is-LinuxImage([string]$Image) {
+  return ($Image -match '(?i)linux')
+}
+
+if ($Args.Count -eq 0) { exit 0 }
+
+$state = Get-State
+$active = [string]$state.activeContext
+if ([string]::IsNullOrWhiteSpace($active)) { $active = 'desktop-windows' }
+
+if ($Args[0] -eq 'context' -and $Args.Count -ge 2 -and $Args[1] -eq 'show') {
+  Write-Output $active
+  exit 0
+}
+
+if ($Args[0] -eq 'context' -and $Args.Count -ge 3 -and $Args[1] -eq 'use') {
+  $target = [string]$Args[2]
+  $failTarget = [Environment]::GetEnvironmentVariable('DOCKER_STUB_FAIL_CONTEXT')
+  if (-not [string]::IsNullOrWhiteSpace($failTarget) -and $target -eq $failTarget) {
+    [Console]::Error.WriteLine(("context use blocked for {0}" -f $target))
+    exit 1
+  }
+  $state.activeContext = $target
+  Set-State -State $state
+  Write-Output $target
+  exit 0
+}
+
+if ($Args[0] -eq 'info') {
+  if ([Environment]::GetEnvironmentVariable('DOCKER_STUB_FORCE_INFO_FAILURE') -eq '1') {
+    [Console]::Error.WriteLine('docker info failed')
+    exit 1
+  }
+  if ($active -match 'linux') { Write-Output 'linux'; exit 0 }
+  Write-Output 'windows'
+  exit 0
+}
+
+if ($Args[0] -eq 'manifest' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') {
+  $manifest = [ordered]@{
+    schemaVersion = 2
+    manifests = @(
+      [ordered]@{
+        digest = 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
+        platform = [ordered]@{
+          os = 'windows'
+          architecture = 'amd64'
+        }
+      },
+      [ordered]@{
+        digest = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'
+        platform = [ordered]@{
+          os = 'linux'
+          architecture = 'amd64'
+        }
+      }
+    )
+  }
+  ($manifest | ConvertTo-Json -Depth 10) | Write-Output
+  exit 0
+}
+
+if ($Args[0] -eq 'image' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') {
+  $image = [string]$Args[2]
+  $requirePullWindows = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_REQUIRE_PULL_WINDOWS') -eq '1')
+  $requirePullLinux = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_REQUIRE_PULL_LINUX') -eq '1')
+
+  $needsPull = $false
+  if ($requirePullWindows -and (Is-WindowsImage -Image $image) -and -not [bool]$state.pulledWindows) { $needsPull = $true }
+  if ($requirePullLinux -and (Is-LinuxImage -Image $image) -and -not [bool]$state.pulledLinux) { $needsPull = $true }
+
+  if ($needsPull) {
+    [Console]::Error.WriteLine(("Error: No such image: {0}" -f $image))
+    exit 1
+  }
+
+  $digest = if (Is-WindowsImage -Image $image) { 'sha256:3333333333333333333333333333333333333333333333333333333333333333' } else { 'sha256:4444444444444444444444444444444444444444444444444444444444444444' }
+  $id = if (Is-WindowsImage -Image $image) { 'sha256:stub-image-id-windows' } else { 'sha256:stub-image-id-linux' }
+  $payload = [ordered]@{
+    Id = $id
+    RepoDigests = @("$image@$digest")
+  }
+  ($payload | ConvertTo-Json -Depth 10 -Compress) | Write-Output
+  exit 0
+}
+
+if ($Args[0] -eq 'pull' -and $Args.Count -ge 2) {
+  $image = [string]$Args[1]
+  if (([Environment]::GetEnvironmentVariable('DOCKER_STUB_PULL_FAIL_WINDOWS') -eq '1') -and (Is-WindowsImage -Image $image)) {
+    [Console]::Error.WriteLine(("pull denied for {0}" -f $image))
+    exit 1
+  }
+  if (([Environment]::GetEnvironmentVariable('DOCKER_STUB_PULL_FAIL_LINUX') -eq '1') -and (Is-LinuxImage -Image $image)) {
+    [Console]::Error.WriteLine(("pull denied for {0}" -f $image))
+    exit 1
+  }
+
+  if (Is-WindowsImage -Image $image) { $state.pulledWindows = $true }
+  if (Is-LinuxImage -Image $image) { $state.pulledLinux = $true }
+  Set-State -State $state
+  $digest = if (Is-WindowsImage -Image $image) { 'sha256:3333333333333333333333333333333333333333333333333333333333333333' } else { 'sha256:4444444444444444444444444444444444444444444444444444444444444444' }
+  Write-Output ("Digest: {0}" -f $digest)
+  exit 0
+}
+
+if ($Args[0] -eq 'run') {
+  $joined = ($Args -join ' ')
+  $runFailWindows = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_RUN_FAIL_WINDOWS') -eq '1')
+  $runFailLinux = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_RUN_FAIL_LINUX') -eq '1')
+  if ($runFailWindows -and $joined -match '(?i)windows') {
+    [Console]::Error.WriteLine('runtime probe failed (windows)')
+    exit 5
+  }
+  if ($runFailLinux -and $joined -match '(?i)linux') {
+    [Console]::Error.WriteLine('runtime probe failed (linux)')
+    exit 6
+  }
+  Write-Output 'ni-runtime-probe-ok'
+  exit 0
+}
+
+exit 0
+'@
+      Set-Content -LiteralPath (Join-Path $binDir 'docker.ps1') -Value $dockerStub -Encoding utf8
+
+      $dockerCmd = @"
+@echo off
+"$pwshPath" -NoLogo -NoProfile -File "%~dp0docker.ps1" %*
+"@
+      Set-Content -LiteralPath (Join-Path $binDir 'docker.cmd') -Value $dockerCmd -Encoding ascii
+
+      $env:PATH = "{0};{1}" -f $binDir, $env:PATH
+    }
+  }
+
+  BeforeEach {
+    $script:SavedPath = $env:PATH
+    $script:SavedEnv = @{
+      DOCKER_STUB_STATE_PATH = $env:DOCKER_STUB_STATE_PATH
+      DOCKER_STUB_INITIAL_CONTEXT = $env:DOCKER_STUB_INITIAL_CONTEXT
+      DOCKER_STUB_FAIL_CONTEXT = $env:DOCKER_STUB_FAIL_CONTEXT
+      DOCKER_STUB_FORCE_INFO_FAILURE = $env:DOCKER_STUB_FORCE_INFO_FAILURE
+      DOCKER_STUB_REQUIRE_PULL_WINDOWS = $env:DOCKER_STUB_REQUIRE_PULL_WINDOWS
+      DOCKER_STUB_REQUIRE_PULL_LINUX = $env:DOCKER_STUB_REQUIRE_PULL_LINUX
+      DOCKER_STUB_PULL_FAIL_WINDOWS = $env:DOCKER_STUB_PULL_FAIL_WINDOWS
+      DOCKER_STUB_PULL_FAIL_LINUX = $env:DOCKER_STUB_PULL_FAIL_LINUX
+      DOCKER_STUB_RUN_FAIL_WINDOWS = $env:DOCKER_STUB_RUN_FAIL_WINDOWS
+      DOCKER_STUB_RUN_FAIL_LINUX = $env:DOCKER_STUB_RUN_FAIL_LINUX
+      RUNNER_TEMP = $env:RUNNER_TEMP
+    }
+  }
+
+  AfterEach {
+    $env:PATH = $script:SavedPath
+    foreach ($key in $script:SavedEnv.Keys) {
+      $value = $script:SavedEnv[$key]
+      if ($null -eq $value -or $value -eq '') {
+        Remove-Item ("Env:{0}" -f $key) -ErrorAction SilentlyContinue
+      } else {
+        Set-Item ("Env:{0}" -f $key) $value
+      }
+    }
+  }
+
+  It 'emits docker-runtime-manager@v1 outputs on successful windows/linux probe cycle' {
+    $work = Join-Path $TestDrive 'success'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-linux'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $outputPath = Join-Path $work 'github-output.txt'
+    $summaryPath = Join-Path $work 'step-summary.md'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -OutputJsonPath $jsonPath `
+      -GitHubOutputPath $outputPath `
+      -StepSummaryPath $summaryPath `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.schema | Should -Be 'docker-runtime-manager@v1'
+    $json.status | Should -Be 'success'
+    $json.failureClass | Should -Be 'none'
+    $json.lock.acquired | Should -BeTrue
+    $json.probes.windows.status | Should -Be 'success'
+    $json.probes.linux.status | Should -Be 'success'
+    $json.probes.windows.digest | Should -Be 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
+    $json.probes.linux.digest | Should -Be 'sha256:2222222222222222222222222222222222222222222222222222222222222222'
+    $json.probes.windows.bootstrap.imagePresent | Should -BeTrue
+    $json.probes.linux.bootstrap.imagePresent | Should -BeTrue
+    $json.probes.windows.bootstrap.localDigest | Should -Be 'sha256:3333333333333333333333333333333333333333333333333333333333333333'
+    $json.probes.linux.bootstrap.localDigest | Should -Be 'sha256:4444444444444444444444444444444444444444444444444444444444444444'
+    $json.probes.windows.probe.status | Should -Be 'success'
+    $json.probes.linux.probe.status | Should -Be 'success'
+    $json.contexts.start | Should -Be 'desktop-linux'
+    $json.contexts.final | Should -Be 'desktop-windows'
+
+    $ghOutput = Get-Content -LiteralPath $outputPath -Raw
+    $ghOutput | Should -Match 'manager_status=success'
+    $ghOutput | Should -Match 'windows_image_digest=sha256:3333333333333333333333333333333333333333333333333333333333333333'
+    $ghOutput | Should -Match 'linux_image_digest=sha256:4444444444444444444444444444444444444444444444444444444444444444'
+    $ghOutput | Should -Match 'windows_probe_status=success'
+    $ghOutput | Should -Match 'linux_probe_status=success'
+
+    $summary = Get-Content -LiteralPath $summaryPath -Raw
+    $summary | Should -Match '### Docker Runtime Manager'
+    $summary | Should -Match 'status: `success`'
+    $summary | Should -Match 'probe=`success`'
+  }
+
+  It 'bootstraps missing windows image when windows-only probe scope is selected' {
+    $work = Join-Path $TestDrive 'bootstrap-windows'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_REQUIRE_PULL_WINDOWS '1'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -ProbeScope windows `
+      -OutputJsonPath $jsonPath `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.status | Should -Be 'success'
+    $json.probes.windows.bootstrap.pulled | Should -BeTrue
+    $json.probes.windows.bootstrap.imagePresent | Should -BeTrue
+    $json.probes.windows.probe.status | Should -Be 'success'
+    $json.probes.linux.status | Should -Be 'skipped'
+  }
+
+  It 'classifies context switch failure as runtime-determinism failure' {
+    $work = Join-Path $TestDrive 'runtime-failure'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_FAIL_CONTEXT 'desktop-linux'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $outputPath = Join-Path $work 'github-output.txt'
+    $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -OutputJsonPath $jsonPath `
+      -GitHubOutputPath $outputPath `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1
+
+    $LASTEXITCODE | Should -Not -Be 0
+    $text = $output -join "`n"
+    $text | Should -Match 'Failed to switch Docker context to'
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'runtime-determinism'
+    $json.probes.windows.status | Should -Be 'success'
+    $json.probes.linux.status | Should -Be 'failure'
+    $json.probes.linux.error | Should -Match 'desktop-linux'
+
+    $ghOutput = Get-Content -LiteralPath $outputPath -Raw
+    $ghOutput | Should -Match 'manager_status=failure'
+  }
+
+  It 'fails with image-bootstrap classification when windows image is missing and bootstrap is disabled' {
+    $work = Join-Path $TestDrive 'bootstrap-disabled'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_REQUIRE_PULL_WINDOWS '1'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -ProbeScope windows `
+      -BootstrapWindowsImage:$false `
+      -OutputJsonPath $jsonPath `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1
+
+    $LASTEXITCODE | Should -Not -Be 0
+    ($output -join "`n") | Should -Match 'Local image inspect failed'
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'image-bootstrap'
+    $json.probes.windows.status | Should -Be 'success'
+  }
+
+  It 'fails with lock timeout when the runtime manager lock is held by another process' {
+    $work = Join-Path $TestDrive 'lock-timeout'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    $runnerTemp = Join-Path $work 'runner-temp'
+    Set-Item Env:RUNNER_TEMP $runnerTemp
+
+    $lockPath = Join-Path $runnerTemp 'docker-runtime-manager\engine-switch.lock'
+    $lockDir = Split-Path -Parent $lockPath
+    New-Item -ItemType Directory -Path $lockDir -Force | Out-Null
+    $lockStream = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+    try {
+      $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+      $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+        -OutputJsonPath $jsonPath `
+        -LockWaitSeconds 5 `
+        -SwitchRetryCount 1 `
+        -SwitchTimeoutSeconds 30 2>&1
+      $LASTEXITCODE | Should -Not -Be 0
+      ($output -join "`n") | Should -Match 'Timed out waiting for Docker manager lock'
+
+      $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+      $json.status | Should -Be 'failure'
+      $json.failureClass | Should -Be 'runtime-determinism'
+      $json.failureMessage | Should -Match 'Timed out waiting for Docker manager lock'
+      $json.lock.acquired | Should -BeFalse
+    } finally {
+      $lockStream.Dispose()
+    }
+  }
+}

--- a/tests/Update-FixtureDriftSessionIndex.Tests.ps1
+++ b/tests/Update-FixtureDriftSessionIndex.Tests.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Update-FixtureDriftSessionIndex.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Update-FixtureDriftSessionIndex.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Update-FixtureDriftSessionIndex.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'persists docker manager and runner label metadata into session-index runContext' {
+    $resultsDir = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $sessionIndexPath = Join-Path $resultsDir 'session-index.json'
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+      status = 'ok'
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $sessionIndexPath -Encoding utf8
+
+    $contextPath = Join-Path $resultsDir 'docker-runtime-manager-context.json'
+    $context = [ordered]@{
+      schema = 'fixture-drift/docker-runtime-manager-context@v1'
+    }
+    ($context | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $contextPath -Encoding utf8
+    $runtimeSnapshotPath = Join-Path $resultsDir 'windows-runtime-determinism.json'
+    $runtimeSnapshot = [ordered]@{
+      schema = 'docker-runtime-determinism@v1'
+      result = [ordered]@{ status = 'ok' }
+    }
+    ($runtimeSnapshot | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $runtimeSnapshotPath -Encoding utf8
+
+    $resultPath = & $script:ToolPath `
+      -ResultsDir $resultsDir `
+      -ContextPath $contextPath `
+      -RuntimeSnapshotPath $runtimeSnapshotPath `
+      -RequiredLabel 'self-hosted-docker' `
+      -HasRequiredLabel:$true `
+      -RunnerLabelsCsv 'self-hosted,windows,self-hosted-docker' `
+      -ManagerStatus 'success' `
+      -ManagerSummaryPath 'results/fixture-drift/docker-runtime-manager.json' `
+      -WindowsImageDigest 'sha256:windows' `
+      -LinuxImageDigest 'sha256:linux' `
+      -StartContext 'desktop-windows' `
+      -FinalContext 'desktop-windows'
+
+    [string]$resultPath | Should -Be $sessionIndexPath
+
+    $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
+    $updated.runContext.dockerRuntimeManager.status | Should -Be 'success'
+    $updated.runContext.dockerRuntimeManager.windowsImageDigest | Should -Be 'sha256:windows'
+    $updated.runContext.dockerRuntimeManager.contextArtifactPath | Should -Be $contextPath
+    $updated.runContext.dockerRuntimeManager.runtimeSnapshotPath | Should -Be $runtimeSnapshotPath
+    $updated.runContext.runnerLabelContract.requiredLabel | Should -Be 'self-hosted-docker'
+    $updated.runContext.runnerLabelContract.hasRequiredLabel | Should -BeTrue
+    @($updated.runContext.runnerLabelContract.labels) | Should -Contain 'self-hosted-docker'
+  }
+
+  It 'does not throw when session-index is missing and IgnoreMissingSessionIndex is enabled' {
+    $resultsDir = Join-Path $TestDrive 'missing'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    {
+      & $script:ToolPath -ResultsDir $resultsDir -IgnoreMissingSessionIndex
+    } | Should -Not -Throw
+  }
+}

--- a/tests/Write-FixtureDriftSummary.Tests.ps1
+++ b/tests/Write-FixtureDriftSummary.Tests.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Write-FixtureDriftSummary.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Write-FixtureDriftSummary.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Write-FixtureDriftSummary.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  BeforeEach {
+    $script:SummaryPath = Join-Path $TestDrive 'step-summary.md'
+    $env:GITHUB_STEP_SUMMARY = $script:SummaryPath
+  }
+
+  AfterEach {
+    Remove-Item Env:GITHUB_STEP_SUMMARY -ErrorAction SilentlyContinue
+  }
+
+  It 'renders docker runtime manager details when context file is present' {
+    $resultsDir = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $driftSummary = [ordered]@{
+      summaryCounts = [ordered]@{
+        passed = 3
+        failed = 0
+      }
+      notes = @('fixture drift ok')
+    }
+    ($driftSummary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath (Join-Path $resultsDir 'drift-summary.json') -Encoding utf8
+
+    $dockerContext = [ordered]@{
+      manager = [ordered]@{
+        status = 'success'
+        startContext = 'desktop-windows'
+        finalContext = 'desktop-windows'
+        windowsImageDigest = 'sha256:windowsdigest'
+        linuxImageDigest = 'sha256:linuxdigest'
+        summaryPath = 'results/fixture-drift/docker-runtime-manager.json'
+      }
+    }
+    ($dockerContext | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath (Join-Path $resultsDir 'docker-runtime-manager-context.json') -Encoding utf8
+
+    & $script:ToolPath -Dir $resultsDir
+
+    $summary = Get-Content -LiteralPath $script:SummaryPath -Raw
+    $summary | Should -Match '### Fixture Drift'
+    $summary | Should -Match 'Docker Runtime Manager'
+    $summary | Should -Match 'Status: success'
+    $summary | Should -Match 'Start Context: desktop-windows'
+    $summary | Should -Match 'Windows Digest: sha256:windowsdigest'
+    $summary | Should -Match 'Linux Digest: sha256:linuxdigest'
+  }
+
+  It 'emits parse-failed note when docker context file is invalid json' {
+    $resultsDir = Join-Path $TestDrive 'parse-failure'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $driftSummary = [ordered]@{
+      summaryCounts = [ordered]@{
+        passed = 1
+      }
+    }
+    ($driftSummary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath (Join-Path $resultsDir 'drift-summary.json') -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $resultsDir 'docker-runtime-manager-context.json') -Value '{invalid' -Encoding utf8
+
+    & $script:ToolPath -Dir $resultsDir
+
+    $summary = Get-Content -LiteralPath $script:SummaryPath -Raw
+    $summary | Should -Match 'Docker Runtime Manager context parse failed'
+  }
+}

--- a/tools/Assert-RunnerLabelContract.ps1
+++ b/tools/Assert-RunnerLabelContract.ps1
@@ -1,0 +1,286 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Validates that the current Actions job runner includes a required label.
+
+.DESCRIPTION
+  Resolves runner metadata from the GitHub Actions run-jobs API and fails with
+  deterministic remediation text when the required label is missing.
+
+  This script supports test/offline execution through -JobsPayloadPath.
+#>
+[CmdletBinding()]
+param(
+  [string]$Repository = $env:GITHUB_REPOSITORY,
+  [string]$RunId = $env:GITHUB_RUN_ID,
+  [string]$RunnerName = $env:RUNNER_NAME,
+  [string]$RequiredLabel = 'self-hosted-docker',
+  [string]$Token = $env:GITHUB_TOKEN,
+  [string]$OutputJsonPath = 'results/fixture-drift/runner-label-contract.json',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY,
+  [string]$JobsPayloadPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [AllowNull()][AllowEmptyString()][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  $dest = Resolve-AbsolutePath -Path $Path
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Add-Content -LiteralPath $dest -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function New-ApiException {
+  param(
+    [Parameter(Mandatory)][string]$Message,
+    [AllowNull()][int]$StatusCode
+  )
+
+  $exception = [System.Exception]::new($Message)
+  if ($null -ne $StatusCode -and $StatusCode -gt 0) {
+    $exception.Data['HttpStatusCode'] = [int]$StatusCode
+  }
+  return $exception
+}
+
+function Get-StatusCodeFromError {
+  param([Parameter(Mandatory)][System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+  $statusCode = 0
+  try {
+    $ex = $ErrorRecord.Exception
+    if ($ex -and $ex.Data -and $ex.Data.Contains('HttpStatusCode')) {
+      return [int]$ex.Data['HttpStatusCode']
+    }
+    if ($ex -and $ex.PSObject.Properties['Response'] -and $ex.Response) {
+      if ($ex.Response.PSObject.Properties['StatusCode'] -and $ex.Response.StatusCode) {
+        return [int]$ex.Response.StatusCode
+      }
+    }
+  } catch {}
+
+  $message = [string]$ErrorRecord.Exception.Message
+  if ($message -match '"status"\s*:\s*"?(\d{3})"?' -or $message -match 'HTTP\s*(\d{3})') {
+    [void][int]::TryParse($Matches[1], [ref]$statusCode)
+  }
+  return $statusCode
+}
+
+function Convert-JobLabelsToArray {
+  param([AllowNull()]$Labels)
+
+  $values = New-Object System.Collections.Generic.List[string]
+  foreach ($entry in @($Labels)) {
+    if ($entry -is [string]) {
+      $candidate = [string]$entry
+    } elseif ($entry -and $entry.PSObject.Properties['name']) {
+      $candidate = [string]$entry.name
+    } else {
+      $candidate = ''
+    }
+    if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+      $values.Add($candidate) | Out-Null
+    }
+  }
+  return @($values.ToArray() | Sort-Object -Unique)
+}
+
+function Get-RunJobs {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [Parameter(Mandatory)][string]$RunId,
+    [string]$Token,
+    [string]$JobsPayloadPath
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($JobsPayloadPath)) {
+    $payloadResolved = Resolve-AbsolutePath -Path $JobsPayloadPath
+    if (-not (Test-Path -LiteralPath $payloadResolved -PathType Leaf)) {
+      throw (New-ApiException -Message ("Jobs payload file not found: {0}" -f $payloadResolved) -StatusCode 0)
+    }
+    $payload = Get-Content -LiteralPath $payloadResolved -Raw | ConvertFrom-Json -Depth 30
+    if ($payload -is [System.Array]) {
+      return @($payload)
+    }
+    if ($payload.PSObject.Properties['jobs'] -and $payload.jobs) {
+      return @($payload.jobs)
+    }
+    if ($payload.PSObject.Properties['status'] -and $payload.PSObject.Properties['message']) {
+      $status = 0
+      [void][int]::TryParse([string]$payload.status, [ref]$status)
+      throw (New-ApiException -Message ([string]$payload.message) -StatusCode $status)
+    }
+    throw (New-ApiException -Message ("Unsupported jobs payload format: {0}" -f $payloadResolved) -StatusCode 0)
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw (New-ApiException -Message 'GITHUB_TOKEN is required to validate runner labels. Set permissions.actions=read.' -StatusCode 401)
+  }
+
+  $headers = @{
+    Authorization = "Bearer $Token"
+    Accept = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+  }
+
+  $jobs = New-Object System.Collections.Generic.List[object]
+  $page = 1
+  $perPage = 100
+  do {
+    $uri = "https://api.github.com/repos/$Repository/actions/runs/$RunId/jobs?per_page=$perPage&page=$page"
+    try {
+      $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop
+    } catch {
+      $status = Get-StatusCodeFromError -ErrorRecord $_
+      $message = [string]$_.Exception.Message
+      throw (New-ApiException -Message $message -StatusCode $status)
+    }
+
+    $candidates = @($response.jobs)
+    foreach ($job in $candidates) {
+      $jobs.Add($job) | Out-Null
+    }
+    $page++
+  } while ($candidates.Count -eq $perPage)
+
+  return @($jobs.ToArray())
+}
+
+$outputJsonResolved = Resolve-AbsolutePath -Path $OutputJsonPath
+$outputParent = Split-Path -Parent $outputJsonResolved
+if ($outputParent -and -not (Test-Path -LiteralPath $outputParent -PathType Container)) {
+  New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
+}
+
+$summary = [ordered]@{
+  schema = 'runner-label-contract@v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  repository = $Repository
+  runId = $RunId
+  runnerName = $RunnerName
+  runnerId = ''
+  requiredLabel = $RequiredLabel
+  labels = @()
+  hasRequiredLabel = $false
+  status = 'failure'
+  failureClass = 'preflight'
+  failureMessage = ''
+  jobsPayloadPath = if ([string]::IsNullOrWhiteSpace($JobsPayloadPath)) { '' } else { Resolve-AbsolutePath -Path $JobsPayloadPath }
+}
+
+$caught = $null
+try {
+  if ([string]::IsNullOrWhiteSpace($Repository)) { throw 'Repository is required.' }
+  if ([string]::IsNullOrWhiteSpace($RunId)) { throw 'RunId is required.' }
+  if ([string]::IsNullOrWhiteSpace($RunnerName)) { throw 'RunnerName is required.' }
+  if ([string]::IsNullOrWhiteSpace($RequiredLabel)) { throw 'RequiredLabel is required.' }
+
+  $jobs = Get-RunJobs -Repository $Repository -RunId $RunId -Token $Token -JobsPayloadPath $JobsPayloadPath
+  if (-not $jobs -or $jobs.Count -eq 0) {
+    throw (New-ApiException -Message ("No jobs returned for run {0} in {1}." -f $RunId, $Repository) -StatusCode 0)
+  }
+
+  $currentJob = $jobs |
+    Where-Object { $_.runner_name -eq $RunnerName -and $_.status -eq 'in_progress' } |
+    Select-Object -First 1
+  if (-not $currentJob) {
+    $currentJob = $jobs |
+      Where-Object { $_.runner_name -eq $RunnerName } |
+      Sort-Object started_at -Descending |
+      Select-Object -First 1
+  }
+  if (-not $currentJob) {
+    throw (New-ApiException -Message ("Unable to resolve current job metadata for runner '{0}' in run {1}. Remediation: verify Actions run-jobs API visibility and rerun fixture-drift." -f $RunnerName, $RunId) -StatusCode 0)
+  }
+
+  $labels = Convert-JobLabelsToArray -Labels $currentJob.labels
+  $hasRequiredLabel = $labels -contains $RequiredLabel
+  $summary.runnerId = [string]$currentJob.runner_id
+  $summary.labels = @($labels)
+  $summary.hasRequiredLabel = [bool]$hasRequiredLabel
+
+  if (-not $hasRequiredLabel) {
+    $summary.status = 'failure'
+    $summary.failureClass = 'missing-label'
+    $summary.failureMessage = ("Runner '{0}' (id={1}) is missing required label '{2}'. Remediation: add the label in Repository Settings > Actions > Runners, then re-run fixture-drift." -f $RunnerName, [string]$summary.runnerId, $RequiredLabel)
+  } else {
+    $summary.status = 'success'
+    $summary.failureClass = 'none'
+    $summary.failureMessage = ''
+  }
+} catch {
+  $caught = $_
+  $statusCode = Get-StatusCodeFromError -ErrorRecord $_
+  $summary.status = 'failure'
+  if ($statusCode -eq 403) {
+    $summary.failureClass = 'api-permission'
+  } elseif ($statusCode -eq 401) {
+    $summary.failureClass = 'auth'
+  } elseif ($statusCode -eq 404) {
+    $summary.failureClass = 'api-not-found'
+  } elseif ([string]::IsNullOrWhiteSpace([string]$summary.failureClass) -or [string]$summary.failureClass -eq 'preflight') {
+    $summary.failureClass = 'api-error'
+  }
+  if ([string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+    $summary.failureMessage = [string]$_.Exception.Message
+  }
+} finally {
+  ($summary | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $outputJsonResolved -Encoding utf8
+
+  $labelsCsv = if ($summary.labels -and @($summary.labels).Count -gt 0) { [string]::Join(',', @($summary.labels)) } else { '' }
+  Write-GitHubOutput -Key 'has_required_label' -Value ([string]$summary.hasRequiredLabel).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'labels' -Value $labelsCsv -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_id' -Value ([string]$summary.runnerId) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_status' -Value ([string]$summary.status) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_summary_path' -Value $outputJsonResolved -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_failure_class' -Value ([string]$summary.failureClass) -Path $GitHubOutputPath
+
+  if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+    $summaryLines = @(
+      '### Runner Label Contract',
+      '',
+      ('- status: `{0}`' -f [string]$summary.status),
+      ('- required label: `{0}`' -f [string]$summary.requiredLabel),
+      ('- runner: `{0}` (id=`{1}`)' -f [string]$summary.runnerName, [string]$summary.runnerId),
+      ('- labels: `{0}`' -f $labelsCsv),
+      ('- summary json: `{0}`' -f $outputJsonResolved)
+    )
+    if ($summary.status -ne 'success') {
+      $summaryLines += ('- failure class: `{0}`' -f [string]$summary.failureClass)
+      if (-not [string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+        $summaryLines += ('- failure: {0}' -f [string]$summary.failureMessage)
+      }
+    }
+    $stepSummaryResolved = Resolve-AbsolutePath -Path $StepSummaryPath
+    $stepSummaryParent = Split-Path -Parent $stepSummaryResolved
+    if ($stepSummaryParent -and -not (Test-Path -LiteralPath $stepSummaryParent -PathType Container)) {
+      New-Item -ItemType Directory -Path $stepSummaryParent -Force | Out-Null
+    }
+    $summaryLines -join "`n" | Out-File -FilePath $stepSummaryResolved -Append -Encoding utf8
+  }
+}
+
+if ([string]$summary.status -ne 'success') {
+  throw ("Runner label contract failed ({0}): {1}" -f [string]$summary.failureClass, [string]$summary.failureMessage)
+}
+
+Write-Output $outputJsonResolved

--- a/tools/Invoke-DockerRuntimeManager.ps1
+++ b/tools/Invoke-DockerRuntimeManager.ps1
@@ -1,0 +1,701 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Manages Docker Desktop context transitions, NI image bootstrap, and runtime probes.
+
+.DESCRIPTION
+  Runs on a Windows host with Docker Desktop, acquires a host lock to avoid
+  concurrent engine flips, validates Windows/Linux NI image manifests, ensures
+  local image availability (bootstrap pull when missing), runs lightweight
+  runtime probes, and restores the desired final context for downstream jobs.
+#>
+[CmdletBinding()]
+param(
+  [string]$WindowsImage = 'nationalinstruments/labview:2026q1-windows',
+  [string]$LinuxImage = 'nationalinstruments/labview:2026q1-linux',
+  [string]$WindowsContext = 'desktop-windows',
+  [string]$LinuxContext = 'desktop-linux',
+  [string]$RestoreContext = 'desktop-windows',
+  [ValidateSet('both', 'windows', 'linux')]
+  [string]$ProbeScope = 'both',
+  [bool]$BootstrapWindowsImage = $true,
+  [bool]$BootstrapLinuxImage = $true,
+  [ValidateRange(30, 900)]
+  [int]$SwitchTimeoutSeconds = 120,
+  [ValidateRange(1, 10)]
+  [int]$SwitchRetryCount = 3,
+  [ValidateRange(1, 30)]
+  [int]$SwitchRetryDelaySeconds = 4,
+  [ValidateRange(5, 600)]
+  [int]$LockWaitSeconds = 90,
+  [string]$WindowsProbeCommand = "[Console]::WriteLine('ni-runtime-probe-ok')",
+  [string]$LinuxProbeCommand = "echo ni-runtime-probe-ok",
+  [string]$OutputJsonPath = 'results/fixture-drift/docker-runtime-manager.json',
+  [string]$GitHubOutputPath = '',
+  [string]$StepSummaryPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [AllowNull()][AllowEmptyString()][string]$Path
+  )
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  $dest = Resolve-AbsolutePath -Path $Path
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Add-Content -LiteralPath $dest -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function Invoke-DockerCommand {
+  param(
+    [Parameter(Mandatory)][string[]]$Arguments,
+    [switch]$IgnoreExitCode
+  )
+
+  $raw = & docker @Arguments 2>&1
+  $exitCode = $LASTEXITCODE
+  $lines = @($raw | ForEach-Object { [string]$_ })
+  $text = ($lines -join "`n")
+
+  if (-not $IgnoreExitCode -and $exitCode -ne 0) {
+    throw ("docker {0} failed (exit={1}). Output: {2}" -f ($Arguments -join ' '), $exitCode, $text)
+  }
+
+  return [pscustomobject]@{
+    ExitCode = [int]$exitCode
+    Lines = $lines
+    Text = $text
+  }
+}
+
+function Acquire-LockStream {
+  param(
+    [Parameter(Mandatory)][string]$LockPath,
+    [ValidateRange(1, 600)][int]$WaitSeconds
+  )
+
+  $lockDir = Split-Path -Parent $LockPath
+  if ($lockDir -and -not (Test-Path -LiteralPath $lockDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $lockDir -Force | Out-Null
+  }
+
+  $deadline = (Get-Date).ToUniversalTime().AddSeconds($WaitSeconds)
+  do {
+    try {
+      $stream = [System.IO.File]::Open($LockPath, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+      return $stream
+    } catch [System.IO.IOException] {
+      Start-Sleep -Seconds 2
+    }
+  } while ((Get-Date).ToUniversalTime() -lt $deadline)
+
+  throw ("Timed out waiting for Docker manager lock: {0}" -f $LockPath)
+}
+
+function Resolve-DockerCliPath {
+  $candidates = @(
+    (Join-Path ${env:ProgramFiles} 'Docker\Docker\DockerCli.exe'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Docker\Docker\DockerCli.exe')
+  ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      return $candidate
+    }
+  }
+  return ''
+}
+
+function Invoke-DockerEngineSwitchFallback {
+  param(
+    [Parameter(Mandatory)][string]$ExpectedOsType
+  )
+
+  $dockerCliPath = Resolve-DockerCliPath
+  if ([string]::IsNullOrWhiteSpace($dockerCliPath)) {
+    throw ("DockerCli.exe not found. Unable to switch engine to '{0}' without context metadata." -f $ExpectedOsType)
+  }
+
+  $switchArg = switch ($ExpectedOsType.Trim().ToLowerInvariant()) {
+    'windows' { '-SwitchWindowsEngine' }
+    'linux' { '-SwitchLinuxEngine' }
+    default { throw ("Unsupported ExpectedOsType for engine switch fallback: {0}" -f $ExpectedOsType) }
+  }
+
+  $raw = & $dockerCliPath $switchArg 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw ("Docker engine switch fallback failed via '{0} {1}'. Output: {2}" -f $dockerCliPath, $switchArg, (@($raw | ForEach-Object { [string]$_ }) -join ' '))
+  }
+}
+
+function Set-ContextAndWait {
+  param(
+    [Parameter(Mandatory)][string]$ContextName,
+    [Parameter(Mandatory)][string]$ExpectedOsType,
+    [ValidateRange(5, 900)][int]$TimeoutSeconds,
+    [ValidateRange(1, 10)][int]$RetryCount,
+    [ValidateRange(1, 60)][int]$RetryDelaySeconds
+  )
+
+  $lastError = $null
+  for ($attempt = 1; $attempt -le $RetryCount; $attempt++) {
+    try {
+      $useContext = Invoke-DockerCommand -Arguments @('context', 'use', $ContextName) -IgnoreExitCode
+      if ($useContext.ExitCode -ne 0) {
+        $switchError = [string]$useContext.Text
+        $missingContext = ($switchError -match '(?i)context.+not found') -or ($switchError -match '(?i)cannot find the path specified')
+        if ($missingContext) {
+          Invoke-DockerEngineSwitchFallback -ExpectedOsType $ExpectedOsType
+        } else {
+          throw ("docker context use {0} failed (exit={1}). Output: {2}" -f $ContextName, $useContext.ExitCode, $switchError)
+        }
+      }
+
+      $deadline = (Get-Date).ToUniversalTime().AddSeconds($TimeoutSeconds)
+      do {
+        $osProbe = Invoke-DockerCommand -Arguments @('info', '--format', '{{.OSType}}') -IgnoreExitCode
+        if ($osProbe.ExitCode -eq 0) {
+          $osType = $osProbe.Text.Trim().ToLowerInvariant()
+          if ($osType -eq $ExpectedOsType.Trim().ToLowerInvariant()) {
+            return [pscustomobject]@{
+              Context = $ContextName
+              OsType = $osType
+              Attempt = $attempt
+            }
+          }
+        }
+        Start-Sleep -Seconds 2
+      } while ((Get-Date).ToUniversalTime() -lt $deadline)
+
+      throw ("Context '{0}' did not reach expected OSType '{1}' within {2}s." -f $ContextName, $ExpectedOsType, $TimeoutSeconds)
+    } catch {
+      $lastError = $_
+      if ($attempt -lt $RetryCount) {
+        Start-Sleep -Seconds $RetryDelaySeconds
+      }
+    }
+  }
+
+  throw ("Failed to switch Docker context to '{0}' with expected OSType '{1}' after {2} attempt(s): {3}" -f $ContextName, $ExpectedOsType, $RetryCount, $lastError.Exception.Message)
+}
+
+function Get-ImageProbeResult {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string]$ExpectedOs
+  )
+
+  $manifestOut = Invoke-DockerCommand -Arguments @('manifest', 'inspect', $Image)
+  $manifest = $manifestOut.Text | ConvertFrom-Json -Depth 30
+
+  $digest = ''
+  $platformValidated = $false
+  $manifestList = $false
+  $matchingPlatform = ''
+
+  if ($manifest -and $manifest.PSObject.Properties['manifests'] -and $manifest.manifests) {
+    $manifestList = $true
+    foreach ($entry in @($manifest.manifests)) {
+      $platform = $entry.platform
+      if (-not $platform) { continue }
+      $os = if ($platform.PSObject.Properties['os']) { [string]$platform.os } else { '' }
+      $arch = if ($platform.PSObject.Properties['architecture']) { [string]$platform.architecture } else { '' }
+      if ($os.Trim().ToLowerInvariant() -eq $ExpectedOs.Trim().ToLowerInvariant() -and $arch.Trim().ToLowerInvariant() -eq 'amd64') {
+        $platformValidated = $true
+        $matchingPlatform = ("{0}/{1}" -f $os.Trim().ToLowerInvariant(), $arch.Trim().ToLowerInvariant())
+        if ($entry.PSObject.Properties['digest']) {
+          $digest = [string]$entry.digest
+        }
+        break
+      }
+    }
+    if (-not $platformValidated) {
+      throw ("Image '{0}' does not expose platform '{1}/amd64' in manifest list." -f $Image, $ExpectedOs)
+    }
+  } else {
+    # Single-manifest tags do not expose per-platform entries.
+    $platformValidated = $true
+    if ($manifest -and $manifest.PSObject.Properties['digest']) {
+      $digest = [string]$manifest.digest
+    }
+    $matchingPlatform = ("{0}/amd64" -f $ExpectedOs.Trim().ToLowerInvariant())
+  }
+
+  return [ordered]@{
+    image = $Image
+    expectedOs = $ExpectedOs.Trim().ToLowerInvariant()
+    digest = $digest
+    manifestList = [bool]$manifestList
+    platformValidated = [bool]$platformValidated
+    matchingPlatform = $matchingPlatform
+  }
+}
+
+function Get-RepoDigestForImage {
+  param(
+    [string[]]$RepoDigests,
+    [Parameter(Mandatory)][string]$Image
+  )
+
+  foreach ($entry in @($RepoDigests)) {
+    $candidate = [string]$entry
+    if ($candidate.StartsWith("$Image@", [System.StringComparison]::OrdinalIgnoreCase)) {
+      return $candidate
+    }
+  }
+  if ($RepoDigests -and @($RepoDigests).Count -gt 0) {
+    return [string]@($RepoDigests)[0]
+  }
+  return ''
+}
+
+function Ensure-LocalImageAvailability {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [bool]$BootstrapIfMissing
+  )
+
+  $result = [ordered]@{
+    attempted = [bool]$BootstrapIfMissing
+    pulled = $false
+    imagePresent = $false
+    localImageId = ''
+    localRepoDigest = ''
+    localDigest = ''
+    pullDurationMs = 0
+    pullError = ''
+  }
+
+  $inspect = Invoke-DockerCommand -Arguments @('image', 'inspect', $Image, '--format', '{{json .}}') -IgnoreExitCode
+  if ($inspect.ExitCode -ne 0 -and $BootstrapIfMissing) {
+    $pullStart = Get-Date
+    $pull = Invoke-DockerCommand -Arguments @('pull', $Image) -IgnoreExitCode
+    $result.pullDurationMs = [int]([Math]::Round(((Get-Date) - $pullStart).TotalMilliseconds))
+    if ($pull.ExitCode -ne 0) {
+      $result.pullError = [string]$pull.Text
+      throw ("docker pull failed for '{0}' (exit={1}). Output: {2}" -f $Image, $pull.ExitCode, $pull.Text)
+    }
+    $result.pulled = $true
+    $inspect = Invoke-DockerCommand -Arguments @('image', 'inspect', $Image, '--format', '{{json .}}') -IgnoreExitCode
+  }
+
+  if ($inspect.ExitCode -ne 0) {
+    throw ("Local image inspect failed for '{0}'. Use docker pull to bootstrap and retry. Output: {1}" -f $Image, $inspect.Text)
+  }
+
+  $inspectText = $inspect.Text.Trim()
+  if ([string]::IsNullOrWhiteSpace($inspectText)) {
+    throw ("Local image inspect returned empty payload for '{0}'." -f $Image)
+  }
+
+  $inspectJson = $inspectText | ConvertFrom-Json -Depth 20
+  $repoDigests = @()
+  if ($inspectJson.PSObject.Properties['RepoDigests']) {
+    $repoDigests = @($inspectJson.RepoDigests | ForEach-Object { [string]$_ })
+  }
+  $repoDigest = Get-RepoDigestForImage -RepoDigests $repoDigests -Image $Image
+  $digest = ''
+  if ($repoDigest -match '@(?<digest>sha256:[0-9a-fA-F]+)$') {
+    $digest = [string]$Matches['digest']
+  }
+
+  $result.imagePresent = $true
+  if ($inspectJson.PSObject.Properties['Id']) {
+    $result.localImageId = [string]$inspectJson.Id
+  }
+  $result.localRepoDigest = $repoDigest
+  $result.localDigest = $digest
+
+  return $result
+}
+
+function Invoke-ContainerRuntimeProbe {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string]$ExpectedOs,
+    [Parameter(Mandatory)][string]$ProbeCommand
+  )
+
+  $args = @('run', '--rm')
+  if ($ExpectedOs -eq 'windows') {
+    $args += @('--entrypoint', 'powershell', $Image, '-NoLogo', '-NoProfile', '-Command', $ProbeCommand)
+  } else {
+    $args += @('--entrypoint', '/bin/sh', $Image, '-lc', $ProbeCommand)
+  }
+
+  $start = Get-Date
+  $probe = Invoke-DockerCommand -Arguments $args -IgnoreExitCode
+  $durationMs = [int]([Math]::Round(((Get-Date) - $start).TotalMilliseconds))
+  $text = [string]$probe.Text
+  if ($text.Length -gt 2000) {
+    $text = $text.Substring(0, 2000)
+  }
+
+  return [ordered]@{
+    attempted = $true
+    status = if ($probe.ExitCode -eq 0) { 'success' } else { 'failure' }
+    exitCode = [int]$probe.ExitCode
+    durationMs = $durationMs
+    output = $text
+    command = ($args -join ' ')
+    error = if ($probe.ExitCode -eq 0) { '' } else { $text }
+  }
+}
+
+function Should-IncludeLane {
+  param(
+    [Parameter(Mandatory)][string]$Scope,
+    [Parameter(Mandatory)][string]$Lane
+  )
+
+  $normalized = $Scope.Trim().ToLowerInvariant()
+  switch ($normalized) {
+    'both' { return $true }
+    'windows' { return ($Lane -eq 'windows') }
+    'linux' { return ($Lane -eq 'linux') }
+    default { return $false }
+  }
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+  throw 'Docker CLI not found on host. Install Docker Desktop and ensure docker.exe is available.'
+}
+
+$outputJsonResolved = Resolve-AbsolutePath -Path $OutputJsonPath
+$outputParent = Split-Path -Parent $outputJsonResolved
+if ($outputParent -and -not (Test-Path -LiteralPath $outputParent -PathType Container)) {
+  New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
+}
+
+$includeWindows = Should-IncludeLane -Scope $ProbeScope -Lane 'windows'
+$includeLinux = Should-IncludeLane -Scope $ProbeScope -Lane 'linux'
+if (-not $includeWindows -and -not $includeLinux) {
+  throw ("ProbeScope '{0}' did not resolve to any lanes." -f $ProbeScope)
+}
+
+$summary = [ordered]@{
+  schema = 'docker-runtime-manager@v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  host = [ordered]@{
+    machineName = $env:COMPUTERNAME
+    runnerName = $env:RUNNER_NAME
+    userName = $env:USERNAME
+    osVersion = [System.Environment]::OSVersion.VersionString
+    platform = [string][System.Environment]::OSVersion.Platform
+  }
+  settings = [ordered]@{
+    windowsImage = $WindowsImage
+    linuxImage = $LinuxImage
+    windowsContext = $WindowsContext
+    linuxContext = $LinuxContext
+    restoreContext = $RestoreContext
+    restoreExpectedOs = ''
+    probeScope = $ProbeScope
+    bootstrapWindowsImage = [bool]$BootstrapWindowsImage
+    bootstrapLinuxImage = [bool]$BootstrapLinuxImage
+    windowsProbeCommand = $WindowsProbeCommand
+    linuxProbeCommand = $LinuxProbeCommand
+    switchTimeoutSeconds = [int]$SwitchTimeoutSeconds
+    switchRetryCount = [int]$SwitchRetryCount
+    switchRetryDelaySeconds = [int]$SwitchRetryDelaySeconds
+    lockWaitSeconds = [int]$LockWaitSeconds
+  }
+  lock = [ordered]@{
+    path = ''
+    acquired = $false
+    acquiredAtUtc = ''
+  }
+  contexts = [ordered]@{
+    start = ''
+    startOsType = ''
+    final = ''
+    finalOsType = ''
+  }
+  probes = [ordered]@{
+    windows = [ordered]@{
+      enabled = [bool]$includeWindows
+      status = if ($includeWindows) { 'pending' } else { 'skipped' }
+      context = $WindowsContext
+      osType = ''
+      image = $WindowsImage
+      digest = ''
+      matchingPlatform = ''
+      attempts = 0
+      error = ''
+      bootstrap = [ordered]@{
+        attempted = $false
+        pulled = $false
+        imagePresent = $false
+        localImageId = ''
+        localRepoDigest = ''
+        localDigest = ''
+        pullDurationMs = 0
+        pullError = ''
+      }
+      probe = [ordered]@{
+        attempted = $false
+        status = 'not-run'
+        exitCode = -1
+        durationMs = 0
+        output = ''
+        command = ''
+        error = ''
+      }
+    }
+    linux = [ordered]@{
+      enabled = [bool]$includeLinux
+      status = if ($includeLinux) { 'pending' } else { 'skipped' }
+      context = $LinuxContext
+      osType = ''
+      image = $LinuxImage
+      digest = ''
+      matchingPlatform = ''
+      attempts = 0
+      error = ''
+      bootstrap = [ordered]@{
+        attempted = $false
+        pulled = $false
+        imagePresent = $false
+        localImageId = ''
+        localRepoDigest = ''
+        localDigest = ''
+        pullDurationMs = 0
+        pullError = ''
+      }
+      probe = [ordered]@{
+        attempted = $false
+        status = 'not-run'
+        exitCode = -1
+        durationMs = 0
+        output = ''
+        command = ''
+        error = ''
+      }
+    }
+  }
+  status = 'failure'
+  failureClass = 'preflight'
+  failureMessage = ''
+  durationMs = 0
+}
+
+$runStart = Get-Date
+$lockStream = $null
+$caught = $null
+$restoreExpectedOs = if ([string]::Equals($RestoreContext, $LinuxContext, [System.StringComparison]::OrdinalIgnoreCase)) { 'linux' } else { 'windows' }
+$summary.settings.restoreExpectedOs = $restoreExpectedOs
+
+try {
+  $runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { [System.IO.Path]::GetTempPath() } else { $env:RUNNER_TEMP }
+  $lockPath = Join-Path $runnerTemp 'docker-runtime-manager\engine-switch.lock'
+  $summary.lock.path = $lockPath
+  $lockStream = Acquire-LockStream -LockPath $lockPath -WaitSeconds $LockWaitSeconds
+  $summary.lock.acquired = $true
+  $summary.lock.acquiredAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+
+  $contextStart = ''
+  try {
+    $contextStart = (Invoke-DockerCommand -Arguments @('context', 'show')).Text.Trim()
+  } catch {
+    $contextStart = 'unknown'
+  }
+  if ([string]::IsNullOrWhiteSpace($contextStart)) { $contextStart = 'unknown' }
+  $summary.contexts.start = $contextStart
+
+  try {
+    $startOsProbe = Invoke-DockerCommand -Arguments @('info', '--format', '{{.OSType}}') -IgnoreExitCode
+    if ($startOsProbe.ExitCode -eq 0) {
+      $summary.contexts.startOsType = $startOsProbe.Text.Trim().ToLowerInvariant()
+    }
+  } catch {}
+
+  if ($includeWindows) {
+    $windowsSwitch = Set-ContextAndWait `
+      -ContextName $WindowsContext `
+      -ExpectedOsType 'windows' `
+      -TimeoutSeconds $SwitchTimeoutSeconds `
+      -RetryCount $SwitchRetryCount `
+      -RetryDelaySeconds $SwitchRetryDelaySeconds
+
+    $summary.probes.windows.status = 'success'
+    $summary.probes.windows.osType = [string]$windowsSwitch.OsType
+    $summary.probes.windows.attempts = [int]$windowsSwitch.Attempt
+
+    $windowsManifest = Get-ImageProbeResult -Image $WindowsImage -ExpectedOs 'windows'
+    $summary.probes.windows.digest = [string]$windowsManifest.digest
+    $summary.probes.windows.matchingPlatform = [string]$windowsManifest.matchingPlatform
+
+    $windowsBootstrap = Ensure-LocalImageAvailability -Image $WindowsImage -BootstrapIfMissing:$BootstrapWindowsImage
+    $summary.probes.windows.bootstrap.attempted = [bool]$windowsBootstrap.attempted
+    $summary.probes.windows.bootstrap.pulled = [bool]$windowsBootstrap.pulled
+    $summary.probes.windows.bootstrap.imagePresent = [bool]$windowsBootstrap.imagePresent
+    $summary.probes.windows.bootstrap.localImageId = [string]$windowsBootstrap.localImageId
+    $summary.probes.windows.bootstrap.localRepoDigest = [string]$windowsBootstrap.localRepoDigest
+    $summary.probes.windows.bootstrap.localDigest = [string]$windowsBootstrap.localDigest
+    $summary.probes.windows.bootstrap.pullDurationMs = [int]$windowsBootstrap.pullDurationMs
+    $summary.probes.windows.bootstrap.pullError = [string]$windowsBootstrap.pullError
+
+    $windowsProbe = Invoke-ContainerRuntimeProbe -Image $WindowsImage -ExpectedOs 'windows' -ProbeCommand $WindowsProbeCommand
+    $summary.probes.windows.probe = $windowsProbe
+    if ([string]$windowsProbe.status -ne 'success') {
+      throw ("Runtime probe failed for Windows image '{0}' (exit={1})." -f $WindowsImage, [int]$windowsProbe.exitCode)
+    }
+  }
+
+  if ($includeLinux) {
+    $linuxSwitch = Set-ContextAndWait `
+      -ContextName $LinuxContext `
+      -ExpectedOsType 'linux' `
+      -TimeoutSeconds $SwitchTimeoutSeconds `
+      -RetryCount $SwitchRetryCount `
+      -RetryDelaySeconds $SwitchRetryDelaySeconds
+
+    $summary.probes.linux.status = 'success'
+    $summary.probes.linux.osType = [string]$linuxSwitch.OsType
+    $summary.probes.linux.attempts = [int]$linuxSwitch.Attempt
+
+    $linuxManifest = Get-ImageProbeResult -Image $LinuxImage -ExpectedOs 'linux'
+    $summary.probes.linux.digest = [string]$linuxManifest.digest
+    $summary.probes.linux.matchingPlatform = [string]$linuxManifest.matchingPlatform
+
+    $linuxBootstrap = Ensure-LocalImageAvailability -Image $LinuxImage -BootstrapIfMissing:$BootstrapLinuxImage
+    $summary.probes.linux.bootstrap.attempted = [bool]$linuxBootstrap.attempted
+    $summary.probes.linux.bootstrap.pulled = [bool]$linuxBootstrap.pulled
+    $summary.probes.linux.bootstrap.imagePresent = [bool]$linuxBootstrap.imagePresent
+    $summary.probes.linux.bootstrap.localImageId = [string]$linuxBootstrap.localImageId
+    $summary.probes.linux.bootstrap.localRepoDigest = [string]$linuxBootstrap.localRepoDigest
+    $summary.probes.linux.bootstrap.localDigest = [string]$linuxBootstrap.localDigest
+    $summary.probes.linux.bootstrap.pullDurationMs = [int]$linuxBootstrap.pullDurationMs
+    $summary.probes.linux.bootstrap.pullError = [string]$linuxBootstrap.pullError
+
+    $linuxProbe = Invoke-ContainerRuntimeProbe -Image $LinuxImage -ExpectedOs 'linux' -ProbeCommand $LinuxProbeCommand
+    $summary.probes.linux.probe = $linuxProbe
+    if ([string]$linuxProbe.status -ne 'success') {
+      throw ("Runtime probe failed for Linux image '{0}' (exit={1})." -f $LinuxImage, [int]$linuxProbe.exitCode)
+    }
+  }
+
+  $summary.status = 'success'
+  $summary.failureClass = 'none'
+  $summary.failureMessage = ''
+} catch {
+  $caught = $_
+  $message = $_.Exception.Message
+  $summary.status = 'failure'
+  if ($message -match '(?i)failed to switch docker context|did not reach expected ostype|docker engine switch|timed out waiting for docker manager lock') {
+    $summary.failureClass = 'runtime-determinism'
+  } elseif ($message -match '(?i)docker pull failed|local image inspect failed') {
+    $summary.failureClass = 'image-bootstrap'
+  } elseif ($message -match '(?i)runtime probe failed') {
+    $summary.failureClass = 'runtime-probe'
+  } else {
+    $summary.failureClass = 'preflight'
+  }
+  $summary.failureMessage = $message
+
+  if ($includeWindows -and $summary.probes.windows.status -eq 'pending') {
+    $summary.probes.windows.status = 'failure'
+    $summary.probes.windows.error = $message
+  } elseif ($includeLinux -and $summary.probes.linux.status -eq 'pending') {
+    $summary.probes.linux.status = 'failure'
+    $summary.probes.linux.error = $message
+  }
+} finally {
+  try {
+    $restored = Set-ContextAndWait `
+      -ContextName $RestoreContext `
+      -ExpectedOsType $restoreExpectedOs `
+      -TimeoutSeconds ([Math]::Min($SwitchTimeoutSeconds, 120)) `
+      -RetryCount $SwitchRetryCount `
+      -RetryDelaySeconds $SwitchRetryDelaySeconds
+    $summary.contexts.final = [string]$restored.Context
+    $summary.contexts.finalOsType = [string]$restored.OsType
+  } catch {
+    if ($summary.status -eq 'success') {
+      $summary.status = 'failure'
+      $summary.failureClass = 'runtime-determinism'
+      $summary.failureMessage = ("Failed to restore Docker context '{0}': {1}" -f $RestoreContext, $_.Exception.Message)
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$summary.contexts.final)) {
+      $summary.contexts.final = 'unknown'
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$summary.contexts.finalOsType)) {
+      $summary.contexts.finalOsType = 'unknown'
+    }
+  }
+
+  if ($lockStream) {
+    $lockStream.Dispose()
+    $lockStream = $null
+  }
+
+  $summary.durationMs = [int]([Math]::Round(((Get-Date) - $runStart).TotalMilliseconds))
+  ($summary | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $outputJsonResolved -Encoding utf8
+
+  $windowsDigestOut = if (-not [string]::IsNullOrWhiteSpace([string]$summary.probes.windows.bootstrap.localDigest)) {
+    [string]$summary.probes.windows.bootstrap.localDigest
+  } else {
+    [string]$summary.probes.windows.digest
+  }
+  $linuxDigestOut = if (-not [string]::IsNullOrWhiteSpace([string]$summary.probes.linux.bootstrap.localDigest)) {
+    [string]$summary.probes.linux.bootstrap.localDigest
+  } else {
+    [string]$summary.probes.linux.digest
+  }
+
+  Write-GitHubOutput -Key 'manager_status' -Value ([string]$summary.status) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'manager_summary_path' -Value $outputJsonResolved -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'windows_image_digest' -Value $windowsDigestOut -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'linux_image_digest' -Value $linuxDigestOut -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'start_context' -Value ([string]$summary.contexts.start) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'final_context' -Value ([string]$summary.contexts.final) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'windows_bootstrap_status' -Value ([string]$summary.probes.windows.bootstrap.imagePresent).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'linux_bootstrap_status' -Value ([string]$summary.probes.linux.bootstrap.imagePresent).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'windows_probe_status' -Value ([string]$summary.probes.windows.probe.status) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'linux_probe_status' -Value ([string]$summary.probes.linux.probe.status) -Path $GitHubOutputPath
+
+  if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+    $lines = @(
+      '### Docker Runtime Manager',
+      '',
+      ('- status: `{0}`' -f [string]$summary.status),
+      ('- start context: `{0}` (`{1}`)' -f [string]$summary.contexts.start, [string]$summary.contexts.startOsType),
+      ('- final context: `{0}` (`{1}`)' -f [string]$summary.contexts.final, [string]$summary.contexts.finalOsType),
+      ('- windows image: `{0}` manifestDigest=`{1}` localDigest=`{2}` pulled=`{3}` probe=`{4}`' -f [string]$summary.probes.windows.image, [string]$summary.probes.windows.digest, [string]$summary.probes.windows.bootstrap.localDigest, [bool]$summary.probes.windows.bootstrap.pulled, [string]$summary.probes.windows.probe.status),
+      ('- linux image: `{0}` manifestDigest=`{1}` localDigest=`{2}` pulled=`{3}` probe=`{4}`' -f [string]$summary.probes.linux.image, [string]$summary.probes.linux.digest, [string]$summary.probes.linux.bootstrap.localDigest, [bool]$summary.probes.linux.bootstrap.pulled, [string]$summary.probes.linux.probe.status),
+      ('- summary json: `{0}`' -f $outputJsonResolved)
+    )
+    if ($summary.status -ne 'success' -and -not [string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+      $lines += ('- failure class: `{0}`' -f [string]$summary.failureClass)
+      $lines += ('- failure: {0}' -f [string]$summary.failureMessage)
+    }
+    $stepSummaryResolved = Resolve-AbsolutePath -Path $StepSummaryPath
+    $stepSummaryParent = Split-Path -Parent $stepSummaryResolved
+    if ($stepSummaryParent -and -not (Test-Path -LiteralPath $stepSummaryParent -PathType Container)) {
+      New-Item -ItemType Directory -Path $stepSummaryParent -Force | Out-Null
+    }
+    $lines -join "`n" | Out-File -FilePath $stepSummaryResolved -Append -Encoding utf8
+  }
+}
+
+if ($caught -or $summary.status -ne 'success') {
+  if ($caught) { throw $caught }
+  throw ("Docker runtime manager failed: {0}" -f [string]$summary.failureMessage)
+}
+
+Write-Output $outputJsonResolved

--- a/tools/Update-FixtureDriftSessionIndex.ps1
+++ b/tools/Update-FixtureDriftSessionIndex.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Attaches Docker runtime manager metadata to fixture-drift session-index.json.
+#>
+[CmdletBinding()]
+param(
+  [string]$ResultsDir = 'results/fixture-drift',
+  [string]$SessionIndexPath = '',
+  [string]$ContextPath = '',
+  [string]$RuntimeSnapshotPath = '',
+  [string]$RequiredLabel = 'self-hosted-docker',
+  [bool]$HasRequiredLabel = $false,
+  [string]$RunnerLabelsCsv = '',
+  [string]$ManagerStatus = '',
+  [string]$ManagerSummaryPath = '',
+  [string]$WindowsImageDigest = '',
+  [string]$LinuxImageDigest = '',
+  [string]$StartContext = '',
+  [string]$FinalContext = '',
+  [switch]$IgnoreMissingSessionIndex
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+$resultsResolved = Resolve-AbsolutePath -Path $ResultsDir
+$sessionPathResolved = if ([string]::IsNullOrWhiteSpace($SessionIndexPath)) {
+  Join-Path $resultsResolved 'session-index.json'
+} else {
+  Resolve-AbsolutePath -Path $SessionIndexPath
+}
+$contextPathResolved = if ([string]::IsNullOrWhiteSpace($ContextPath)) {
+  Join-Path $resultsResolved 'docker-runtime-manager-context.json'
+} else {
+  Resolve-AbsolutePath -Path $ContextPath
+}
+$runtimeSnapshotPathResolved = if ([string]::IsNullOrWhiteSpace($RuntimeSnapshotPath)) {
+  Join-Path $resultsResolved 'windows-runtime-determinism.json'
+} else {
+  Resolve-AbsolutePath -Path $RuntimeSnapshotPath
+}
+
+if (-not (Test-Path -LiteralPath $sessionPathResolved -PathType Leaf)) {
+  if ($IgnoreMissingSessionIndex) {
+    Write-Host ("::warning::session-index.json not found at {0}; docker manager metadata was not attached." -f $sessionPathResolved)
+    return
+  }
+  throw ("session-index.json not found: {0}" -f $sessionPathResolved)
+}
+
+$labels = @()
+if (-not [string]::IsNullOrWhiteSpace($RunnerLabelsCsv)) {
+  $labels = @($RunnerLabelsCsv -split ',' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+$index = Get-Content -LiteralPath $sessionPathResolved -Raw | ConvertFrom-Json -Depth 30
+if (-not $index.PSObject.Properties['runContext'] -or $null -eq $index.runContext) {
+  $index | Add-Member -MemberType NoteProperty -Name 'runContext' -Value ([ordered]@{}) -Force
+}
+
+$index.runContext.dockerRuntimeManager = [ordered]@{
+  status = [string]$ManagerStatus
+  summaryPath = [string]$ManagerSummaryPath
+  windowsImageDigest = [string]$WindowsImageDigest
+  linuxImageDigest = [string]$LinuxImageDigest
+  startContext = [string]$StartContext
+  finalContext = [string]$FinalContext
+  contextArtifactPath = if (Test-Path -LiteralPath $contextPathResolved -PathType Leaf) { $contextPathResolved } else { '' }
+  runtimeSnapshotPath = if (Test-Path -LiteralPath $runtimeSnapshotPathResolved -PathType Leaf) { $runtimeSnapshotPathResolved } else { '' }
+}
+$index.runContext.runnerLabelContract = [ordered]@{
+  requiredLabel = [string]$RequiredLabel
+  hasRequiredLabel = [bool]$HasRequiredLabel
+  labels = @($labels)
+}
+
+($index | ConvertTo-Json -Depth 30) | Set-Content -LiteralPath $sessionPathResolved -Encoding utf8
+Write-Output $sessionPathResolved

--- a/tools/Write-FixtureDriftSummary.ps1
+++ b/tools/Write-FixtureDriftSummary.ps1
@@ -5,7 +5,8 @@
 [CmdletBinding()]
 param(
   [string]$Dir = 'results/fixture-drift',
-  [string]$SummaryFile = 'drift-summary.json'
+  [string]$SummaryFile = 'drift-summary.json',
+  [string]$DockerRuntimeManagerContextFile = 'docker-runtime-manager-context.json'
 )
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -32,10 +33,10 @@ function AddCounts($obj){
     $lines += ('- {0}: {1}' -f $k,$v)
   }
 }
-if ($json.summaryCounts) { AddCounts $json.summaryCounts }
-elseif ($json.counts) { AddCounts $json.counts }
+if ($json.PSObject.Properties['summaryCounts'] -and $json.summaryCounts) { AddCounts $json.summaryCounts }
+elseif ($json.PSObject.Properties['counts'] -and $json.counts) { AddCounts $json.counts }
 
-if ($json.notes) {
+if ($json.PSObject.Properties['notes'] -and $json.notes) {
   $n = $json.notes
   if ($n -is [array]) { foreach ($x in $n) { $lines += ('- Note: {0}' -f $x) } }
   else { $lines += ('- Note: {0}' -f $n) }
@@ -108,5 +109,30 @@ try {
     if ($hsLines.Count -gt 0) { $lines += ''; $lines += $hsLines }
   }
 } catch {}
+
+$dockerContextPath = if ([System.IO.Path]::IsPathRooted($DockerRuntimeManagerContextFile)) {
+  $DockerRuntimeManagerContextFile
+} elseif ([string]::IsNullOrWhiteSpace($Dir)) {
+  $DockerRuntimeManagerContextFile
+} else {
+  Join-Path $Dir $DockerRuntimeManagerContextFile
+}
+if (Test-Path -LiteralPath $dockerContextPath -PathType Leaf) {
+  try {
+    $dockerContext = Get-Content -LiteralPath $dockerContextPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $manager = if ($dockerContext.PSObject.Properties['manager']) { $dockerContext.manager } else { $dockerContext }
+    $lines += ''
+    $lines += '- Docker Runtime Manager:'
+    if ($manager.PSObject.Properties['status']) { $lines += ('  - Status: {0}' -f $manager.status) }
+    if ($manager.PSObject.Properties['startContext']) { $lines += ('  - Start Context: {0}' -f $manager.startContext) }
+    if ($manager.PSObject.Properties['finalContext']) { $lines += ('  - Final Context: {0}' -f $manager.finalContext) }
+    if ($manager.PSObject.Properties['windowsImageDigest']) { $lines += ('  - Windows Digest: {0}' -f $manager.windowsImageDigest) }
+    if ($manager.PSObject.Properties['linuxImageDigest']) { $lines += ('  - Linux Digest: {0}' -f $manager.linuxImageDigest) }
+    if ($manager.PSObject.Properties['summaryPath'] -and $manager.summaryPath) { $lines += ('  - Summary Path: {0}' -f $manager.summaryPath) }
+    $lines += ('  - Context JSON: {0}' -f $dockerContextPath)
+  } catch {
+    $lines += ('- Docker Runtime Manager context parse failed: {0}' -f $dockerContextPath)
+  }
+}
 
 $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8


### PR DESCRIPTION
## Summary
Batch 1 origin -> upstream alignment for issue #155.

- Mirrors fixture-drift runtime contract files from `origin/develop` into upstream.
- Keeps scope to workflow/runtime + tests only.

## Included
- `.github/workflows/fixture-drift.yml`
- `tools/Invoke-DockerRuntimeManager.ps1`
- `tools/Assert-RunnerLabelContract.ps1`
- `tools/Update-FixtureDriftSessionIndex.ps1`
- `tools/Write-FixtureDriftSummary.ps1`
- matching tests for all above scripts

## Validation
- `Invoke-PesterTests.ps1 -IncludePatterns Assert-RunnerLabelContract.Tests.ps1`
- `Invoke-PesterTests.ps1 -IncludePatterns Invoke-DockerRuntimeManager.Tests.ps1`
- `Invoke-PesterTests.ps1 -IncludePatterns Update-FixtureDriftSessionIndex.Tests.ps1`
- `Invoke-PesterTests.ps1 -IncludePatterns Write-FixtureDriftSummary.Tests.ps1`
- `tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Refs: #155
