### PR TITLE
Alignment batch 2: VI history compare runtime contracts

### DIFF
--- a/.github/workflows/pr-vi-history.yml
+++ b/.github/workflows/pr-vi-history.yml
@@ -24,9 +24,9 @@ on:
         required: false
         default: '10'
       compare_timeout_seconds:
-        description: 'Per-compare timeout in seconds passed to history compare (default 900)'
+        description: 'Per-compare timeout in seconds passed to history compare (default 600)'
         required: false
-        default: '900'
+        default: '600'
       labview_path:
         description: 'LabVIEW.exe path used by headless compare operations'
         required: false
@@ -56,7 +56,7 @@ jobs:
       NOTE: ${{ inputs.note }}
       MAX_PAIRS: ${{ inputs.max_pairs || '6' }}
       FETCH_DEPTH: ${{ github.event.inputs.fetch_depth || '20' }}
-      COMPARE_TIMEOUT_SECONDS: ${{ github.event.inputs.compare_timeout_seconds || '900' }}
+      COMPARE_TIMEOUT_SECONDS: ${{ github.event.inputs.compare_timeout_seconds || '600' }}
       LABVIEW_PATH: ${{ github.event.inputs.labview_path || 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe' }}
     steps:
       - name: Resolve pull request metadata

--- a/.github/workflows/vi-compare-fork.yml
+++ b/.github/workflows/vi-compare-fork.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: vi-compare-fork-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-and-compare:
     name: Compare Changed VIs
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
     permissions:
       contents: read
       actions: read
@@ -18,12 +22,29 @@ jobs:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       FETCH_DEPTH: 20
+      NI_WINDOWS_IMAGE: nationalinstruments/labview:2026q1-windows
+      COMPARE_TIMEOUT_SECONDS: 600
     steps:
       - name: Checkout base (parent repository)
         uses: actions/checkout@v4
         with:
           ref: ${{ env.BASE_SHA }}
           fetch-depth: 0
+
+      - name: Assert self-hosted-docker runner label
+        id: runner_label_contract
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 `
+            -Repository '${{ github.repository }}' `
+            -RunId '${{ github.run_id }}' `
+            -RunnerName '${{ runner.name }}' `
+            -RequiredLabel 'self-hosted-docker' `
+            -OutputJsonPath 'results/vi-compare-fork/runner-label-contract.json' `
+            -GitHubOutputPath $env:GITHUB_OUTPUT `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY
 
       - name: Checkout PR head
         shell: pwsh
@@ -39,6 +60,13 @@ jobs:
           $fetchDepth = if ($env:FETCH_DEPTH) { [int]$env:FETCH_DEPTH } else { 20 }
           git fetch --no-tags --depth=$fetchDepth origin ("pull/{0}/head:pr-{0}-head" -f $env:PR_NUMBER)
           git checkout --detach ("pr-{0}-head" -f $env:PR_NUMBER)
+          $checkedOutHead = (git rev-parse HEAD).Trim()
+          if (-not $checkedOutHead) {
+            throw 'Unable to resolve checked out PR head SHA.'
+          }
+          if ($checkedOutHead -ne "${{ env.HEAD_SHA }}") {
+            throw ("PR head SHA mismatch. Expected {0} but checked out {1}." -f "${{ env.HEAD_SHA }}", $checkedOutHead)
+          }
           git branch -D ("pr-{0}-head" -f $env:PR_NUMBER) 2>$null | Out-Null
 
       - name: Generate VI manifest
@@ -58,10 +86,13 @@ jobs:
 
           if ($pairCount -eq 0) {
             Write-Host '::notice::No VI changes detected between base/head; skipping staging.'
+            "manifest_path=$manifestPath" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
             "has_pairs=false" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+            "pair_count=0" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
             exit 0
           }
 
+          "manifest_path=$manifestPath" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
           "has_pairs=true" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
           "pair_count=$pairCount" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
 
@@ -86,23 +117,184 @@ jobs:
             Write-Host '::warning::Found VI manifest entries but none were stageable (missing files?).'
             "compare_dir=" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
             "compare_json=" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+            "summary_json=" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+            "summary_md=" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+            "summary_html=" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
             exit 0
           }
 
           $stagedPairs | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $resultsPath -Encoding UTF8
 
+          $containerCompareScript = Join-Path $repoRoot 'tools' 'Run-NIWindowsContainerCompare.ps1'
+          if (-not (Test-Path -LiteralPath $containerCompareScript -PathType Leaf)) {
+            throw "Container compare script not found: $containerCompareScript"
+          }
+
+          $image = [string]$env:NI_WINDOWS_IMAGE
+          if ([string]::IsNullOrWhiteSpace($image)) {
+            throw 'NI_WINDOWS_IMAGE is not set.'
+          }
+          & docker image inspect $image *> $null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host ("Image not present locally; pulling {0}" -f $image)
+            & docker pull $image
+            if ($LASTEXITCODE -ne 0) {
+              throw ("Failed to pull image: {0}" -f $image)
+            }
+          }
+
+          $invokeContainerCompare = {
+            param(
+              [string]$BaseVi,
+              [string]$HeadVi,
+              [string]$OutputDir,
+              [switch]$AllowSameLeaf,
+              [switch]$RenderReport,
+              [string[]]$Flags,
+              [switch]$ReplaceFlags,
+              [ValidateSet('full','legacy')]
+              [string]$NoiseProfile = 'full',
+              [Nullable[int]]$TimeoutSeconds
+            )
+
+            $reportPath = Join-Path $OutputDir 'compare-report.html'
+            $runtimeSnapshotPath = Join-Path $OutputDir 'runtime-determinism.json'
+            $effectiveTimeout = if ($TimeoutSeconds -and $TimeoutSeconds -gt 0) { [int]$TimeoutSeconds } else { [int]$env:COMPARE_TIMEOUT_SECONDS }
+
+            $args = @(
+              '-NoLogo', '-NoProfile',
+              '-File', $containerCompareScript,
+              '-BaseVi', $BaseVi,
+              '-HeadVi', $HeadVi,
+              '-Image', $env:NI_WINDOWS_IMAGE,
+              '-ReportPath', $reportPath,
+              '-ReportType', 'html',
+              '-RuntimeSnapshotPath', $runtimeSnapshotPath,
+              '-TimeoutSeconds', [string]$effectiveTimeout
+            )
+            if ($Flags) {
+              $args += '-Flags'
+              $args += $Flags
+            }
+
+            $output = & pwsh @args 2>&1
+            if ($output) {
+              $output | ForEach-Object { Write-Host $_ }
+            }
+
+            $capturePath = Join-Path $OutputDir 'ni-windows-container-capture.json'
+            [pscustomobject]@{
+              ExitCode    = $LASTEXITCODE
+              ReportPath  = $reportPath
+              CapturePath = $(if (Test-Path -LiteralPath $capturePath -PathType Leaf) { $capturePath } else { $null })
+            }
+          }.GetNewClosure()
+
           $compareScript = Join-Path $repoRoot 'tools' 'Run-StagedLVCompare.ps1'
-          & $compareScript -ResultsPath $resultsPath -ArtifactsDir $artifactsDir -RenderReport | Out-Null
+          & $compareScript -ResultsPath $resultsPath -ArtifactsDir $artifactsDir -RenderReport -InvokeLVCompare $invokeContainerCompare | Out-Null
+
+          $compareJsonPath = Join-Path $artifactsDir 'vi-staging-compare.json'
+          if (-not (Test-Path -LiteralPath $compareJsonPath -PathType Leaf)) {
+            throw "Compare output JSON not found: $compareJsonPath"
+          }
 
           $summaryScript = Join-Path $repoRoot 'tools' 'Summarize-VIStaging.ps1'
           $summaryPath = Join-Path $artifactsDir 'vi-compare-summary.md'
-          & $summaryScript -CompareJson (Join-Path $artifactsDir 'vi-staging-compare.json') -MarkdownPath $summaryPath -SummaryJsonPath (Join-Path $artifactsDir 'vi-compare-summary.json') | Out-Null
+          $summaryJsonPath = Join-Path $artifactsDir 'vi-compare-summary.json'
+          $summaryHtmlPath = Join-Path $artifactsDir 'vi-compare-summary.html'
+          & $summaryScript -CompareJson $compareJsonPath -MarkdownPath $summaryPath -SummaryJsonPath $summaryJsonPath -HtmlPath $summaryHtmlPath | Out-Null
+          if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+            throw "Summary markdown not found: $summaryPath"
+          }
+          if (-not (Test-Path -LiteralPath $summaryJsonPath -PathType Leaf)) {
+            throw "Summary JSON not found: $summaryJsonPath"
+          }
+          if (-not (Test-Path -LiteralPath $summaryHtmlPath -PathType Leaf)) {
+            throw "Summary HTML not found: $summaryHtmlPath"
+          }
+
+          "compare_dir=$artifactsDir" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+          "compare_json=$compareJsonPath" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+          "summary_json=$summaryJsonPath" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+          "summary_md=$summaryPath" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+          "summary_html=$summaryHtmlPath" | Out-File -FilePath $ENV:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Validate compare contract
+        if: steps.compare.outputs.compare_json != ''
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $compareJsonPath = "${{ steps.compare.outputs.compare_json }}"
+          $summaryJsonPath = "${{ steps.compare.outputs.summary_json }}"
+          $summaryMarkdownPath = "${{ steps.compare.outputs.summary_md }}"
+          $summaryHtmlPath = "${{ steps.compare.outputs.summary_html }}"
+
+          if (-not (Test-Path -LiteralPath $compareJsonPath -PathType Leaf)) {
+            throw "Compare JSON missing: $compareJsonPath"
+          }
+          if (-not (Test-Path -LiteralPath $summaryJsonPath -PathType Leaf)) {
+            throw "Summary JSON missing: $summaryJsonPath"
+          }
+          if (-not (Test-Path -LiteralPath $summaryMarkdownPath -PathType Leaf)) {
+            throw "Summary markdown missing: $summaryMarkdownPath"
+          }
+          if (-not (Test-Path -LiteralPath $summaryHtmlPath -PathType Leaf)) {
+            throw "Summary HTML missing: $summaryHtmlPath"
+          }
+
+          $compare = Get-Content -LiteralPath $compareJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
+          if (-not $compare) {
+            throw "Compare JSON is empty: $compareJsonPath"
+          }
+          $items = @($compare)
+          if ($items.Count -eq 0) {
+            throw "Compare JSON did not contain any staged compare entries: $compareJsonPath"
+          }
+
+          $missingStatus = @($items | Where-Object { -not $_.status })
+          if ($missingStatus.Count -gt 0) {
+            throw ("Compare JSON contains entries without status: {0}" -f $compareJsonPath)
+          }
+
+      - name: Emit compare summary
+        if: always()
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $manifestPath = "${{ steps.manifest.outputs.manifest_path }}"
+          $pairCount = "${{ steps.manifest.outputs.pair_count }}"
+          $compareJsonPath = "${{ steps.compare.outputs.compare_json }}"
+          $summaryMarkdownPath = "${{ steps.compare.outputs.summary_md }}"
+          $summaryHtmlPath = "${{ steps.compare.outputs.summary_html }}"
+          $out = New-Object System.Collections.Generic.List[string]
+          $out.Add("## VI Compare (Fork PR)") | Out-Null
+          $out.Add("- Manifest: $manifestPath") | Out-Null
+          $out.Add("- Manifest pairs: $pairCount") | Out-Null
+          if ($compareJsonPath) {
+            $out.Add("- Compare JSON: $compareJsonPath") | Out-Null
+          } else {
+            $out.Add("- Compare JSON: (not produced)") | Out-Null
+          }
+          if ($summaryMarkdownPath) {
+            $out.Add("- Summary markdown: $summaryMarkdownPath") | Out-Null
+          } else {
+            $out.Add("- Summary markdown: (not produced)") | Out-Null
+          }
+          if ($summaryHtmlPath) {
+            $out.Add("- Summary HTML: $summaryHtmlPath") | Out-Null
+          } else {
+            $out.Add("- Summary HTML: (not produced)") | Out-Null
+          }
+          $out -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
       - name: Upload VI compare artifacts
-        if: steps.compare.outputs.compare_dir != ''
-        uses: actions/upload-artifact@v4
+        if: always() && steps.compare.outputs.compare_dir != ''
+        uses: actions/upload-artifact@v5
         with:
           name: vi-compare-${{ github.run_id }}
           path: |
             ${{ steps.compare.outputs.compare_dir }}
             vi-diff-manifest.json
+            results/vi-compare-fork/runner-label-contract.json

--- a/tests/Invoke-PRVIHistory.Tests.ps1
+++ b/tests/Invoke-PRVIHistory.Tests.ps1
@@ -113,10 +113,14 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $target.status | Should -Be 'completed'
         $target.stats.processed | Should -Be 3
         $target.stats.diffs | Should -Be 1
+        $target.stats.durationSeconds | Should -Be 0
+        $target.stats.durationSamples | Should -Be 0
         $target.reportImages.status | Should -Be 'completed'
         $target.reportImages.exportedImageCount | Should -Be 1
         $target.reportImages.sourceImageCount | Should -Be 1
         Test-Path -LiteralPath $target.reportImages.indexPath -PathType Leaf | Should -BeTrue
+        $result.totals.durationSeconds | Should -Be 0
+        $result.totals.durationSamples | Should -Be 0
 
         Test-Path -LiteralPath $result.resultsRoot -PathType Container | Should -BeTrue
         Test-Path -LiteralPath $result.targets[0].manifest -PathType Leaf | Should -BeTrue
@@ -201,6 +205,8 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $result.targets | Should -Not -BeNullOrEmpty
         $result.targets[0].status | Should -Be 'completed'
         $result.targets[0].stats.processed | Should -Be 2
+        $result.targets[0].stats.durationSeconds | Should -Be 0
+        $result.targets[0].stats.durationSamples | Should -Be 0
         $result.targets[0].reportImages.status | Should -Be 'no-html-report'
         $result.targets[0].reportImages.exportedImageCount | Should -Be 0
 
@@ -406,7 +412,12 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $result.targets[0].commitPairs[1].classification | Should -Be 'noise-masscompile'
         $result.targets[0].timing.totalSeconds | Should -Be 4
         $result.targets[0].timing.medianSeconds | Should -Be 2
+        $result.targets[0].stats.durationSeconds | Should -Be 4
+        $result.targets[0].stats.durationSamples | Should -Be 2
+        $result.targets[0].stats.durationAvgSeconds | Should -Be 2
         $result.totals.timing.totalSeconds | Should -Be 4
+        $result.totals.durationSeconds | Should -Be 4
+        $result.totals.durationSamples | Should -Be 2
         $result.estimatedCompareTime.seconds | Should -Be 2
         $result.kpi.signalRecall | Should -Be 0.5
         $result.kpi.noisePrecisionMasscompile | Should -Be 1

--- a/tests/Summarize-PRVIHistory.Tests.ps1
+++ b/tests/Summarize-PRVIHistory.Tests.ps1
@@ -85,8 +85,11 @@ Describe 'Summarize-PRVIHistory.ps1' {
                     status      = 'completed'
                     changeTypes = @('modified','renamed')
                     stats       = [ordered]@{
-                        processed = 4
-                        diffs     = 2
+                        processed          = 4
+                        diffs              = 2
+                        durationSeconds    = 12.5
+                        durationSamples    = 4
+                        durationAvgSeconds = 3.125
                     }
                     reportMd   = $reportMd
                     reportHtml = $reportHtml
@@ -124,6 +127,8 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.totals.diffPairRows | Should -Be 1
         $result.totals.previewImages | Should -Be 1
         $result.totals.markdownTruncated | Should -BeFalse
+        $result.totals.durationSeconds | Should -Be 12.5
+        $result.totals.durationSamples | Should -Be 4
         $result.totals.timing.totalSeconds | Should -Be 3.75
         $result.kpi.signalRecall | Should -Be 1
         $result.kpi.noisePrecisionMasscompile | Should -BeNullOrEmpty
@@ -143,6 +148,7 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.markdown | Should -Match 'Timing'
         $result.markdown | Should -Match '\[signal\]'
         $result.markdown | Should -Match '\[fast 1\.5s\]'
+        $result.markdown | Should -Match 'time: 12\.50s total'
         $result.markdown | Should -Match '### Mobile Preview'
         $result.markdown | Should -Match 'history-image-000.png'
 

--- a/tests/Summarize-VIStaging.Tests.ps1
+++ b/tests/Summarize-VIStaging.Tests.ps1
@@ -290,6 +290,71 @@ Describe 'Summarize-VIStaging.ps1' -Tag 'Unit' {
         $result.pairs[0].diffCategoryDetails[0].slug | Should -Be 'block-diagram-functional'
     }
 
+    It 'renders consolidated html with valid local artifact links' {
+        $compareRoot = Join-Path $TestDrive 'compare-html'
+        $pairDir = Join-Path $compareRoot 'pair-01'
+        New-Item -ItemType Directory -Path $pairDir -Force | Out-Null
+
+        $reportPath = Join-Path $pairDir 'compare-report.html'
+        @'
+<!DOCTYPE html>
+<html>
+<body>
+<details open>
+  <summary class="difference-heading">1. Front Panel - Panel</summary>
+  <ol class="detailed-description-list">
+    <li class="diff-detail">Control moved</li>
+  </ol>
+</details>
+</body>
+</html>
+'@ | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+        $capturePath = Join-Path $pairDir 'lvcompare-capture.json'
+        '{"exitCode":1,"status":"diff"}' | Set-Content -LiteralPath $capturePath -Encoding utf8
+
+        $compareEntry = @(
+            [ordered]@{
+                index      = 1
+                changeType = 'modify'
+                basePath   = 'fixtures/vi-stage/fp-cosmetic/Base.vi'
+                headPath   = 'fixtures/vi-stage/fp-cosmetic/Head.vi'
+                status     = 'diff'
+                exitCode   = 1
+                outputDir  = $pairDir
+                reportPath = $reportPath
+                capturePath= $capturePath
+            }
+        )
+
+        $compareJson = Join-Path $TestDrive 'vi-staging-compare-html.json'
+        $compareEntry | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $compareJson -Encoding utf8
+
+        $htmlPath = Join-Path $TestDrive 'vi-compare-summary.html'
+        $result = & $script:scriptPath -CompareJson $compareJson -HtmlPath $htmlPath
+
+        Test-Path -LiteralPath $htmlPath -PathType Leaf | Should -BeTrue
+        $result.htmlPath | Should -Be ([System.IO.Path]::GetFullPath($htmlPath))
+
+        $html = Get-Content -LiteralPath $htmlPath -Raw
+        $html | Should -Match '<a href="[^"]+">compare-report</a>'
+        $html | Should -Match '<a href="[^"]+">capture-json</a>'
+
+        $hrefMatches = [regex]::Matches($html, 'href="(?<href>[^"]+)"')
+        $hrefMatches.Count | Should -BeGreaterThan 0
+        $htmlDir = Split-Path -Parent $htmlPath
+        foreach ($match in $hrefMatches) {
+            $href = [string]$match.Groups['href'].Value
+            if ([string]::IsNullOrWhiteSpace($href)) { continue }
+            if ($href -match '^(?i)https?://') { continue }
+            if ($href.StartsWith('#')) { continue }
+            $decodedHref = [Uri]::UnescapeDataString($href)
+            $relativePath = $decodedHref -replace '/', [System.IO.Path]::DirectorySeparatorChar
+            $resolvedTarget = [System.IO.Path]::GetFullPath((Join-Path $htmlDir $relativePath))
+            Test-Path -LiteralPath $resolvedTarget -PathType Leaf | Should -BeTrue
+        }
+    }
+
     It 'handles missing report gracefully' {
         $compareEntry = @(
             [ordered]@{

--- a/tools/Invoke-PRVIHistory.ps1
+++ b/tools/Invoke-PRVIHistory.ps1
@@ -987,6 +987,8 @@ $pairDurations = [System.Collections.Generic.List[double]]::new()
 $reportImageTargetCount = 0
 $reportImageExportedCount = 0
 $reportImageExtractionErrors = 0
+$totalDurationSeconds = 0.0
+$totalDurationSamples = 0
 
 for ($i = 0; $i -lt $targets.Count; $i++) {
     $target = $targets[$i]
@@ -1245,6 +1247,21 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
     $targetPairs = @($targetTimeline.Pairs)
     $targetDurations = @($targetTimeline.Durations)
     $targetTiming = New-TimingSummary -DurationsSeconds $targetDurations
+    $targetDurationSeconds = if ($targetTiming -and $targetTiming.PSObject.Properties['totalSeconds'] -and $null -ne $targetTiming.totalSeconds) {
+        [double]$targetTiming.totalSeconds
+    } else {
+        0.0
+    }
+    $targetDurationSamples = if ($targetTiming -and $targetTiming.PSObject.Properties['comparisonCount']) {
+        [int]$targetTiming.comparisonCount
+    } else {
+        0
+    }
+    $targetDurationAvgSeconds = if ($targetDurationSamples -gt 0) {
+        [Math]::Round(($targetDurationSeconds / [double]$targetDurationSamples), 6)
+    } else {
+        $null
+    }
 
     $totalPairRows += $targetPairs.Count
     foreach ($pairRow in $targetPairs) {
@@ -1260,6 +1277,8 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
         if ($candidateDuration -lt 0) { continue }
         $pairDurations.Add([double]$candidateDuration) | Out-Null
     }
+    $totalDurationSeconds += $targetDurationSeconds
+    $totalDurationSamples += $targetDurationSamples
 
     [void]$summaryTargets.Add([pscustomobject]@{
         repoPath    = $repoPath
@@ -1276,9 +1295,12 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
         timing      = $targetTiming
         estimatedCompareTime = $targetTiming.estimatedCompareTime
         stats       = [pscustomobject]@{
-            processed = $processed
-            diffs     = $diffs
-            missing   = $missing
+            processed          = $processed
+            diffs              = $diffs
+            missing            = $missing
+            durationSeconds    = [Math]::Round($targetDurationSeconds, 6)
+            durationSamples    = $targetDurationSamples
+            durationAvgSeconds = $targetDurationAvgSeconds
         }
     }) | Out-Null
 }
@@ -1322,6 +1344,8 @@ $summary = [pscustomobject]@{
         imageErrors      = $reportImageExtractionErrors
         pairRows         = $totalPairRows
         diffPairRows     = $diffPairRows
+        durationSeconds  = [Math]::Round($totalDurationSeconds, 6)
+        durationSamples  = $totalDurationSamples
         timing           = $overallTiming
         estimatedCompareTime = $overallTiming.estimatedCompareTime
     }

--- a/tools/Show-VIStagingReport.ps1
+++ b/tools/Show-VIStagingReport.ps1
@@ -1,0 +1,167 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Render a VI staging compare report summary for terminal sessions.
+
+.DESCRIPTION
+  Reads `vi-staging-compare.json` (from Run-StagedLVCompare) and prints a
+  concise markdown table with per-pair status, exit code, report analysis, and
+  artifact paths. This is intended for interactive agent/operator sessions.
+
+.PARAMETER CompareJsonPath
+  Path to `vi-staging-compare.json`.
+
+.PARAMETER PairIndex
+  Optional 1-based pair index filter.
+
+.PARAMETER ShowHeadings
+  Include first few difference headings extracted from HTML reports.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$CompareJsonPath,
+  [int]$PairIndex = 0,
+  [switch]$ShowHeadings
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-ReportSignals {
+  param([string]$ReportPath)
+
+  $result = [ordered]@{
+    diffMarkerCount = 0
+    diffDetailCount = 0
+    diffImageCount  = 0
+    headings        = @()
+  }
+
+  if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+    return [pscustomobject]$result
+  }
+  if (-not (Test-Path -LiteralPath $ReportPath -PathType Leaf)) {
+    return [pscustomobject]$result
+  }
+
+  $html = Get-Content -LiteralPath $ReportPath -Raw -ErrorAction Stop
+  if ([string]::IsNullOrWhiteSpace($html)) {
+    return [pscustomobject]$result
+  }
+
+  $result.diffMarkerCount = [regex]::Matches(
+    $html,
+    'summary[^>]+class="[^"]*\bdifference-heading\b[^"]*"',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  ).Count
+  $result.diffDetailCount = [regex]::Matches(
+    $html,
+    'li[^>]+class="[^"]*\bdiff-detail(?:-cosmetic)?\b[^"]*"',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  ).Count
+  $result.diffImageCount = [regex]::Matches(
+    $html,
+    '<img[^>]+class\s*=\s*["''][^"'']*difference-image',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  ).Count
+
+  $headingMatches = [regex]::Matches(
+    $html,
+    '<summary[^>]+class="[^"]*\bdifference-heading\b[^"]*"[^>]*>\s*(?<text>.*?)\s*</summary>',
+    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+  )
+  $headings = New-Object System.Collections.Generic.List[string]
+  foreach ($match in $headingMatches) {
+    $text = [System.Net.WebUtility]::HtmlDecode($match.Groups['text'].Value)
+    $text = [regex]::Replace($text, '<[^>]+>', ' ')
+    $text = [regex]::Replace($text, '\s+', ' ').Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) { continue }
+    $headings.Add(($text -replace '^\s*\d+\.\s*', '')) | Out-Null
+  }
+  $result.headings = @($headings | Select-Object -First 5)
+  return [pscustomobject]$result
+}
+
+if (-not (Test-Path -LiteralPath $CompareJsonPath -PathType Leaf)) {
+  throw "Compare JSON not found: $CompareJsonPath"
+}
+
+$raw = Get-Content -LiteralPath $CompareJsonPath -Raw -Encoding UTF8
+if ([string]::IsNullOrWhiteSpace($raw)) {
+  throw "Compare JSON is empty: $CompareJsonPath"
+}
+
+$data = $raw | ConvertFrom-Json -Depth 12
+$items = @($data)
+if ($items.Count -eq 0) {
+  throw "No compare entries found in $CompareJsonPath"
+}
+
+if ($PairIndex -gt 0) {
+  if ($PairIndex -gt $items.Count) {
+    throw ("PairIndex {0} is out of range (count={1})." -f $PairIndex, $items.Count)
+  }
+  $items = @($items[$PairIndex - 1])
+}
+
+$rows = New-Object System.Collections.Generic.List[pscustomobject]
+$rowIndex = 0
+foreach ($item in $items) {
+  $rowIndex++
+  $reportPath = $null
+  $capturePath = $null
+  $status = $null
+  $exitCode = $null
+  $target = $null
+
+  if ($item.PSObject.Properties['reportPath']) { $reportPath = [string]$item.reportPath }
+  if ($item.PSObject.Properties['capturePath']) { $capturePath = [string]$item.capturePath }
+  if ($item.PSObject.Properties['status']) { $status = [string]$item.status }
+  if ($item.PSObject.Properties['exitCode']) {
+    try { $exitCode = [int]$item.exitCode } catch { $exitCode = $item.exitCode }
+  }
+  if ($item.PSObject.Properties['headPath']) { $target = [string]$item.headPath }
+  if ([string]::IsNullOrWhiteSpace($target) -and $item.PSObject.Properties['basePath']) {
+    $target = [string]$item.basePath
+  }
+
+  $signals = Get-ReportSignals -ReportPath $reportPath
+  $rows.Add([pscustomobject]@{
+    pair            = $rowIndex
+    target          = $target
+    status          = $status
+    exitCode        = $exitCode
+    diffMarkers     = [int]$signals.diffMarkerCount
+    diffDetails     = [int]$signals.diffDetailCount
+    diffImages      = [int]$signals.diffImageCount
+    reportPath      = $reportPath
+    capturePath     = $capturePath
+    headings        = @($signals.headings)
+  }) | Out-Null
+}
+
+Write-Host ("# VI Staging Report View") -ForegroundColor Cyan
+Write-Host ("Compare JSON: {0}" -f $CompareJsonPath)
+Write-Host ""
+Write-Host "| Pair | Target | Status | Exit | Markers | Details | Images |"
+Write-Host "| --- | --- | --- | --- | --- | --- | --- |"
+foreach ($row in $rows) {
+  Write-Host ("| {0} | {1} | {2} | {3} | {4} | {5} | {6} |" -f `
+    $row.pair, $row.target, $row.status, $row.exitCode, $row.diffMarkers, $row.diffDetails, $row.diffImages)
+}
+
+Write-Host ""
+foreach ($row in $rows) {
+  Write-Host ("## Pair {0}" -f $row.pair) -ForegroundColor DarkCyan
+  Write-Host ("- Target: {0}" -f $row.target)
+  Write-Host ("- Report: {0}" -f $row.reportPath)
+  Write-Host ("- Capture: {0}" -f $row.capturePath)
+  if ($ShowHeadings -and $row.headings -and $row.headings.Count -gt 0) {
+    Write-Host "- Headings:"
+    foreach ($heading in $row.headings) {
+      Write-Host ("  - {0}" -f $heading)
+    }
+  }
+  Write-Host ""
+}

