### PR TITLE
docs(session-index): publish v1 deprecation policy and cutover checklist (#679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Updated README, developer guide, and workflow notes to describe the optional `-MaxPairs` cap and refreshed examples to
   highlight the new default behaviour.
+- Added Session Index cutover docs (`docs/SESSION_INDEX_V1_DEPRECATION.md`,
+  `docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md`) to formalize v1 freeze rules, deprecation window criteria, and final
+  v2-only evidence expectations.
 
 ## [v0.6.0] - 2025-11-02
 

--- a/docs/SESSION_INDEX_V1_DEPRECATION.md
+++ b/docs/SESSION_INDEX_V1_DEPRECATION.md
@@ -1,0 +1,48 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Session Index v1 Deprecation Policy
+
+## Announcement
+
+As of **2026-03-04**, Session Index v1 enters deprecation mode.
+
+- v1 is frozen: no new fields or semantic expansions.
+- v2 is the primary contract for all critical consumers.
+- v1 remains temporary compatibility only during the deprecation window.
+
+## Deprecation window
+
+The window remains open until all of the following are true:
+
+1. `session-index-v2-contract` promotion gate is ready (`burnIn.promotionReady = true`).
+2. Critical consumer migration matrix is complete and verified:
+   - see `docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md`.
+3. No consumer regression for 5 consecutive upstream runs.
+4. Maintainers approve v1 removal in a standing-priority PR.
+
+## Freeze rules (effective immediately)
+
+- Do not add new fields to `docs/schemas/session-index-v1.schema.json`.
+- Do not add new workflow consumers that require `session-index.json`.
+- New telemetry fields must target v2 schema and v2 readers.
+
+## Removal checklist (v1 cutover)
+
+- [ ] Remove v1 generation from producer paths/workflows.
+- [ ] Remove v1 fallback from critical consumers.
+- [ ] Remove v1 schema validation from CI jobs.
+- [ ] Update branch-protection required checks if names/behavior changed.
+- [ ] Update docs and release notes to state v2-only status.
+- [ ] Publish final cutover report with evidence links.
+
+## Evidence package required for cutover
+
+- Final consumer readiness matrix snapshot.
+- `session-index-v2-contract` artifact evidence (`consecutiveSuccess`, `promotionReady`).
+- 5-run no-regression evidence for critical consumers.
+- CI evidence showing no required path depends on `session-index.json`.
+
+## Temporary compatibility note
+
+During deprecation, references to `session-index.json` are allowed only where required
+for controlled fallback or migration bookkeeping. Any new fallback usage must include a
+justification and removal target in the same PR.

--- a/docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md
+++ b/docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md
@@ -22,6 +22,7 @@ operator dashboards, or developer feedback loops.
 - Required runs for promotion: **10 consecutive successful upstream runs**.
 - Regression guard target: **5 consecutive upstream runs without consumer regressions**.
 - Promotion evidence source: `validate-session-index-v2-contract/session-index-v2-contract.json`.
+- Deprecation policy and v1 cutover checklist: `docs/SESSION_INDEX_V1_DEPRECATION.md`.
 
 ## Remaining non-critical consumers
 

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-04T23:30:00Z",
+  "updated": "2026-03-04T23:55:00Z",
   "entries": [
     {
       "name": "Root Playbooks",
@@ -95,6 +95,7 @@
         "docs/SCHEMA_HELPER.md",
         "docs/SELFHOSTED_CI_SETUP.md",
         "docs/SESSION_LOCK_HANDOFF.md",
+        "docs/SESSION_INDEX_V1_DEPRECATION.md",
         "docs/SESSION_INDEX_V2_PROMOTION.md",
         "docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md",
         "docs/session-index/SESSION_INDEX_V2.md",


### PR DESCRIPTION
## Summary
- add explicit Session Index v1 deprecation policy with freeze rules and cutover gate criteria
- link deprecation policy from v2 consumer migration matrix
- update docs manifest and unreleased changelog for cutover governance

## Testing
- npm run docs:manifest:validate

Closes #679