### PR TITLE
sync: align runtime manager parity from origin develop

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
-    - self-hosted-docker
+    - self-hosted-docker-windows
+    - self-hosted-docker-linux

--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -57,7 +57,7 @@ jobs:
 
   docker-runtime-manager:
     name: Docker Runtime Manager (Host)
-    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker-windows]
     needs:
     - preflight-windows
     timeout-minutes: 10
@@ -165,7 +165,7 @@ jobs:
 
   validate-windows:
     name: Fixture Drift (Docker Desktop Host - LabVIEW 2026 q1 windows)
-    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker-windows]
     concurrency:
       group: lv-fixture-win
       cancel-in-progress: false
@@ -224,7 +224,7 @@ jobs:
           -ManageDockerEngine:$true `
           -SnapshotPath 'results/fixture-drift/windows-runtime-determinism.json' `
           -GitHubOutputPath $env:GITHUB_OUTPUT
-    - name: Assert self-hosted-docker runner label
+    - name: Assert self-hosted-docker-windows runner label
       id: runner_label_contract
       shell: pwsh
       env:
@@ -234,7 +234,7 @@ jobs:
           -Repository '${{ github.repository }}' `
           -RunId '${{ github.run_id }}' `
           -RunnerName '${{ runner.name }}' `
-          -RequiredLabel 'self-hosted-docker' `
+          -RequiredLabel 'self-hosted-docker-windows' `
           -OutputJsonPath 'results/fixture-drift/runner-label-contract.json' `
           -GitHubOutputPath $env:GITHUB_OUTPUT `
           -StepSummaryPath $env:GITHUB_STEP_SUMMARY
@@ -263,7 +263,7 @@ jobs:
           runner = [ordered]@{
             name = '${{ runner.name }}'
             id = '${{ steps.runner_label_contract.outputs.runner_id }}'
-            requiredLabel = 'self-hosted-docker'
+            requiredLabel = 'self-hosted-docker-windows'
             hasRequiredLabel = ('${{ steps.runner_label_contract.outputs.has_required_label }}' -eq 'true')
             labels = $labels
           }
@@ -510,7 +510,7 @@ jobs:
           -ResultsDir 'results/fixture-drift' `
           -ContextPath '${{ steps.docker_manager_context.outputs.context_path }}' `
           -RuntimeSnapshotPath 'results/fixture-drift/windows-runtime-determinism.json' `
-          -RequiredLabel 'self-hosted-docker' `
+          -RequiredLabel 'self-hosted-docker-windows' `
           -HasRequiredLabel:$hasRequiredLabel `
           -RunnerLabelsCsv '${{ steps.runner_label_contract.outputs.labels }}' `
           -ManagerStatus $env:DOCKER_MANAGER_STATUS `

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -862,54 +862,25 @@ jobs:
         github.repository == 'LabVIEW-Community-CI-CD/compare-vi-cli-action' ||
         github.event.inputs.allow_noncanonical_vi_history == 'true'
       )
-    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker-windows]
     defaults:
       run:
         shell: pwsh
-    timeout-minutes: 20
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v5
 
-      - name: Bootstrap Docker Windows engine (self-hosted)
+      - name: Ensure Docker Desktop service is running (self-hosted)
         run: |
           $service = Get-Service -Name 'com.docker.service' -ErrorAction SilentlyContinue
-          if ($service -and $service.Status -ne 'Running') {
+          if (-not $service) {
+            throw "Docker service 'com.docker.service' was not found on this runner."
+          }
+          if ($service.Status -ne 'Running') {
             Start-Service -Name 'com.docker.service' -ErrorAction Stop
+            $service = Get-Service -Name 'com.docker.service' -ErrorAction Stop
           }
-
-          $dockerCliCandidates = @(
-            (Join-Path $env:ProgramFiles 'Docker\Docker\DockerCli.exe'),
-            (Join-Path $env:ProgramW6432 'Docker\Docker\DockerCli.exe'),
-            (Join-Path $env:ProgramFiles 'Docker\Docker\com.docker.cli.exe'),
-            (Join-Path $env:ProgramW6432 'Docker\Docker\com.docker.cli.exe')
-          ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -LiteralPath $_ -PathType Leaf) }
-
-          if ($dockerCliCandidates.Count -gt 0) {
-            $dockerCli = $dockerCliCandidates[0]
-            Write-Host ("[docker-bootstrap] switching engine via {0} -SwitchWindowsEngine" -f $dockerCli)
-            & $dockerCli -SwitchWindowsEngine 2>&1 | Out-Host
-          } else {
-            Write-Host '[docker-bootstrap] DockerCli.exe not found; relying on existing engine mode'
-          }
-
-          $deadline = (Get-Date).AddMinutes(3)
-          $ready = $false
-          while ((Get-Date) -lt $deadline) {
-            $probe = & docker info --format '{{.OSType}}' 2>&1
-            if ($LASTEXITCODE -eq 0 -and $probe) {
-              $osType = ([string]$probe).Trim().ToLowerInvariant()
-              if ($osType -eq 'windows') {
-                Write-Host '[docker-bootstrap] docker info reports windows'
-                $ready = $true
-                break
-              }
-            }
-            Start-Sleep -Seconds 3
-          }
-
-          if (-not $ready) {
-            throw 'Docker windows engine did not become ready within 3 minutes.'
-          }
+          Write-Host ("[docker-bootstrap] com.docker.service status={0}" -f $service.Status)
 
       - name: Manage Docker runtime (Windows lane preflight)
         run: |
@@ -921,7 +892,7 @@ jobs:
             -ExpectedContext desktop-windows `
             -AutoRepair:$true `
             -ManageDockerEngine:$true `