--- a/tools/Summarize-PRVIHistory.ps1
+++ b/tools/Summarize-PRVIHistory.ps1
@@ -338,6 +338,8 @@ $rows.Add('| --- | --- | --- | --- | --- | --- |') | Out-Null
 $diffTotal = 0
 $comparisonTotal = 0
 $completed = 0
+$durationTotalSeconds = 0.0
+$durationSampleTotal = 0
 
 foreach ($target in $targets) {
     $repoPath = if ($target.PSObject.Properties['repoPath']) { [string]$target.repoPath } else { '(unknown)' }
@@ -355,6 +357,9 @@ foreach ($target in $targets) {
     $comparisons = '0'
     $diffs = '0'
     $reportNote = '_n/a_'
+    $durationSecondsValue = $null
+    $durationSamplesValue = 0
+    $durationAvgSecondsValue = $null
 
     if ($target.PSObject.Properties['stats'] -and $target.stats) {
         $stats = $target.stats
@@ -367,6 +372,27 @@ foreach ($target in $targets) {
             $diffValue = [int]$stats.diffs
             $diffTotal += $diffValue
             $diffs = $diffValue.ToString()
+        }
+        if ($stats.PSObject.Properties['durationSeconds']) {
+            $parsedDuration = 0.0
+            if ([double]::TryParse([string]$stats.durationSeconds, [ref]$parsedDuration)) {
+                $durationSecondsValue = $parsedDuration
+                $durationTotalSeconds += $parsedDuration
+            }
+        }
+        if ($stats.PSObject.Properties['durationSamples']) {
+            try {
+                $durationSamplesValue = [int]$stats.durationSamples
+                if ($durationSamplesValue -gt 0) {
+                    $durationSampleTotal += $durationSamplesValue
+                }
+            } catch {}
+        }
+        if ($stats.PSObject.Properties['durationAvgSeconds']) {
+            $parsedAvg = 0.0
+            if ([double]::TryParse([string]$stats.durationAvgSeconds, [ref]$parsedAvg)) {
+                $durationAvgSecondsValue = $parsedAvg
+            }
         }
     }
 
@@ -389,6 +415,24 @@ foreach ($target in $targets) {
         $reportNote = [string]::Join('<br />', $reportPaths)
     } elseif ($message) {
         $reportNote = $message
+    }
+
+    $timingNote = $null
+    if ($durationSecondsValue -ne $null -and $durationSamplesValue -gt 0) {
+        $timingNote = ("time: {0:N2}s total ({1} compare{2}" -f $durationSecondsValue, $durationSamplesValue, $(if ($durationSamplesValue -eq 1) { '' } else { 's' }))
+        if ($durationAvgSecondsValue -ne $null) {
+            $timingNote += (", avg {0:N2}s" -f $durationAvgSecondsValue)
+        }
+        $timingNote += ')'
+    } elseif ($durationSecondsValue -ne $null) {
+        $timingNote = ("time: {0:N2}s total" -f $durationSecondsValue)
+    }
+    if ($timingNote) {
+        if ($reportNote -eq '_n/a_') {
+            $reportNote = $timingNote
+        } else {
+            $reportNote = ($reportNote + '<br />' + $timingNote)
+        }
     }
 
     $statusLabel = switch ($status) {
@@ -627,6 +671,8 @@ $result = [pscustomobject]@{
         diffPairRows= $diffPairRows
         previewImages = $previewEntries.Count
         markdownTruncated = $markdownTruncated
+        durationSeconds = [Math]::Round($durationTotalSeconds, 6)
+        durationSamples = $durationSampleTotal
         timing      = $timingSummary
     }
     targets  = $targets

--- a/tools/Summarize-VIStaging.ps1
+++ b/tools/Summarize-VIStaging.ps1
@@ -18,8 +18,11 @@
 .PARAMETER SummaryJsonPath
   Optional path for writing the enriched summary (pairs, totals, markdown).
 
+.PARAMETER HtmlPath
+  Optional path where a consolidated HTML summary should be written.
+
 .OUTPUTS
-  PSCustomObject with `totals`, `pairs`, `markdown`, and `compareDir`.
+  PSCustomObject with `totals`, `pairs`, `markdown`, `html`, and `compareDir`.
 #>
 [CmdletBinding()]
 param(
@@ -28,7 +31,9 @@ param(
 
     [string]$MarkdownPath,
 
-    [string]$SummaryJsonPath
+    [string]$SummaryJsonPath,
+
+    [string]$HtmlPath
 )
 
 Set-StrictMode -Version Latest
@@ -83,6 +88,32 @@ function Get-RelativePath {
     } catch {
         return $TargetPath
     }
+}
+
+function Convert-ToSafeHtmlText {
+    param([string]$Value)
+    if ($null -eq $Value) { return '' }
+    return [System.Net.WebUtility]::HtmlEncode([string]$Value)
+}
+
+function Convert-ToHtmlHref {
+    param(
+        [string]$BasePath,
+        [string]$TargetPath
+    )
+    if ([string]::IsNullOrWhiteSpace($TargetPath)) { return $null }
+    $relative = Get-RelativePath -BasePath $BasePath -TargetPath $TargetPath
+    if ([string]::IsNullOrWhiteSpace($relative)) { return $null }
+    $normalized = ($relative -replace '\\', '/')
+    $segments = $normalized -split '/'
+    $encoded = foreach ($segment in $segments) {
+        if ($segment -eq '.' -or $segment -eq '..' -or [string]::IsNullOrWhiteSpace($segment)) {
+            $segment
+        } else {
+            [Uri]::EscapeDataString($segment)
+        }
+    }
+    return ($encoded -join '/')
 }
 
 function Parse-InclusionList {
@@ -629,6 +660,118 @@ function Build-MarkdownTable {
     return ($summaryLines + '' + $rows) -join "`n"
 }
 
+function Build-HtmlReport {
+    param(
+        [pscustomobject[]]$Pairs,
+        [pscustomobject]$Totals,
+        [string]$CompareDir,
+        [string]$HtmlRoot
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add('<!DOCTYPE html>') | Out-Null
+    $lines.Add('<html lang="en">') | Out-Null
+    $lines.Add('<head>') | Out-Null
+    $lines.Add('  <meta charset="utf-8">') | Out-Null
+    $lines.Add('  <meta name="viewport" content="width=device-width, initial-scale=1">') | Out-Null
+    $lines.Add('  <title>VI Compare Summary</title>') | Out-Null
+    $lines.Add('  <style>') | Out-Null
+    $lines.Add('    body { font-family: Segoe UI, Arial, sans-serif; margin: 20px; color: #111; }') | Out-Null
+    $lines.Add('    h1 { margin: 0 0 8px 0; }') | Out-Null
+    $lines.Add('    .meta { margin: 0 0 12px 0; color: #333; }') | Out-Null
+    $lines.Add('    table { border-collapse: collapse; width: 100%; }') | Out-Null
+    $lines.Add('    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; vertical-align: top; }') | Out-Null
+    $lines.Add('    th { background: #f2f2f2; }') | Out-Null
+    $lines.Add('    .status-diff { color: #7a1515; font-weight: 700; }') | Out-Null
+    $lines.Add('    .status-match { color: #155724; font-weight: 700; }') | Out-Null
+    $lines.Add('    .status-error { color: #8a6d3b; font-weight: 700; }') | Out-Null
+    $lines.Add('    .status-skipped { color: #555; font-weight: 700; }') | Out-Null
+    $lines.Add('    .mono { font-family: Consolas, Menlo, monospace; font-size: 12px; }') | Out-Null
+    $lines.Add('  </style>') | Out-Null
+    $lines.Add('</head>') | Out-Null
+    $lines.Add('<body>') | Out-Null
+    $lines.Add('  <h1>VI Compare Summary</h1>') | Out-Null
+    $summaryText = "Totals: diff=$($Totals.diff), match=$($Totals.match), skipped=$($Totals.skipped), error=$($Totals.error), leaks=$($Totals.leakWarnings)"
+    $lines.Add("  <p class=`"meta`">$([System.Net.WebUtility]::HtmlEncode($summaryText))</p>") | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($CompareDir)) {
+        $lines.Add("  <p class=`"meta`">Artifacts root: <span class=`"mono`">$([System.Net.WebUtility]::HtmlEncode(($CompareDir -replace '\\','/')))</span></p>") | Out-Null
+    }
+    $lines.Add('  <table>') | Out-Null
+    $lines.Add('    <thead><tr><th>Pair</th><th>Target</th><th>Status</th><th>Exit</th><th>Categories</th><th>Details</th><th>Report</th><th>Capture</th></tr></thead>') | Out-Null
+    $lines.Add('    <tbody>') | Out-Null
+
+    foreach ($pair in $Pairs) {
+        $pairLabel = Convert-ToSafeHtmlText -Value ("Pair {0} ({1})" -f $pair.index, $pair.changeType)
+        $targetText = if (-not [string]::IsNullOrWhiteSpace([string]$pair.headPath)) { [string]$pair.headPath } else { [string]$pair.basePath }
+        $targetCell = Convert-ToSafeHtmlText -Value $targetText
+        $statusRaw = [string]$pair.status
+        $statusClass = switch ($statusRaw) {
+            'diff'    { 'status-diff' }
+            'match'   { 'status-match' }
+            'error'   { 'status-error' }
+            'skipped' { 'status-skipped' }
+            default   { '' }
+        }
+        $statusCell = Convert-ToSafeHtmlText -Value $statusRaw
+        $exitCell = if ($null -ne $pair.exitCode) { Convert-ToSafeHtmlText -Value ([string]$pair.exitCode) } else { '-' }
+
+        $categoryValues = New-Object System.Collections.Generic.List[string]
+        if ($pair.PSObject.Properties['diffCategoryDetails'] -and $pair.diffCategoryDetails) {
+            foreach ($detail in $pair.diffCategoryDetails) {
+                if (-not $detail) { continue }
+                $label = if ($detail.PSObject.Properties['label'] -and $detail.label) { [string]$detail.label } else { [string]$detail.slug }
+                if (-not [string]::IsNullOrWhiteSpace($label)) {
+                    $categoryValues.Add($label) | Out-Null
+                }
+            }
+        } elseif ($pair.PSObject.Properties['diffCategories'] -and $pair.diffCategories) {
+            foreach ($category in $pair.diffCategories) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$category)) {
+                    $categoryValues.Add([string]$category) | Out-Null
+                }
+            }
+        }
+        $categoriesCell = if ($categoryValues.Count -gt 0) {
+            Convert-ToSafeHtmlText -Value ($categoryValues -join ', ')
+        } else {
+            '-'
+        }
+
+        $detailValues = @()
+        if ($pair.PSObject.Properties['diffDetailPreview'] -and $pair.diffDetailPreview) {
+            $detailValues = @($pair.diffDetailPreview | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | Select-Object -First 3)
+        }
+        $detailsCell = if ($detailValues.Count -gt 0) {
+            (Convert-ToSafeHtmlText -Value ($detailValues -join '; '))
+        } else {
+            '-'
+        }
+
+        $reportHref = if ($pair.PSObject.Properties['reportPath']) { Convert-ToHtmlHref -BasePath $HtmlRoot -TargetPath ([string]$pair.reportPath) } else { $null }
+        $reportCell = if (-not [string]::IsNullOrWhiteSpace($reportHref)) {
+            "<a href=`"$reportHref`">compare-report</a>"
+        } else {
+            '-'
+        }
+
+        $captureHref = if ($pair.PSObject.Properties['capturePath']) { Convert-ToHtmlHref -BasePath $HtmlRoot -TargetPath ([string]$pair.capturePath) } else { $null }
+        $captureCell = if (-not [string]::IsNullOrWhiteSpace($captureHref)) {
+            "<a href=`"$captureHref`">capture-json</a>"
+        } else {
+            '-'
+        }
+
+        $lines.Add("      <tr><td>$pairLabel</td><td><span class=`"mono`">$targetCell</span></td><td class=`"$statusClass`">$statusCell</td><td>$exitCell</td><td>$categoriesCell</td><td>$detailsCell</td><td>$reportCell</td><td>$captureCell</td></tr>") | Out-Null
+    }
+
+    $lines.Add('    </tbody>') | Out-Null
+    $lines.Add('  </table>') | Out-Null
+    $lines.Add('</body>') | Out-Null
+    $lines.Add('</html>') | Out-Null
+
+    return ($lines -join "`n")
+}
+
 if (-not (Test-Path -LiteralPath $CompareJson -PathType Leaf)) {
     throw "Compare summary file not found: $CompareJson"
 }
@@ -969,11 +1112,24 @@ $totals.bucketCounts = $sortedBucketTotals
 
 $totalsObj = [pscustomobject]$totals
 $markdown = Build-MarkdownTable -Pairs $pairs -Totals $totalsObj -CompareDir $compareRoot
+$html = $null
+$resolvedHtmlPath = $null
+if ($HtmlPath) {
+    $resolvedHtmlPath = [System.IO.Path]::GetFullPath($HtmlPath)
+    $htmlRoot = Split-Path -Parent $resolvedHtmlPath
+    if (-not [string]::IsNullOrWhiteSpace($htmlRoot)) {
+        New-Item -ItemType Directory -Path $htmlRoot -Force | Out-Null
+    }
+    $html = Build-HtmlReport -Pairs $pairs -Totals $totalsObj -CompareDir $compareRoot -HtmlRoot $htmlRoot
+    $html | Set-Content -LiteralPath $resolvedHtmlPath -Encoding utf8
+}
 
 $result = [pscustomobject]@{
     totals     = $totalsObj
     pairs      = $pairs
     markdown   = $markdown
+    html       = $html
+    htmlPath   = $resolvedHtmlPath
     compareDir = $compareRoot
 }
 
@@ -991,6 +1147,9 @@ if ($Env:GITHUB_OUTPUT) {
     }
     if ($SummaryJsonPath) {
         "summary_json=$SummaryJsonPath" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+    }
+    if ($resolvedHtmlPath) {
+        "summary_html=$resolvedHtmlPath" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
     }
     if ($compareRoot) {
         "compare_dir=$compareRoot" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append


### PR DESCRIPTION
## Summary
Batch 2 of #156 origin->upstream deterministic alignment.

Aligned VI history compare runtime contract files and matching tests.

## Included
- `.github/workflows/pr-vi-history.yml`
- `.github/workflows/vi-compare-fork.yml`
- `tools/Invoke-PRVIHistory.ps1`
- `tools/Summarize-PRVIHistory.ps1`
- `tools/Show-VIStagingReport.ps1`
- `tools/Summarize-VIStaging.ps1`
- tests:
  - `tests/Invoke-PRVIHistory.Tests.ps1`
  - `tests/Summarize-PRVIHistory.Tests.ps1`
  - `tests/Summarize-VIStaging.Tests.ps1`

## Validation
- `Invoke-PesterTests.ps1 -IncludePatterns Invoke-PRVIHistory.Tests.ps1`
- `Invoke-PesterTests.ps1 -IncludePatterns Summarize-PRVIHistory.Tests.ps1`
- `Invoke-PesterTests.ps1 -IncludePatterns Summarize-VIStaging.Tests.ps1`
- `tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Refs: #156
