### PR TITLE
Surface parity telemetry in Validate session-index flow (#161)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -803,6 +803,19 @@ jobs:
         if ($bpResult.notes) { $updateArgs['AdditionalNotes'] = @($bpResult.notes) }
         & $bpScript @updateArgs
 
+    - name: Attach origin/upstream parity telemetry
+      shell: pwsh
+      run: |
+        $res = Join-Path $env:RUNNER_TEMP 'sessionindex'
+        $parityPath = Join-Path $res 'origin-upstream-parity.json'
+        try {
+          git remote add upstream 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action.git' 2>$null | Out-Null
+        } catch { }
+        try { git fetch --no-tags --prune --depth=1 origin develop | Out-Null } catch { Write-Host ("::notice::origin/develop fetch skipped: {0}" -f $_.Exception.Message) }
+        try { git fetch --no-tags --prune --depth=1 upstream develop | Out-Null } catch { Write-Host ("::notice::upstream/develop fetch skipped: {0}" -f $_.Exception.Message) }
+        node tools/priority/report-origin-upstream-parity.mjs --base-ref 'upstream/develop' --head-ref 'origin/develop' --sample-limit 20 --output-path "$parityPath"
+        pwsh -File tools/Update-SessionIndexParity.ps1 -ResultsDir $res -ParityReportPath $parityPath -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+
     - name: Validate session index schema (schema-lite)
       shell: pwsh
       run: |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -269,6 +269,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - `priority:parity` reports origin/upstream parity using two metrics:
   - `tipDiff.fileCount` from `git diff --name-only upstream/develop origin/develop` (primary KPI; `0` means tip parity)
   - commit divergence from `git rev-list --left-right --count upstream/develop...origin/develop` (telemetry only)
+- Validate `session-index` now embeds parity telemetry under `runContext.parity` and appends an
+  `Origin/Upstream Parity Telemetry` block to the step summary.
 - The release router now suggests `npm run release:finalize -- <version>` automatically when the latest branch artifact
   lacks a matching finalize record.
 

--- a/tests/Update-SessionIndexParity.Tests.ps1
+++ b/tests/Update-SessionIndexParity.Tests.ps1
@@ -1,0 +1,94 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Update-SessionIndexParity.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Update-SessionIndexParity.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'injects parity telemetry into session-index and appends step summary' {
+    $resultsDir = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $sessionIndexPath = Join-Path $resultsDir 'session-index.json'
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+      status = 'ok'
+      runContext = [ordered]@{}
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $sessionIndexPath -Encoding utf8
+
+    $parityPath = Join-Path $resultsDir 'origin-upstream-parity.json'
+    $parity = [ordered]@{
+      schema = 'origin-upstream-parity@v1'
+      status = 'ok'
+      generatedAt = '2026-03-03T00:00:00Z'
+      baseRef = 'upstream/develop'
+      headRef = 'origin/develop'
+      tipDiff = [ordered]@{
+        fileCount = 0
+      }
+      commitDivergence = [ordered]@{
+        baseOnly = 33
+        headOnly = 126
+      }
+    }
+    ($parity | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $parityPath -Encoding utf8
+
+    $summaryPath = Join-Path $resultsDir 'summary.md'
+    New-Item -ItemType File -Path $summaryPath -Force | Out-Null
+
+    $resultPath = & $script:ToolPath `
+      -ResultsDir $resultsDir `
+      -ParityReportPath $parityPath `
+      -StepSummaryPath $summaryPath
+
+    [string]$resultPath | Should -Be $sessionIndexPath
+
+    $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
+    $updated.runContext.parity.status | Should -Be 'ok'
+    $updated.runContext.parity.tipDiff.fileCount | Should -Be 0
+    $updated.runContext.parity.commitDivergence.baseOnly | Should -Be 33
+    $updated.runContext.parity.commitDivergence.headOnly | Should -Be 126
+    $updated.runContext.parity.reportPath | Should -Be $parityPath
+
+    $summary = Get-Content -LiteralPath $summaryPath -Raw
+    $summary | Should -Match 'Origin/Upstream Parity Telemetry'
+    $summary | Should -Match 'Tip Diff File Count \| 0'
+    $summary | Should -Match 'Commit Divergence \(base-only/head-only\) \| 33/126'
+  }
+
+  It 'writes unavailable parity telemetry when report is missing' {
+    $resultsDir = Join-Path $TestDrive 'missing'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $sessionIndexPath = Join-Path $resultsDir 'session-index.json'
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+      status = 'ok'
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $sessionIndexPath -Encoding utf8
+
+    & $script:ToolPath -ResultsDir $resultsDir -ParityReportPath (Join-Path $resultsDir 'does-not-exist.json') | Out-Null
+
+    $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
+    $updated.runContext.parity.status | Should -Be 'unavailable'
+    $updated.runContext.parity.reason | Should -Be 'report-missing'
+  }
+
+  It 'does not throw when session-index is missing and IgnoreMissingSessionIndex is enabled' {
+    $resultsDir = Join-Path $TestDrive 'ignore'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    {
+      & $script:ToolPath -ResultsDir $resultsDir -IgnoreMissingSessionIndex
+    } | Should -Not -Throw
+  }
+}
+

--- a/tools/Update-SessionIndexParity.ps1
+++ b/tools/Update-SessionIndexParity.ps1
@@ -1,0 +1,190 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Injects origin/upstream parity telemetry into session-index.json.
+#>
+[CmdletBinding()]
+param(
+  [string]$ResultsDir = 'tests/results',
+  [string]$SessionIndexPath = '',
+  [string]$ParityReportPath = '',
+  [string]$StepSummaryPath = '',
+  [switch]$IgnoreMissingSessionIndex
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function New-UnavailableParityPayload {
+  param(
+    [Parameter(Mandatory)][string]$Reason,
+    [string]$ReportPath = ''
+  )
+  return [ordered]@{
+    schema      = 'origin-upstream-parity@v1'
+    status      = 'unavailable'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    reason      = [string]$Reason
+    reportPath  = [string]$ReportPath
+    baseRef     = $null
+    headRef     = $null
+    tipDiff     = [ordered]@{
+      fileCount = $null
+    }
+    commitDivergence = [ordered]@{
+      baseOnly = $null
+      headOnly = $null
+    }
+  }
+}
+
+function Get-ChildValue {
+  param(
+    [Parameter(Mandatory=$false)]$Object,
+    [Parameter(Mandatory)][string]$Name
+  )
+  if ($null -eq $Object) { return $null }
+  if ($Object -is [System.Collections.IDictionary]) {
+    if ($Object.Contains($Name)) { return $Object[$Name] }
+    return $null
+  }
+  if ($Object.PSObject -and $Object.PSObject.Properties[$Name]) {
+    return $Object.$Name
+  }
+  return $null
+}
+
+function Convert-ToParityTelemetry {
+  param(
+    [Parameter(Mandatory)][psobject]$ParityReport,
+    [string]$ReportPath = ''
+  )
+
+  $status = [string]$ParityReport.status
+  if ([string]::IsNullOrWhiteSpace($status)) {
+    $status = 'unavailable'
+  }
+
+  $tipDiffCount = $null
+  $tipDiff = Get-ChildValue -Object $ParityReport -Name 'tipDiff'
+  if ($null -ne $tipDiff) { $tipDiffCount = Get-ChildValue -Object $tipDiff -Name 'fileCount' }
+
+  $baseOnly = $null
+  $headOnly = $null
+  $commitDivergence = Get-ChildValue -Object $ParityReport -Name 'commitDivergence'
+  if ($null -ne $commitDivergence) {
+    $baseOnly = Get-ChildValue -Object $commitDivergence -Name 'baseOnly'
+    $headOnly = Get-ChildValue -Object $commitDivergence -Name 'headOnly'
+  }
+
+  return [ordered]@{
+    schema      = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'schema')) { [string](Get-ChildValue -Object $ParityReport -Name 'schema') } else { 'origin-upstream-parity@v1' }
+    status      = $status
+    generatedAt = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'generatedAt')) { [string](Get-ChildValue -Object $ParityReport -Name 'generatedAt') } elseif ($null -ne (Get-ChildValue -Object $ParityReport -Name 'generatedAtUtc')) { [string](Get-ChildValue -Object $ParityReport -Name 'generatedAtUtc') } else { (Get-Date).ToUniversalTime().ToString('o') }
+    reason      = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'reason')) { [string](Get-ChildValue -Object $ParityReport -Name 'reason') } else { '' }
+    reportPath  = [string]$ReportPath
+    baseRef     = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'baseRef')) { [string](Get-ChildValue -Object $ParityReport -Name 'baseRef') } else { $null }
+    headRef     = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'headRef')) { [string](Get-ChildValue -Object $ParityReport -Name 'headRef') } else { $null }
+    tipDiff     = [ordered]@{
+      fileCount = $tipDiffCount
+    }
+    commitDivergence = [ordered]@{
+      baseOnly = $baseOnly
+      headOnly = $headOnly
+    }
+  }
+}
+
+function Write-ParityStepSummary {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][psobject]$Parity
+  )
+  $tipDiffCount = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'tipDiff') -Name 'fileCount'
+  $baseOnly = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'commitDivergence') -Name 'baseOnly'
+  $headOnly = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'commitDivergence') -Name 'headOnly'
+
+  $statusValue = if ($Parity.status) { [string]$Parity.status } else { 'unavailable' }
+  $reasonValue = if ($Parity.reason) { [string]$Parity.reason } else { '' }
+  $tipDiffValue = if ($null -ne $tipDiffCount -and "$tipDiffCount".Trim() -ne '') { [string]$tipDiffCount } else { 'n/a' }
+  $divergenceValue = if (($null -ne $baseOnly -and "$baseOnly".Trim() -ne '') -and ($null -ne $headOnly -and "$headOnly".Trim() -ne '')) { ('{0}/{1}' -f $baseOnly, $headOnly) } else { 'n/a' }
+
+  $lines = @(
+    '### Origin/Upstream Parity Telemetry',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    ('| Status | {0} |' -f $statusValue),
+    ('| Tip Diff File Count | {0} |' -f $tipDiffValue),
+    ('| Commit Divergence (base-only/head-only) | {0} |' -f $divergenceValue)
+  )
+  if (-not [string]::IsNullOrWhiteSpace($reasonValue)) {
+    $lines += ('| Reason | {0} |' -f $reasonValue.Replace('|', '\|'))
+  }
+  if (-not [string]::IsNullOrWhiteSpace([string]$Parity.reportPath)) {
+    $lines += ('| Report Path | `{0}` |' -f [string]$Parity.reportPath)
+  }
+  $lines += ''
+  ($lines -join "`n") | Out-File -FilePath $Path -Append -Encoding utf8
+}
+
+$resultsResolved = Resolve-AbsolutePath -Path $ResultsDir
+$sessionPathResolved = if ([string]::IsNullOrWhiteSpace($SessionIndexPath)) {
+  Join-Path $resultsResolved 'session-index.json'
+} else {
+  Resolve-AbsolutePath -Path $SessionIndexPath
+}
+$parityPathResolved = if ([string]::IsNullOrWhiteSpace($ParityReportPath)) {
+  Join-Path $resultsResolved 'origin-upstream-parity.json'
+} else {
+  Resolve-AbsolutePath -Path $ParityReportPath
+}
+$summaryPathResolved = if ([string]::IsNullOrWhiteSpace($StepSummaryPath)) { '' } else { Resolve-AbsolutePath -Path $StepSummaryPath }
+
+if (-not (Test-Path -LiteralPath $sessionPathResolved -PathType Leaf)) {
+  if ($IgnoreMissingSessionIndex) {
+    Write-Host ("::warning::session-index.json not found at {0}; parity metadata was not attached." -f $sessionPathResolved)
+    return
+  }
+  throw ("session-index.json not found: {0}" -f $sessionPathResolved)
+}
+
+$index = Get-Content -LiteralPath $sessionPathResolved -Raw | ConvertFrom-Json -Depth 30
+if (-not $index.PSObject.Properties['runContext'] -or $null -eq $index.runContext) {
+  $index | Add-Member -MemberType NoteProperty -Name 'runContext' -Value ([ordered]@{}) -Force
+}
+
+$parityTelemetry = $null
+if (Test-Path -LiteralPath $parityPathResolved -PathType Leaf) {
+  try {
+    $parityJson = Get-Content -LiteralPath $parityPathResolved -Raw | ConvertFrom-Json -Depth 30 -ErrorAction Stop
+    $parityTelemetry = Convert-ToParityTelemetry -ParityReport $parityJson -ReportPath $parityPathResolved
+  } catch {
+    $parityTelemetry = New-UnavailableParityPayload -Reason ("invalid-report-json: {0}" -f $_.Exception.Message) -ReportPath $parityPathResolved
+  }
+} else {
+  $parityTelemetry = New-UnavailableParityPayload -Reason 'report-missing' -ReportPath $parityPathResolved
+}
+
+if ($index.runContext -is [System.Collections.IDictionary]) {
+  $index.runContext['parity'] = $parityTelemetry
+} elseif ($index.runContext.PSObject -and $index.runContext.PSObject.Properties['parity']) {
+  $index.runContext.parity = $parityTelemetry
+} else {
+  $index.runContext | Add-Member -MemberType NoteProperty -Name 'parity' -Value $parityTelemetry -Force
+}
+($index | ConvertTo-Json -Depth 30) | Set-Content -LiteralPath $sessionPathResolved -Encoding utf8
+
+if (-not [string]::IsNullOrWhiteSpace($summaryPathResolved)) {
+  Write-ParityStepSummary -Path $summaryPathResolved -Parity $parityTelemetry
+}
+
+Write-Output $sessionPathResolved


### PR DESCRIPTION
## Summary
- mirror origin change for parity telemetry in Validate/session-index flow
- add Update-SessionIndexParity script + tests
- wire Validate session-index job to include parity block and artifact node

## Testing
- pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -IncludePatterns 'Update-SessionIndexParity.Tests.ps1'
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Mirrors svelderrainruiz/compare-vi-cli-action#162.