-            -EngineReadyTimeoutSeconds 300 `
+            -EngineReadyTimeoutSeconds 120 `
             -EngineReadyPollSeconds 3 `
             -SnapshotPath $snapshotPath `
             -GitHubOutputPath ''
@@ -952,16 +923,16 @@ jobs:
 
           "history_scenario_set=$set" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Run Docker Desktop fast-loop (Windows VI history lane)
+      - name: Run Docker Desktop fast-loop (Windows VI history lane, self-hosted only)
         id: loop
         run: |
           $set = '${{ steps.resolve.outputs.history_scenario_set }}'
           $resultsRoot = 'tests/results/local-parity/windows'
           $summaryOutput = pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 `
             -ResultsRoot $resultsRoot `
+            -LaneScope windows `
             -SkipLinuxProbe `
-            -HistoryScenarioSet $set `
-            -ManageDockerEngine:$true
+            -HistoryScenarioSet $set
           $exit = $LASTEXITCODE
           $summaryPath = ''
           if ($summaryOutput) {

--- a/.github/workflows/vi-compare-fork.yml
+++ b/.github/workflows/vi-compare-fork.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   detect-and-compare:
     name: Compare Changed VIs
-    runs-on: [self-hosted, Windows, X64, self-hosted-docker]
+    runs-on: [self-hosted, Windows, X64, self-hosted-docker-windows]
     permissions:
       contents: read
       actions: read
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ env.BASE_SHA }}
           fetch-depth: 0
 
-      - name: Assert self-hosted-docker runner label
+      - name: Assert self-hosted-docker-windows runner label
         id: runner_label_contract
         shell: pwsh
         env:
@@ -41,7 +41,7 @@ jobs:
             -Repository '${{ github.repository }}' `
             -RunId '${{ github.run_id }}' `
             -RunnerName '${{ runner.name }}' `
-            -RequiredLabel 'self-hosted-docker' `
+            -RequiredLabel 'self-hosted-docker-windows' `
             -OutputJsonPath 'results/vi-compare-fork/runner-label-contract.json' `
             -GitHubOutputPath $env:GITHUB_OUTPUT `
             -StepSummaryPath $env:GITHUB_STEP_SUMMARY

--- a/tests/Assert-DockerRuntimeDeterminism.Tests.ps1
+++ b/tests/Assert-DockerRuntimeDeterminism.Tests.ps1
@@ -216,11 +216,39 @@ exit 0
 
     $snapshot = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json -Depth 12
     $snapshot.result.status | Should -Be 'mismatch-failed'
+    $snapshot.result.failureClass | Should -Be 'daemon-unavailable'
     $snapshot.observed.osType | Should -BeNullOrEmpty
     $snapshot.observed.dockerOsProbe.last.parseReason | Should -Match '^(daemon-unavailable|docker-info-command-failed)$'
     $snapshot.observed.PSObject.Properties.Name | Should -Contain 'dockerBackendProcesses'
     $snapshot.result.reason | Should -Match 'parseReason=(daemon-unavailable|docker-info-command-failed)'
     $snapshot.result.reason | Should -Match 'exitCode=1'
