### PR TITLE
Controlled split: independent release streams for comparevi-tools and CompareVi.Shared

### DIFF
--- a/.github/workflows/dotnet-shared.yml
+++ b/.github/workflows/dotnet-shared.yml
@@ -23,23 +23,84 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shared_source: [project, package]
     steps:
       - uses: actions/checkout@v5
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
-      - name: Restore
+
+      - name: Restore shared project
         run: dotnet restore src/CompareVi.Shared/CompareVi.Shared.csproj
-      - name: Build
+
+      - name: Build shared project
         run: dotnet build -c Release src/CompareVi.Shared/CompareVi.Shared.csproj --no-restore
-      - name: Pack
+
+      - name: Pack shared project
         run: dotnet pack -c Release src/CompareVi.Shared/CompareVi.Shared.csproj -o artifacts --no-build
-      - name: Upload package
+
+      - name: Resolve packed shared version
+        id: shared
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkg="$(find artifacts -maxdepth 1 -name 'CompareVi.Shared.*.nupkg' | head -n 1)"
+          if [ -z "$pkg" ]; then
+            echo "No CompareVi.Shared nupkg found in artifacts/"
+            exit 1
+          fi
+          version="$(basename "$pkg" | sed -E 's/^CompareVi\.Shared\.([0-9A-Za-z\.-]+)\.nupkg$/\1/')"
+          if [ -z "$version" ]; then
+            echo "Failed to derive package version from $pkg"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Restore CompareVi CLI
+        run: >
+          dotnet restore src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
+          -p:CompareViSharedSource=${{ matrix.shared_source }}
+          -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }}
+          --source "${{ github.workspace }}/artifacts"
+          --source "https://api.nuget.org/v3/index.json"
+
+      - name: Build CompareVi CLI
+        run: >
+          dotnet build -c Release src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
+          -p:CompareViSharedSource=${{ matrix.shared_source }}
+          -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }}
+          --no-restore
+
+      - name: CLI smoke (version/tokenize/procs)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_cli() {
+            dotnet run --project src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj -c Release --no-build \
+              -p:CompareViSharedSource=${{ matrix.shared_source }} \
+              -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }} -- "$@"
+          }
+
+          ver_json="$(run_cli version)"
+          node -e "const o=JSON.parse(process.argv[1]); if(o.name!=='comparevi-cli'){throw new Error('unexpected name')}" "$ver_json"
+
+          tok_json="$(run_cli tokenize --input "foo -x=1 bar")"
+          node -e "const o=JSON.parse(process.argv[1]); if(!o.normalized.includes('-x')||!o.normalized.includes('1')||!o.normalized.includes('bar')){throw new Error('tokenize regression')}" "$tok_json"
+
+          run_cli procs >/dev/null
+
+      - name: Upload shared package artifacts
         uses: actions/upload-artifact@v5
         with:
