### PR TITLE
sync: mirror CLI phase1 command contracts from origin

### DIFF
--- a/src/CompareVi.Shared.Tests/ExitClassificationTests.cs
+++ b/src/CompareVi.Shared.Tests/ExitClassificationTests.cs
@@ -1,0 +1,57 @@
+using CompareVi.Shared;
+using Xunit;
+
+namespace CompareVi.Shared.Tests
+{
+    public class ExitClassificationTests
+    {
+        [Fact]
+        public void Classify_ZeroExit_NoDiff_IsSuccessNoDiff()
+        {
+            var result = ExitClassification.Classify(0, hasDiffEvidence: false);
+            Assert.Equal("success-no-diff", result.ResultClass);
+            Assert.False(result.IsDiff);
+            Assert.Equal("pass", result.GateOutcome);
+            Assert.Equal("none", result.FailureClass);
+        }
+
+        [Fact]
+        public void Classify_ExitOne_WithDiff_IsSuccessDiff()
+        {
+            var result = ExitClassification.Classify(1, hasDiffEvidence: true);
+            Assert.Equal("success-diff", result.ResultClass);
+            Assert.True(result.IsDiff);
+            Assert.Equal("pass", result.GateOutcome);
+            Assert.Equal("none", result.FailureClass);
+        }
+
+        [Fact]
+        public void Classify_ExitOne_NoDiffDefaultsToDiffPass()
+        {
+            var result = ExitClassification.Classify(1, hasDiffEvidence: false);
+            Assert.Equal("success-diff", result.ResultClass);
+            Assert.True(result.IsDiff);
+            Assert.Equal("pass", result.GateOutcome);
+            Assert.Equal("none", result.FailureClass);
+        }
+
+        [Fact]
+        public void Classify_TimeoutExit_IsFailureTimeout()
+        {
+            var result = ExitClassification.Classify(124, hasDiffEvidence: false);
+            Assert.Equal("failure-timeout", result.ResultClass);
+            Assert.Equal("fail", result.GateOutcome);
+            Assert.Equal("timeout", result.FailureClass);
+        }
+
+        [Fact]
+        public void Classify_DeclaredRuntimeFailure_IsFailureRuntime()
+        {
+            var result = ExitClassification.Classify(0, hasDiffEvidence: true, declaredFailureClass: "runtime");
+            Assert.Equal("failure-runtime", result.ResultClass);
+            Assert.Equal("fail", result.GateOutcome);
+            Assert.Equal("runtime-determinism", result.FailureClass);
+            Assert.False(result.IsDiff);
+        }
+    }
+}

--- a/src/CompareVi.Shared/ExitClassification.cs
+++ b/src/CompareVi.Shared/ExitClassification.cs
@@ -1,0 +1,88 @@
+namespace CompareVi.Shared
+{
+    public sealed class ExitClassificationResult
+    {
+        public string ResultClass { get; init; } = "failure-tool";
+        public bool IsDiff { get; init; }
+        public string GateOutcome { get; init; } = "fail";
+        public string FailureClass { get; init; } = "cli/tool";
+    }
+
+    public static class ExitClassification
+    {
+        public static ExitClassificationResult Classify(int exitCode, bool hasDiffEvidence = false, string? declaredFailureClass = null)
+        {
+            var normalizedFailureClass = NormalizeFailureClass(declaredFailureClass);
+            if (!string.Equals(normalizedFailureClass, "none", System.StringComparison.Ordinal))
+            {
+                return normalizedFailureClass switch
+                {
+                    "runtime-determinism" => Fail("failure-runtime", normalizedFailureClass),
+                    "timeout" => Fail("failure-timeout", normalizedFailureClass),
+                    "preflight" => Fail("failure-preflight", normalizedFailureClass),
+                    _ => Fail("failure-tool", normalizedFailureClass)
+                };
+            }
+
+            if (exitCode == 124)
+            {
+                return Fail("failure-timeout", "timeout");
+            }
+
+            if (hasDiffEvidence || exitCode == 1)
+            {
+                return Pass(diff: true, resultClass: "success-diff");
+            }
+
+            if (exitCode == 0)
+            {
+                return Pass(diff: false, resultClass: "success-no-diff");
+            }
+
+            return Fail("failure-tool", "cli/tool");
+        }
+
+        private static ExitClassificationResult Pass(bool diff, string resultClass)
+        {
+            return new ExitClassificationResult
+            {
+                ResultClass = resultClass,
+                IsDiff = diff,
+                GateOutcome = "pass",
+                FailureClass = "none"
+            };
+        }
+
+        private static ExitClassificationResult Fail(string resultClass, string failureClass)
+        {
+            return new ExitClassificationResult
+            {
+                ResultClass = resultClass,
+                IsDiff = false,
+                GateOutcome = "fail",
+                FailureClass = failureClass
+            };
+        }
+
+        private static string NormalizeFailureClass(string? failureClass)
+        {
+            if (string.IsNullOrWhiteSpace(failureClass))
+            {
+                return "none";
+            }
+
+            var normalized = failureClass.Trim().ToLowerInvariant();
+            return normalized switch
+            {
+                "none" => "none",
+                "runtime" => "runtime-determinism",
+                "runtime-determinism" => "runtime-determinism",
+                "timeout" => "timeout",
+                "preflight" => "preflight",
+                "startup-connectivity" => "startup-connectivity",
+                "cli/tool" => "cli/tool",
+                _ => normalized
+            };
+        }
+    }
+}

