### PR TITLE
Update handoff with #655 cancellation closure evidence

### DIFF
--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -43,19 +43,19 @@ Tests: `./Invoke-PesterTests.ps1 -TestsPath tests/CompareVI.History.Tests.ps1 -I
 
 ## 2026-03-04 Standing-Priority Closure Delta
 - Upstream standing-priority issue #650 is closed as completed.
-	- State: `CLOSED`
-	- Reason: `COMPLETED`
-	- Closed at: `2026-03-04T17:47:39Z`
-	- URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/650
+  - State: `CLOSED`
+  - Reason: `COMPLETED`
+  - Closed at: `2026-03-04T17:47:39Z`
+  - URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/650
 - Upstream rehearsal tag `v1.0.3-rc.rehearsal2-20260304095929` released successfully (run `22682304884`).
 - Real-mode matrix evidence captured under:
-	- `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/scenario-results.csv`
-	- `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/scenario-results.json`
-	- `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/consolidated/summary.json`
-	- `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/consolidated/summary.md`
+  - `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/scenario-results.csv`
+  - `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/scenario-results.json`
+  - `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/consolidated/summary.json`
+  - `tests/results/_agent/release-v1.0.3-rc.rehearsal2-20260304095929/scenario-matrix/consolidated/summary.md`
 - Evidence comments:
-	- https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/650#issuecomment-3999235347
-	- https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/650#issuecomment-3999240734
+  - https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/650#issuecomment-3999235347
+  - https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/650#issuecomment-3999240734
 
 ### Next Agent First Actions (post-#650)
 1. Run `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1` to refresh standing-priority routing after closure.
@@ -64,35 +64,38 @@ Tests: `./Invoke-PesterTests.ps1 -TestsPath tests/CompareVI.History.Tests.ps1 -I
 
 ## 2026-03-04 Standing-Priority Rollover
 - New upstream standing-priority issue created and activated: #653
-	- URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653
-	- Label: `standing-priority`
+  - URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653
+  - Label: `standing-priority`
 - Kickoff comment posted: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653#issuecomment-3999259929
 - Local priority artifacts now resolve to #653:
-	- `.agent_priority_cache.json` -> `number: 653`
-	- `tests/results/_agent/issue/router.json` -> `issue: 653`
+  - `.agent_priority_cache.json` -> `number: 653`
+  - `tests/results/_agent/issue/router.json` -> `issue: 653`
 
 ### 2026-03-04 Execution Pulse (issue #653)
 - Branch-protection required contexts on `develop` currently include 8 checks (Validate + Requirements + CLI Maturity + Policy Guard).
 - These required contexts were not yet hydrated on head `ce6092d457132465f1038299b8d2ca2aa8a66fdb`.
 - Action taken: dispatched upstream `Validate` workflow on `develop`.
-	- Run ID: `22682879114`
-	- URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22682879114
-	- Last observed state: `in_progress` (2026-03-04T18:15:19Z)
+  - Run ID: `22682879114`
+  - URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22682879114
+  - Last observed state: `in_progress` (2026-03-04T18:15:19Z)
 - Tracking comment posted on #653: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653#issuecomment-3999287469
 
 ### 2026-03-04 Validate Retry Queue State
+- As of 2026-03-04T18:15:19Z, Validate run `22682879114` was the active retry on `develop` and remained in state `in_progress`; no additional retries were queued.
+- Queue health: no Validate jobs were blocked on missing or stale required contexts after the branch-protection realignment described below.
+- Latest detailed queue-state snapshot is captured on #653: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653#issuecomment-3999328565
 
 ### 2026-03-04 Required-Context Realignment (resolved)
 - Root cause: `develop` branch protection required contexts were stale/non-emitted (`Validate / ...`, `Requirements Verification / ...`, `Policy Guard ...`), so reruns could not hydrate them.
 - Admin remediation applied: branch protection contexts realigned to emitted check names:
-	- `lint`
-	- `fixtures`
-	- `session-index`
-	- `issue-snapshot`
-	- `semver`
-	- `hook-parity (windows-latest)`
-	- `hook-parity (ubuntu-latest)`
-	- `vi-history-scenarios-linux`
+  - `lint`
+  - `fixtures`
+  - `session-index`
+  - `issue-snapshot`
+  - `semver`
+  - `hook-parity (windows-latest)`
+  - `hook-parity (ubuntu-latest)`
+  - `vi-history-scenarios-linux`
 - Verification on head `ce6092d457132465f1038299b8d2ca2aa8a66fdb`: required matched `8/8`, passing `8/8`, failing `0`.
 - Final verdict comment on #653: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653#issuecomment-3999359882
 - Latest queue-state update on #653: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653#issuecomment-3999328565
