### PR TITLE
fix: fallback docker fast-loop readiness when summary missing (#655)

### DIFF
--- a/tests/Write-DockerFastLoopReadiness.Tests.ps1
+++ b/tests/Write-DockerFastLoopReadiness.Tests.ps1
@@ -363,6 +363,30 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.toolFailureCount | Should -Be 0
   }
 
+  It 'falls back to not-ready when summary json is missing' {
+    $resultsRoot = Join-Path $TestDrive 'missing-summary'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    $jsonOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.json'
+    $mdOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.md'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ReadinessScript `
+      -ResultsRoot $resultsRoot `
+      -OutputJsonPath $jsonOut `
+      -OutputMarkdownPath $mdOut `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    Test-Path -LiteralPath $jsonOut | Should -BeTrue
+    $readiness = Get-Content -LiteralPath $jsonOut -Raw | ConvertFrom-Json -Depth 16
+    $readiness.verdict | Should -Be 'not-ready'
+    $readiness.recommendation | Should -Be 'do-not-push'
+    $readiness.hardStopTriggered | Should -BeTrue
+    $readiness.run.status | Should -Be 'missing-summary'
+    $readiness.source.summaryPath | Should -Be ''
+    $readiness.hardStopReason | Should -Match 'Unable to locate docker fast-loop summary json'
+  }
+
   It 'writes GitHub outputs for readiness paths and verdict' {
     $resultsRoot = Join-Path $TestDrive 'github-output-contract'
     New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null

--- a/tools/Write-DockerFastLoopReadiness.ps1
+++ b/tools/Write-DockerFastLoopReadiness.ps1
@@ -174,7 +174,7 @@ function Get-HistoricalStats {
 }
 
 function Get-LaneFromSteps {
-  param([Parameter(Mandatory)][object[]]$Steps)
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Steps)
 
   $laneState = @{
     windows = [ordered]@{ total = 0; completed = 0; failed = 0; durationMs = 0; diffDetected = $false; failureClass = 'none' }
@@ -247,7 +247,7 @@ function Resolve-LaneLifecycle {
   param(
     [AllowNull()]$Summary,
     [Parameter(Mandatory)][hashtable]$LaneState,
-    [Parameter(Mandatory)][object[]]$Steps,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Steps,
     [bool]$HardStopTriggered = $false,
     [AllowEmptyString()][string]$HardStopReason = ''
   )
@@ -318,7 +318,7 @@ function Resolve-LaneLifecycle {
 }
 
 function Get-ClassificationAggregate {
-  param([Parameter(Mandatory)][object[]]$Steps)
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Steps)
 
   $diffStepCount = 0
   $diffEvidenceSteps = 0
@@ -392,8 +392,22 @@ $summaryResolved = if ([string]::IsNullOrWhiteSpace($SummaryPath)) {
 } else {
   Resolve-AbsolutePath -Path $SummaryPath
 }
+
+$summary = $null
 if ([string]::IsNullOrWhiteSpace($summaryResolved) -or -not (Test-Path -LiteralPath $summaryResolved -PathType Leaf)) {
-  throw ("Unable to locate docker fast-loop summary json under: {0}" -f $resultsRootResolved)
+  $summaryResolved = ''
+  $summaryMissingReason = "Unable to locate docker fast-loop summary json under: $resultsRootResolved"
+  Write-Warning $summaryMissingReason
+  $summary = [pscustomobject][ordered]@{
+    schema = 'docker-desktop-fast-loop@v1'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    status = 'missing-summary'
+    historyScenarioSet = 'none'
+    historyScenarioCount = 0
+    hardStopTriggered = $true
+    hardStopReason = $summaryMissingReason
+    steps = @()
+  }
 }
 
 $statusResolved = if ([string]::IsNullOrWhiteSpace($StatusPath)) {
@@ -413,9 +427,25 @@ $mdOutResolved = if ([string]::IsNullOrWhiteSpace($OutputMarkdownPath)) {
   Resolve-AbsolutePath -Path $OutputMarkdownPath
 }
 
-$summary = Read-JsonOrNull -Path $summaryResolved
-if (-not $summary) {
-  throw ("Unable to parse summary json: {0}" -f $summaryResolved)
+$parsedSummary = $null
+if ($summaryResolved) {
+  $parsedSummary = Read-JsonOrNull -Path $summaryResolved
+}
+if ($parsedSummary) {
+  $summary = $parsedSummary
+} elseif (-not $summary) {
+  $summaryMissingReason = "Unable to parse summary json: $summaryResolved"
+  Write-Warning $summaryMissingReason
+  $summary = [pscustomobject][ordered]@{
+    schema = 'docker-desktop-fast-loop@v1'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    status = 'invalid-summary'
+    historyScenarioSet = 'none'
+    historyScenarioCount = 0
+    hardStopTriggered = $true
+    hardStopReason = $summaryMissingReason
+    steps = @()
+  }
 }
 $status = Read-JsonOrNull -Path $statusResolved
 $steps = @()


### PR DESCRIPTION
## Summary
- handle missing/invalid Docker fast-loop summary in `Write-DockerFastLoopReadiness.ps1` without hard-throwing
- emit deterministic fallback readiness artifact with `verdict=not-ready` and `recommendation=do-not-push`
- allow empty `steps` arrays in readiness aggregation helpers
- add a regression unit test for missing-summary fallback behavior

## Testing
- `Invoke-Pester -Path tests/Write-DockerFastLoopReadiness.Tests.ps1 -Tag Unit -Output Normal`

Closes #655