--- a/src/CompareVi.Tools.Cli.Tests/CompareVi.Tools.Cli.Tests.csproj
+++ b/src/CompareVi.Tools.Cli.Tests/CompareVi.Tools.Cli.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>CompareVi.Tools.Cli.Tests</RootNamespace>
+    <AssemblyName>CompareVi.Tools.Cli.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/src/CompareVi.Tools.Cli.Tests/PhaseOneCommandContractsTests.cs
+++ b/src/CompareVi.Tools.Cli.Tests/PhaseOneCommandContractsTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace CompareVi.Tools.Cli.Tests
+{
+    public class PhaseOneCommandContractsTests
+    {
+        private static readonly string RepoRoot = ResolveRepoRoot();
+        private static readonly string CliProjectPath = Path.Combine(RepoRoot, "src", "CompareVi.Tools.Cli", "CompareVi.Tools.Cli.csproj");
+        private static readonly string CliDllPath = Path.Combine(RepoRoot, "src", "CompareVi.Tools.Cli", "bin", "Debug", "net8.0", "comparevi-cli.dll");
+
+        static PhaseOneCommandContractsTests()
+        {
+            var build = RunProcess("dotnet", $"build \"{CliProjectPath}\" -c Debug --nologo");
+            Assert.True(build.ExitCode == 0, $"CLI build failed: {build.StdErr}\n{build.StdOut}");
+            Assert.True(File.Exists(CliDllPath), $"Expected CLI output at {CliDllPath}");
+        }
+
+        [Fact]
+        public void CompareSingle_DryRunDiff_EmitsDiffPassContract()
+        {
+            var inputPath = Path.Combine(RepoRoot, "tests", "results", "_agent", "cli-phase1-compare-input.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(inputPath)!);
+            File.WriteAllText(inputPath, "{}");
+
+            var run = RunCli($"compare single --input \"{inputPath}\" --dry-run --diff");
+            Assert.Equal(0, run.ExitCode);
+
+            var json = JsonNode.Parse(run.StdOut)!.AsObject();
+            Assert.Equal("comparevi-cli/compare-single@v1", json["schema"]!.GetValue<string>());
+            Assert.Equal("compare single", json["command"]!.GetValue<string>());
+            Assert.Equal("success-diff", json["resultClass"]!.GetValue<string>());
+            Assert.True(json["isDiff"]!.GetValue<bool>());
+            Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
+            Assert.Equal("none", json["failureClass"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void HistoryRun_DryRun_EmitsHistoryContract()
+        {
+            var inputPath = Path.Combine(RepoRoot, "tests", "results", "_agent", "cli-phase1-history-input.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(inputPath)!);
+            File.WriteAllText(inputPath, "{}");
+
+            var run = RunCli($"history run --input \"{inputPath}\" --dry-run");
+            Assert.Equal(0, run.ExitCode);
+
+            var json = JsonNode.Parse(run.StdOut)!.AsObject();
+            Assert.Equal("comparevi-cli/history-run@v1", json["schema"]!.GetValue<string>());
+            Assert.Equal("history run", json["command"]!.GetValue<string>());
+            Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void ReportConsolidate_DryRun_EmitsReportContract()
+        {
+            var inputPath = Path.Combine(RepoRoot, "tests", "results", "_agent", "cli-phase1-report-input.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(inputPath)!);
+            File.WriteAllText(inputPath, "{}");
+
+            var run = RunCli($"report consolidate --input \"{inputPath}\" --dry-run");
+            Assert.Equal(0, run.ExitCode);
+
+            var json = JsonNode.Parse(run.StdOut)!.AsObject();
+            Assert.Equal("comparevi-cli/report-consolidate@v1", json["schema"]!.GetValue<string>());
+            Assert.Equal("report consolidate", json["command"]!.GetValue<string>());
+            Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void ContractsValidate_MissingInputFile_FailsPreflight()
+        {
+            var missingPath = Path.Combine(RepoRoot, "tests", "results", "_agent", "missing-input-does-not-exist.json");
+            if (File.Exists(missingPath))
+            {
+                File.Delete(missingPath);
+            }
+
+            var run = RunCli($"contracts validate --input \"{missingPath}\"");
+            Assert.Equal(1, run.ExitCode);
+
+            var json = JsonNode.Parse(run.StdOut)!.AsObject();
+            Assert.Equal("comparevi-cli/contracts-validate@v1", json["schema"]!.GetValue<string>());
+            Assert.False(json["valid"]!.GetValue<bool>());
+            Assert.Equal("fail", json["gateOutcome"]!.GetValue<string>());
+            Assert.Equal("failure-preflight", json["resultClass"]!.GetValue<string>());
+        }
+
+        private static (int ExitCode, string StdOut, string StdErr) RunCli(string arguments)
+        {
+            return RunProcess("dotnet", $"\"{CliDllPath}\" {arguments}");
+        }
+
+        private static (int ExitCode, string StdOut, string StdErr) RunProcess(string fileName, string arguments)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                WorkingDirectory = RepoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi)!;
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return (process.ExitCode, stdout, stderr);
+        }
+
+        private static string ResolveRepoRoot()
+        {
+            var current = AppContext.BaseDirectory;
+            for (var i = 0; i < 10; i++)
+            {
+                var candidate = Path.GetFullPath(Path.Combine(current, string.Join(Path.DirectorySeparatorChar, Enumerable.Repeat("..", i))));
+                var marker = Path.Combine(candidate, "src", "CompareVi.Tools.Cli", "CompareVi.Tools.Cli.csproj");
+                if (File.Exists(marker))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException("Unable to resolve repository root for CLI tests.");
+        }
+    }
+}

--- a/src/CompareVi.Tools.Cli/Program.cs
+++ b/src/CompareVi.Tools.Cli/Program.cs
@@ -35,6 +35,14 @@ internal static class Program
                     return CmdOperations(args);
                 case "providers":
                     return CmdProviders(args);
+                case "compare":
+                    return CmdCompare(args);
+                case "history":
+                    return CmdHistory(args);
+                case "report":
+                    return CmdReport(args);
+                case "contracts":
+                    return CmdContracts(args);
                 default:
                     Console.Error.WriteLine($"Unknown command: {cmd}");
                     PrintHelp();
@@ -61,6 +69,10 @@ internal static class Program
         Console.WriteLine("  comparevi-cli quote --path <path>");
         Console.WriteLine("  comparevi-cli operations [--name <operation>] [--names-only]");
         Console.WriteLine("  comparevi-cli providers [--name <provider>] [--names-only]");
+        Console.WriteLine("  comparevi-cli compare single --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
+        Console.WriteLine("  comparevi-cli history run --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
+        Console.WriteLine("  comparevi-cli report consolidate --input <file> --dry-run");
+        Console.WriteLine("  comparevi-cli contracts validate --input <file>");
     }
 
     private static int CmdVersion()
@@ -242,6 +254,173 @@ internal static class Program
 
         Console.Error.WriteLine($"Provider '{providerName}' was not found in the providers catalog.");
         return 3;
+    }
+
+    private static int CmdCompare(string[] args)
+    {
+        if (args.Length < 2 || !args[1].Equals("single", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Usage: comparevi-cli compare single --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
+            return 2;
+        }
+
+        return RunDryContractLane(
+            lane: "compare-single",
+            schema: "comparevi-cli/compare-single@v1",
+            command: "compare single",
+            args: args,
+            tailStart: 2
+        );
+    }
+
+    private static int CmdHistory(string[] args)
+    {
+        if (args.Length < 2 || !args[1].Equals("run", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Usage: comparevi-cli history run --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
+            return 2;
+        }
+
+        return RunDryContractLane(
+            lane: "history-run",
+            schema: "comparevi-cli/history-run@v1",
+            command: "history run",
+            args: args,
+            tailStart: 2
+        );
+    }
+
+    private static int CmdReport(string[] args)
+    {
+        if (args.Length < 2 || !args[1].Equals("consolidate", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Usage: comparevi-cli report consolidate --input <file> --dry-run");
+            return 2;
+        }
+
+        return RunDryContractLane(
+            lane: "report-consolidate",
+            schema: "comparevi-cli/report-consolidate@v1",
+            command: "report consolidate",
+            args: args,
+            tailStart: 2
+        );
+    }
+
+    private static int CmdContracts(string[] args)
+    {
+        if (args.Length < 2 || !args[1].Equals("validate", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("Usage: comparevi-cli contracts validate --input <file>");
+            return 2;
+        }
+
+        if (!TryReadOption(args, 2, "--input", out var inputPath) || string.IsNullOrWhiteSpace(inputPath))
+        {
+            Console.Error.WriteLine("Missing required option: --input <file>");
+            return 2;
+        }
+
+        var exists = File.Exists(inputPath);
+        var payload = new Dictionary<string, object?>
+        {
+            ["schema"] = "comparevi-cli/contracts-validate@v1",
+            ["command"] = "contracts validate",
+            ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["inputPath"] = Path.GetFullPath(inputPath),
+            ["exists"] = exists,
+            ["valid"] = exists,
+            ["resultClass"] = exists ? "success-no-diff" : "failure-preflight",
+            ["isDiff"] = false,
+            ["gateOutcome"] = exists ? "pass" : "fail",
+            ["failureClass"] = exists ? "none" : "preflight"
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(payload, SerializerOptions));
+        return exists ? 0 : 1;
+    }
+
+    private static int RunDryContractLane(string lane, string schema, string command, string[] args, int tailStart)
+    {
+        if (!TryReadOption(args, tailStart, "--input", out var inputPath) || string.IsNullOrWhiteSpace(inputPath))
+        {
+            Console.Error.WriteLine("Missing required option: --input <file>");
+            return 2;
+        }
+
+        var dryRun = HasFlag(args, tailStart, "--dry-run");
+        if (!dryRun)
+        {
+            Console.Error.WriteLine($"Command '{command}' currently supports adapter-dry-run only. Pass --dry-run.");
+            return 2;
+        }
+
+        var isDiff = HasFlag(args, tailStart, "--diff");
+        var exitCode = TryReadIntOption(args, tailStart, "--exit-code", out var parsedExitCode)
+            ? parsedExitCode
+            : (isDiff ? 1 : 0);
+        var declaredFailureClass = TryReadOption(args, tailStart, "--failure-class", out var failureClassValue)
+            ? failureClassValue
+            : null;
+
+        var classification = ExitClassification.Classify(exitCode, isDiff, declaredFailureClass);
+        var payload = new Dictionary<string, object?>
+        {
+            ["schema"] = schema,
+            ["lane"] = lane,
+            ["command"] = command,
+            ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["inputPath"] = Path.GetFullPath(inputPath),
+            ["dryRun"] = dryRun,
+            ["simulatedExitCode"] = exitCode,
+            ["resultClass"] = classification.ResultClass,
+            ["isDiff"] = classification.IsDiff,
+            ["gateOutcome"] = classification.GateOutcome,
+            ["failureClass"] = classification.FailureClass
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(payload, SerializerOptions));
+        return string.Equals(classification.GateOutcome, "pass", StringComparison.OrdinalIgnoreCase) ? 0 : 1;
+    }
+
+    private static bool HasFlag(string[] args, int startIndex, string flag)
+    {
+        for (int i = startIndex; i < args.Length; i++)
+        {
+            if (args[i].Equals(flag, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadOption(string[] args, int startIndex, string option, out string? value)
+    {
+        for (int i = startIndex; i < args.Length; i++)
+        {
+            if (args[i].Equals(option, StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                value = args[i + 1];
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryReadIntOption(string[] args, int startIndex, string option, out int value)
+    {
+        if (TryReadOption(args, startIndex, option, out var raw) && int.TryParse(raw, out var parsed))
+        {
+            value = parsed;
+            return true;
+        }
+
+        value = 0;
+        return false;
     }
 
     private static JsonSerializerOptions CreateSerializerOptions()


### PR DESCRIPTION
## Summary
- mirror origin PR https://github.com/svelderrainruiz/compare-vi-cli-action/pull/172 into upstream
- add phase-1 .NET CLI command contracts (`compare single`, `history run`, `report consolidate`, `contracts validate`)
- add shared exit classification helper and CLI contract tests

## Validation
- `dotnet test src/CompareVi.Shared.Tests/CompareVi.Shared.Tests.csproj -c Debug --nologo`
- `dotnet test src/CompareVi.Tools.Cli.Tests/CompareVi.Tools.Cli.Tests.csproj -c Debug --nologo`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
