### PR TITLE
Fix runbook validation by removing setup-python step (#655)

### DIFF
--- a/.github/workflows/runbook-validation.yml
+++ b/.github/workflows/runbook-validation.yml
@@ -25,12 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup PowerShell Core
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
-        # (Using setup-python only to ensure UTF-8 locale; PowerShell 7 available by default on windows-latest.)
-
       - name: Run Runbook Core Phases
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- remove `actions/setup-python` from `runbook-validation.yml`
- keep runbook validation on built-in PowerShell only (no Python dependency)
- resolves repeated self-hosted failure in `Setup PowerShell Core` during Python 3.14.3 install

## Validation
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` (pass)

Refs: #655