### PR TITLE
Add non-blocking NI Windows 2026 runbook container canary (#662)

### DIFF
--- a/.github/workflows/runbook-validation.yml
+++ b/.github/workflows/runbook-validation.yml
@@ -26,9 +26,18 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Runbook Core Phases
+        id: host_runbook
         shell: pwsh
         run: |
+          $startedAt = (Get-Date)
           pwsh -File scripts/Invoke-IntegrationRunbook.ps1 -Phases Prereqs,CanonicalCli,ViInputs -JsonReport runbook-ci.json -PassThru | Out-Null
+          $elapsedSeconds = [math]::Round((New-TimeSpan -Start $startedAt -End (Get-Date)).TotalSeconds, 2)
+          $json = Get-Content runbook-ci.json -Raw | ConvertFrom-Json
+          $json | Add-Member -NotePropertyName hostElapsedSeconds -NotePropertyValue $elapsedSeconds -Force
+          $json | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath runbook-ci.json -Encoding utf8
+          if ($env:GITHUB_OUTPUT) {
+            Add-Content -Path $env:GITHUB_OUTPUT -Value ("host_elapsed_seconds=$elapsedSeconds") -Encoding utf8
+          }
           Get-Content runbook-ci.json
 
       - name: Upload Runbook Artifact
@@ -43,3 +52,107 @@ jobs:
           $json = Get-Content runbook-ci.json -Raw | ConvertFrom-Json
           if ($json.schema -ne 'integration-runbook-v1') { throw 'Schema mismatch' }
           if (-not $json.phases) { throw 'No phases in runbook output' }
+
+  runbook-check-container:
+    if: ${{ github.repository_owner == 'LabVIEW-Community-CI-CD' && !startsWith(github.ref, 'refs/tags/') }}
+    needs: runbook-check
+    runs-on: [self-hosted, Windows, X64]
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download Host Runbook Artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: integration-runbook-result
+          path: tests/results/runbook-host
+
+      - name: Run Container Canary Fast-Loop (Windows 2026)
+        id: canary_fastloop
+        shell: pwsh
+        run: |
+          $resultsRoot = 'tests/results/runbook-container-canary'
+          $startedAt = Get-Date
+          pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 `
+            -LaneScope windows `
+            -HistoryScenarioSet none `
+            -WindowsImage 'nationalinstruments/labview:2026q1-windows' `
+            -StepTimeoutSeconds 600 `
+            -ResultsRoot $resultsRoot
+
+          $exitCode = $LASTEXITCODE
+          $elapsedSeconds = [math]::Round((New-TimeSpan -Start $startedAt -End (Get-Date)).TotalSeconds, 2)
+          $summary = Get-ChildItem -LiteralPath $resultsRoot -Filter 'docker-runtime-fastloop-*.json' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $summary) {
+            throw "Container canary summary not found under $resultsRoot"
+          }
+
+          $summaryJson = Get-Content -LiteralPath $summary.FullName -Raw | ConvertFrom-Json -Depth 12
+          $hostArtifactPath = 'tests/results/runbook-host/runbook-ci.json'
+          $hostJson = if (Test-Path -LiteralPath $hostArtifactPath -PathType Leaf) {
+            Get-Content -LiteralPath $hostArtifactPath -Raw | ConvertFrom-Json -Depth 20
+          } else {
+            $null
+          }
+
+          $canary = [ordered]@{
+            schema = 'runbook-container-canary@v1'
+            generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+            host = [ordered]@{
+              artifactPath = $hostArtifactPath
+              available = ($null -ne $hostJson)
+              status = if ($null -ne $hostJson) { 'passed' } else { 'missing-artifact' }
+              elapsedSeconds = if ($null -ne $hostJson -and $hostJson.PSObject.Properties['hostElapsedSeconds']) { [double]$hostJson.hostElapsedSeconds } else { $null }
+            }
+            container = [ordered]@{
+              image = 'nationalinstruments/labview:2026q1-windows'
+              laneScope = 'windows'
+              exitCode = [int]$exitCode
+              elapsedSeconds = [double]$elapsedSeconds
+              summaryPath = $summary.FullName
+              status = if ($summaryJson.PSObject.Properties['status']) { [string]$summaryJson.status } else { '' }
+              hardStopTriggered = if ($summaryJson.PSObject.Properties['hardStopTriggered']) { [bool]$summaryJson.hardStopTriggered } else { $true }
+              windowsLaneStatus = if ($summaryJson.PSObject.Properties['laneLifecycle'] -and $summaryJson.laneLifecycle -and $summaryJson.laneLifecycle.PSObject.Properties['windows']) { [string]$summaryJson.laneLifecycle.windows.status } else { '' }
+              windowsStopClass = if ($summaryJson.PSObject.Properties['laneLifecycle'] -and $summaryJson.laneLifecycle -and $summaryJson.laneLifecycle.PSObject.Properties['windows']) { [string]$summaryJson.laneLifecycle.windows.stopClass } else { '' }
+            }
+          }
+
+          $canaryPath = 'tests/results/runbook-container-canary/runbook-container-canary.json'
+          $canary | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $canaryPath -Encoding utf8
+
+          if ($env:GITHUB_STEP_SUMMARY) {
+            $hostElapsed = if ($canary.host.elapsedSeconds -ne $null) { [string]$canary.host.elapsedSeconds } else { 'n/a' }
+            $summaryLines = @(
+              '## Runbook Container Canary (non-blocking)',
+              '',
+              '| Lane | Status | Elapsed (s) | Notes |',
+              '|---|---|---:|---|',
+              ("| host | {0} | {1} | artifact: {2} |" -f $canary.host.status, $hostElapsed, $canary.host.artifactPath),
+              ("| container | {0} | {1} | windowsLane={2}; stopClass={3}; image={4} |" -f $canary.container.status, $canary.container.elapsedSeconds, $canary.container.windowsLaneStatus, $canary.container.windowsStopClass, $canary.container.image),
+              '',
+              ("- Container summary: {0}" -f $canary.container.summaryPath),
+              ("- Canary JSON: {0}" -f $canaryPath)
+            )
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($summaryLines -join "`n") -Encoding utf8
+          }
+
+          if ($env:GITHUB_OUTPUT) {
+            Add-Content -Path $env:GITHUB_OUTPUT -Value ("container_elapsed_seconds=$elapsedSeconds") -Encoding utf8
+            Add-Content -Path $env:GITHUB_OUTPUT -Value ("container_summary_path=$($summary.FullName)") -Encoding utf8
+            Add-Content -Path $env:GITHUB_OUTPUT -Value ("container_canary_json=$canaryPath") -Encoding utf8
+          }
+
+          if ($exitCode -ne 0) {
+            throw "Container canary fast-loop failed with exit code $exitCode"
+          }
+
+      - name: Upload Container Canary Artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: integration-runbook-container-canary
+          path: |
+            tests/results/runbook-container-canary/runbook-container-canary.json
+            tests/results/runbook-container-canary/docker-runtime-fastloop-*.json


### PR DESCRIPTION
## Summary
- add `runbook-check-container` non-blocking canary job to `.github/workflows/runbook-validation.yml`
- execute Windows-lane Docker fast-loop on NI Windows 2026 image (`nationalinstruments/labview:2026q1-windows`)
- keep host `runbook-check` lane unchanged
- emit host-vs-container timing/outcome summary in step summary
- upload canary artifacts (`runbook-container-canary.json` + fast-loop summary)

## Safety model
- canary is additive and non-required (`continue-on-error: true`)
- host lane remains source of truth during burn-in

## Validation
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` (pass)
- local #662 Phase 1 rehearsal evidence: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/662#issuecomment-4000185347

Refs: #662