### PR TITLE
#721 Hard-fail policy guard skips for merge queue drift

### DIFF
--- a/.github/workflows/policy-guard-upstream.yml
+++ b/.github/workflows/policy-guard-upstream.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run policy guard
         shell: pwsh
         run: |
-          pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -ResultsDir tests/results/_agent/policy
+          pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -FailOnSkip -ResultsDir tests/results/_agent/policy
 
       - name: Upload policy drift artifact
         if: always()

--- a/.github/workflows/policy-sync.yml
+++ b/.github/workflows/policy-sync.yml
@@ -48,9 +48,9 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ inputs.apply }}' -eq 'true') {
-            pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -Apply -ResultsDir tests/results/_agent/policy
+            pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -Apply -FailOnSkip -ResultsDir tests/results/_agent/policy
           } else {
-            pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -ResultsDir tests/results/_agent/policy
+            pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -FailOnSkip -ResultsDir tests/results/_agent/policy
           }
 
       - name: Upload policy sync artifact

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -292,6 +292,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - Run `node tools/npm/run-script.mjs priority:policy` (or `node tools/npm/run-script.mjs priority:policy:sync`) if you
   need to audit merge settings locally; the command also runs during `priority:handoff-tests` and fails when
   repo/branch policy drifts.
+- Use strict verification (`node tools/priority/check-policy.mjs --fail-on-skip`) when you need token/permission skips to
+  fail deterministically (for example in upstream policy guard workflows).
 - Use `node tools/npm/run-script.mjs priority:policy:apply` only with admin token scope when you intentionally need to
   sync GitHub protections/rulesets back to `tools/priority/policy.json`.
 - Prefer opening PRs from your fork with `node tools/npm/run-script.mjs priority:pr`; the helper ensures `origin` targets your fork (creating

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -44,8 +44,9 @@ standing GitHub protection rules (including queue-managed `develop` and `main`).
   out the PR head with the upstream repository token and re-runs `priority:policy`, guaranteeing that branch protection
   rules are enforced even when the lint job skips in fork contexts. Its status
   (`Policy Guard (Upstream) / policy-guard`) is required on `develop`, `main`, and `release/*`.
-- Branch protection verification treats workflow-prefixed and short check contexts as equivalent (for example,
-  `Validate / lint` and `lint`) to avoid false drift when comparing live API contexts against policy mappings.
+- Upstream policy guard runs in strict mode (`--fail-on-skip`), so reduced token scope is treated as a failing gate
+  rather than a pass-through skip.
+- Branch protection verification requires canonical check context names exactly as declared in policy files.
 - `Validate` runs `priority:handoff-tests` automatically for heads that start with `feature/`, enforcing leak-sensitive
   suites before parallel work merges.
 - **Important:** Required checks for queued branches must run on both the `pull_request` and `merge_group` events;
@@ -77,6 +78,7 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 - `node tools/npm/run-script.mjs priority:policy -- --apply` – pushes the manifest configuration back to GitHub (branch
   protections + rulesets); rerun without `--apply` afterward to confirm parity.
 - `node tools/npm/run-script.mjs priority:policy:apply` – apply via the wrapper (`Sync-BranchProtectionPolicy.ps1`) and emit report summary.
+- Policy guard workflows invoke sync in strict mode (`-FailOnSkip`) so permission shortfalls fail CI.
 - The Validate workflow runs the verify-only command on every PR and queue run targeting `develop`; fix GitHub settings or update
   `tools/priority/policy.json` before re-running CI when it fails.
 

--- a/tools/priority/Sync-BranchProtectionPolicy.ps1
+++ b/tools/priority/Sync-BranchProtectionPolicy.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
   [switch]$Apply,
+  [switch]$FailOnSkip,
   [string]$ResultsDir = 'tests/results/_agent/policy',
   [string]$ReportFile = 'policy-drift-report.json',
   [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
@@ -35,6 +36,9 @@ $args = @(
 if ($Apply) {
   $args += '--apply'
 }
+if ($FailOnSkip) {
+  $args += '--fail-on-skip'
+}
 
 Write-Host "[policy-sync] Running: node $($args -join ' ')"
 & node @args
@@ -57,6 +61,7 @@ Write-Host "[policy-sync] Result: $($report.result)"
 Write-Host "[policy-sync] Total diffs: $($report.summary.totalDiffCount)"
 Write-Host "[policy-sync] Branch updates: $branchSummary"
 Write-Host "[policy-sync] Ruleset updates: $rulesetSummary"
+Write-Host "[policy-sync] FailOnSkip: $FailOnSkip"
 Write-Host "[policy-sync] Report: $reportPath"
 
 if ($StepSummaryPath) {
@@ -69,6 +74,7 @@ if ($StepSummaryPath) {
     "- Total diffs: $($report.summary.totalDiffCount)",
     "- Branch updates: $branchSummary",
     "- Ruleset updates: $rulesetSummary",
+    "- Fail on skip: $FailOnSkip",
     "- Report path: $reportPath"
   ) -join "`n"
   $summary | Out-File -FilePath $StepSummaryPath -Append -Encoding utf8

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -848,3 +848,338 @@ test('priority:policy emits machine-readable report when --report is provided', 
   assert.equal(report.result, 'skipped');
   assert.equal(report.apply, false);
 });
+
+test('priority:policy verify fails when queue-managed ruleset is missing merge_queue', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const rulesetDevelopUrl = `${repoUrl}/rulesets/8811898`;
+  const rulesetMainUrl = `${repoUrl}/rulesets/8614140`;
+  const rulesetReleaseUrl = `${repoUrl}/rulesets/8614172`;
+  const branchDevelopUrl = `${repoUrl}/branches/develop/protection`;
+  const branchMainUrl = `${repoUrl}/branches/main/protection`;
+  const repoState = {
+    allow_squash_merge: true,
+    allow_merge_commit: false,
+    allow_rebase_merge: true,
+    allow_auto_merge: true,
+    delete_branch_on_merge: true,
+    permissions: {
+      admin: true
+    }
+  };
+
+  const developChecks = [
+    'lint',
+    'fixtures',
+    'session-index',
+    'issue-snapshot',
+    'semver',
+    'Policy Guard (Upstream) / policy-guard',
+    'Promotion Contract / promotion-contract',
+    'hook-parity (windows-latest)',
+    'hook-parity (ubuntu-latest)',
+    'vi-history-scenarios-linux'
+  ];
+  const mainChecks = [
+    'lint',
+    'pester',
+    'vi-binary-check',
+    'vi-compare',
+    'Policy Guard (Upstream) / policy-guard'
+  ];
+  const releaseChecks = [
+    'lint',
+    'pester',
+    'publish',
+    'vi-binary-check',
+    'vi-compare',
+    'mock-cli',
+    'Policy Guard (Upstream) / policy-guard',
+    'Promotion Contract / promotion-contract'
+  ];
+
+  const branchDevelopProtection = {
+    required_status_checks: {
+      strict: true,
+      checks: developChecks.map((context) => ({ context }))
+    },
+    required_linear_history: { enabled: true }
+  };
+  const branchMainProtection = {
+    required_status_checks: {
+      strict: true,
+      checks: mainChecks.map((context) => ({ context }))
+    },
+    required_linear_history: { enabled: true }
+  };
+
+  const rulesetDevelop = {
+    id: 8811898,
+    name: 'develop',
+    target: 'branch',
+    conditions: { ref_name: { include: ['refs/heads/develop'], exclude: [] } },
+    rules: [
+      { type: 'required_linear_history' },
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: developChecks.map((context) => ({ context }))
+        }
+      },
+      {
+        type: 'pull_request',
+        parameters: {
+          required_approving_review_count: 0,
+          dismiss_stale_reviews_on_push: false,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_review_thread_resolution: false,
+          allowed_merge_methods: ['squash', 'rebase']
+        }
+      }
+    ]
+  };
+  const rulesetMain = {
+    id: 8614140,
+    name: 'main',
+    target: 'branch',
+    conditions: { ref_name: { include: ['refs/heads/main'], exclude: [] } },
+    rules: [
+      {
+        type: 'merge_queue',
+        parameters: {
+          merge_method: 'SQUASH',
+          grouping_strategy: 'ALLGREEN',
+          max_entries_to_build: 5,
+          min_entries_to_merge: 1,
+          max_entries_to_merge: 5,
+          min_entries_to_merge_wait_minutes: 5,
+          check_response_timeout_minutes: 60
+        }
+      },
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: mainChecks.map((context) => ({ context }))
+        }
+      },
+      {
+        type: 'pull_request',
+        parameters: {
+          required_approving_review_count: 0,
+          dismiss_stale_reviews_on_push: false,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_review_thread_resolution: false,
+          allowed_merge_methods: ['squash', 'rebase']
+        }
+      }
+    ]
+  };
+  const rulesetRelease = {
+    id: 8614172,
+    name: 'release',
+    target: 'branch',
+    conditions: { ref_name: { include: ['refs/heads/release/*'], exclude: [] } },
+    rules: [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: releaseChecks.map((context) => ({ context }))
+        }
+      },
+      {
+        type: 'pull_request',
+        parameters: {
+          required_approving_review_count: 0,
+          dismiss_stale_reviews_on_push: true,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_review_thread_resolution: false,
+          allowed_merge_methods: ['rebase']
+        }
+      }
+    ]
+  };
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method !== 'GET') {
+      throw new Error(`Unexpected request ${method} ${url}`);
+    }
+    if (url === repoUrl) {
+      return createResponse(repoState);
+    }
+    if (url === branchDevelopUrl) {
+      return createResponse(branchDevelopProtection);
+    }
+    if (url === branchMainUrl) {
+      return createResponse(branchMainProtection);
+    }
+    if (url === rulesetDevelopUrl) {
+      return createResponse(rulesetDevelop);
+    }
+    if (url === rulesetMainUrl) {
+      return createResponse(rulesetMain);
+    }
+    if (url === rulesetReleaseUrl) {
+      return createResponse(rulesetRelease);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const logMessages = [];
+  const errorMessages = [];
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 1, 'verify mode should fail when queue rule is missing');
+  assert.ok(
+    errorMessages.some((msg) => msg.includes('merge_queue: rule missing')),
+    'expected merge_queue missing diagnostic'
+  );
+  assert.ok(
+    logMessages.some((msg) => msg.includes('auth source: GITHUB_TOKEN')),
+    'expected auth source to be logged'
+  );
+});
+
+test('priority:policy --fail-on-skip fails non-apply validation when GH_TOKEN 401 has no fallback', async () => {
+  const fetchMock = async () => createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+  const logMessages = [];
+  const errorMessages = [];
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--fail-on-skip'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GH_TOKEN: 'gh-stale',
+      GITHUB_TOKEN: ''
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 1, 'non-apply mode should fail on auth-unavailable path in strict mode');
+  assert.ok(
+    errorMessages.some((msg) => msg.includes('Strict mode enabled (--fail-on-skip)')),
+    'strict-mode failure diagnostic expected'
+  );
+  assert.ok(
+    !logMessages.some((msg) => msg.includes('skipping non-apply validation')),
+    'strict mode should not leave auth-unavailable as pass-through skip'
+  );
+});
+
+test('priority:policy --fail-on-skip fails when admin permission is unavailable in verify mode', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const rulesetDevelopUrl = `${repoUrl}/rulesets/8811898`;
+  const rulesetMainUrl = `${repoUrl}/rulesets/8614140`;
+  const rulesetReleaseUrl = `${repoUrl}/rulesets/8614172`;
+  const repoState = {
+    permissions: {
+      admin: false
+    }
+  };
+  const rulesetStub = {
+    id: 8811898,
+    name: 'develop',
+    target: 'branch',
+    conditions: {
+      ref_name: {
+        include: ['refs/heads/develop'],
+        exclude: []
+      }
+    },
+    bypass_actors: [],
+    rules: []
+  };
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse(repoState);
+    }
+    if (method === 'GET' && url === rulesetDevelopUrl) {
+      return createResponse(rulesetStub);
+    }
+    if (method === 'GET' && url === rulesetMainUrl) {
+      return createResponse({ ...rulesetStub, id: 8614140, name: 'main' });
+    }
+    if (method === 'GET' && url === rulesetReleaseUrl) {
+      return createResponse({ ...rulesetStub, id: 8614172, name: 'release' });
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const logMessages = [];
+  const errorMessages = [];
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--fail-on-skip'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 1, 'verify mode should fail when admin permission skip path is hit in strict mode');
+  assert.ok(
+    errorMessages.some((msg) => msg.includes('Strict mode enabled (--fail-on-skip)')),
+    'strict-mode failure diagnostic expected for admin-skip path'
+  );
+  assert.ok(
+    logMessages.some((msg) => msg.includes('auth source: GITHUB_TOKEN')),
+    'auth source log expected'
+  );
+});
+
+test('priority:policy --fail-on-skip emits fail report when auth-unavailable skip path is blocked', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'priority-policy-report-strict-'));
+  const reportPath = path.join(tempDir, 'report.json');
+  const fetchMock = async () => createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--report', reportPath, '--fail-on-skip'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GH_TOKEN: 'gh-stale',
+      GITHUB_TOKEN: ''
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: () => {},
+    error: () => {}
+  });
+
+  assert.equal(code, 1, 'strict mode should fail instead of skip');
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(report.schema, 'priority/policy-report@v1');
+  assert.equal(report.result, 'fail');
+  assert.match(report.skippedReason, /Strict mode enabled \(\-\-fail-on-skip\)/);
+});

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -13,7 +13,8 @@ function parseArgs(argv = process.argv) {
     apply: false,
     help: false,
     debug: false,
-    report: null
+    report: null,
+    failOnSkip: false
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -37,6 +38,10 @@ function parseArgs(argv = process.argv) {
       }
       options.report = reportPath;
       index += 1;
+      continue;
+    }
+    if (arg === '--fail-on-skip') {
+      options.failOnSkip = true;
       continue;
     }
     throw new Error(`Unknown option: ${arg}`);