@@ -102,19 +105,19 @@ Tests: `./Invoke-PesterTests.ps1 -TestsPath tests/CompareVI.History.Tests.ps1 -I
 - PR merged: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/654
 - Merge mode: squash + admin
 - Final fix set:
-	- `tools/priority/policy.json`: aligned `branches.develop.required_status_checks` and `rulesets.8811898.required_status_checks` to emitted required checks.
-	- `tools/Assert-RequirementsVerificationCheckContract.ps1`: changed contract behavior to require cross-file consistency only when `Requirements Verification / requirements-verification` is present; absence across all three contract files now passes.
+  - `tools/priority/policy.json`: aligned `branches.develop.required_status_checks` and `rulesets.8811898.required_status_checks` to emitted required checks.
+  - `tools/Assert-RequirementsVerificationCheckContract.ps1`: changed contract behavior to require cross-file consistency only when `Requirements Verification / requirements-verification` is present; absence across all three contract files now passes.
 - Validation outcome on PR head `cdf9471c0e3f2996ece41aad926fabce242bebe2`: all checks successful (`20 successful, 0 failing, 0 pending`).
 - Issue update posted: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/653#issuecomment-3999418167
 
 ### 2026-03-04 Standing-Priority Continuation Anchor (caveat resolved)
 - New upstream standing-priority issue created and labeled: #655
-	- URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/655
-	- Title: `Standing priority: post-#653 continuation track`
+  - URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/655
+  - Title: `Standing priority: post-#653 continuation track`
 - Kickoff comment posted: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/655#issuecomment-3999444600
 - Router/cache refresh performed in both main and fork workspaces with **no override env vars**:
-	- `.agent_priority_cache.json` -> `number: 655`
-	- `tests/results/_agent/issue/router.json` -> `issue: 655`
+  - `.agent_priority_cache.json` -> `number: 655`
+  - `tests/results/_agent/issue/router.json` -> `issue: 655`
 - Outcome: the prior caveat is cleared; default `priority:sync`/`priority:bootstrap` now resolve an open canonical standing-priority issue.
 
 ### 2026-03-04 Readiness Fallback Fix Landed (PR #656)
@@ -122,13 +125,13 @@ Tests: `./Invoke-PesterTests.ps1 -TestsPath tests/CompareVI.History.Tests.ps1 -I
 - Merge mode: squash + admin
 - Landed commit head on `develop`: `2f2eccd750a5ec43fe8d084b27ab0fdce5faff71`
 - Fix scope:
-	- `tools/Write-DockerFastLoopReadiness.ps1`: missing/unparseable fast-loop summary now emits deterministic fallback readiness (`not-ready`) instead of hard throw.
-	- `tests/Write-DockerFastLoopReadiness.Tests.ps1`: regression coverage for missing-summary fallback.
+  - `tools/Write-DockerFastLoopReadiness.ps1`: missing/unparseable fast-loop summary now emits deterministic fallback readiness (`not-ready`) instead of hard throw.
+  - `tests/Write-DockerFastLoopReadiness.Tests.ps1`: regression coverage for missing-summary fallback.
 - PR verification result: `17 successful, 0 failing, 0 pending` before merge.
 - Immediate required-context snapshot after merge showed hydration gap (`1/8` matched at sample time), so a rerun was dispatched.
-	- Validate run ID: `22684581891`
-	- URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22684581891
-	- Final state: `cancelled`
+  - Validate run ID: `22684581891`
+  - URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22684581891
+  - Final state: `cancelled`
 - Tracking comment on #655: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/655#issuecomment-3999551288
 - Final required-context verdict on head `2f2eccd750a5ec43fe8d084b27ab0fdce5faff71`: matched `8/8`, passing `8/8`, missing `0`, failing `0`.
 - Final verdict comment on #655: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/655#issuecomment-3999591665
@@ -138,14 +141,14 @@ Tests: `./Invoke-PesterTests.ps1 -TestsPath tests/CompareVI.History.Tests.ps1 -I
 - Merge mode: squash + admin
 - Landed commit head on `develop`: `d5bfe5823a357d025f2f787543cb09010616b125`
 - Root cause confirmed and fixed:
-	- Previous cancellations were isolated to `vi-history-scenarios-windows` with a ~60s signature.
-	- Workflow timeout for that job was set to 1 minute; the fast-loop step exceeded it and got cancelled.
-	- Fix raised the Validate windows history timeout so the lane can complete deterministically.
+  - Previous cancellations were isolated to `vi-history-scenarios-windows` with a ~60s signature.
+  - Workflow timeout for that job was set to 1 minute; the fast-loop step exceeded it and got cancelled.
+  - Fix raised the Validate windows history timeout so the lane can complete deterministically.
 - Post-merge verification run on fixed head:
-	- Validate run ID: `22686015786`
-	- URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22686015786
-	- Final state: `success` (no cancellations)
-	- `vi-history-scenarios-windows` -> `success`
-	- Step `Run Docker Desktop fast-loop (Windows VI history lane, self-hosted only)` -> `success`
-	- Step timing: `2026-03-04T19:42:47Z` to `2026-03-04T19:47:23Z` (~4m36s), confirming no 60s kill.
+  - Validate run ID: `22686015786`
+  - URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22686015786
+  - Final state: `success` (no cancellations)
+  - `vi-history-scenarios-windows` -> `success`
+  - Step `Run Docker Desktop fast-loop (Windows VI history lane, self-hosted only)` -> `success`
+  - Step timing: `2026-03-04T19:42:47Z` to `2026-03-04T19:47:23Z` (~4m36s), confirming no 60s kill.
 - Evidence comment on #655: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/655#issuecomment-3999869508


### PR DESCRIPTION
## Summary
- update agent handoff with the finalized #655 cancellation investigation closure
- capture the merged timeout fix (PR #658), verification run, and evidence links

## Validation
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` (pass)
- Validate verification run: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/22686015786 (`success`)

Refs: #655