### PR TITLE
Fix 60s Validate windows history cancellation timeout (#655)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -866,7 +866,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
-    timeout-minutes: 1
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- fix deterministic cancellations in `Validate` windows VI-history lane
- root cause: `vi-history-scenarios-windows` job had `timeout-minutes: 1`, which cut off `Run Docker Desktop fast-loop` around 60s
- update `.github/workflows/validate.yml` to `timeout-minutes: 20`

## Evidence
- canceled run on old SHA: `22684581891` (windows fast-loop step canceled at ~60s)
- canceled run on current SHA before fix: `22685486520` (same step canceled at ~60s)
- both runs emitted `##[error]The operation was canceled.` during the fast-loop step

## Scope
- workflow-only change (no product/runtime script changes)
- keeps existing fallback readiness/proof artifact behavior