@@ -710,7 +715,7 @@ export async function run({
 } = {}) {
   const options = parseArgs(argv);
   if (options.help) {
-    log('Usage: node tools/priority/check-policy.mjs [--apply] [--debug] [--report <path>]');
+    log('Usage: node tools/priority/check-policy.mjs [--apply] [--debug] [--report <path>] [--fail-on-skip]');
     return 0;
   }
 
@@ -759,6 +764,25 @@ export async function run({
     report.skippedReason = skippedReason;
     await writeReportIfRequested(options.report, report, log);
     return code;
+  };
+
+  const finalizeSkip = async (message) => {
+    if (options.failOnSkip) {
+      const strictMessage = `${message} Strict mode enabled (--fail-on-skip), failing.`;
+      error(strictMessage);
+      return finalize({
+        code: 1,
+        result: 'fail',
+        skippedReason: strictMessage
+      });
+    }
+
+    log(message);
+    return finalize({
+      code: 0,
+      result: 'skipped',
+      skippedReason: message
+    });
   };
 
   try {
@@ -836,12 +860,7 @@ export async function run({
           ? authError.attemptedSources.join(' -> ')
           : 'unknown';
         const message = `[policy] Authorization unavailable for policy check (attempted: ${attempted}); skipping non-apply validation. Upstream status "Policy Guard (Upstream) / policy-guard" remains authoritative.`;
-        log(message);
-        return finalize({
-          code: 0,
-          result: 'skipped',
-          skippedReason: message
-        });
+        return finalizeSkip(message);
       }
       throw authError;
     }
@@ -882,12 +901,7 @@ export async function run({
 
     if (!options.apply && repoFieldsAllMissing && (!hasAdminPermission || forkRun)) {
       const message = '[policy] Repository settings unavailable with current token; skipping policy check (admin permissions required). Upstream status "Policy Guard (Upstream) / policy-guard" will enforce branch protection.';
-      log(message);
-      return finalize({
-        code: 0,
-        result: 'skipped',
-        skippedReason: message
-      });
+      return finalizeSkip(message);
     }
 
     if (options.apply) {


### PR DESCRIPTION
## Summary
- implements #721 hard-fail behavior for queue-policy guard paths
- adds strict `--fail-on-skip` mode to `tools/priority/check-policy.mjs`
- ensures policy guard workflows fail when token/admin shortfalls would previously skip checks
- keeps default non-strict behavior unchanged for non-guard local verify flows

## What changed
- `tools/priority/check-policy.mjs`
  - adds `--fail-on-skip`
  - converts skip paths to failure when strict mode is enabled
  - keeps machine-readable report emission in strict failure cases
- `tools/priority/Sync-BranchProtectionPolicy.ps1`
  - adds `-FailOnSkip` switch
  - passes through to `check-policy.mjs --fail-on-skip`
- `.github/workflows/policy-guard-upstream.yml`
  - runs sync with `-FailOnSkip`
- `.github/workflows/policy-sync.yml`
  - runs both verify/apply dispatch paths with `-FailOnSkip`
- regression tests in `tools/priority/__tests__/check-policy-apply.test.mjs`
  - verify fails when queue-managed ruleset is missing `merge_queue`
  - strict mode fails auth-skip path
  - strict mode fails admin-permission skip path
  - strict mode still emits fail report
- docs updates in `docs/knowledgebase/FEATURE_BRANCH_POLICY.md` and `docs/DEVELOPER_GUIDE.md`

Closes #721.

## Validation
- `node --test tools/priority/__tests__/check-policy-apply.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `node tools/npm/run-script.mjs lint:md:changed`
- `pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1 -FailOnSkip -ResultsDir tests/results/_agent/policy` (expected fail on live upstream drift)
