### PR TITLE
fix(release): immutable release-safe asset publishing (#650)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,6 @@ jobs:
             echo "fallback=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release (CHANGELOG)
-        if: steps.notes.outputs.fallback == 'false'
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: RELEASE_NOTES.md
-
-      - name: Create GitHub Release (auto notes)
-        if: steps.notes.outputs.fallback == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v5
         with:
@@ -96,9 +84,23 @@ jobs:
             artifacts/cli/sbom.spdx.json
             artifacts/cli/provenance.json
 
-      - name: Upload assets to GitHub Release
+      - name: Create GitHub Release with assets (CHANGELOG)
+        if: steps.notes.outputs.fallback == 'false'
         uses: softprops/action-gh-release@v2
         with:
+          body_path: RELEASE_NOTES.md
+          files: |
+            artifacts/cli/*.zip
+            artifacts/cli/*.tar.gz
+            artifacts/cli/SHA256SUMS.txt
+            artifacts/cli/sbom.spdx.json
+            artifacts/cli/provenance.json
+
+      - name: Create GitHub Release with assets (auto notes)
+        if: steps.notes.outputs.fallback == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
           files: |
             artifacts/cli/*.zip
             artifacts/cli/*.tar.gz


### PR DESCRIPTION
## Summary
- fix release workflow failure on immutable releases
- create release with assets in one step instead of uploading assets after release creation

## Root cause
Run 22681503335 failed at Upload assets to GitHub Release with: "Cannot upload assets to an immutable release".

## Validation plan
- trigger upstream rehearsal tag after merge
- confirm release workflow completes and publishes CLI assets

Closes #650
