### PR TITLE
ci(session-index): add v2 contract burn-in check and promotion gate (#677)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -840,8 +840,52 @@ jobs:
           ${{ runner.temp }}/sessionindex/session-index-v2.json
         if-no-files-found: warn
 
+  session-index-v2-contract:
+    needs: [smoke-gate, session-index]
+    if: needs.smoke-gate.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    env:
+      SESSION_INDEX_V2_CONTRACT_ENFORCE: ${{ vars.SESSION_INDEX_V2_CONTRACT_ENFORCE || 'false' }}
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Download session index artifact
+      uses: actions/download-artifact@v5
+      with:
+        name: validate-session-index
+        path: ${{ runner.temp }}/sessionindex-v2-contract
+
+    - name: Evaluate session index v2 contract (burn-in aware)
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      run: |
+        $res = Join-Path $env:RUNNER_TEMP 'sessionindex-v2-contract'
+        $enforceRaw = "$env:SESSION_INDEX_V2_CONTRACT_ENFORCE"
+        $enforce = $false
+        if (-not [string]::IsNullOrWhiteSpace($enforceRaw)) {
+          $enforce = $enforceRaw.Trim().ToLowerInvariant() -eq 'true'
+        }
+
+        if ($enforce) {
+          Write-Host '::notice::session-index-v2 contract is running in enforce mode.'
+          pwsh -File tools/Test-SessionIndexV2Contract.ps1 -ResultsDir $res -Branch 'develop' -BurnInThreshold 10 -Enforce
+        } else {
+          Write-Host '::notice::session-index-v2 contract is running in burn-in mode (non-blocking).'
+          pwsh -File tools/Test-SessionIndexV2Contract.ps1 -ResultsDir $res -Branch 'develop' -BurnInThreshold 10
+        }
+
+    - name: Upload v2 contract report
+      if: always()
+      uses: actions/upload-artifact@v5
+      with:
+        name: validate-session-index-v2-contract
+        path: ${{ runner.temp }}/sessionindex-v2-contract/session-index-v2-contract.json
+        if-no-files-found: warn
+
   vi-history-scenarios-skip-note:
-    needs: [smoke-gate, lint, fixtures, session-index]
+    needs: [smoke-gate, lint, fixtures, session-index, session-index-v2-contract]
     if: >
       needs.smoke-gate.outputs.skip != 'true' &&
       github.event_name == 'workflow_dispatch' &&

--- a/docs/SESSION_INDEX_V2_PROMOTION.md
+++ b/docs/SESSION_INDEX_V2_PROMOTION.md
@@ -1,0 +1,49 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Session Index v2 Contract Promotion
+
+## Goal
+
+Promote `session-index-v2-contract` from burn-in (non-blocking) to required status only after deterministic evidence.
+
+## Contract health scope
+
+The check validates:
+
+- `session-index-v2.json` exists and passes schema validation.
+- `branchProtection.expected`/`branchProtection.actual` are populated.
+- Required branch-check contexts from `tools/policy/branch-required-checks.json` are represented in
+  `branchProtection.expected`.
+- Session index artifacts are complete (`session-index.json` and `session-index-v2.json`).
+
+## Burn-in policy
+
+- Threshold: **10 consecutive successful upstream runs**.
+- The check writes `session-index-v2-contract.json` with burn-in counters and promotion readiness.
+- While burn-in is active, failures are **non-blocking** but include warnings and triage details in the step summary.
+
+## Enforce toggle
+
+The workflow uses repository variable:
+
+- `SESSION_INDEX_V2_CONTRACT_ENFORCE`
+  - `false` (default): burn-in mode, non-blocking.
+  - `true`: enforce mode, failing contract blocks the job.
+
+## Promotion procedure
+
+1. Confirm `burnIn.promotionReady = true` in recent upstream artifacts.
+2. Set repository variable `SESSION_INDEX_V2_CONTRACT_ENFORCE=true`.
+3. Add `session-index-v2-contract` to `develop` required checks in
+   `tools/policy/branch-required-checks.json` and branch protection settings.
+4. Verify `session-index-v2-contract` appears in branch protection parity output and remains green.
+
+## Triage runbook
+
+When `session-index-v2-contract` reports failures:
+
+1. Open the artifact `validate-session-index-v2-contract/session-index-v2-contract.json`.
+2. Use the `failures[]` list to identify whether the issue is schema, parity, or artifact completeness.
+3. For schema failures, validate and inspect `session-index-v2.json` payload generation.
+4. For parity failures, compare `branchProtection.expected` against
+   `tools/policy/branch-required-checks.json` and live branch protection output.
+5. Re-run Validate and confirm burn-in counter progression resumes.

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-03T21:35:00Z",
+  "updated": "2026-03-05T18:50:00Z",
   "entries": [
     {
       "name": "Root Playbooks",
@@ -95,6 +95,7 @@
         "docs/SCHEMA_HELPER.md",
         "docs/SELFHOSTED_CI_SETUP.md",
         "docs/SESSION_LOCK_HANDOFF.md",
+        "docs/SESSION_INDEX_V2_PROMOTION.md",
         "docs/session-index/SESSION_INDEX_V2.md",
         "docs/SHARED_LIB.md",
         "docs/TESTING_PATTERNS.md",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "semver:check": "node tools/priority/validate-semver.mjs",
     "session-index:sample": "tsc -p tsconfig.json && node dist/src/session-index/cli.js --sample",
     "session-index:test": "npm run build && node --test src/session-index/__tests__/*.test.mjs",
+    "session-index:v2-contract": "pwsh -NoLogo -NoProfile -File tools/Test-SessionIndexV2Contract.ps1",
     "session-index:validate": "npm run schema:validate -- --schema docs/schema/generated/session-index-v2.schema.json --data tests/results/_agent/session-index-v2-sample.json --optional",
     "session:teststand:validate": "npm run schema:validate -- --schema docs/schema/generated/teststand-compare-session.schema.json --data fixtures/teststand-session/session-index.json --data tests/results/teststand-session/session-index.json --optional",
     "smoke:vi-history": "pwsh -NoLogo -NoProfile -File tools/Test-PRVIHistorySmoke.ps1",

--- a/tools/Test-SessionIndexV2Contract.ps1
+++ b/tools/Test-SessionIndexV2Contract.ps1
@@ -1,0 +1,254 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ResultsDir,
+
+  [string]$Branch = 'develop',
+  [string]$PolicyPath = 'tools/policy/branch-required-checks.json',
+  [string]$Owner = 'LabVIEW-Community-CI-CD',
+  [string]$Repository = 'compare-vi-cli-action',
+  [string]$WorkflowFileName = 'validate.yml',
+  [int]$BurnInThreshold = 10,
+  [switch]$Enforce
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Add-Failure {
+  param(
+    [ref]$Failures,
+    [string]$Message
+  )
+
+  $Failures.Value += $Message
+  Write-Host ("::warning::{0}" -f $Message)
+}
+
+function Get-ApiHeaders {
+  param([string]$Token)
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    return $null
+  }
+
+  return @{
+    Authorization          = "Bearer $Token"
+    Accept                 = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+    'User-Agent'           = 'comparevi-session-index-v2-contract'
+  }
+}
+
+function Get-ConsecutiveSuccessCount {
+  param(
+    [hashtable]$Headers,
+    [string]$Owner,
+    [string]$Repository,
+    [string]$WorkflowFileName,
+    [string]$Branch,
+    [string]$JobName,
+    [int]$MaxRuns = 30
+  )
+
+  if (-not $Headers) {
+    return [pscustomobject]@{
+      status             = 'unavailable'
+      reason             = 'missing_token'
+      consecutiveSuccess = 0
+      inspectedRuns      = 0
+    }
+  }
+
+  $url = "https://api.github.com/repos/$Owner/$Repository/actions/workflows/$WorkflowFileName/runs?status=completed&branch=$Branch&per_page=$MaxRuns"
+  try {
+    $runs = Invoke-RestMethod -Method Get -Uri $url -Headers $Headers
+  } catch {
+    return [pscustomobject]@{
+      status             = 'unavailable'
+      reason             = 'api_error'
+      error              = $_.Exception.Message
+      consecutiveSuccess = 0
+      inspectedRuns      = 0
+    }
+  }
+
+  $count = 0
+  $inspected = 0
+  foreach ($run in @($runs.workflow_runs)) {
+    if ($run.conclusion -ne 'success') {
+      break
+    }
+
+    $inspected++
+    try {
+      $jobs = Invoke-RestMethod -Method Get -Uri $run.jobs_url -Headers $Headers
+    } catch {
+      break
+    }
+
+    $targetJob = @($jobs.jobs) | Where-Object { $_.name -eq $JobName } | Select-Object -First 1
+    if (-not $targetJob) {
+      break
+    }
+    if ($targetJob.conclusion -ne 'success') {
+      break
+    }
+
+    $count++
+  }
+
+  return [pscustomobject]@{
+    status             = 'ok'
+    reason             = 'queried'
+    consecutiveSuccess = $count
+    inspectedRuns      = $inspected
+  }
+}
+
+if (-not (Test-Path -LiteralPath $ResultsDir -PathType Container)) {
+  throw "ResultsDir does not exist: $ResultsDir"
+}
+
+$v1Path = Join-Path $ResultsDir 'session-index.json'
+$v2Path = Join-Path $ResultsDir 'session-index-v2.json'
+$reportPath = Join-Path $ResultsDir 'session-index-v2-contract.json'
+$schemaPath = Join-Path (Get-Location) 'docs/schema/generated/session-index-v2.schema.json'
+
+$failures = @()
+$notes = @()
+
+if (-not (Test-Path -LiteralPath $v1Path -PathType Leaf)) {
+  Add-Failure -Failures ([ref]$failures) -Message "Missing v1 artifact: $v1Path"
+}
+if (-not (Test-Path -LiteralPath $v2Path -PathType Leaf)) {
+  Add-Failure -Failures ([ref]$failures) -Message "Missing v2 artifact: $v2Path"
+}
+
+$v2 = $null
+if (Test-Path -LiteralPath $v2Path -PathType Leaf) {
+  try {
+    & node tools/schemas/validate-json.js --schema $schemaPath --data $v2Path
+    if ($LASTEXITCODE -ne 0) {
+      Add-Failure -Failures ([ref]$failures) -Message "Schema validation failed for session-index-v2.json (exit $LASTEXITCODE)."
+    }
+  } catch {
+    Add-Failure -Failures ([ref]$failures) -Message "Schema validation failed: $($_.Exception.Message)"
+  }
+
+  try {
+    $v2 = Get-Content -Raw -LiteralPath $v2Path | ConvertFrom-Json -Depth 100
+  } catch {
+    Add-Failure -Failures ([ref]$failures) -Message "Unable to parse session-index-v2.json: $($_.Exception.Message)"
+  }
+}
+
+$expectedContexts = @()
+if (Test-Path -LiteralPath $PolicyPath -PathType Leaf) {
+  try {
+    $policy = Get-Content -Raw -LiteralPath $PolicyPath | ConvertFrom-Json -Depth 50
+    $expectedContexts = @($policy.branches.$Branch)
+  } catch {
+    Add-Failure -Failures ([ref]$failures) -Message "Unable to read required-check policy: $($_.Exception.Message)"
+  }
+} else {
+  Add-Failure -Failures ([ref]$failures) -Message "Policy file not found: $PolicyPath"
+}
+
+$missingExpected = @()
+if ($v2) {
+  if (-not $v2.branchProtection) {
+    Add-Failure -Failures ([ref]$failures) -Message 'branchProtection block missing from session-index-v2.json.'
+  } else {
+    $bpExpected = @($v2.branchProtection.expected)
+    $bpActual = @($v2.branchProtection.actual)
+    if ($bpExpected.Count -eq 0) {
+      Add-Failure -Failures ([ref]$failures) -Message 'branchProtection.expected is empty in session-index-v2.json.'
+    }
+    if ($bpActual.Count -eq 0) {
+      Add-Failure -Failures ([ref]$failures) -Message 'branchProtection.actual is empty in session-index-v2.json.'
+    }
+
+    if ($expectedContexts.Count -gt 0) {
+      $missingExpected = @($expectedContexts | Where-Object { $bpExpected -notcontains $_ })
+      if ($missingExpected.Count -gt 0) {
+        Add-Failure -Failures ([ref]$failures) -Message ("branchProtection.expected missing required contexts: {0}" -f ($missingExpected -join ', '))
+      }
+    }
+  }
+
+  if (-not $v2.artifacts -or @($v2.artifacts).Count -eq 0) {
+    Add-Failure -Failures ([ref]$failures) -Message 'artifacts block is empty in session-index-v2.json.'
+  }
+}
+
+$token = $env:GH_TOKEN
+if ([string]::IsNullOrWhiteSpace($token)) {
+  $token = $env:GITHUB_TOKEN
+}
+
+$burnIn = Get-ConsecutiveSuccessCount -Headers (Get-ApiHeaders -Token $token) -Owner $Owner -Repository $Repository -WorkflowFileName $WorkflowFileName -Branch $Branch -JobName 'session-index-v2-contract'
+$promotionReady = ($burnIn.status -eq 'ok' -and $burnIn.consecutiveSuccess -ge $BurnInThreshold)
+
+if ($burnIn.status -eq 'unavailable') {
+  $notes += ("Burn-in status unavailable ({0})." -f $burnIn.reason)
+}
+
+$report = [ordered]@{
+  schema = 'session-index-v2-contract/v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  branch = $Branch
+  status = if ($failures.Count -eq 0) { 'pass' } else { 'fail' }
+  enforce = [bool]$Enforce
+  failures = @($failures)
+  notes = @($notes)
+  branchProtection = [ordered]@{
+    policyPath = $PolicyPath
+    requiredContexts = @($expectedContexts)
+    missingContexts = @($missingExpected)
+  }
+  burnIn = [ordered]@{
+    threshold = $BurnInThreshold
+    status = $burnIn.status
+    reason = $burnIn.reason
+    consecutiveSuccess = $burnIn.consecutiveSuccess
+    inspectedRuns = $burnIn.inspectedRuns
+    promotionReady = $promotionReady
+  }
+}
+
+$report | ConvertTo-Json -Depth 50 | Out-File -LiteralPath $reportPath -Encoding utf8
+Write-Host ("session-index-v2 contract report written: {0}" -f $reportPath)
+
+if ($env:GITHUB_STEP_SUMMARY) {
+  $summary = @(
+    '### Session Index v2 Contract',
+    '',
+    ("- Status: **{0}**" -f $report.status),
+    ("- Enforced: **{0}**" -f ([bool]$Enforce)),
+    ("- Burn-in: **{0}/{1}** consecutive successful runs" -f $burnIn.consecutiveSuccess, $BurnInThreshold),
+    ("- Promotion ready: **{0}**" -f $promotionReady)
+  )
+  if ($failures.Count -gt 0) {
+    $summary += ''
+    $summary += '#### Failures'
+    foreach ($failure in $failures) {
+      $summary += ("- {0}" -f $failure)
+    }
+  }
+  if ($notes.Count -gt 0) {
+    $summary += ''
+    $summary += '#### Notes'
+    foreach ($note in $notes) {
+      $summary += ("- {0}" -f $note)
+    }
+  }
+  $summary -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+
+if ($failures.Count -gt 0 -and $Enforce) {
+  throw "session-index-v2 contract check failed in enforce mode."
+}
+
+if ($failures.Count -gt 0 -and -not $Enforce) {
+  Write-Host '::warning::session-index-v2 contract check failed in burn-in mode (non-blocking).'
+}


### PR DESCRIPTION
## Summary
- add `session-index-v2-contract` job to Validate with burn-in (non-blocking) and enforce toggle
- add `tools/Test-SessionIndexV2Contract.ps1` for schema/parity/artifact checks and 10-run burn-in tracking
- add promotion + triage runbook documentation for v2 required-check promotion

## Testing
- npm run docs:manifest:validate
- tools/Test-SessionIndexV2Contract.ps1 syntax/parse validation via editor diagnostics

Closes #677