+  }
+
+  It 'classifies parse-defect when docker info output is non-empty but unparseable' {
+    $work = Join-Path $TestDrive 'parse-defect-unparseable'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerWslStubs -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_INFO_MODE 'unparseable-success'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-windows'
+
+    $snapshotPath = Join-Path $work 'runtime.json'
+    $githubOutput = Join-Path $work 'github-output.txt'
+    $output = & pwsh -NoLogo -NoProfile -File $script:GuardScript `
+      -ExpectedOsType windows `
+      -ExpectedContext desktop-windows `
+      -AutoRepair:$false `
+      -SnapshotPath $snapshotPath `
+      -GitHubOutputPath $githubOutput 2>&1
+    $LASTEXITCODE | Should -Not -Be 0
+
+    $snapshot = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json -Depth 12
+    $snapshot.result.status | Should -Be 'mismatch-failed'
+    $snapshot.result.failureClass | Should -Be 'parse-defect'
+    $snapshot.result.probeParseReason | Should -Be 'unparseable-output'
+
+    $ghOut = Get-Content -LiteralPath $githubOutput -Raw
+    $ghOut | Should -Match 'runtime-failure-class=parse-defect'
   }
 
   It 'hard-stops when observed OSType is empty even under auto-repair' {
@@ -269,6 +297,7 @@ exit 0
 
     $snapshot = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json -Depth 12
     $snapshot.result.status | Should -Be 'ok'
+    $snapshot.result.failureClass | Should -Be 'none'
     $snapshot.observed.osType | Should -Be 'windows'
     $snapshot.observed.context | Should -Be 'desktop-windows'
     $snapshot.observed.dockerOsProbe.initial.parseReason | Should -Be 'parsed'
@@ -277,6 +306,7 @@ exit 0
 
     $ghOut = Get-Content -LiteralPath $githubOutput -Raw
     $ghOut | Should -Match 'runtime-status=ok'
+    $ghOut | Should -Match 'runtime-failure-class=none'
     $ghOut | Should -Match 'docker-ostype-parse-reason=parsed'
   }
 
@@ -328,6 +358,5 @@ exit 0
     $snapshot.observed.context | Should -Be 'default'
   }
 }
-
 
 

--- a/tests/Assert-RunnerLabelContract.Tests.ps1
+++ b/tests/Assert-RunnerLabelContract.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
           runner_id = 42
           status = 'in_progress'
           started_at = '2026-03-02T00:00:00Z'
-          labels = @('self-hosted', 'windows', 'self-hosted-docker')
+          labels = @('self-hosted', 'windows', 'self-hosted-docker-windows')
         }
       )
     }
@@ -39,7 +39,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
         -Repository 'owner/repo' `
         -RunId '100' `
         -RunnerName 'host-a' `
-        -RequiredLabel 'self-hosted-docker' `
+        -RequiredLabel 'self-hosted-docker-windows' `
         -JobsPayloadPath $jobsPayloadPath `
         -OutputJsonPath $outputJsonPath `
         -GitHubOutputPath $githubOutputPath `
@@ -52,7 +52,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
     $json.failureClass | Should -Be 'none'
     $json.hasRequiredLabel | Should -BeTrue
     $json.runnerId | Should -Be '42'
-    @($json.labels) | Should -Contain 'self-hosted-docker'
+    @($json.labels) | Should -Contain 'self-hosted-docker-windows'
 
     $ghOutput = Get-Content -LiteralPath $githubOutputPath -Raw
     $ghOutput | Should -Match 'has_required_label=true'
@@ -89,7 +89,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
         -Repository 'owner/repo' `
         -RunId '101' `
         -RunnerName 'host-b' `
-        -RequiredLabel 'self-hosted-docker' `
+        -RequiredLabel 'self-hosted-docker-windows' `
         -JobsPayloadPath $jobsPayloadPath `
         -OutputJsonPath $outputJsonPath
     } | Should -Throw
@@ -119,7 +119,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
         -Repository 'owner/repo' `
         -RunId '102' `
         -RunnerName 'host-c' `
-        -RequiredLabel 'self-hosted-docker' `
+        -RequiredLabel 'self-hosted-docker-windows' `
         -JobsPayloadPath $jobsPayloadPath `
         -OutputJsonPath $outputJsonPath
     } | Should -Throw

--- a/tests/Test-DockerDesktopFastLoop.Tests.ps1
+++ b/tests/Test-DockerDesktopFastLoop.Tests.ps1
@@ -53,7 +53,13 @@ $snapshot = [ordered]@{
   generatedAt = (Get-Date).ToUniversalTime().ToString('o')
   expected = [ordered]@{ osType = $ExpectedOsType; context = $ExpectedContext }
   observed = [ordered]@{ osType = $ExpectedOsType; context = $ExpectedContext }
-  result = [ordered]@{ status = 'ok'; reason = '' }
+  repairActions = @()
+  result = [ordered]@{
+    status = 'ok'
+    reason = ''
+    failureClass = 'none'
+    probeParseReason = 'parsed'
+  }
 }
 
 if (-not [string]::IsNullOrWhiteSpace($env:FASTLOOP_ASSERT_TRACE_PATH)) {
@@ -78,6 +84,9 @@ if ([string]::Equals($env:FASTLOOP_ASSERT_FAIL_WINDOWS, '1', [System.StringCompa
   $snapshot.observed.context = 'desktop-linux'
   $snapshot.result.status = 'mismatch-failed'
   $snapshot.result.reason = 'Runtime determinism check failed: expected os=windows'
+  $snapshot.result.failureClass = 'daemon-unavailable'
+  $snapshot.result.probeParseReason = 'daemon-unavailable'
+  $snapshot.repairActions = @('docker service recovery: restart-service')
 }
 
 if (-not [string]::IsNullOrWhiteSpace($SnapshotPath)) {
@@ -491,6 +500,9 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       $summary.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
       $summary.laneLifecycle.windows.endStep | Should -Be 'windows-runtime-preflight'
       $summary.laneLifecycle.linux.status | Should -Be 'skipped'
+      $summary.runtimeManager.schema | Should -Be 'docker-fast-loop/runtime-manager@v1'
+      $summary.runtimeManager.daemonUnavailableCount | Should -Be 1
+      $summary.runtimeManager.transitionCount | Should -BeGreaterThan 0
     } finally {
       Remove-Item Env:FASTLOOP_ASSERT_FAIL_WINDOWS -ErrorAction SilentlyContinue
       Pop-Location | Out-Null
@@ -764,4 +776,3 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
     }
   }
 }
-

--- a/tests/Update-FixtureDriftSessionIndex.Tests.ps1
+++ b/tests/Update-FixtureDriftSessionIndex.Tests.ps1
@@ -39,9 +39,9 @@ Describe 'Update-FixtureDriftSessionIndex.ps1' -Tag 'Unit' {
       -ResultsDir $resultsDir `
       -ContextPath $contextPath `
       -RuntimeSnapshotPath $runtimeSnapshotPath `
-      -RequiredLabel 'self-hosted-docker' `
+      -RequiredLabel 'self-hosted-docker-windows' `
       -HasRequiredLabel:$true `
-      -RunnerLabelsCsv 'self-hosted,windows,self-hosted-docker' `
+      -RunnerLabelsCsv 'self-hosted,windows,self-hosted-docker-windows' `
       -ManagerStatus 'success' `
       -ManagerSummaryPath 'results/fixture-drift/docker-runtime-manager.json' `
       -WindowsImageDigest 'sha256:windows' `
@@ -56,9 +56,9 @@ Describe 'Update-FixtureDriftSessionIndex.ps1' -Tag 'Unit' {
     $updated.runContext.dockerRuntimeManager.windowsImageDigest | Should -Be 'sha256:windows'
     $updated.runContext.dockerRuntimeManager.contextArtifactPath | Should -Be $contextPath
     $updated.runContext.dockerRuntimeManager.runtimeSnapshotPath | Should -Be $runtimeSnapshotPath
-    $updated.runContext.runnerLabelContract.requiredLabel | Should -Be 'self-hosted-docker'
+    $updated.runContext.runnerLabelContract.requiredLabel | Should -Be 'self-hosted-docker-windows'
     $updated.runContext.runnerLabelContract.hasRequiredLabel | Should -BeTrue
-    @($updated.runContext.runnerLabelContract.labels) | Should -Contain 'self-hosted-docker'
+    @($updated.runContext.runnerLabelContract.labels) | Should -Contain 'self-hosted-docker-windows'
   }
 
   It 'does not throw when session-index is missing and IgnoreMissingSessionIndex is enabled' {

--- a/tests/Write-DockerFastLoopProof.Tests.ps1
+++ b/tests/Write-DockerFastLoopProof.Tests.ps1
@@ -45,6 +45,15 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       toolFailureCount = 0
       hardStopTriggered = $false
       hardStopReason = ''
+      runtimeManagerTransitionCount = 2
+      runtimeManagerDaemonUnavailableCount = 1
+      runtimeManagerParseDefectCount = 0
+      runtimeManager = [ordered]@{
+        schema = 'docker-fast-loop/runtime-manager@v1'
+        transitionCount = 2
+        daemonUnavailableCount = 1
+        parseDefectCount = 0
+      }
       source = [ordered]@{
         summaryPath = $summaryPath
         statusPath = $statusPath
@@ -92,6 +101,10 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.runtimeFailureCount | Should -Be 0
     $proof.toolFailureCount | Should -Be 0
     $proof.hardStopTriggered | Should -BeFalse
+    $proof.runtimeManagerTransitionCount | Should -Be 2
+    $proof.runtimeManagerDaemonUnavailableCount | Should -Be 1
+    $proof.runtimeManagerParseDefectCount | Should -Be 0
+    $proof.runtimeManager.transitionCount | Should -Be 2
     $proof.hashes.readinessSha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.summarySha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.statusSha256 | Should -Not -BeNullOrEmpty
@@ -121,6 +134,12 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       toolFailureCount = 2
       hardStopTriggered = $true
       hardStopReason = 'Runtime determinism check failed at step windows-runtime-preflight'
+      runtimeManager = [ordered]@{
+        schema = 'docker-fast-loop/runtime-manager@v1'
+        transitionCount = 4
+        daemonUnavailableCount = 1
+        parseDefectCount = 1
+      }
       laneLifecycle = [ordered]@{
         windows = [ordered]@{
           status = 'failure'
@@ -164,6 +183,10 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.toolFailureCount | Should -Be 2
     $proof.hardStopTriggered | Should -BeTrue
     $proof.hardStopReason | Should -Match 'Runtime determinism'
+    $proof.runtimeManagerTransitionCount | Should -Be 4
+    $proof.runtimeManagerDaemonUnavailableCount | Should -Be 1
+    $proof.runtimeManagerParseDefectCount | Should -Be 1
+    $proof.runtimeManager.transitionCount | Should -Be 4
     $proof.laneLifecycle.windows.stopClass | Should -Be 'hard-stop'
     $proof.laneLifecycle.linux.stopClass | Should -Be 'blocked'
   }

--- a/tests/Write-DockerFastLoopReadiness.Tests.ps1
+++ b/tests/Write-DockerFastLoopReadiness.Tests.ps1
@@ -25,6 +25,12 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
       generatedAt = (Get-Date).ToUniversalTime().ToString('o')
       status = 'success'
       hardStopTriggered = $false
+      runtimeManager = [ordered]@{
+        schema = 'docker-fast-loop/runtime-manager@v1'
+        transitionCount = 3
+        daemonUnavailableCount = 1
+        parseDefectCount = 0
+      }
       steps = @(
         [ordered]@{
           name = 'windows-runtime-preflight'
@@ -88,6 +94,10 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.containerExportFailureCount | Should -Be 0
     $readiness.runtimeFailureCount | Should -Be 0
     $readiness.toolFailureCount | Should -Be 0
+    $readiness.runtimeManagerTransitionCount | Should -Be 3
+    $readiness.runtimeManagerDaemonUnavailableCount | Should -Be 1
+    $readiness.runtimeManagerParseDefectCount | Should -Be 0
+    $readiness.runtimeManager.transitionCount | Should -Be 3
     $readiness.lanes.windows.diffDetected | Should -BeTrue
     $readiness.lanes.windows.failureClass | Should -Be 'none'
     $readiness.lanes.linux.diffDetected | Should -BeFalse

--- a/tools/Assert-DockerRuntimeDeterminism.ps1
+++ b/tools/Assert-DockerRuntimeDeterminism.ps1
@@ -332,6 +332,53 @@ function Test-IsDaemonUnavailableProbe {
   return $false
 }
 
+function Get-ProbeParseReasonNormalized {
+  param([AllowNull()]$Probe)
+
+  if ($null -eq $Probe) { return '' }
+  $parseReason = ''
+  if ($Probe.PSObject.Properties['parseReason']) {
+    $parseReason = [string]$Probe.parseReason
+  }
+  if ([string]::IsNullOrWhiteSpace($parseReason)) {
+    return ''
+  }
+  return $parseReason.Trim().ToLowerInvariant()
+}
+
+function Resolve-RuntimeFailureClass {
+  param(
+    [AllowNull()]$Probe,
+    [AllowEmptyString()][string]$ObservedOsType,
+    [bool]$HostAlignmentFailure = $false,
+    [bool]$ContextOrOsMismatch = $false
+  )
+
+  if ($HostAlignmentFailure) {
+    return 'host-mismatch'
+  }
+
+  $parseReason = Get-ProbeParseReasonNormalized -Probe $Probe
+  if ($parseReason -in @('daemon-unavailable', 'docker-info-command-failed')) {
+    return 'daemon-unavailable'
+  }
+
+  if ([string]::IsNullOrWhiteSpace($ObservedOsType)) {
+    if ($parseReason -in @('empty-output', 'unparseable-output', 'exception', 'timeout', 'parsed-fallback-default-context')) {
+      return 'parse-defect'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($parseReason)) {
+      return 'parse-defect'
+    }
+  }
+
+  if ($ContextOrOsMismatch) {
+    return 'context-os-mismatch'
+  }
+
+  return 'runtime-mismatch'
+}
+
 function Get-DockerOsType {
   param([AllowNull()][string]$Context)
   $probe = Get-DockerOsProbe -Context $Context -TimeoutSeconds $CommandTimeoutSeconds
@@ -737,6 +784,7 @@ if ($snapshotDir -and -not (Test-Path -LiteralPath $snapshotDir -PathType Contai
 
 $resultStatus = 'ok'
 $reason = ''
+$resultFailureClass = 'none'
 $repairActions = New-Object System.Collections.Generic.List[string]
 $initialDockerOsProbe = $null
 $fallbackDockerOsProbe = $null
@@ -772,9 +820,11 @@ if ([string]::IsNullOrWhiteSpace($observedOsType)) {
 
 if (-not $hostAlignmentOk) {
   $resultStatus = 'mismatch-failed'
+  $resultFailureClass = Resolve-RuntimeFailureClass -Probe $lastDockerOsProbe -ObservedOsType $observedOsType -HostAlignmentFailure:$true
 } else {
   if ([string]::IsNullOrWhiteSpace($observedOsType)) {
     $resultStatus = 'mismatch-failed'
+    $resultFailureClass = Resolve-RuntimeFailureClass -Probe $lastDockerOsProbe -ObservedOsType $observedOsType
     $probeHint = Format-DockerOsProbeHint -Probe $lastDockerOsProbe
     $manualSteps = Get-ManualRemediationSteps -TargetOsType $ExpectedOsType -ExpectedContext $effectiveExpectedContext
     $manualText = if ($manualSteps.Count -gt 0) { [string]::Join('; ', $manualSteps) } else { 'n/a' }
@@ -876,15 +926,24 @@ if (-not $hostAlignmentOk) {
         $manualText = if ($manualSteps.Count -gt 0) { [string]::Join('; ', $manualSteps) } else { 'n/a' }
         $probeHint = Format-DockerOsProbeHint -Probe $lastDockerOsProbe
         $resultStatus = 'mismatch-failed'
+        $resultFailureClass = Resolve-RuntimeFailureClass `
+          -Probe $lastDockerOsProbe `
+          -ObservedOsType $observedOsType `
+          -ContextOrOsMismatch:($osMismatchAfter -or $contextMismatchAfter)
         $reason = ("Runtime invariant mismatch after repair. expected os={0}, context={1}; observed os={2}, context={3}. Manual remediation: {4}. {5}" -f $ExpectedOsType, $effectiveExpectedContext, ($observedOsType ?? '<null>'), ($observedContext ?? '<null>'), $manualText, $probeHint)
         } else {
           $resultStatus = 'mismatch-repaired'
+          $resultFailureClass = 'none'
         }
       } else {
         $manualSteps = Get-ManualRemediationSteps -TargetOsType $ExpectedOsType -ExpectedContext $effectiveExpectedContext
         $manualText = if ($manualSteps.Count -gt 0) { [string]::Join('; ', $manualSteps) } else { 'n/a' }
         $probeHint = Format-DockerOsProbeHint -Probe $lastDockerOsProbe
         $resultStatus = 'mismatch-failed'
+        $resultFailureClass = Resolve-RuntimeFailureClass `
+          -Probe $lastDockerOsProbe `
+          -ObservedOsType $observedOsType `
+          -ContextOrOsMismatch:$true
         $reason = ("Runtime invariant mismatch. expected os={0}, context={1}; observed os={2}, context={3}. Manual remediation: {4}. {5}" -f $ExpectedOsType, $effectiveExpectedContext, ($observedOsType ?? '<null>'), ($observedContext ?? '<null>'), $manualText, $probeHint)
       }
     }
@@ -926,6 +985,8 @@ $snapshot = [ordered]@{
   result = [ordered]@{
     status = $resultStatus
     reason = $reason
+    failureClass = $resultFailureClass
+    probeParseReason = (Get-ProbeParseReasonNormalized -Probe $lastDockerOsProbe)
   }
 }
 
@@ -934,6 +995,7 @@ $snapshot | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $snapshotResolve
 Write-GitHubOutput -Key 'runtime-status' -Value $resultStatus -DestPath $GitHubOutputPath
 Write-GitHubOutput -Key 'docker-ostype' -Value ($observedOsType ?? '') -DestPath $GitHubOutputPath
 Write-GitHubOutput -Key 'docker-context' -Value ($observedContext ?? '') -DestPath $GitHubOutputPath
+Write-GitHubOutput -Key 'runtime-failure-class' -Value ($resultFailureClass ?? '') -DestPath $GitHubOutputPath
 $dockerOsParseReason = ''
 if ($lastDockerOsProbe -and $lastDockerOsProbe.PSObject.Properties['parseReason']) {
   $dockerOsParseReason = [string]$lastDockerOsProbe.parseReason
@@ -946,4 +1008,3 @@ Write-Host ("[runtime-determinism] status={0} expectedContext={1} observedContex
 if ($resultStatus -eq 'mismatch-failed') {
   throw ($reason ?? 'Runtime determinism check failed.')
 }
-

--- a/tools/Assert-RunnerLabelContract.ps1
+++ b/tools/Assert-RunnerLabelContract.ps1
@@ -14,7 +14,7 @@ param(
   [string]$Repository = $env:GITHUB_REPOSITORY,
   [string]$RunId = $env:GITHUB_RUN_ID,
   [string]$RunnerName = $env:RUNNER_NAME,
-  [string]$RequiredLabel = 'self-hosted-docker',
+  [string]$RequiredLabel = 'self-hosted-docker-windows',
   [string]$Token = $env:GITHUB_TOKEN,
   [string]$OutputJsonPath = 'results/fixture-drift/runner-label-contract.json',
   [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,

--- a/tools/Test-DockerDesktopFastLoop.ps1
+++ b/tools/Test-DockerDesktopFastLoop.ps1
@@ -72,6 +72,99 @@ function Resolve-RepoRelativePath {
   return $resolved
 }
 
+function Read-JsonFileOrNull {
+  param([AllowNull()][AllowEmptyString()][string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+  try {
+    return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 12)
+  } catch {
+    return $null
+  }
+}
+
+function Get-RuntimeManagerLaneTelemetry {
+  param(
+    [Parameter(Mandatory)][ValidateSet('windows', 'linux')][string]$Lane,
+    [Parameter(Mandatory)][string]$SnapshotPath
+  )
+
+  $snapshot = Read-JsonFileOrNull -Path $SnapshotPath
+  $repairActions = @()
+  if ($snapshot -and $snapshot.PSObject.Properties['repairActions'] -and $snapshot.repairActions) {
+    $repairActions = @($snapshot.repairActions | ForEach-Object { [string]$_ })
+  }
+
+  $status = ''
+  $failureClass = ''
+  $probeParseReason = ''
+  $observedOsType = ''
+  $observedContext = ''
+  if ($snapshot -and $snapshot.PSObject.Properties['result'] -and $snapshot.result) {
+    if ($snapshot.result.PSObject.Properties['status']) { $status = [string]$snapshot.result.status }
+    if ($snapshot.result.PSObject.Properties['failureClass']) { $failureClass = [string]$snapshot.result.failureClass }
+    if ($snapshot.result.PSObject.Properties['probeParseReason']) { $probeParseReason = [string]$snapshot.result.probeParseReason }
+  }
+  if ($snapshot -and $snapshot.PSObject.Properties['observed'] -and $snapshot.observed) {
+    if ($snapshot.observed.PSObject.Properties['osType']) { $observedOsType = [string]$snapshot.observed.osType }
+    if ($snapshot.observed.PSObject.Properties['context']) { $observedContext = [string]$snapshot.observed.context }
+  }
+  if ([string]::IsNullOrWhiteSpace($probeParseReason) -and $snapshot -and $snapshot.PSObject.Properties['observed'] -and $snapshot.observed -and $snapshot.observed.PSObject.Properties['dockerOsProbe'] -and $snapshot.observed.dockerOsProbe -and $snapshot.observed.dockerOsProbe.PSObject.Properties['last'] -and $snapshot.observed.dockerOsProbe.last -and $snapshot.observed.dockerOsProbe.last.PSObject.Properties['parseReason']) {
+    $probeParseReason = [string]$snapshot.observed.dockerOsProbe.last.parseReason
+  }
+
+  $contextSwitchCount = 0
+  $engineSwitchCount = 0
+  $serviceRecoveryCount = 0
+  foreach ($action in @($repairActions)) {
+    if ($action -match '(?i)^docker context use ') { $contextSwitchCount++ }
+    if ($action -match '(?i)^docker engine switch to ') { $engineSwitchCount++ }
+    if ($action -match '(?i)^docker service recovery:') { $serviceRecoveryCount++ }
+  }
+
+  return [ordered]@{
+    lane = $Lane
+    snapshotPath = $SnapshotPath
+    snapshotPresent = ($null -ne $snapshot)
+    status = $status
+    failureClass = if ([string]::IsNullOrWhiteSpace($failureClass)) { 'none' } else { $failureClass }
+    probeParseReason = $probeParseReason
+    observedOsType = $observedOsType
+    observedContext = $observedContext
+    repairActionCount = @($repairActions).Count
+    contextSwitchCount = [int]$contextSwitchCount
+    engineSwitchCount = [int]$engineSwitchCount
+    serviceRecoveryCount = [int]$serviceRecoveryCount
+    daemonUnavailable = ([string]$failureClass -eq 'daemon-unavailable')
+    parseDefect = ([string]$failureClass -eq 'parse-defect')
+    repairActions = @($repairActions)
+  }
+}
+
+function Get-RuntimeManagerTelemetry {
+  param(
+    [Parameter(Mandatory)][string]$WindowsSnapshotPath,
+    [Parameter(Mandatory)][string]$LinuxSnapshotPath
+  )
+
+  $windows = Get-RuntimeManagerLaneTelemetry -Lane windows -SnapshotPath $WindowsSnapshotPath
+  $linux = Get-RuntimeManagerLaneTelemetry -Lane linux -SnapshotPath $LinuxSnapshotPath
+  return [ordered]@{
+    schema = 'docker-fast-loop/runtime-manager@v1'
+    lanes = [ordered]@{
+      windows = $windows
+      linux = $linux
+    }
+    transitionCount = [int]($windows.repairActionCount + $linux.repairActionCount)
+    contextSwitchCount = [int]($windows.contextSwitchCount + $linux.contextSwitchCount)
+    engineSwitchCount = [int]($windows.engineSwitchCount + $linux.engineSwitchCount)
+    serviceRecoveryCount = [int]($windows.serviceRecoveryCount + $linux.serviceRecoveryCount)
+    daemonUnavailableCount = [int](([int]$windows.daemonUnavailable) + ([int]$linux.daemonUnavailable))
+    parseDefectCount = [int](([int]$windows.parseDefect) + ([int]$linux.parseDefect))
+  }
+}
+
 function Get-HistoryScenarioIdsForSet {
   param(
     [Parameter(Mandatory)][string]$ScenarioSet,
@@ -585,7 +678,8 @@ function Write-SemiLiveStatus {
     [Parameter(Mandatory)][hashtable]$HistoricalStepMedians,
     [bool]$HardStopTriggered = $false,
     [AllowEmptyString()][string]$HardStopReason = '',
-    [AllowEmptyString()][string]$SummaryPath
+    [AllowEmptyString()][string]$SummaryPath,
+    [AllowNull()]$RuntimeManagerTelemetry = $null
   )
 
   if ([string]::IsNullOrWhiteSpace($Path)) {
@@ -626,6 +720,7 @@ function Write-SemiLiveStatus {
     hardStopReason = ($HardStopReason ?? '')
     laneLifecycle = $telemetry.laneLifecycle
     telemetry = $telemetry
+    runtimeManager = $RuntimeManagerTelemetry
     steps = @($Steps)
     summaryPath = ($SummaryPath ?? '')
   }
@@ -1524,6 +1619,7 @@ $summary = [ordered]@{
   stepTimeoutSeconds = [int]$StepTimeoutSeconds
   manageDockerEngine = [bool]$effectiveManageDockerEngine
   laneOrder = $LaneOrder
+  runtimeManager = (Get-RuntimeManagerTelemetry -WindowsSnapshotPath $windowsSnapshot -LinuxSnapshotPath $linuxSnapshot)
   laneLifecycle = (Get-LaneLifecycleFromPlan `
     -StepPlan $stepPlan `
     -ObservedSteps $results.ToArray() `
@@ -1549,7 +1645,8 @@ Write-SemiLiveStatus `
   -HistoricalStepMedians $historicalStepMedians `
   -HardStopTriggered:$hardStopTriggered `
   -HardStopReason $hardStopReason `
-  -SummaryPath $summaryPath
+  -SummaryPath $summaryPath `
+  -RuntimeManagerTelemetry $summary.runtimeManager
 
 pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Write-DockerFastLoopReadiness.ps1') `
   -ResultsRoot $root `
@@ -1573,4 +1670,3 @@ if ($failed.Count -gt 0) {
 }
 
 Write-Output $summaryPath
-

--- a/tools/Update-FixtureDriftSessionIndex.ps1
+++ b/tools/Update-FixtureDriftSessionIndex.ps1
@@ -9,7 +9,7 @@ param(
   [string]$SessionIndexPath = '',
   [string]$ContextPath = '',
   [string]$RuntimeSnapshotPath = '',
-  [string]$RequiredLabel = 'self-hosted-docker',
+  [string]$RequiredLabel = 'self-hosted-docker-windows',
   [bool]$HasRequiredLabel = $false,
   [string]$RunnerLabelsCsv = '',
   [string]$ManagerStatus = '',

--- a/tools/Write-DockerFastLoopProof.ps1
+++ b/tools/Write-DockerFastLoopProof.ps1
@@ -163,6 +163,40 @@ $hardStopReason = if ($readiness.PSObject.Properties['hardStopReason']) {
 } else {
   ''
 }
+$runtimeManager = if ($readiness.PSObject.Properties['runtimeManager']) {
+  $readiness.runtimeManager
+} elseif ($summary -and $summary.PSObject.Properties['runtimeManager']) {
+  $summary.runtimeManager
+} else {
+  $null
+}
+$runtimeManagerTransitionCount = if ($readiness.PSObject.Properties['runtimeManagerTransitionCount']) {
+  [int]$readiness.runtimeManagerTransitionCount
+} elseif ($summary -and $summary.PSObject.Properties['runtimeManagerTransitionCount']) {
+  [int]$summary.runtimeManagerTransitionCount
+} elseif ($runtimeManager -and $runtimeManager.PSObject.Properties['transitionCount']) {
+  [int]$runtimeManager.transitionCount
+} else {
+  0
+}
+$runtimeManagerDaemonUnavailableCount = if ($readiness.PSObject.Properties['runtimeManagerDaemonUnavailableCount']) {
+  [int]$readiness.runtimeManagerDaemonUnavailableCount
+} elseif ($summary -and $summary.PSObject.Properties['runtimeManagerDaemonUnavailableCount']) {
+  [int]$summary.runtimeManagerDaemonUnavailableCount
+} elseif ($runtimeManager -and $runtimeManager.PSObject.Properties['daemonUnavailableCount']) {
+  [int]$runtimeManager.daemonUnavailableCount
+} else {
+  0
+}
+$runtimeManagerParseDefectCount = if ($readiness.PSObject.Properties['runtimeManagerParseDefectCount']) {
+  [int]$readiness.runtimeManagerParseDefectCount
+} elseif ($summary -and $summary.PSObject.Properties['runtimeManagerParseDefectCount']) {
+  [int]$summary.runtimeManagerParseDefectCount
+} elseif ($runtimeManager -and $runtimeManager.PSObject.Properties['parseDefectCount']) {
+  [int]$runtimeManager.parseDefectCount
+} else {
+  0
+}
 
 $proof = [ordered]@{
   schema = 'vi-history/docker-fast-loop-proof@v1'
@@ -178,6 +212,10 @@ $proof = [ordered]@{
   toolFailureCount = [int]$toolFailureCount
   hardStopTriggered = [bool]$hardStopTriggered
   hardStopReason = $hardStopReason
+  runtimeManagerTransitionCount = [int]$runtimeManagerTransitionCount
+  runtimeManagerDaemonUnavailableCount = [int]$runtimeManagerDaemonUnavailableCount
+  runtimeManagerParseDefectCount = [int]$runtimeManagerParseDefectCount
+  runtimeManager = $runtimeManager
   readinessPath = $readinessResolved
   summaryPath = $summaryResolved
   statusPath = $statusResolved

--- a/tools/Write-DockerFastLoopReadiness.ps1
+++ b/tools/Write-DockerFastLoopReadiness.ps1
@@ -438,6 +438,24 @@ if ($summary.PSObject.Properties['hardStopTriggered']) {
   $hardStopTriggered = [bool]$summary.hardStopTriggered
 }
 $hardStopReason = if ($summary.PSObject.Properties['hardStopReason']) { [string]$summary.hardStopReason } else { '' }
+$runtimeManager = $null
+if ($summary.PSObject.Properties['runtimeManager']) {
+  $runtimeManager = $summary.runtimeManager
+}
+$runtimeManagerTransitionCount = 0
+$runtimeManagerDaemonUnavailableCount = 0
+$runtimeManagerParseDefectCount = 0
+if ($runtimeManager) {
+  if ($runtimeManager.PSObject.Properties['transitionCount']) {
+    $runtimeManagerTransitionCount = [int]$runtimeManager.transitionCount
+  }
+  if ($runtimeManager.PSObject.Properties['daemonUnavailableCount']) {
+    $runtimeManagerDaemonUnavailableCount = [int]$runtimeManager.daemonUnavailableCount
+  }
+  if ($runtimeManager.PSObject.Properties['parseDefectCount']) {
+    $runtimeManagerParseDefectCount = [int]$runtimeManager.parseDefectCount
+  }
+}
 $laneLifecycle = Resolve-LaneLifecycle `
   -Summary $summary `
   -LaneState $lane `
@@ -481,6 +499,10 @@ $readiness = [ordered]@{
   toolFailureCount = [int]$classification.toolFailureCount
   hardStopTriggered = [bool]$hardStopTriggered
   hardStopReason = $hardStopReason
+  runtimeManagerTransitionCount = [int]$runtimeManagerTransitionCount
+  runtimeManagerDaemonUnavailableCount = [int]$runtimeManagerDaemonUnavailableCount
+  runtimeManagerParseDefectCount = [int]$runtimeManagerParseDefectCount
+  runtimeManager = $runtimeManager
   source = [ordered]@{
     summaryPath = $summaryResolved
     statusPath = if (Test-Path -LiteralPath $statusResolved -PathType Leaf) { $statusResolved } else { '' }
@@ -494,6 +516,9 @@ $readiness = [ordered]@{
     historyScenarioCount = [int]$historyScenarioCount
     hardStopTriggered = [bool]$hardStopTriggered
     hardStopReason = $hardStopReason
+    runtimeManagerTransitionCount = [int]$runtimeManagerTransitionCount
+    runtimeManagerDaemonUnavailableCount = [int]$runtimeManagerDaemonUnavailableCount
+    runtimeManagerParseDefectCount = [int]$runtimeManagerParseDefectCount
     diffStepCount = [int]$classification.diffStepCount
     diffEvidenceSteps = [int]$classification.diffEvidenceSteps
     extractedReportCount = [int]$classification.extractedReportCount
@@ -556,6 +581,9 @@ $mdLines.Add(('| Extracted Report Count | `{0}` |' -f $readiness.extractedReport
 $mdLines.Add(('| Container Export Failure Count | `{0}` |' -f $readiness.containerExportFailureCount)) | Out-Null
 $mdLines.Add(('| Runtime Failure Count | `{0}` |' -f $readiness.runtimeFailureCount)) | Out-Null
 $mdLines.Add(('| Tool Failure Count | `{0}` |' -f $readiness.toolFailureCount)) | Out-Null
+$mdLines.Add(('| Runtime Manager Transitions | `{0}` |' -f $readiness.runtimeManagerTransitionCount)) | Out-Null
+$mdLines.Add(('| Runtime Manager Daemon-Unavailable Count | `{0}` |' -f $readiness.runtimeManagerDaemonUnavailableCount)) | Out-Null
+$mdLines.Add(('| Runtime Manager Parse-Defect Count | `{0}` |' -f $readiness.runtimeManagerParseDefectCount)) | Out-Null
 $mdLines.Add(('| Timeout Failure Count | `{0}` |' -f $readiness.run.timeoutFailureCount)) | Out-Null
 $mdLines.Add(('| Preflight Failure Count | `{0}` |' -f $readiness.run.preflightFailureCount)) | Out-Null
 $mdLines.Add(('| Completed Steps | `{0}` |' -f @($steps).Count)) | Out-Null


### PR DESCRIPTION
## Summary
- sync runtime-manager and VI history lane contracts from `origin/develop` into upstream `develop`
- align self-hosted Docker behavior to Windows-only fast-loop semantics
- keep Linux VI history lane hosted and independent from self-hosted engine switching
- carry deterministic runtime guard/test updates used by standing-priority flow

## Scope
This PR applies the current tip-diff parity set (16 files) identified by parity reporter:
- `.github/actionlint.yaml`
- `.github/workflows/fixture-drift.yml`
- `.github/workflows/validate.yml`
- `.github/workflows/vi-compare-fork.yml`
- runtime-manager scripts/tests under `tools/` and `tests/`

## Validation
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `pwsh -NoLogo -NoProfile -Command "& { .\\Invoke-PesterTests.ps1 -TestsPath tests -IncludePatterns @(''Assert-DockerRuntimeDeterminism.Tests.ps1'',''Test-DockerDesktopFastLoop.Tests.ps1'',''Write-DockerFastLoopReadiness.Tests.ps1'',''Write-DockerFastLoopProof.Tests.ps1'',''Assert-RunnerLabelContract.Tests.ps1'',''Update-FixtureDriftSessionIndex.Tests.ps1'') }"`

## Intent
Progress deterministic origin/upstream alignment for the next upstream release cut.