-          name: comparevi-shared-nuget
-          path: artifacts/*.nupkg
+          name: comparevi-shared-nuget-${{ matrix.shared_source }}
+          path: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg
           if-no-files-found: error
-

--- a/.github/workflows/monthly-stability-release.yml
+++ b/.github/workflows/monthly-stability-release.yml
@@ -1,0 +1,198 @@
+name: Monthly Stability Release
+
+on:
+  schedule:
+    - cron: '0 18 * * 3'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Allow execution outside the first-Wednesday window'
+        required: false
+        default: false
+        type: boolean
+      ref:
+        description: 'Git ref used when dispatching publish workflows'
+        required: false
+        default: develop
+        type: string
+      publish_tools:
+        description: 'Dispatch comparevi-tools publish workflow'
+        required: false
+        default: false
+        type: boolean
+      tools_version:
+        description: 'comparevi-tools version (for example: 0.7.0 or 0.7.0-rc.1)'
+        required: false
+        type: string
+      tools_channel:
+        description: 'comparevi-tools channel'
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+      publish_shared:
+        description: 'Dispatch CompareVi.Shared package publish workflow'
+        required: false
+        default: false
+        type: boolean
+      shared_version:
+        description: 'CompareVi.Shared version (for example: 0.2.0 or 0.2.0-rc.1)'
+        required: false
+        type: string
+      shared_channel:
+        description: 'CompareVi.Shared channel'
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  evaluate-window:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.eval.outputs.should_run }}
+      publish_requested: ${{ steps.eval.outputs.publish_requested }}
+      publish_tools: ${{ steps.eval.outputs.publish_tools }}
+      publish_shared: ${{ steps.eval.outputs.publish_shared }}
+      ref: ${{ steps.eval.outputs.ref }}
+      tools_version: ${{ steps.eval.outputs.tools_version }}
+      tools_channel: ${{ steps.eval.outputs.tools_channel }}
+      shared_version: ${{ steps.eval.outputs.shared_version }}
+      shared_channel: ${{ steps.eval.outputs.shared_channel }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Evaluate monthly window and requested dispatches
+        id: eval
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const inputs = context.payload.inputs || {};
+            const isDispatch = context.eventName === 'workflow_dispatch';
+            const force = isDispatch && String(inputs.force || 'false') === 'true';
+            const publishTools = isDispatch && String(inputs.publish_tools || 'false') === 'true';
+            const publishShared = isDispatch && String(inputs.publish_shared || 'false') === 'true';
+            const publishRequested = publishTools || publishShared;
+
+            const now = new Date();
+            const isFirstWednesdayUtc = now.getUTCDay() === 3 && now.getUTCDate() <= 7;
+            const shouldRun = force || isFirstWednesdayUtc;
+
+            const ref = String(inputs.ref || 'develop');
+            const toolsChannel = String(inputs.tools_channel || 'stable');
+            const sharedChannel = String(inputs.shared_channel || 'stable');
+
+            let toolsVersion = String(inputs.tools_version || '').trim();
+            if (!toolsVersion) {
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              toolsVersion = String(pkg.version || '').trim();
+            }
+
+            let sharedVersion = String(inputs.shared_version || '').trim();
+            if (!sharedVersion) {
+              const csproj = fs.readFileSync('src/CompareVi.Shared/CompareVi.Shared.csproj', 'utf8');
+              const match = csproj.match(/<PackageVersion>([^<]+)<\/PackageVersion>/i) || csproj.match(/<Version>([^<]+)<\/Version>/i);
+              sharedVersion = match ? String(match[1]).trim() : '';
+            }
+
+            const reason = shouldRun
+              ? (force ? 'forced-run' : 'first-wednesday-window')
+              : 'outside-window';
+
+            if (publishRequested && !shouldRun) {
+              core.setFailed('Publish dispatch requested outside first-Wednesday window. Re-run with force=true to override.');
+              return;
+            }
+
+            if (publishTools && !toolsVersion) {
+              core.setFailed('publish_tools=true requires tools_version (or package.json version).');
+              return;
+            }
+            if (publishShared && !sharedVersion) {
+              core.setFailed('publish_shared=true requires shared_version (or CompareVi.Shared PackageVersion).');
+              return;
+            }
+
+            core.setOutput('should_run', String(shouldRun));
+            core.setOutput('publish_requested', String(publishRequested));
+            core.setOutput('publish_tools', String(publishTools));
+            core.setOutput('publish_shared', String(publishShared));
+            core.setOutput('ref', ref);
+            core.setOutput('tools_version', toolsVersion);
+            core.setOutput('tools_channel', toolsChannel);
+            core.setOutput('shared_version', sharedVersion);
+            core.setOutput('shared_channel', sharedChannel);
+
+            await core.summary
+              .addHeading('Monthly Stability Evaluation')
+              .addRaw(`Window reason: \`${reason}\`\n`)
+              .addRaw(`should_run: \`${shouldRun}\`\n`)
+              .addRaw(`publish_requested: \`${publishRequested}\`\n`)
+              .addRaw(`ref: \`${ref}\`\n`)
+              .addRaw(`tools_version: \`${toolsVersion || 'unset'}\` (${toolsChannel})\n`)
+              .addRaw(`shared_version: \`${sharedVersion || 'unset'}\` (${sharedChannel})\n`)
+              .write();
+
+  approval-gate:
+    runs-on: ubuntu-latest
+    needs: evaluate-window
+    if: needs.evaluate-window.outputs.should_run == 'true' && needs.evaluate-window.outputs.publish_requested == 'true'
+    environment:
+      name: monthly-stability-release
+    steps:
+      - name: Approval checkpoint
+        run: |
+          echo "Approval gate passed for monthly stability release dispatches."
+
+  publish-tools:
+    runs-on: ubuntu-latest
+    needs: [evaluate-window, approval-gate]
+    if: needs.evaluate-window.outputs.should_run == 'true' && needs.evaluate-window.outputs.publish_tools == 'true'
+    steps:
+      - name: Dispatch Publish Tools Image workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish-tools-image.yml',
+              ref: '${{ needs.evaluate-window.outputs.ref }}',
+              inputs: {
+                version: '${{ needs.evaluate-window.outputs.tools_version }}',
+                channel: '${{ needs.evaluate-window.outputs.tools_channel }}'
+              }
+            });
+            core.info('Dispatched publish-tools-image workflow.');
+
+  publish-shared:
+    runs-on: ubuntu-latest
+    needs: [evaluate-window, approval-gate]
+    if: needs.evaluate-window.outputs.should_run == 'true' && needs.evaluate-window.outputs.publish_shared == 'true'
+    steps:
+      - name: Dispatch Publish CompareVi.Shared workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish-shared-package.yml',
+              ref: '${{ needs.evaluate-window.outputs.ref }}',
+              inputs: {
+                version: '${{ needs.evaluate-window.outputs.shared_version }}',
+                channel: '${{ needs.evaluate-window.outputs.shared_channel }}',
+                publish: 'true'
+              }
+            });
+            core.info('Dispatched publish-shared-package workflow.');

--- a/.github/workflows/publish-shared-package.yml
+++ b/.github/workflows/publish-shared-package.yml
@@ -1,0 +1,157 @@
+name: Publish CompareVi.Shared Package
+
+on:
+  push:
+    tags:
+      - 'shared-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version (for example: 0.2.0 or 0.2.0-rc.1)'
+        required: false
+        type: string
+      channel:
+        description: 'Release channel'
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+      publish:
+        description: 'Push package to GitHub Packages'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-pack-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Resolve publish context
+        id: ctx
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
+          INPUT_CHANNEL: ${{ inputs.channel || '' }}
+          INPUT_PUBLISH: ${{ inputs.publish || false }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          version="$INPUT_VERSION"
+          if [ -z "$version" ]; then
+            case "$REF_NAME" in
+              shared-v*)
+                version="${REF_NAME#shared-v}"
+                ;;
+              v*)
+                version="${REF_NAME#v}"
+                ;;
+            esac
+          fi
+
+          if [ -z "$version" ]; then
+            echo "Unable to determine package version. Provide workflow_dispatch input 'version' or push a shared-v* tag."
+            exit 1
+          fi
+
+          channel="$INPUT_CHANNEL"
+          if [ -z "$channel" ]; then
+            if [[ "$version" == *"-rc."* ]]; then
+              channel="rc"
+            else
+              channel="stable"
+            fi
+          fi
+
+          if [ "$channel" = "stable" ]; then
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Stable channel requires X.Y.Z version. Received: $version"
+              exit 1
+            fi
+          elif [ "$channel" = "rc" ]; then
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+              echo "RC channel requires X.Y.Z-rc.N version. Received: $version"
+              exit 1
+            fi
+          else
+            echo "Unsupported channel: $channel"
+            exit 1
+          fi
+
+          should_publish="$INPUT_PUBLISH"
+          if [ "$EVENT_NAME" = "push" ] && [[ "$REF_NAME" == shared-v* ]]; then
+            should_publish="true"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "publish=$should_publish" >> "$GITHUB_OUTPUT"
+
+      - name: Restore
+        run: dotnet restore src/CompareVi.Shared/CompareVi.Shared.csproj
+
+      - name: Build
+        run: dotnet build -c Release src/CompareVi.Shared/CompareVi.Shared.csproj --no-restore
+
+      - name: Pack
+        run: >
+          dotnet pack -c Release src/CompareVi.Shared/CompareVi.Shared.csproj
+          -o artifacts
+          --no-build
+          -p:PackageVersion=${{ steps.ctx.outputs.version }}
+          -p:Version=${{ steps.ctx.outputs.version }}
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-shared-package-${{ steps.ctx.outputs.version }}
+          path: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg
+          if-no-files-found: error
+
+      - name: Publish to GitHub Packages NuGet
+        if: steps.ctx.outputs.publish == 'true'
+        shell: bash
+        env:
+          GH_PACKAGES_SOURCE: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(artifacts/*.nupkg artifacts/*.snupkg)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No package files found to publish."
+            exit 1
+          fi
+          dotnet nuget push artifacts/*.nupkg --source "$GH_PACKAGES_SOURCE" --api-key "${{ github.token }}" --skip-duplicate
+          if compgen -G "artifacts/*.snupkg" > /dev/null; then
+            dotnet nuget push artifacts/*.snupkg --source "$GH_PACKAGES_SOURCE" --api-key "${{ github.token }}" --skip-duplicate
+          fi
+
+      - name: Append summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## CompareVi.Shared publish summary"
+            echo ""
+            echo "- Version: \`${{ steps.ctx.outputs.version }}\`"
+            echo "- Channel: \`${{ steps.ctx.outputs.channel }}\`"
+            echo "- Published: \`${{ steps.ctx.outputs.publish }}\`"
+            echo "- Registry: \`https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-tools-image.yml
+++ b/.github/workflows/publish-tools-image.yml
@@ -5,9 +5,22 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
-        description: Optional tag override (defaults to release tag or branch)
+      version:
+        description: 'Image version (for example: 0.7.0 or 0.7.0-rc.1)'
         required: false
+        type: string
+      channel:
+        description: 'Release channel'
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+      tag:
+        description: 'Optional legacy tag override (deprecated, use version)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,14 +31,106 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Compute Image Name
-        id: imagename
+      - name: Resolve image publish context
+        id: context
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
+          INPUT_CHANNEL: ${{ inputs.channel || '' }}
+          INPUT_TAG: ${{ inputs.tag || '' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+          REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA: ${{ github.sha }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          owner="${GITHUB_REPOSITORY_OWNER,,}"
-          IMAGE_NAME="ghcr.io/${owner}/comparevi-tools"
-          echo "IMAGE_NAME=${IMAGE_NAME}" >> "$GITHUB_ENV"
+          set -euo pipefail
+
+          owner="$(echo "$REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          image_name="ghcr.io/${owner}/comparevi-tools"
+
+          raw_version="$INPUT_VERSION"
+          if [ -z "$raw_version" ] && [ -n "$INPUT_TAG" ]; then
+            raw_version="$INPUT_TAG"
+          fi
+          if [ -z "$raw_version" ] && [ -n "$RELEASE_TAG" ]; then
+            raw_version="$RELEASE_TAG"
+          fi
+          if [ -z "$raw_version" ]; then
+            raw_version="$REF_NAME"
+          fi
+
+          version="$raw_version"
+          version="${version#comparevi-tools-v}"
+          version="${version#shared-v}"
+          version="${version#v}"
+
+          if [ -z "$version" ]; then
+            echo "Unable to determine version from inputs/release/ref context."
+            exit 1
+          fi
+
+          channel="$INPUT_CHANNEL"
+          if [ -z "$channel" ]; then
+            if [[ "$version" == *"-rc."* ]]; then
+              channel="rc"
+            else
+              channel="stable"
+            fi
+          fi
+
+          if [ "$channel" = "stable" ]; then
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Stable channel requires X.Y.Z version. Received: $version"
+              exit 1
+            fi
+          elif [ "$channel" = "rc" ]; then
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+              echo "RC channel requires X.Y.Z-rc.N version. Received: $version"
+              exit 1
+            fi
+          else
+            echo "Unsupported channel: $channel"
+            exit 1
+          fi
+
+          declare -a tags
+          tags+=("${image_name}:sha-${GITHUB_SHA:0:7}")
+          tags+=("${image_name}:comparevi-tools-v${version}")
+          tags+=("${image_name}:v${version}")
+          tags+=("${image_name}:${version}")
+
+          if [ "$channel" = "stable" ]; then
+            IFS='.' read -r major minor patch <<< "$version"
+            tags+=("${image_name}:comparevi-tools-v${major}.${minor}")
+            tags+=("${image_name}:comparevi-tools-v${major}")
+            tags+=("${image_name}:latest")
+          fi
+
+          tags_file="${RUNNER_TEMP}/tools-image-tags.txt"
+          : > "$tags_file"
+          printf '%s\n' "${tags[@]}" | awk '!seen[$0]++' > "$tags_file"
+
+          {
+            echo "image_name=$image_name"
+            echo "version=$version"
+            echo "channel=$channel"
+            echo "tags_file=$tags_file"
+            echo "tags<<EOF"
+            cat "$tags_file"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "org.opencontainers.image.source=${SERVER_URL}/${REPOSITORY}"
+            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            echo "org.opencontainers.image.version=${version}"
+            echo "org.opencontainers.image.title=comparevi-tools"
+          } > "${RUNNER_TEMP}/tools-image-labels.txt"
+          echo "labels_file=${RUNNER_TEMP}/tools-image-labels.txt" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -37,27 +142,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-
       - name: Build and push tools image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: tools/docker/Dockerfile.tools
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.context.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.context.outputs.version }}
+            org.opencontainers.image.title=comparevi-tools
+
+      - name: Write release summary artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tests/results/_agent/release
+          summary_path="tests/results/_agent/release/tools-image-release-summary.md"
+          {
+            echo "# comparevi-tools publish summary"
+            echo ""
+            echo "- Image: \`${{ steps.context.outputs.image_name }}\`"
+            echo "- Version: \`${{ steps.context.outputs.version }}\`"
+            echo "- Channel: \`${{ steps.context.outputs.channel }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Source ref: \`${{ github.ref_name }}\`"
+            echo ""
+            echo "## Published tags"
+            while IFS= read -r tag; do
+              echo "- \`${tag}\`"
+            done < "${{ steps.context.outputs.tags_file }}"
+          } | tee "$summary_path"
+
+      - name: Append summary
+        shell: bash
+        run: |
+          cat tests/results/_agent/release/tools-image-release-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release summary artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-tools-release-summary-${{ github.run_id }}
+          path: tests/results/_agent/release/tools-image-release-summary.md
+          if-no-files-found: error

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -1,0 +1,207 @@
+name: Release Cadence Check
+
+on:
+  schedule:
+    - cron: '0 18 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  packages: read
+
+jobs:
+  cadence-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate package freshness and reconcile stale issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- cadence-check:package-staleness -->';
+            const staleThresholdDays = 45;
+
+            const now = new Date();
+            const dayMs = 24 * 60 * 60 * 1000;
+            const stableSemver = /^(?:comparevi-tools-v|v)?\d+\.\d+\.\d+$/;
+            const stableNuget = /^\d+\.\d+\.\d+$/;
+
+            const daysSince = (iso) => {
+              if (!iso) return null;
+              const ms = now.getTime() - new Date(iso).getTime();
+              return Math.floor(ms / dayMs);
+            };
+
+            async function getContainerStableSnapshot() {
+              try {
+                const versions = await github.paginate(
+                  github.request,
+                  'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                  {
+                    org: owner,
+                    package_type: 'container',
+                    package_name: 'comparevi-tools',
+                    per_page: 100
+                  }
+                );
+
+                let latest = null;
+                for (const version of versions) {
+                  const tags = version?.metadata?.container?.tags || [];
+                  const hasStableTag = tags.some((tag) => stableSemver.test(tag) && !tag.includes('-rc.'));
+                  if (!hasStableTag) continue;
+                  const createdAt = version?.created_at;
+                  if (!createdAt) continue;
+                  if (!latest || new Date(createdAt) > new Date(latest.createdAt)) {
+                    latest = { createdAt, tags };
+                  }
+                }
+
+                return latest;
+              } catch (error) {
+                core.warning(`Unable to query comparevi-tools package versions: ${error.message}`);
+                return null;
+              }
+            }
+
+            async function getNugetStableSnapshot() {
+              try {
+                const versions = await github.paginate(
+                  github.request,
+                  'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                  {
+                    org: owner,
+                    package_type: 'nuget',
+                    package_name: 'CompareVi.Shared',
+                    per_page: 100
+                  }
+                );
+
+                let latest = null;
+                for (const version of versions) {
+                  const name = String(version?.name || '').trim();
+                  if (!stableNuget.test(name)) continue;
+                  const createdAt = version?.created_at;
+                  if (!createdAt) continue;
+                  if (!latest || new Date(createdAt) > new Date(latest.createdAt)) {
+                    latest = { createdAt, version: name };
+                  }
+                }
+
+                return latest;
+              } catch (error) {
+                core.warning(`Unable to query CompareVi.Shared package versions: ${error.message}`);
+                return null;
+              }
+            }
+
+            const toolsSnapshot = await getContainerStableSnapshot();
+            const sharedSnapshot = await getNugetStableSnapshot();
+
+            const streams = [
+              {
+                name: 'comparevi-tools',
+                latestAt: toolsSnapshot?.createdAt ?? null,
+                latestRef: toolsSnapshot?.tags?.find((tag) => stableSemver.test(tag) && !tag.includes('-rc.')) ?? 'none'
+              },
+              {
+                name: 'CompareVi.Shared',
+                latestAt: sharedSnapshot?.createdAt ?? null,
+                latestRef: sharedSnapshot?.version ?? 'none'
+              }
+            ].map((stream) => {
+              const ageDays = daysSince(stream.latestAt);
+              const stale = ageDays === null || ageDays > staleThresholdDays;
+              return { ...stream, ageDays, stale };
+            });
+
+            const staleStreams = streams.filter((stream) => stream.stale);
+            const staleDetected = staleStreams.length > 0;
+            const checkedAtIso = now.toISOString();
+
+            const lines = [];
+            lines.push(marker);
+            lines.push('');
+            lines.push(`# Package stream freshness (${checkedAtIso})`);
+            lines.push('');
+            lines.push(`Threshold: **>${staleThresholdDays} days** without a stable publish.`);
+            lines.push('');
+            lines.push('| Stream | Latest stable ref | Latest publish (UTC) | Age (days) | Status |');
+            lines.push('|---|---|---|---:|---|');
+            for (const stream of streams) {
+              lines.push(
+                `| ${stream.name} | \`${stream.latestRef}\` | ${stream.latestAt ?? 'missing'} | ${stream.ageDays ?? 'n/a'} | ${stream.stale ? 'stale' : 'fresh'} |`
+              );
+            }
+            lines.push('');
+            if (staleDetected) {
+              lines.push('## Action');
+              lines.push('');
+              lines.push('- Cut a release for each stale stream or document why release is intentionally deferred.');
+              lines.push('- Keep this issue open until both streams are fresh.');
+            } else {
+              lines.push('All streams are currently fresh. This issue can remain closed.');
+            }
+            const body = lines.join('\n');
+
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner, repo, state: 'open', per_page: 100 }
+            );
+            const existing = openIssues.find((issue) => !issue.pull_request && issue.body && issue.body.includes(marker));
+
+            if (staleDetected) {
+              const title = '[cadence] Package stream freshness alert';
+              if (existing) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  title,
+                  body
+                });
+                core.info(`Updated stale cadence issue #${existing.number}.`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title,
+                  body
+                });
+                core.info(`Opened stale cadence issue #${created.data.number}.`);
+              }
+            } else if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: `Freshness check at ${checkedAtIso}: all package streams are within the ${staleThresholdDays}-day window. Closing this issue.`
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                state: 'closed'
+              });
+              core.info(`Closed stale cadence issue #${existing.number} because streams are fresh.`);
+            } else {
+              core.info('No stale issue found and no stale streams detected.');
+            }
+
+            await core.summary
+              .addHeading('Release Cadence Check')
+              .addRaw(`Checked at: \`${checkedAtIso}\`\n`)
+              .addRaw(`Threshold: \`${staleThresholdDays}\` days\n\n`)
+              .addTable([
+                [{data: 'Stream', header: true}, {data: 'Latest ref', header: true}, {data: 'Latest publish', header: true}, {data: 'Age (days)', header: true}, {data: 'Status', header: true}],
+                ...streams.map((stream) => [
+                  stream.name,
+                  stream.latestRef,
+                  stream.latestAt ?? 'missing',
+                  String(stream.ageDays ?? 'n/a'),
+                  stream.stale ? 'stale' : 'fresh'
+                ])
+              ])
+              .write();

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,8 @@
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>0.1.0.0</FileVersion>
     <InformationalVersion>0.1.0+local</InformationalVersion>
+    <CompareViSharedSource Condition="'$(CompareViSharedSource)' == ''">project</CompareViSharedSource>
+    <CompareViSharedPackageVersion Condition="'$(CompareViSharedPackageVersion)' == ''">0.1.0</CompareViSharedPackageVersion>
   </PropertyGroup>
 </Project>
 

--- a/src/CompareVi.Shared/CompareVi.Shared.csproj
+++ b/src/CompareVi.Shared/CompareVi.Shared.csproj
@@ -12,12 +12,19 @@
     <Company>LabVIEW Community CI/CD</Company>
     <RepositoryUrl>https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>LabVIEW;LVCompare;Pester;CI</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Version>0.1.0</Version>
     <PackageVersion>0.1.0</PackageVersion>
 </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="/" Link="README.md" />
     <EmbeddedResource Include="..\..\tools\providers\spec\operations.json" Link="Operations\operations.json" />
     <EmbeddedResource Include="..\..\tools\providers\spec\providers.json" Link="Providers\providers.json" />
   </ItemGroup>

--- a/src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
+++ b/src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
@@ -11,7 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CompareVi.Shared\CompareVi.Shared.csproj" />
+    <ProjectReference Include="..\CompareVi.Shared\CompareVi.Shared.csproj"
+                      Condition="'$(CompareViSharedSource)' == 'project'" />
+    <PackageReference Include="CompareVi.Shared"
+                      Version="$(CompareViSharedPackageVersion)"
+                      Condition="'$(CompareViSharedSource)' == 'package'" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
## Summary
Implements the controlled split plan for `comparevi-tools` and `CompareVi.Shared` without a big-bang rewrite.

### Phase coverage
- Phase 1: dedicated `publish-shared-package` workflow and package metadata hardening.
- Phase 2: independent version/channel tagging for `publish-tools-image` with release trace summary.
- Phase 3: optional `CompareViSharedSource=project|package` consumption path and matrix validation in `.NET Shared Library` workflow.
- Phase 4: weekly cadence stale-guard workflow and monthly stability coordinator with manual approval environment gate.

## Validation
- actionlint passes.
- Local .NET validation completed:
  - shared restore/build/pack
  - CLI `version`/`tokenize`/`procs` smoke in both `project` and `package` modes.

## Follow-up smoke dispatches planned
- `publish-shared-package.yml` with `publish=false`
- `publish-tools-image.yml` with RC inputs