### PR TITLE
Align release verification and docs to root changelog source (#284)

### DIFF
--- a/PR_RELEASE_DESCRIPTION_v0.6.0.md
+++ b/PR_RELEASE_DESCRIPTION_v0.6.0.md
@@ -13,7 +13,6 @@
 
 - Notes: `RELEASE_NOTES_v0.6.0.md`
 - Changelog section: `CHANGELOG.md` (`v0.6.0`)
-- Docs mirror: `docs/CHANGELOG.md`
 
 ## Validation
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -288,7 +288,7 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
     `RELEASE_PARITY_TIP_DIFF_TARGET`.
 - `tools/priority/verify-release-branch.mjs` enforces release-doc consistency before tag cut by requiring
   `PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, and `RELEASE_NOTES_<tag>.md` to reference the current release tag.
-  It also requires both `package.json` and `docs/CHANGELOG.md` to change relative to the configured release base ref.
+  It also requires both `package.json` and `CHANGELOG.md` to change relative to the configured release base ref.
 - `tools/priority/validate-semver.mjs` now performs branch-aware integrity checks: on `release/<tag>` heads it enforces
   `package.json` SemVer parity with the branch tag.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream

--- a/tools/priority/__tests__/verify-release-branch.test.mjs
+++ b/tools/priority/__tests__/verify-release-branch.test.mjs
@@ -3,7 +3,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -39,9 +39,8 @@ test('verify-release-branch succeeds when version/changelog updated', async (t) 
   const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-'));
   t.after(() => rm(repoDir, { recursive: true, force: true }));
 
-  await mkdir(path.join(repoDir, 'docs'), { recursive: true });
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
@@ -66,7 +65,7 @@ test('verify-release-branch succeeds when version/changelog updated', async (t) 
     'utf8'
   );
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.2.0 - Next\n- Updates\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
@@ -83,9 +82,8 @@ test('verify-release-branch fails when changelog missing update', async (t) => {
   const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-fail-'));
   t.after(() => rm(repoDir, { recursive: true, force: true }));
 
-  await mkdir(path.join(repoDir, 'docs'), { recursive: true });
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
@@ -123,9 +121,8 @@ test('verify-release-branch fails when release docs are inconsistent', async (t)
   const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-docs-fail-'));
   t.after(() => rm(repoDir, { recursive: true, force: true }));
 
-  await mkdir(path.join(repoDir, 'docs'), { recursive: true });
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
@@ -150,7 +147,7 @@ test('verify-release-branch fails when release docs are inconsistent', async (t)
     'utf8'
   );
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.4.0 - Next\n- Updates\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
@@ -168,9 +165,8 @@ test('verify-release-branch fails when package.json is not updated relative to b
   const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-package-diff-fail-'));
   t.after(() => rm(repoDir, { recursive: true, force: true }));
 
-  await mkdir(path.join(repoDir, 'docs'), { recursive: true });
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
@@ -190,7 +186,7 @@ test('verify-release-branch fails when package.json is not updated relative to b
 
   runGit(repoDir, ['checkout', '-b', 'release/v0.1.0']);
   await writeFile(
-    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    path.join(repoDir, 'CHANGELOG.md'),
     '# Changelog\n\n## v0.1.0 - Refresh\n- Notes updated\n',
     'utf8'
   );

--- a/tools/priority/verify-release-branch.mjs
+++ b/tools/priority/verify-release-branch.mjs
@@ -29,7 +29,7 @@ function ensureVersionMatches(branchTag, packageVersion) {
 }
 
 function ensureChangelogContains(repoRoot, tag) {
-  const changelogPath = path.join(repoRoot, 'docs', 'CHANGELOG.md');
+  const changelogPath = path.join(repoRoot, 'CHANGELOG.md');
   const contents = readFileSync(changelogPath, 'utf8');
   if (!contents.includes(tag) && !contents.includes(tag.replace(/^v/, ''))) {
     throw new Error(`CHANGELOG.md missing entry for ${tag}`);
@@ -37,9 +37,9 @@ function ensureChangelogContains(repoRoot, tag) {
 }
 
 function ensureChangelogDiff(repoRoot, baseRef) {
-  const diff = run('git', ['diff', `${baseRef}`, '--', 'docs/CHANGELOG.md'], { cwd: repoRoot });
+  const diff = run('git', ['diff', `${baseRef}`, '--', 'CHANGELOG.md'], { cwd: repoRoot });
   if (!diff.trim()) {
-    throw new Error(`docs/CHANGELOG.md not updated relative to ${baseRef}`);
+    throw new Error(`CHANGELOG.md not updated relative to ${baseRef}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- switch `tools/priority/verify-release-branch.mjs` to enforce root `CHANGELOG.md` for tag presence and base-diff checks
- update release verification tests to stage and validate root `CHANGELOG.md` instead of `docs/CHANGELOG.md`
- align release docs/checklist references to `CHANGELOG.md` and remove conflicting mirror wording

## Testing
- node --test tools/priority/__tests__/verify-release-branch.test.mjs
- node tools/npm/run-script.mjs priority:test
- node tools/npm/run-script.mjs lint:md:changed
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1

Fixes #284
