### PR TITLE
#719 Autonomous mainline queue policy + drift evidence

### DIFF
--- a/.github/workflows/policy-guard-upstream.yml
+++ b/.github/workflows/policy-guard-upstream.yml
@@ -10,9 +10,16 @@ on:
       - main
       - develop
       - release/**
+  merge_group:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 1'
 
 concurrency:
-  group: policy-guard-upstream-${{ github.event.pull_request.number }}
+  group: policy-guard-upstream-${{ (github.event_name == 'pull_request_target' && github.event.pull_request.number) || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -23,12 +30,19 @@ jobs:
       contents: read
     steps:
       - name: Checkout PR head
+        if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v5
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -38,10 +52,10 @@ jobs:
       - name: Prepare policy guard token
         shell: pwsh
         env:
-          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           if (-not $env:INPUT_TOKEN -or (-not $env:INPUT_TOKEN.Trim())) {
-            throw 'Policy Guard requires secrets.GITHUB_TOKEN to be populated.'
+            throw 'Policy Guard requires secrets.GH_TOKEN or secrets.GITHUB_TOKEN to be populated.'
           }
 
           $token = $env:INPUT_TOKEN.Trim()
@@ -59,4 +73,14 @@ jobs:
         run: pwsh -NoLogo -NoProfile -File tools/Assert-NoAmbiguousRemoteRefs.ps1
 
       - name: Run policy guard
-        run: node tools/priority/check-policy.mjs
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -ResultsDir tests/results/_agent/policy
+
+      - name: Upload policy drift artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: policy-drift-${{ github.run_id }}
+          path: tests/results/_agent/policy/policy-drift-report.json
+          if-no-files-found: error

--- a/.github/workflows/policy-sync.yml
+++ b/.github/workflows/policy-sync.yml
@@ -1,0 +1,62 @@
+name: Policy Sync (Admin)
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply policy.json settings to GitHub branch protections/rulesets'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  policy-sync:
+    name: policy-sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Prepare policy sync token
+        shell: pwsh
+        env:
+          INPUT_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          if (-not $env:INPUT_TOKEN -or (-not $env:INPUT_TOKEN.Trim())) {
+            throw 'Policy Sync requires secrets.GH_TOKEN or secrets.GITHUB_TOKEN to be populated.'
+          }
+
+          $token = $env:INPUT_TOKEN.Trim()
+          $tokenFile = Join-Path $env:RUNNER_TEMP 'policy-sync-gh-token.txt'
+          Set-Content -Path $tokenFile -Value $token -Encoding utf8 -NoNewline
+
+          Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN=$token"
+          Add-Content -Path $env:GITHUB_ENV -Value "GITHUB_TOKEN=$token"
+          Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN_FILE=$tokenFile"
+
+          Write-Host "Policy sync token exported. GH_TOKEN_FILE=$tokenFile"
+
+      - name: Run policy sync/check
+        shell: pwsh
+        run: |
+          if ('${{ inputs.apply }}' -eq 'true') {
+            pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -Apply -ResultsDir tests/results/_agent/policy
+          } else {
+            pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -ResultsDir tests/results/_agent/policy
+          }
+
+      - name: Upload policy sync artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: policy-sync-${{ github.run_id }}
+          path: tests/results/_agent/policy/policy-drift-report.json
+          if-no-files-found: error

--- a/.github/workflows/promotion-contract.yml
+++ b/.github/workflows/promotion-contract.yml
@@ -19,6 +19,10 @@ on:
     branches:
       - develop
       - 'release/**'
+  merge_group:
+    branches:
+      - develop
+      - 'release/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
   merge_group:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
     inputs:
       summary-verbose:
@@ -162,7 +162,15 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       run: |
-        node tools/npm/run-script.mjs priority:policy
+        pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -ResultsDir tests/results/_agent/policy
+
+    - name: Upload policy drift artifact
+      if: ${{ always() && github.event.repository.fork == false }}
+      uses: actions/upload-artifact@v5
+      with:
+        name: policy-drift-validate-${{ github.run_id }}-${{ github.run_attempt }}
+        path: tests/results/_agent/policy/policy-drift-report.json
+        if-no-files-found: error
 
     - name: Lint unanchored dot-sourcing (non-blocking)
       shell: pwsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ line buffers).
 
 - Enforce the required statuses listed in `tools/policy/branch-required-checks.json` (contract source of truth). At
   present these are: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`,
-  `Promotion Contract / promotion-contract`, `hook-parity (windows-latest)`,
+  `Policy Guard (Upstream) / policy-guard`, `Promotion Contract / promotion-contract`, `hook-parity (windows-latest)`,
   `hook-parity (ubuntu-latest)`, and `vi-history-scenarios-linux`.
   Optionally apply the same requirement to `main` per repository policy.
 - One-time GitHub CLI snippet (admin only):
@@ -190,6 +190,7 @@ line buffers).
     -f required_status_checks.contexts[]='session-index' \
     -f required_status_checks.contexts[]='issue-snapshot' \
     -f required_status_checks.contexts[]='semver' \
+    -f required_status_checks.contexts[]='Policy Guard (Upstream) / policy-guard' \
     -f required_status_checks.contexts[]='Promotion Contract / promotion-contract' \
     -f required_status_checks.contexts[]='hook-parity (windows-latest)' \
     -f required_status_checks.contexts[]='hook-parity (ubuntu-latest)' \

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -289,8 +289,11 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   commits land on `develop`/`main`.
 - Keep PRs focused and include the standing issue reference (`#<number>`) in the commit subject and PR description.
 - Ensure required checks (`validate`, `fixtures`, `session-index`) are green before merging; rerun as needed.
-- Run `node tools/npm/run-script.mjs priority:policy` if you need to audit merge settings locally; the command also runs during
-  `priority:handoff-tests` and fails when repo/branch policy drifts.
+- Run `node tools/npm/run-script.mjs priority:policy` (or `node tools/npm/run-script.mjs priority:policy:sync`) if you
+  need to audit merge settings locally; the command also runs during `priority:handoff-tests` and fails when
+  repo/branch policy drifts.
+- Use `node tools/npm/run-script.mjs priority:policy:apply` only with admin token scope when you intentionally need to
+  sync GitHub protections/rulesets back to `tools/priority/policy.json`.
 - Prefer opening PRs from your fork with `node tools/npm/run-script.mjs priority:pr`; the helper ensures `origin` targets your fork (creating
   it via `gh repo fork` if needed), pushes the current branch, and calls
   `gh pr create --fill --repo <upstream> --base develop --head <fork>:branch`.

--- a/docs/RUNBOOK_CONTAINER_LANE_PROMOTION_POLICY.md
+++ b/docs/RUNBOOK_CONTAINER_LANE_PROMOTION_POLICY.md
@@ -72,7 +72,7 @@ Rollback behavior was validated against the canary state for #662/#663:
 
 - Canary lane remains non-required during this policy phase.
 - Current develop required-check contract remains satisfiable with no runbook-container context required.
-- Expected branch-protection behavior after rollback: merges continue using canonical required contexts (`lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `hook-parity (windows-latest)`, `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux`).
+- Expected branch-protection behavior after rollback: merges continue using canonical required contexts (`lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `Promotion Contract / promotion-contract`, `hook-parity (windows-latest)`, `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux`).
 
 ## Decision for #663
 

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -1,12 +1,12 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Feature Branch Enforcement & Merge Queue
 
-_Last updated: 2026-03-05 (standing priority #283)._ 
+_Last updated: 2026-03-05 (standing priority #719)._ 
 
 ## Purpose
 
 Serve as the canonical quick reference for how contributors branch, validate, and promote work while satisfying the
-standing GitHub protection rules (including the `main` merge queue).
+standing GitHub protection rules (including queue-managed `develop` and `main`).
 
 ## Branch Expectations
 
@@ -40,10 +40,10 @@ standing GitHub protection rules (including the `main` merge queue).
 - `Validate` includes a `Policy guard (branch protection)` step that runs `node tools/npm/run-script.mjs priority:policy`
   with the repository token when it is available. On fork PRs the step now detects the reduced token scope, logs that the
   upstream guard will run, and exits cleanly so community contributors are not blocked.
-- `.github/workflows/policy-guard-upstream.yml` (triggered via `pull_request_target`) checks out the PR head with the
-  upstream repository token and re-runs `priority:policy`, guaranteeing that branch protection rules are enforced even
-  when the lint job skips in fork contexts. Its status (`Policy Guard (Upstream) / policy-guard`) is required on
-  `main` and `release/*`.
+- `.github/workflows/policy-guard-upstream.yml` (triggered via `pull_request_target`, `merge_group`, and schedule) checks
+  out the PR head with the upstream repository token and re-runs `priority:policy`, guaranteeing that branch protection
+  rules are enforced even when the lint job skips in fork contexts. Its status
+  (`Policy Guard (Upstream) / policy-guard`) is required on `develop`, `main`, and `release/*`.
 - Branch protection verification treats workflow-prefixed and short check contexts as equivalent (for example,
   `Validate / lint` and `lint`) to avoid false drift when comparing live API contexts against policy mappings.
 - `Validate` runs `priority:handoff-tests` automatically for heads that start with `feature/`, enforcing leak-sensitive
@@ -60,9 +60,9 @@ standing GitHub protection rules (including the `main` merge queue).
 ### GitHub rulesets
 | Ruleset ID | Scope                | Highlights                                                                                   |
 |------------|----------------------|----------------------------------------------------------------------------------------------|
-| `8811898`  | `refs/heads/develop` | Linear history required, squash-only merges, checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `hook-parity (windows-latest)`, `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux` |
-| `8614140`  | `refs/heads/main`    | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`. Requires one approving review with resolved threads. |
-| `8614172`  | `refs/heads/release/*` | No merge queue; protects against force-push/deletion. Required checks: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`. Requires one approving review with resolved threads. |
+| `8811898`  | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `Promotion Contract / promotion-contract`, `hook-parity (windows-latest)`, `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux`. |
+| `8614140`  | `refs/heads/main`    | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`. Required approving reviews: `0`. |
+| `8614172`  | `refs/heads/release/*` | No merge queue; protects against force-push/deletion. Required checks: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`, `Promotion Contract / promotion-contract`. Required approving reviews: `0`. |
 
 `node tools/npm/run-script.mjs priority:policy` queries these rulesets and fails if the live configuration drifts from
 `tools/priority/policy.json`; run it whenever you adjust protections.
@@ -73,9 +73,11 @@ Keep GitHub’s live protections in lockstep with the repository contract below.
 checked into `tools/priority/policy.json` so `priority:policy` stays authoritative.
 
 - `node tools/npm/run-script.mjs priority:policy` – verify only (fails on drift).
+- `node tools/npm/run-script.mjs priority:policy:sync` – verify via the policy-sync wrapper with machine-readable report output.
 - `node tools/npm/run-script.mjs priority:policy -- --apply` – pushes the manifest configuration back to GitHub (branch
   protections + rulesets); rerun without `--apply` afterward to confirm parity.
-- The Validate workflow runs the verify-only command on every PR targeting `develop`; fix GitHub settings or update
+- `node tools/npm/run-script.mjs priority:policy:apply` – apply via the wrapper (`Sync-BranchProtectionPolicy.ps1`) and emit report summary.
+- The Validate workflow runs the verify-only command on every PR and queue run targeting `develop`; fix GitHub settings or update
   `tools/priority/policy.json` before re-running CI when it fails.
 
 ### Runbook container canary policy note
@@ -86,9 +88,10 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   `docs/RUNBOOK_CONTAINER_LANE_PROMOTION_POLICY.md`.
 
 ### `develop`
-- **Merge strategy**: squash only (enforce linear history, disable merge commits).
-- **Required checks**: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `hook-parity (windows-latest)`,
-  `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux`.
+- **Merge strategy**: queue-managed squash with linear history enforced; merge commits disabled.
+- **Required checks**: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`,
+  `Policy Guard (Upstream) / policy-guard`, `Promotion Contract / promotion-contract`,
+  `hook-parity (windows-latest)`, `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux`.
 - **Admin bypass**: leave disabled; administrators should only intervene when `priority:policy` confirms parity.
 - **Reapply**: Use `node tools/npm/run-script.mjs priority:policy -- --apply` to push the manifest configuration when drift is detected.
 
@@ -210,7 +213,7 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   - `check_response_timeout_minutes=60`
 - **Required checks**: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`.
 - **Workflow triggers**: Ensure those required checks run on both `pull_request` and `merge_group` so queued entries can merge.
-- **Approval policy**: >= 1 review; dismiss stale reviews on push; require thread resolution.
+- **Approval policy**: 0 required reviews; stale review dismissal and thread resolution are not enforced.
 - **Quick verification**:
   ```powershell
   gh api repos/$REPO/rulesets/8614140 --jq '{name,enforcement,conditions,rules:[.rules[]|{type,parameters}]}'
@@ -220,23 +223,22 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 
 ### `release/*`
 - **Ruleset**: `8614172` (scope `refs/heads/release/*`).
-- **Required checks**: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`.
-- **Approvals**: >= 1 review, stale review dismissal enabled, enforce thread resolution.
+- **Required checks**: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`, `Promotion Contract / promotion-contract`.
+- **Approvals**: 0 required reviews; stale review dismissal remains enabled.
 - **Merge queue**: intentionally disabled; rely on manual review + required checks.
 - **Maintenance tip**: revisit after each release cycle to ensure the workflow matrix still emits the expected check
   names.
 
-## Merge Queue Workflow (main)
-Prereq: All required checks for `main` must execute on both `pull_request` and `merge_group`. Use the YAML snippet above
+## Merge Queue Workflow (develop/main)
+Prereq: All required checks for queue-managed branches must execute on both `pull_request` and `merge_group`. Use the YAML snippet above
 to confirm each workflow includes both triggers.
 
-1. Ensure the PR targets `main` (typically a release PR) and all required checks (`lint`, `pester`, `vi-binary-check`,
-   `vi-compare`, `Policy Guard (Upstream) / policy-guard`) are green on the latest commit.
-2. Click **Merge when ready** (queue-managed **squash**). Ensure >= 1 approval and all review threads are resolved; the
-   queue enforces both before merging.
-3. Monitor `https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/queue/main`. GitHub stages entries, reruns
-   the required checks on the merge group tip, and waits up to your configured minimum group size wait time before
-   merging smaller groups.
+1. Ensure the PR targets a queue-managed branch (`develop` or `main`) and all required checks for that branch are green
+   on the latest commit.
+2. Click **Merge when ready** (queue-managed **squash**). No reviewer approval is required under the current policy.
+3. Monitor the corresponding queue page (`/queue/develop` or `/queue/main`). GitHub stages entries, reruns the required
+   checks on the merge group tip, and waits up to your configured minimum group size wait time before merging smaller
+   groups.
 4. If the run fails or new commits land, the queue ejects the entry back to the PR. Address the failure, rerun the
    relevant check (`priority:validate`, `Validate` workflow, or manual reruns), and re-enable the queue.
 

--- a/docs/schemas/policy-drift-report-v1.schema.json
+++ b/docs/schemas/policy-drift-report-v1.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Policy Drift Report v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAt",
+    "apply",
+    "result",
+    "summary",
+    "diffs",
+    "applied",
+    "errors"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/policy-report@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "apply": {
+      "type": "boolean"
+    },
+    "repository": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "authSource": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "forkRun": {
+      "type": "boolean"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "unknown",
+        "pass",
+        "fail",
+        "applied",
+        "skipped",
+        "error"
+      ]
+    },
+    "skippedReason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "repoDiffCount",
+        "branchDiffCount",
+        "rulesetDiffCount",
+        "totalDiffCount"
+      ],
+      "properties": {
+        "repoDiffCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "branchDiffCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesetDiffCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalDiffCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "diffs": {
+      "type": "object",
+      "required": [
+        "repo",
+        "branch",
+        "ruleset"
+      ],
+      "properties": {
+        "repo": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "branch": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ruleset": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "applied": {
+      "type": "object",
+      "required": [
+        "branches",
+        "rulesets"
+      ],
+      "properties": {
+        "branches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rulesets": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "priority:policy": "node tools/priority/check-policy.mjs",
     "priority:operator-status": "pwsh -NoLogo -NoProfile -File tools/priority/Write-OperatorStatusSummary.ps1",
     "priority:parity": "node tools/priority/report-origin-upstream-parity.mjs",
+    "priority:policy:apply": "pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -Apply",
+    "priority:policy:sync": "pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1",
     "priority:pr": "node tools/priority/create-pr.mjs",
     "priority:release": "pwsh -NoLogo -NoProfile -File tools/priority/Simulate-Release.ps1",
     "priority:schema": "node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/standing-priority-issue-v1.schema.json --data tests/results/_agent/issue/[0-9]*.json --optional",

--- a/tools/policy/branch-required-checks.json
+++ b/tools/policy/branch-required-checks.json
@@ -8,6 +8,7 @@
       "session-index",
       "issue-snapshot",
       "semver",
+      "Policy Guard (Upstream) / policy-guard",
       "Promotion Contract / promotion-contract",
       "hook-parity (windows-latest)",
       "hook-parity (ubuntu-latest)",

--- a/tools/policy/promotion-contract.json
+++ b/tools/policy/promotion-contract.json
@@ -38,6 +38,7 @@
       "session-index",
       "issue-snapshot",
       "semver",
+      "Policy Guard (Upstream) / policy-guard",
       "Promotion Contract / promotion-contract",
       "hook-parity (windows-latest)",
       "hook-parity (ubuntu-latest)",

--- a/tools/priority/Sync-BranchProtectionPolicy.ps1
+++ b/tools/priority/Sync-BranchProtectionPolicy.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding()]
+param(
+  [switch]$Apply,
+  [string]$ResultsDir = 'tests/results/_agent/policy',
+  [string]$ReportFile = 'policy-drift-report.json',
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-OutputPath {
+  param(
+    [Parameter(Mandatory)][string]$BaseDir,
+    [Parameter(Mandatory)][string]$ChildPath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($ChildPath)) {
+    return $ChildPath
+  }
+  return Join-Path $BaseDir $ChildPath
+}
+
+$workspaceRoot = (Get-Location).Path
+$resolvedResultsDir = Resolve-OutputPath -BaseDir $workspaceRoot -ChildPath $ResultsDir
+New-Item -ItemType Directory -Path $resolvedResultsDir -Force | Out-Null
+
+$reportPath = Resolve-OutputPath -BaseDir $resolvedResultsDir -ChildPath $ReportFile
+
+$args = @(
+  'tools/priority/check-policy.mjs',
+  '--report',
+  $reportPath
+)
+if ($Apply) {
+  $args += '--apply'
+}
+
+Write-Host "[policy-sync] Running: node $($args -join ' ')"
+& node @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+  throw "Policy sync/check failed (exit=$exitCode)."
+}
+
+if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+  throw "Policy report not found: $reportPath"
+}
+
+$report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json
+$branchUpdates = @($report.applied.branches)
+$rulesetUpdates = @($report.applied.rulesets)
+$branchSummary = if ($branchUpdates.Count -gt 0) { $branchUpdates -join ', ' } else { '(none)' }
+$rulesetSummary = if ($rulesetUpdates.Count -gt 0) { $rulesetUpdates -join ', ' } else { '(none)' }
+
+Write-Host "[policy-sync] Result: $($report.result)"
+Write-Host "[policy-sync] Total diffs: $($report.summary.totalDiffCount)"
+Write-Host "[policy-sync] Branch updates: $branchSummary"
+Write-Host "[policy-sync] Ruleset updates: $rulesetSummary"
+Write-Host "[policy-sync] Report: $reportPath"
+
+if ($StepSummaryPath) {
+  $summary = @(
+    '### Branch Protection Policy Sync',
+    '',
+    "- Result: $($report.result)",
+    "- Apply mode: $($report.apply)",
+    "- Repository: $($report.repository)",
+    "- Total diffs: $($report.summary.totalDiffCount)",
+    "- Branch updates: $branchSummary",
+    "- Ruleset updates: $rulesetSummary",
+    "- Report path: $reportPath"
+  ) -join "`n"
+  $summary | Out-File -FilePath $StepSummaryPath -Append -Encoding utf8
+}

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -1,5 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { run } from '../check-policy.mjs';
 
 function createResponse(data, status = 200, statusText = 'OK') {
@@ -26,6 +29,7 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     'session-index',
     'issue-snapshot',
     'semver',
+    'Policy Guard (Upstream) / policy-guard',
     'Promotion Contract / promotion-contract',
     'hook-parity (windows-latest)',
     'hook-parity (ubuntu-latest)',
@@ -387,6 +391,9 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     rulesetDevelop.rules.some((rule) => rule.type === 'required_linear_history'),
     'required_linear_history rule expected on develop'
   );
+  const developMergeQueueRule = rulesetDevelop.rules.find((rule) => rule.type === 'merge_queue');
+  assert.ok(developMergeQueueRule, 'merge_queue rule expected on develop');
+  assert.equal(developMergeQueueRule.parameters.min_entries_to_merge_wait_minutes, 5);
   const developPullRule = rulesetDevelop.rules.find((rule) => rule.type === 'pull_request');
   assert.deepEqual(
     developPullRule.parameters.allowed_merge_methods.sort(),
@@ -403,8 +410,8 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   );
 
   const pullRule = rulesetMain.rules.find((rule) => rule.type === 'pull_request');
-  assert.equal(pullRule.parameters.required_approving_review_count, 1);
-  assert.equal(pullRule.parameters.required_review_thread_resolution, true);
+  assert.equal(pullRule.parameters.required_approving_review_count, 0);
+  assert.equal(pullRule.parameters.required_review_thread_resolution, false);
 
   const statusRuleRelease = rulesetRelease.rules.find((rule) => rule.type === 'required_status_checks');
   assert.deepEqual(
@@ -812,4 +819,32 @@ test('priority:policy --apply fails when GH_TOKEN 401 has no fallback', async ()
     'auth source log should report GH_TOKEN'
   );
   assert.deepEqual(errorMessages, []);
+});
+
+test('priority:policy emits machine-readable report when --report is provided', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'priority-policy-report-'));
+  const reportPath = path.join(tempDir, 'report.json');
+  const fetchMock = async () => createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--report', reportPath],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GH_TOKEN: 'gh-stale',
+      GITHUB_TOKEN: ''
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: () => {},
+    error: () => {}
+  });
+
+  assert.equal(code, 0, 'non-apply mode should still return skip code');
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(report.schema, 'priority/policy-report@v1');
+  assert.equal(report.result, 'skipped');
+  assert.equal(report.apply, false);
 });

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFile, access } from 'node:fs/promises';
+import { readFile, access, writeFile, mkdir } from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,10 +12,12 @@ function parseArgs(argv = process.argv) {
   const options = {
     apply: false,
     help: false,
-    debug: false
+    debug: false,
+    report: null
   };
 
-  for (const arg of args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
     if (arg === '--apply') {
       options.apply = true;
       continue;
@@ -28,10 +30,30 @@ function parseArgs(argv = process.argv) {
       options.debug = true;
       continue;
     }
+    if (arg === '--report') {
+      const reportPath = args[index + 1];
+      if (!reportPath || reportPath.startsWith('-')) {
+        throw new Error('Missing value for --report.');
+      }
+      options.report = reportPath;
+      index += 1;
+      continue;
+    }
     throw new Error(`Unknown option: ${arg}`);
   }
 
   return options;
+}
+
+async function writeReportIfRequested(reportPath, report, logFn = console.log) {
+  if (!reportPath) {
+    return;
+  }
+
+  const resolvedPath = path.resolve(reportPath);
+  await mkdir(path.dirname(resolvedPath), { recursive: true });
+  await writeFile(resolvedPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  logFn(`[policy] report written: ${resolvedPath}`);
 }
 
 async function loadManifest() {
@@ -688,216 +710,284 @@ export async function run({
 } = {}) {
   const options = parseArgs(argv);
   if (options.help) {
-    log('Usage: node tools/priority/check-policy.mjs [--apply] [--debug]');
+    log('Usage: node tools/priority/check-policy.mjs [--apply] [--debug] [--report <path>]');
     return 0;
   }
 
-  const dbg = options.debug ? (...args) => log('[policy][debug]', ...args) : () => {};
+  const report = {
+    schema: 'priority/policy-report@v1',
+    schemaVersion: '1.0.0',
+    generatedAt: new Date().toISOString(),
+    apply: options.apply,
+    repository: null,
+    authSource: null,
+    forkRun: false,
+    result: 'unknown',
+    skippedReason: null,
+    summary: {
+      repoDiffCount: 0,
+      branchDiffCount: 0,
+      rulesetDiffCount: 0,
+      totalDiffCount: 0
+    },
+    diffs: {
+      repo: [],
+      branch: [],
+      ruleset: []
+    },
+    applied: {
+      branches: [],
+      rulesets: []
+    },
+    errors: []
+  };
 
-  const manifest = await loadManifest();
-  const forkRun = await detectForkRun(env);
-  const tokenCandidates = await resolveTokenCandidates(env);
-  if (tokenCandidates.length === 0) {
-    throw new Error('GitHub token not found. Set GITHUB_TOKEN, GH_TOKEN, or GH_TOKEN_FILE.');
-  }
-  let activeTokenIndex = 0;
-  let activeTokenResult = tokenCandidates[activeTokenIndex];
-  log(`[policy] auth source: ${activeTokenResult.source}`);
+  const applyDiffsToReport = (diffs) => {
+    report.diffs.repo = [...diffs.repoDiffs];
+    report.diffs.branch = [...diffs.branchDiffs];
+    report.diffs.ruleset = [...diffs.rulesetDiffs];
+    report.summary = {
+      repoDiffCount: report.diffs.repo.length,
+      branchDiffCount: report.diffs.branch.length,
+      rulesetDiffCount: report.diffs.ruleset.length,
+      totalDiffCount: report.diffs.repo.length + report.diffs.branch.length + report.diffs.ruleset.length
+    };
+  };
 
-  const invokeWithAuthFallback = async (operationName, operationFn) => {
-    const attemptedSources = [activeTokenResult.source];
-    try {
-      return await operationFn(activeTokenResult.token);
-    } catch (initialError) {
-      if (!isUnauthorizedAuthError(initialError)) {
-        throw initialError;
-      }
+  const finalize = async ({ code, result, skippedReason = null }) => {
+    report.result = result;
+    report.skippedReason = skippedReason;
+    await writeReportIfRequested(options.report, report, log);
+    return code;
+  };
 
-      const fallback = tokenCandidates.find(
-        (candidate, index) => index > activeTokenIndex && candidate.token !== activeTokenResult.token
-      );
-      if (!fallback) {
-        throw createAuthUnavailableError(
-          operationName,
-          attemptedSources,
-          `No fallback token available. Last error: ${initialError.message}`
-        );
-      }
+  try {
+    const dbg = options.debug ? (...args) => log('[policy][debug]', ...args) : () => {};
 
-      log(`[policy] auth fallback: ${activeTokenResult.source} -> ${fallback.source} (401 Unauthorized)`);
-      activeTokenIndex = tokenCandidates.indexOf(fallback);
-      activeTokenResult = fallback;
-      attemptedSources.push(activeTokenResult.source);
+    const manifest = await loadManifest();
+    const forkRun = await detectForkRun(env);
+    report.forkRun = forkRun;
+    const tokenCandidates = await resolveTokenCandidates(env);
+    if (tokenCandidates.length === 0) {
+      throw new Error('GitHub token not found. Set GITHUB_TOKEN, GH_TOKEN, or GH_TOKEN_FILE.');
+    }
+    let activeTokenIndex = 0;
+    let activeTokenResult = tokenCandidates[activeTokenIndex];
+    report.authSource = activeTokenResult.source;
+    log(`[policy] auth source: ${activeTokenResult.source}`);
 
+    const invokeWithAuthFallback = async (operationName, operationFn) => {
+      const attemptedSources = [activeTokenResult.source];
       try {
         return await operationFn(activeTokenResult.token);
-      } catch (fallbackError) {
-        if (isUnauthorizedAuthError(fallbackError)) {
+      } catch (initialError) {
+        if (!isUnauthorizedAuthError(initialError)) {
+          throw initialError;
+        }
+
+        const fallback = tokenCandidates.find(
+          (candidate, index) => index > activeTokenIndex && candidate.token !== activeTokenResult.token
+        );
+        if (!fallback) {
           throw createAuthUnavailableError(
             operationName,
             attemptedSources,
-            `Last error: ${fallbackError.message}`
+            `No fallback token available. Last error: ${initialError.message}`
           );
         }
-        throw fallbackError;
+
+        log(`[policy] auth fallback: ${activeTokenResult.source} -> ${fallback.source} (401 Unauthorized)`);
+        activeTokenIndex = tokenCandidates.indexOf(fallback);
+        activeTokenResult = fallback;
+        report.authSource = activeTokenResult.source;
+        attemptedSources.push(activeTokenResult.source);
+
+        try {
+          return await operationFn(activeTokenResult.token);
+        } catch (fallbackError) {
+          if (isUnauthorizedAuthError(fallbackError)) {
+            throw createAuthUnavailableError(
+              operationName,
+              attemptedSources,
+              `Last error: ${fallbackError.message}`
+            );
+          }
+          throw fallbackError;
+        }
       }
+    };
+
+    const { owner, repo } = getRepoFromEnv(env, execSyncFn);
+    report.repository = `${owner}/${repo}`;
+    dbg(`Resolved repository ${owner}/${repo}`);
+    if (activeTokenResult?.source) {
+      dbg(`Token source ${activeTokenResult.source}`);
     }
-  };
+    const repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
 
-  const { owner, repo } = getRepoFromEnv(env, execSyncFn);
-  dbg(`Resolved repository ${owner}/${repo}`);
-  if (activeTokenResult?.source) {
-    dbg(`Token source ${activeTokenResult.source}`);
-  }
-  const repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
-
-  let initialState;
-  try {
-    initialState = await invokeWithAuthFallback('collectState', (token) =>
-      collectState(manifest, repoUrl, token, fetchFn)
-    );
-  } catch (authError) {
-    if (!options.apply && authError?.code === 'POLICY_AUTH_UNAVAILABLE') {
-      const attempted = Array.isArray(authError.attemptedSources) && authError.attemptedSources.length > 0
-        ? authError.attemptedSources.join(' -> ')
-        : 'unknown';
-      log(
-        `[policy] Authorization unavailable for policy check (attempted: ${attempted}); skipping non-apply validation. Upstream status "Policy Guard (Upstream) / policy-guard" remains authoritative.`
+    let initialState;
+    try {
+      initialState = await invokeWithAuthFallback('collectState', (token) =>
+        collectState(manifest, repoUrl, token, fetchFn)
       );
-      return 0;
+    } catch (authError) {
+      if (!options.apply && authError?.code === 'POLICY_AUTH_UNAVAILABLE') {
+        const attempted = Array.isArray(authError.attemptedSources) && authError.attemptedSources.length > 0
+          ? authError.attemptedSources.join(' -> ')
+          : 'unknown';
+        const message = `[policy] Authorization unavailable for policy check (attempted: ${attempted}); skipping non-apply validation. Upstream status "Policy Guard (Upstream) / policy-guard" remains authoritative.`;
+        log(message);
+        return finalize({
+          code: 0,
+          result: 'skipped',
+          skippedReason: message
+        });
+      }
+      throw authError;
     }
-    throw authError;
-  }
-  if (options.debug) {
-    const repoKeys = initialState.repoData ? Object.keys(initialState.repoData) : [];
-    dbg(`Repo response keys: ${repoKeys.length ? repoKeys.join(', ') : '(none)'}`);
-    for (const entry of initialState.branchStates) {
-      if (entry.error) {
-        dbg(`Branch ${entry.branch} protection fetch error: ${entry.error.message}`);
-      } else {
-        const protection = entry.protection ?? {};
-        dbg(`Branch ${entry.branch} protection keys: ${Object.keys(protection).join(', ') || '(none)'}`);
+    if (options.debug) {
+      const repoKeys = initialState.repoData ? Object.keys(initialState.repoData) : [];
+      dbg(`Repo response keys: ${repoKeys.length ? repoKeys.join(', ') : '(none)'}`);
+      for (const entry of initialState.branchStates) {
+        if (entry.error) {
+          dbg(`Branch ${entry.branch} protection fetch error: ${entry.error.message}`);
+        } else {
+          const protection = entry.protection ?? {};
+          dbg(`Branch ${entry.branch} protection keys: ${Object.keys(protection).join(', ') || '(none)'}`);
+        }
+      }
+      for (const entry of initialState.rulesetStates) {
+        if (entry.error) {
+          dbg(`Ruleset ${entry.id} fetch error: ${entry.error.message}`);
+        } else {
+          const rule = entry.ruleset ?? {};
+          dbg(`Ruleset ${entry.id} keys: ${Object.keys(rule).join(', ') || '(none)'}`);
+        }
       }
     }
-    for (const entry of initialState.rulesetStates) {
-      if (entry.error) {
-        dbg(`Ruleset ${entry.id} fetch error: ${entry.error.message}`);
-      } else {
-        const rule = entry.ruleset ?? {};
-        dbg(`Ruleset ${entry.id} keys: ${Object.keys(rule).join(', ') || '(none)'}`);
-      }
-    }
-  }
 
-  const initialDiffs = evaluateDiffs(manifest, initialState);
+    const initialDiffs = evaluateDiffs(manifest, initialState);
+    applyDiffsToReport(initialDiffs);
 
-  const allDiffs = [
-    ...initialDiffs.repoDiffs,
-    ...initialDiffs.branchDiffs,
-    ...initialDiffs.rulesetDiffs
-  ];
-
-  const missingRepoFields = initialDiffs.repoDiffs.filter((diff) => diff.includes('actual undefined'));
-  const repoFieldsAllMissing =
-    initialDiffs.repoDiffs.length > 0 && missingRepoFields.length === initialDiffs.repoDiffs.length;
-  const hasAdminPermission = initialState.repoData?.permissions?.admin === true;
-
-  if (!options.apply && repoFieldsAllMissing && (!hasAdminPermission || forkRun)) {
-    log(
-      '[policy] Repository settings unavailable with current token; skipping policy check (admin permissions required). Upstream status "Policy Guard (Upstream) / policy-guard" will enforce branch protection.'
-    );
-    return 0;
-  }
-
-  if (options.apply) {
-    const branchStatesNeedingUpdates = initialState.branchStates.filter((entry, index) => {
-      if (entry.skipReason === 'pattern') {
-        return false;
-      }
-      if (entry.error) {
-        return isNotFoundError(entry.error);
-      }
-      const diffs = compareBranchSettings(
-        entry.branch,
-        entry.expectations,
-        entry.protection
-      );
-      return diffs.length > 0;
-    });
-
-    for (const entry of branchStatesNeedingUpdates) {
-      await invokeWithAuthFallback(`applyBranchProtection(${entry.branch})`, (token) =>
-        applyBranchProtection(
-          repoUrl,
-          token,
-          entry.branch,
-          entry.expectations,
-          entry.protection,
-          fetchFn,
-          log
-        )
-      );
-    }
-
-    const rulesetStatesNeedingUpdates = initialState.rulesetStates.filter((entry) => {
-      if (entry.error) {
-        return false;
-      }
-      const diffs = compareRuleset(entry.id, entry.expectations, entry.ruleset);
-      return diffs.length > 0;
-    });
-
-    for (const entry of rulesetStatesNeedingUpdates) {
-      await invokeWithAuthFallback(`applyRuleset(${entry.id})`, (token) =>
-        applyRuleset(
-          repoUrl,
-          token,
-          entry.id,
-          entry.expectations,
-          entry.ruleset,
-          fetchFn,
-          log
-        )
-      );
-    }
-
-    const postState = await invokeWithAuthFallback('collectState(post-apply)', (token) =>
-      collectState(manifest, repoUrl, token, fetchFn)
-    );
-    const postDiffs = evaluateDiffs(manifest, postState);
-    const remainingDiffs = [
-      ...postDiffs.repoDiffs,
-      ...postDiffs.branchDiffs,
-      ...postDiffs.rulesetDiffs
+    const allDiffs = [
+      ...initialDiffs.repoDiffs,
+      ...initialDiffs.branchDiffs,
+      ...initialDiffs.rulesetDiffs
     ];
 
-    if (remainingDiffs.length > 0) {
-      error('Merge policy mismatches detected after apply:');
-      for (const diff of remainingDiffs) {
+    const missingRepoFields = initialDiffs.repoDiffs.filter((diff) => diff.includes('actual undefined'));
+    const repoFieldsAllMissing =
+      initialDiffs.repoDiffs.length > 0 && missingRepoFields.length === initialDiffs.repoDiffs.length;
+    const hasAdminPermission = initialState.repoData?.permissions?.admin === true;
+
+    if (!options.apply && repoFieldsAllMissing && (!hasAdminPermission || forkRun)) {
+      const message = '[policy] Repository settings unavailable with current token; skipping policy check (admin permissions required). Upstream status "Policy Guard (Upstream) / policy-guard" will enforce branch protection.';
+      log(message);
+      return finalize({
+        code: 0,
+        result: 'skipped',
+        skippedReason: message
+      });
+    }
+
+    if (options.apply) {
+      const branchStatesNeedingUpdates = initialState.branchStates.filter((entry) => {
+        if (entry.skipReason === 'pattern') {
+          return false;
+        }
+        if (entry.error) {
+          return isNotFoundError(entry.error);
+        }
+        const diffs = compareBranchSettings(
+          entry.branch,
+          entry.expectations,
+          entry.protection
+        );
+        return diffs.length > 0;
+      });
+
+      for (const entry of branchStatesNeedingUpdates) {
+        await invokeWithAuthFallback(`applyBranchProtection(${entry.branch})`, (token) =>
+          applyBranchProtection(
+            repoUrl,
+            token,
+            entry.branch,
+            entry.expectations,
+            entry.protection,
+            fetchFn,
+            log
+          )
+        );
+        report.applied.branches.push(entry.branch);
+      }
+
+      const rulesetStatesNeedingUpdates = initialState.rulesetStates.filter((entry) => {
+        if (entry.error) {
+          return false;
+        }
+        const diffs = compareRuleset(entry.id, entry.expectations, entry.ruleset);
+        return diffs.length > 0;
+      });
+
+      for (const entry of rulesetStatesNeedingUpdates) {
+        await invokeWithAuthFallback(`applyRuleset(${entry.id})`, (token) =>
+          applyRuleset(
+            repoUrl,
+            token,
+            entry.id,
+            entry.expectations,
+            entry.ruleset,
+            fetchFn,
+            log
+          )
+        );
+        report.applied.rulesets.push(entry.id);
+      }
+
+      const postState = await invokeWithAuthFallback('collectState(post-apply)', (token) =>
+        collectState(manifest, repoUrl, token, fetchFn)
+      );
+      const postDiffs = evaluateDiffs(manifest, postState);
+      applyDiffsToReport(postDiffs);
+      const remainingDiffs = [
+        ...postDiffs.repoDiffs,
+        ...postDiffs.branchDiffs,
+        ...postDiffs.rulesetDiffs
+      ];
+
+      if (remainingDiffs.length > 0) {
+        error('Merge policy mismatches detected after apply:');
+        for (const diff of remainingDiffs) {
+          error(` - ${diff}`);
+        }
+        return finalize({ code: 1, result: 'fail' });
+      }
+
+      log('Merge policy apply completed successfully.');
+      return finalize({ code: 0, result: 'applied' });
+    }
+
+    if (allDiffs.length > 0) {
+      if (missingRepoFields.length > 0 && !options.debug) {
+        error(
+          '[policy] Repository settings were returned as undefined. Ensure the provided token has admin access to the repository or rerun with --debug for more details.'
+        );
+      }
+      error('Merge policy mismatches detected:');
+      for (const diff of allDiffs) {
         error(` - ${diff}`);
       }
-      return 1;
+      return finalize({ code: 1, result: 'fail' });
     }
 
-    log('Merge policy apply completed successfully.');
-    return 0;
+    log('Merge policy check passed.');
+    return finalize({ code: 0, result: 'pass' });
+  } catch (errObj) {
+    report.result = report.result === 'unknown' ? 'error' : report.result;
+    report.errors.push(errObj?.message ?? String(errObj));
+    await writeReportIfRequested(options.report, report, log);
+    throw errObj;
   }
-
-  if (allDiffs.length > 0) {
-    if (missingRepoFields.length > 0 && !options.debug) {
-      error(
-        '[policy] Repository settings were returned as undefined. Ensure the provided token has admin access to the repository or rerun with --debug for more details.'
-      );
-    }
-    error('Merge policy mismatches detected:');
-    for (const diff of allDiffs) {
-      error(` - ${diff}`);
-    }
-    return 1;
-  }
-
-  log('Merge policy check passed.');
-  return 0;
 }
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));

--- a/tools/priority/policy.json
+++ b/tools/priority/policy.json
@@ -14,6 +14,7 @@
         "session-index",
         "issue-snapshot",
         "semver",
+        "Policy Guard (Upstream) / policy-guard",
         "Promotion Contract / promotion-contract",
         "hook-parity (windows-latest)",
         "hook-parity (ubuntu-latest)",
@@ -58,12 +59,21 @@
         "session-index",
         "issue-snapshot",
         "semver",
+        "Policy Guard (Upstream) / policy-guard",
         "Promotion Contract / promotion-contract",
         "hook-parity (windows-latest)",
         "hook-parity (ubuntu-latest)",
         "vi-history-scenarios-linux"
       ],
-      "merge_queue": null,
+      "merge_queue": {
+        "merge_method": "SQUASH",
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 5,
+        "check_response_timeout_minutes": 60
+      },
       "pull_request": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
@@ -98,11 +108,15 @@
         "check_response_timeout_minutes": 60
       },
       "pull_request": {
-        "required_approving_review_count": 1,
-        "dismiss_stale_reviews_on_push": true,
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
-        "required_review_thread_resolution": true
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash",
+          "rebase"
+        ]
       }
     },
     "8614172": {


### PR DESCRIPTION
## Summary
- implements #719 autonomous mainline policy contract for queue-managed `develop` + `main`
- enables `merge_group` coverage for required develop checks (`Validate`, `Promotion Contract`, `Policy Guard (Upstream)`)
- adds machine-readable policy drift report output and a dedicated sync wrapper (`Sync-BranchProtectionPolicy.ps1`)
- adds admin workflow dispatch lane (`policy-sync.yml`) and drift artifacts on policy-guard + validate lanes
- aligns branch/ruleset contracts to zero required reviewers and develop queue settings

## Policy contract updates
- `tools/priority/policy.json`
  - `rulesets.8811898` (`develop`) now has merge queue settings
  - `rulesets.8614140` (`main`) now enforces 0 required approvals and no review-thread gate
  - `develop` required checks now include `Policy Guard (Upstream) / policy-guard`
- synced to:
  - `tools/policy/branch-required-checks.json`
  - `tools/policy/promotion-contract.json`

## Tooling and evidence
- `tools/priority/check-policy.mjs`
  - adds `--report <path>` output (`priority/policy-report@v1`)
- `tools/priority/Sync-BranchProtectionPolicy.ps1`
  - verify/apply wrapper that writes policy report + step summary
- `docs/schemas/policy-drift-report-v1.schema.json`

## Workflow updates
- `.github/workflows/validate.yml`
  - `merge_group` now includes `develop`
  - policy-guard step uses sync wrapper and uploads drift artifact
- `.github/workflows/promotion-contract.yml`
  - adds `merge_group` trigger for `develop` and `release/**`
- `.github/workflows/policy-guard-upstream.yml`
  - adds `merge_group` + schedule + workflow_dispatch
  - emits drift artifact
- `.github/workflows/policy-sync.yml`
  - new admin dispatch workflow for verify/apply sync

## Documentation
- updates in `AGENTS.md`, `docs/knowledgebase/FEATURE_BRANCH_POLICY.md`, `docs/DEVELOPER_GUIDE.md`, and `docs/RUNBOOK_CONTAINER_LANE_PROMOTION_POLICY.md`

Closes #719.

## Local validation
- `node --test tools/priority/__tests__/check-policy-apply.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `pwsh -NoLogo -NoProfile -File tools/Assert-PromotionContractAlignment.ps1 -OutputJsonPath tests/results/promotion-contract/alignment.local.json`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `node tools/npm/run-script.mjs lint:md:changed`
