### PR TITLE
docs(ci): migrate critical session-index consumers to v2-first fallback (#678)

### DIFF
--- a/.github/actions/session-index-post/action.yml
+++ b/.github/actions/session-index-post/action.yml
@@ -26,17 +26,27 @@ runs:
         $dir = '${{ inputs.results-dir }}'
         $idxV1 = Join-Path $dir 'session-index.json'
         $idxV2 = Join-Path $dir 'session-index-v2.json'
-        if (Test-Path $idxV1) {
+        $preferredPath = $null
+        $preferredSource = 'missing'
+        if (Test-Path $idxV2) {
+          $preferredPath = $idxV2
+          $preferredSource = 'v2'
+        } elseif (Test-Path $idxV1) {
+          $preferredPath = $idxV1
+          $preferredSource = 'v1'
+        }
+
+        if ($preferredPath) {
           try {
-            $j = Get-Content $idxV1 -Raw | ConvertFrom-Json -ErrorAction Stop
+            $j = Get-Content $preferredPath -Raw | ConvertFrom-Json -ErrorAction Stop
             if ($j.stepSummary) {
               $j.stepSummary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
             } else {
-              ("Session index v1 available: {0}" -f $idxV1) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+              ("Session index ({0}) available: {1}" -f $preferredSource, $preferredPath) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
             }
           } catch { Write-Host "::warning::Failed to read session index: $_" }
         } else {
-          Write-Host '::notice::session-index.json not found.'
+          Write-Host '::notice::No session index found (v2 or v1).'
         }
 
         if (Test-Path $idxV2) {

--- a/docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md
+++ b/docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md
@@ -1,0 +1,37 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Session Index v2 Consumer Migration Matrix
+
+## Scope
+
+Critical consumers are tools that parse session-index payloads to drive CI summaries,
+operator dashboards, or developer feedback loops.
+
+## Matrix
+
+| Consumer | Area | v2-first status | v1 fallback | Notes |
+| --- | --- | --- | --- | --- |
+| `.github/actions/session-index-post/action.yml` | CI post-processing summary | ✅ | ✅ | Reads `session-index-v2.json` first, then `session-index.json`.
+| `tools/Write-SessionIndexSummary.ps1` | Step summary reporting | ✅ | ✅ | Uses shared reader module; emits source and requirement-tagged case counts.
+| `tools/Dev-Dashboard.psm1` | Dashboard telemetry model | ✅ | ✅ | Loads preferred index (v2→v1), surfaces source + requirement coverage fields.
+| `tools/Dev-Dashboard.ps1` | Dashboard terminal/HTML rendering | ✅ | ✅ | Displays index source and requirement coverage when available.
+| `tools/vscode/comparevi-extension/src/extension.ts` | VS Code status updates | ✅ | ✅ | Resolves preferred index path (v2→v1) before status refresh.
+| `.github/workflows/validate.yml` `session-index-v2-contract` | CI contract gate | ✅ | ✅ | Burn-in + enforce toggle validates artifact parity and contract shape.
+
+## Burn-in tracking
+
+- Required runs for promotion: **10 consecutive successful upstream runs**.
+- Regression guard target: **5 consecutive upstream runs without consumer regressions**.
+- Promotion evidence source: `validate-session-index-v2-contract/session-index-v2-contract.json`.
+
+## Remaining non-critical consumers
+
+The following scripts still target `session-index.json` directly and are not currently
+classified as critical for v2-first cutover:
+
+- `tools/Update-SessionIndexWatcher.ps1`
+- `tools/Update-SessionIndexParity.ps1`
+- `tools/Update-FixtureDriftSessionIndex.ps1`
+- `tools/Run-SessionIndexValidation.ps1`
+
+These remain compatible through v1 fallback and can be migrated in follow-up work if
+criticality changes.

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-05T18:50:00Z",
+  "updated": "2026-03-04T23:30:00Z",
   "entries": [
     {
       "name": "Root Playbooks",
@@ -96,6 +96,7 @@
         "docs/SELFHOSTED_CI_SETUP.md",
         "docs/SESSION_LOCK_HANDOFF.md",
         "docs/SESSION_INDEX_V2_PROMOTION.md",
+        "docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md",
         "docs/session-index/SESSION_INDEX_V2.md",
         "docs/SHARED_LIB.md",
         "docs/TESTING_PATTERNS.md",

--- a/tools/Dev-Dashboard.ps1
+++ b/tools/Dev-Dashboard.ps1
@@ -364,12 +364,21 @@ function Write-TerminalReport {
   if ($Snapshot.ResultsRoot) { Write-Host "Results: $($Snapshot.ResultsRoot)" }
   $sessionStatus = $Snapshot.PesterTelemetry.SessionStatus
   $sessionInclude = $Snapshot.PesterTelemetry.SessionIncludeIntegration
+  $sessionSource = $Snapshot.PesterTelemetry.SessionIndexSource
+  $requirementTagged = $Snapshot.PesterTelemetry.RequirementTaggedCases
+  $requirementCount = $Snapshot.PesterTelemetry.RequirementCaseCount
   if ($sessionStatus -or $sessionInclude -ne $null) {
     $statusText = if ($sessionStatus) { $sessionStatus } else { 'unknown' }
     if ($sessionInclude -ne $null) {
       $statusText = "$statusText (include_integration=$sessionInclude)"
     }
+    if ($sessionSource) {
+      $statusText = "$statusText [source=$sessionSource]"
+    }
     Write-Host "Session: $statusText"
+  }
+  if ($requirementCount -and $requirementCount -gt 0) {
+    Write-Host ("Session Requirements: {0}/{1} tagged" -f $requirementTagged, $requirementCount)
   }
   $runnerInfo = $Snapshot.PesterTelemetry.Runner
   if ($runnerInfo) {
@@ -733,6 +742,9 @@ function ConvertTo-HtmlReport {
   }
   $sessionStatusValue = if ($pester.PSObject.Properties.Name -contains 'SessionStatus') { $pester.SessionStatus } else { $null }
   $sessionIncludeRaw = if ($pester.PSObject.Properties.Name -contains 'SessionIncludeIntegration') { $pester.SessionIncludeIntegration } else { $null }
+  $sessionSourceValue = if ($pester.PSObject.Properties.Name -contains 'SessionIndexSource') { $pester.SessionIndexSource } else { $null }
+  $requirementTaggedValue = if ($pester.PSObject.Properties.Name -contains 'RequirementTaggedCases') { $pester.RequirementTaggedCases } else { $null }
+  $requirementCaseCountValue = if ($pester.PSObject.Properties.Name -contains 'RequirementCaseCount') { $pester.RequirementCaseCount } else { $null }
   $sessionIncludeDisplay = ''
   if ($sessionIncludeRaw -ne $null) {
     try { $sessionIncludeDisplay = ([bool]$sessionIncludeRaw) } catch { $sessionIncludeDisplay = $sessionIncludeRaw }
@@ -933,6 +945,8 @@ function ConvertTo-HtmlReport {
     <dl>
       <dt>Status</dt><dd>$(& $encode $sessionStatusValue)</dd>
       <dt>Include Integration</dt><dd>$(& $encode $sessionIncludeDisplay)</dd>
+      @(if ($sessionSourceValue) { "<dt>Index Source</dt><dd>$(& $encode $sessionSourceValue)</dd>" })
+      @(if ($requirementCaseCountValue -ne $null -and $requirementCaseCountValue -gt 0) { "<dt>Requirements</dt><dd>$(& $encode $requirementTaggedValue)/$(& $encode $requirementCaseCountValue) tagged test cases</dd>" })
       @(if ($sessionIndexPathValue) { "<dt>Index Path</dt><dd>$(& $encode $sessionIndexPathValue)</dd>" })
     </dl>
   </section>

--- a/tools/Dev-Dashboard.psm1
+++ b/tools/Dev-Dashboard.psm1
@@ -2,6 +2,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $script:repoRoot = Split-Path -Parent $PSScriptRoot
+$sessionIndexReaderModule = Join-Path $PSScriptRoot 'SessionIndex-Readers.psm1'
+Import-Module $sessionIndexReaderModule -Force
 
 function Resolve-PathSafe {
   param([string]$Path)
@@ -510,12 +512,19 @@ function Get-PesterTelemetry {
   if ($summaryInfo.Error) { $errors += "pester-summary.json: $($summaryInfo.Error)" }
   if ($dispatcherInfo.Error) { $errors += "pester-dispatcher.log: $($dispatcherInfo.Error)" }
 
-  $sessionIndexPath = Join-Path $ResultsRoot 'session-index.json'
-  $sessionIndexInfo = Read-JsonFile -Path $sessionIndexPath
-  if ($sessionIndexInfo.Error) { $errors += "session-index.json: $($sessionIndexInfo.Error)" }
+  $sessionPreferred = Read-PreferredSessionIndex -ResultsDir $ResultsRoot
+  $sessionIndexInfo = [pscustomobject]@{
+    Path = $sessionPreferred.Path
+    Data = $sessionPreferred.Data
+    Error = $sessionPreferred.Error
+  }
+  if ($sessionIndexInfo.Error) { $errors += "session-index ($($sessionPreferred.Source)): $($sessionIndexInfo.Error)" }
   $sessionStatus = $null
   $sessionIncludeIntegration = $null
   $runnerInfo = $null
+  $sessionIndexSource = $sessionPreferred.Source
+  $requirementTaggedCases = 0
+  $requirementCaseCount = 0
   if ($sessionIndexInfo.Data) {
     $sessionData = $sessionIndexInfo.Data
     if ($sessionData.PSObject.Properties.Name -contains 'status') {
@@ -568,6 +577,14 @@ function Get-PesterTelemetry {
         $runnerInfo = [pscustomobject]$runnerProps
       }
     }
+
+    if ($sessionPreferred.Source -eq 'v2' -and $sessionData.PSObject.Properties.Name -contains 'tests' -and $sessionData.tests -and $sessionData.tests.PSObject.Properties.Name -contains 'cases') {
+      $cases = @($sessionData.tests.cases)
+      $requirementCaseCount = $cases.Count
+      if ($requirementCaseCount -gt 0) {
+        $requirementTaggedCases = @($cases | Where-Object { $_ -and $_.PSObject.Properties.Name -contains 'requirement' -and -not [string]::IsNullOrWhiteSpace([string]$_.requirement) }).Count
+      }
+    }
   }
 
   return [pscustomobject][ordered]@{
@@ -579,8 +596,11 @@ function Get-PesterTelemetry {
     DispatcherErrors   = $dispatcherErrors
     DispatcherWarnings = $dispatcherWarnings
     SessionIndexPath   = $sessionIndexInfo.Path
+    SessionIndexSource = $sessionIndexSource
     SessionStatus      = $sessionStatus
     SessionIncludeIntegration = $sessionIncludeIntegration
+    RequirementTaggedCases = $requirementTaggedCases
+    RequirementCaseCount = $requirementCaseCount
     Runner             = $runnerInfo
     Errors             = $errors
   }

--- a/tools/SessionIndex-Readers.psm1
+++ b/tools/SessionIndex-Readers.psm1
@@ -1,0 +1,74 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-SessionIndexCandidates {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDir
+  )
+
+  $base = if ([System.IO.Path]::IsPathRooted($ResultsDir)) {
+    [System.IO.Path]::GetFullPath($ResultsDir)
+  } else {
+    [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $ResultsDir))
+  }
+
+  [pscustomobject]@{
+    ResultsDir = $base
+    V2Path = Join-Path $base 'session-index-v2.json'
+    V1Path = Join-Path $base 'session-index.json'
+  }
+}
+
+function Resolve-PreferredSessionIndexPath {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDir
+  )
+
+  $paths = Resolve-SessionIndexCandidates -ResultsDir $ResultsDir
+  if (Test-Path -LiteralPath $paths.V2Path -PathType Leaf) {
+    return [pscustomobject]@{ Path = $paths.V2Path; Source = 'v2' }
+  }
+  if (Test-Path -LiteralPath $paths.V1Path -PathType Leaf) {
+    return [pscustomobject]@{ Path = $paths.V1Path; Source = 'v1' }
+  }
+
+  return [pscustomobject]@{ Path = $null; Source = 'missing' }
+}
+
+function Read-PreferredSessionIndex {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDir
+  )
+
+  $resolved = Resolve-PreferredSessionIndexPath -ResultsDir $ResultsDir
+  $payload = [ordered]@{
+    Path = $resolved.Path
+    Source = $resolved.Source
+    Data = $null
+    Error = $null
+  }
+
+  if (-not $resolved.Path) {
+    $payload.Error = "No session index found under $ResultsDir"
+    return [pscustomobject]$payload
+  }
+
+  try {
+    $raw = Get-Content -LiteralPath $resolved.Path -Raw -Encoding utf8
+    if (-not [string]::IsNullOrWhiteSpace($raw)) {
+      $payload.Data = $raw | ConvertFrom-Json -ErrorAction Stop
+    }
+  } catch {
+    $payload.Error = $_.Exception.Message
+  }
+
+  return [pscustomobject]$payload
+}
+
+Export-ModuleMember -Function Resolve-SessionIndexCandidates, Resolve-PreferredSessionIndexPath, Read-PreferredSessionIndex

--- a/tools/Write-SessionIndexSummary.ps1
+++ b/tools/Write-SessionIndexSummary.ps1
@@ -11,12 +11,17 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 if (-not $env:GITHUB_STEP_SUMMARY) { return }
 
+$readerModule = Join-Path (Split-Path -Parent $PSCommandPath) 'SessionIndex-Readers.psm1'
+Import-Module $readerModule -Force
+
 $path = if ($ResultsDir) { Join-Path $ResultsDir $FileName } else { $FileName }
-if (-not (Test-Path -LiteralPath $path)) {
-  ("### Session`n- File: (missing) {0}" -f $path) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+$preferred = Read-PreferredSessionIndex -ResultsDir $ResultsDir
+if (-not $preferred.Path) {
+  ("### Session`n- File: (missing) {0}`n- Source: missing" -f $path) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
   return
 }
-try { $j = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json -ErrorAction Stop } catch { $j = $null }
+$path = $preferred.Path
+$j = $preferred.Data
 
 $lines = @('### Session','')
 if ($j) {
@@ -40,7 +45,17 @@ if ($j) {
   Add-LineIfPresent -Object $j -Property 'errors' -Label 'Errors' -Target ([ref]$lines)
   Add-LineIfPresent -Object $j -Property 'skipped' -Label 'Skipped' -Target ([ref]$lines)
   Add-LineIfPresent -Object $j -Property 'duration_s' -Label 'Duration (s)' -Target ([ref]$lines)
+  $lines += ('- Source: {0}' -f $preferred.Source)
   $lines += ('- File: {0}' -f $path)
+
+  if ($preferred.Source -eq 'v2' -and $j.PSObject.Properties.Name -contains 'tests' -and $j.tests -and $j.tests.PSObject.Properties.Name -contains 'cases') {
+    $cases = @($j.tests.cases)
+    if ($cases.Count -gt 0) {
+      $withRequirement = @($cases | Where-Object { $_ -and $_.PSObject.Properties.Name -contains 'requirement' -and -not [string]::IsNullOrWhiteSpace([string]$_.requirement) }).Count
+      $lines += ('- Requirement-tagged cases: {0}/{1}' -f $withRequirement, $cases.Count)
+    }
+  }
+
   $runContext = $null
   if ($j.PSObject.Properties.Name -contains 'runContext') {
     $runContext = $j.runContext
@@ -100,6 +115,7 @@ if ($j) {
     }
   }
 } else {
+  $lines += ('- Source: {0}' -f $preferred.Source)
   $lines += ('- File: failed to parse: {0}' -f $path)
 }
 

--- a/tools/vscode/comparevi-extension/src/extension.ts
+++ b/tools/vscode/comparevi-extension/src/extension.ts
@@ -1153,7 +1153,7 @@ export function activate(context: vscode.ExtensionContext) {
     statusBar.show();
     // Initial session-index read if present
     const initialResultsRoot = getConfiguration().get<string>("watch.resultsPath", "tests/results");
-    const initialSessionIndex = path.join(repoRoot, initialResultsRoot, "session-index.json");
+    const initialSessionIndex = resolvePreferredSessionIndexPath(repoRoot, initialResultsRoot);
     void refreshFromSessionIndex(initialSessionIndex, statusBar);
 
     const disposables: vscode.Disposable[] = [];
@@ -1163,7 +1163,7 @@ export function activate(context: vscode.ExtensionContext) {
         void evaluateOutcomeDiagnostics(artifactProvider, diagnosticState);
         // Opportunistically refresh status bar from session index on any results change
         const resultsRoot = getConfiguration().get<string>("watch.resultsPath", "tests/results");
-        const sessionIndex = path.join(repoRoot, resultsRoot, "session-index.json");
+        const sessionIndex = resolvePreferredSessionIndexPath(repoRoot, resultsRoot);
         void refreshFromSessionIndex(sessionIndex, statusBar);
     };
 
@@ -1380,7 +1380,7 @@ export function activate(context: vscode.ExtensionContext) {
                             cp.stdout?.on("data", d => manualOutputChannel?.append(utf8Decoder.decode(d)));
                             cp.stderr?.on("data", d => manualOutputChannel?.append(utf8Decoder.decode(d)));
                             cp.on("close", async () => {
-                                await refreshFromSessionIndex(sessionIndex, statusBar);
+                                await refreshFromSessionIndex(resolvePreferredSessionIndexPath(repoRoot, resultsRoot), statusBar);
                                 resolve();
                             });
                         });
@@ -1394,7 +1394,7 @@ export function activate(context: vscode.ExtensionContext) {
                             cp.stderr?.on("data", d => manualOutputChannel?.append(utf8Decoder.decode(d)));
                             cp.on("close", async () => {
                                 await mergeWatcherIntoSessionIndex(outPath, sessionIndex);
-                                await refreshFromSessionIndex(sessionIndex, statusBar);
+                                await refreshFromSessionIndex(resolvePreferredSessionIndexPath(repoRoot, resultsRoot), statusBar);
                                 resolve();
                             });
                         });
@@ -1423,6 +1423,16 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {}
+
+function resolvePreferredSessionIndexPath(repoRoot: string, resultsRoot: string): string {
+    const dir = path.join(repoRoot, resultsRoot);
+    const v2 = path.join(dir, "session-index-v2.json");
+    const v1 = path.join(dir, "session-index.json");
+    if (fs.existsSync(v2)) {
+        return v2;
+    }
+    return v1;
+}
 
 async function refreshFromSessionIndex(sessionIndexPath: string, statusBar: vscode.StatusBarItem) {
     try {


### PR DESCRIPTION
## Summary
- migrate critical consumers to `session-index-v2.json` first with explicit `session-index.json` fallback
- add shared PowerShell reader module and apply to session summary + dashboard telemetry
- update VS Code status refresh path resolution and publish a v2 consumer migration matrix

## Testing
- npm run docs:manifest:validate
- targeted diagnostics for modified files via Problems check

Closes #678