### PR TITLE
#729 Harden policy guard token resolution and auth diagnostics

### DIFF
--- a/.github/workflows/policy-guard-upstream.yml
+++ b/.github/workflows/policy-guard-upstream.yml
@@ -52,21 +52,11 @@ jobs:
       - name: Prepare policy guard token
         shell: pwsh
         env:
-          INPUT_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN_PRIMARY: ${{ secrets.GH_TOKEN }}
+          INPUT_TOKEN_SECONDARY: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN_TERTIARY: ${{ github.token }}
         run: |
-          if (-not $env:INPUT_TOKEN -or (-not $env:INPUT_TOKEN.Trim())) {
-            throw 'Policy Guard requires secrets.GH_TOKEN or secrets.GITHUB_TOKEN to be populated.'
-          }
-
-          $token = $env:INPUT_TOKEN.Trim()
-          $tokenFile = Join-Path $env:RUNNER_TEMP 'policy-guard-gh-token.txt'
-          Set-Content -Path $tokenFile -Value $token -Encoding utf8 -NoNewline
-
-          Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN=$token"
-          Add-Content -Path $env:GITHUB_ENV -Value "GITHUB_TOKEN=$token"
-          Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN_FILE=$tokenFile"
-
-          Write-Host "Policy guard token exported. GH_TOKEN_FILE=$tokenFile"
+          pwsh -NoLogo -NoProfile -File tools/priority/Resolve-PolicyToken.ps1 -TokenFileName policy-guard-gh-token.txt
 
       - name: Verify remote refs are unambiguous
         shell: pwsh

--- a/.github/workflows/policy-sync.yml
+++ b/.github/workflows/policy-sync.yml
@@ -28,21 +28,11 @@ jobs:
       - name: Prepare policy sync token
         shell: pwsh
         env:
-          INPUT_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN_PRIMARY: ${{ secrets.GH_TOKEN }}
+          INPUT_TOKEN_SECONDARY: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN_TERTIARY: ${{ github.token }}
         run: |
-          if (-not $env:INPUT_TOKEN -or (-not $env:INPUT_TOKEN.Trim())) {
-            throw 'Policy Sync requires secrets.GH_TOKEN or secrets.GITHUB_TOKEN to be populated.'
-          }
-
-          $token = $env:INPUT_TOKEN.Trim()
-          $tokenFile = Join-Path $env:RUNNER_TEMP 'policy-sync-gh-token.txt'
-          Set-Content -Path $tokenFile -Value $token -Encoding utf8 -NoNewline
-
-          Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN=$token"
-          Add-Content -Path $env:GITHUB_ENV -Value "GITHUB_TOKEN=$token"
-          Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN_FILE=$tokenFile"
-
-          Write-Host "Policy sync token exported. GH_TOKEN_FILE=$tokenFile"
+          pwsh -NoLogo -NoProfile -File tools/priority/Resolve-PolicyToken.ps1 -TokenFileName policy-sync-gh-token.txt
 
       - name: Run policy sync/check
         shell: pwsh

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -294,6 +294,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   repo/branch policy drifts.
 - Use strict verification (`node tools/priority/check-policy.mjs --fail-on-skip`) when you need token/permission skips to
   fail deterministically (for example in upstream policy guard workflows).
+- Policy guard workflows resolve token candidates with
+  `tools/priority/Resolve-PolicyToken.ps1` and require an admin-capable token source. If policy guard fails with
+  `Authorization unavailable` or `authenticated-no-admin`, rotate `GH_TOKEN`/`GITHUB_TOKEN` secrets in upstream.
 - Use `node tools/npm/run-script.mjs priority:policy:apply` only with admin token scope when you intentionally need to
   sync GitHub protections/rulesets back to `tools/priority/policy.json`.
 - Prefer opening PRs from your fork with `node tools/npm/run-script.mjs priority:pr`; the helper ensures `origin` targets your fork (creating

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -46,6 +46,9 @@ standing GitHub protection rules (including queue-managed `develop` and `main`).
   (`Policy Guard (Upstream) / policy-guard`) is required on `develop`, `main`, and `release/*`.
 - Upstream policy guard runs in strict mode (`--fail-on-skip`), so reduced token scope is treated as a failing gate
   rather than a pass-through skip.
+- Policy guard/sync workflows now resolve token candidates in order (`secrets.GH_TOKEN`, `secrets.GITHUB_TOKEN`,
+  `github.token`) via `tools/priority/Resolve-PolicyToken.ps1` and require an admin-capable token for deterministic
+  branch-protection checks.
 - Branch protection verification requires canonical check context names exactly as declared in policy files.
 - `Validate` runs `priority:handoff-tests` automatically for heads that start with `feature/`, enforcing leak-sensitive
   suites before parallel work merges.
@@ -251,6 +254,15 @@ to confirm each workflow includes both triggers.
   required checks. Cancel stale queue jobs from the PR if necessary.
 - **Policy drift detected by `priority:policy`** – Align GitHub settings with `tools/priority/policy.json` (update the
   JSON if the new configuration is intentional), then rerun the helper.
+- **Policy guard auth failure (`Authorization unavailable` / `authenticated-no-admin`)** – verify and rotate upstream
+  secrets with an admin-capable token:
+  ```powershell
+  $repo = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+  $token = (Get-Content C:\github_token.txt -Raw).Trim()
+  gh api "repos/$repo" -H "Authorization: Bearer $token" --jq '.permissions.admin'
+  $token | gh secret set GH_TOKEN --repo $repo
+  $token | gh secret set GITHUB_TOKEN --repo $repo
+  ```
 - **Release artifacts stale** – For release branches, rerun `priority:release` helpers or the finalize workflow to
   regenerate `tests/results/_agent/release/*` snapshots before broadcasting status updates.
 

--- a/tools/priority/Resolve-PolicyToken.ps1
+++ b/tools/priority/Resolve-PolicyToken.ps1
@@ -1,0 +1,198 @@
+[CmdletBinding()]
+param(
+  [string]$Repository = $env:GITHUB_REPOSITORY,
+  [string]$PrimaryToken = $env:INPUT_TOKEN_PRIMARY,
+  [string]$SecondaryToken = $env:INPUT_TOKEN_SECONDARY,
+  [string]$TertiaryToken = $env:INPUT_TOKEN_TERTIARY,
+  [string]$TokenFileName = 'policy-gh-token.txt',
+  [bool]$RequireAdmin = $true,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($Repository)) {
+  throw 'Repository slug is required (owner/repo). Set GITHUB_REPOSITORY or pass -Repository.'
+}
+
+function New-CandidateEntry {
+  param(
+    [Parameter(Mandatory)][string]$Token,
+    [Parameter(Mandatory)][string]$Source
+  )
+
+  [PSCustomObject]@{
+    Token   = $Token
+    Sources = @($Source)
+  }
+}
+
+function Add-TokenCandidate {
+  param(
+    [System.Collections.Generic.List[object]]$Candidates,
+    [hashtable]$ByToken,
+    [string]$Token,
+    [string]$Source
+  )
+
+  $normalized = if ($Token) { $Token.Trim() } else { '' }
+  if ([string]::IsNullOrWhiteSpace($normalized)) {
+    return
+  }
+
+  if ($ByToken.ContainsKey($normalized)) {
+    $entry = $ByToken[$normalized]
+    if (-not ($entry.Sources -contains $Source)) {
+      $entry.Sources += $Source
+    }
+    return
+  }
+
+  $candidate = New-CandidateEntry -Token $normalized -Source $Source
+  $ByToken[$normalized] = $candidate
+  [void]$Candidates.Add($candidate)
+}
+
+function Invoke-RepositoryProbe {
+  param(
+    [Parameter(Mandatory)][string]$RepoSlug,
+    [Parameter(Mandatory)][string]$Token
+  )
+
+  $uri = "https://api.github.com/repos/$RepoSlug"
+  $headers = @{
+    Authorization         = "Bearer $Token"
+    Accept                = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+    'User-Agent'          = 'priority-policy-token-resolver'
+  }
+
+  try {
+    $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+    $isAdmin = $response.permissions.admin -eq $true
+    return [PSCustomObject]@{
+      Success    = $true
+      StatusCode = 200
+      Message    = 'ok'
+      IsAdmin    = $isAdmin
+    }
+  } catch {
+    $statusCode = $null
+    $statusDescription = ''
+    if ($_.Exception.Response) {
+      try {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      } catch {
+        $statusCode = $null
+      }
+      try {
+        $statusDescription = [string]$_.Exception.Response.StatusDescription
+      } catch {
+        $statusDescription = ''
+      }
+    }
+
+    $message = if ($statusCode) {
+      "$statusCode $statusDescription".Trim()
+    } else {
+      $_.Exception.Message
+    }
+
+    return [PSCustomObject]@{
+      Success    = $false
+      StatusCode = $statusCode
+      Message    = $message
+      IsAdmin    = $false
+    }
+  }
+}
+
+$candidateList = [System.Collections.Generic.List[object]]::new()
+$candidateByToken = @{}
+
+Add-TokenCandidate -Candidates $candidateList -ByToken $candidateByToken -Token $PrimaryToken -Source 'secrets.GH_TOKEN'
+Add-TokenCandidate -Candidates $candidateList -ByToken $candidateByToken -Token $SecondaryToken -Source 'secrets.GITHUB_TOKEN'
+Add-TokenCandidate -Candidates $candidateList -ByToken $candidateByToken -Token $TertiaryToken -Source 'github.token'
+
+if ($candidateList.Count -eq 0) {
+  throw 'No policy token candidates were provided. Populate secrets.GH_TOKEN (preferred) or secrets.GITHUB_TOKEN.'
+}
+
+$probeResults = [System.Collections.Generic.List[object]]::new()
+$selected = $null
+
+foreach ($candidate in $candidateList) {
+  $probe = Invoke-RepositoryProbe -RepoSlug $Repository -Token $candidate.Token
+  $sourceSummary = ($candidate.Sources -join ' + ')
+  $resultLabel = if (-not $probe.Success) {
+    if ($probe.StatusCode -eq 401) { 'unauthorized' }
+    elseif ($probe.StatusCode -eq 403) { 'forbidden' }
+    elseif ($probe.StatusCode) { "error-$($probe.StatusCode)" }
+    else { 'error' }
+  } elseif ($RequireAdmin -and -not $probe.IsAdmin) {
+    'authenticated-no-admin'
+  } else {
+    'selected'
+  }
+
+  [void]$probeResults.Add([PSCustomObject]@{
+      source = $sourceSummary
+      status = $resultLabel
+      detail = $probe.Message
+    })
+
+  if ($resultLabel -eq 'selected') {
+    $selected = [PSCustomObject]@{
+      Token  = $candidate.Token
+      Source = $sourceSummary
+      Probe  = $probe
+    }
+    break
+  }
+}
+
+if (-not $selected) {
+  $resultText = ($probeResults | ForEach-Object { "$($_.source)=$($_.status)" }) -join '; '
+  $guidance = if ($RequireAdmin) {
+    'No admin-capable token resolved. Rotate/update secrets.GH_TOKEN (preferred) or secrets.GITHUB_TOKEN with repository administration access.'
+  } else {
+    'No authenticated token resolved.'
+  }
+  throw "$guidance Candidates: $resultText"
+}
+
+$tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { (Get-Location).Path }
+$tokenFilePath = Join-Path $tempRoot $TokenFileName
+Set-Content -Path $tokenFilePath -Value $selected.Token -Encoding utf8 -NoNewline
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_ENV)) {
+  throw 'GITHUB_ENV is not set; cannot export resolved policy token.'
+}
+
+Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN=$($selected.Token)"
+Add-Content -Path $env:GITHUB_ENV -Value "GH_TOKEN_FILE=$tokenFilePath"
+Add-Content -Path $env:GITHUB_ENV -Value "POLICY_TOKEN_SOURCE=$($selected.Source)"
+Add-Content -Path $env:GITHUB_ENV -Value "POLICY_TOKEN_REPOSITORY=$Repository"
+
+Write-Host "Policy token source: $($selected.Source)"
+Write-Host "Policy token file: $tokenFilePath"
+Write-Host "Policy token admin: $($selected.Probe.IsAdmin)"
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  $summaryLines = @(
+    '### Policy Token Resolution',
+    '',
+    "- Repository: $Repository",
+    "- Require admin: $RequireAdmin",
+    "- Selected source: $($selected.Source)",
+    "- Selected token admin: $($selected.Probe.IsAdmin)",
+    '- Candidate probe results:'
+  )
+
+  foreach ($result in $probeResults) {
+    $summaryLines += "  - $($result.source): $($result.status)"
+  }
+
+  ($summaryLines -join "`n") | Out-File -FilePath $StepSummaryPath -Append -Encoding utf8
+}


### PR DESCRIPTION
## Summary
- add `tools/priority/Resolve-PolicyToken.ps1` to resolve policy token candidates in order and require an admin-capable token before policy sync/guard runs
- wire `policy-guard-upstream.yml` and `policy-sync.yml` to use the resolver with three candidates: `secrets.GH_TOKEN`, `secrets.GITHUB_TOKEN`, `github.token`
- stop flattening both `GH_TOKEN` and `GITHUB_TOKEN` to a single secret value, preserving deterministic token source behavior and clearer auth diagnostics
- document policy guard auth remediation (token probe + rotation commands)

## Why
Issue #729 tracks strict-mode guard failures caused by stale/insufficient token sources. This makes token selection deterministic, auditable, and explicit, and fails early with actionable diagnostics when no admin-capable token is available.

## Validation
- `node --test tools/priority/__tests__/check-policy-apply.test.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `node tools/npm/run-script.mjs lint:md:changed`

## Links
- Closes #729
- Related: #721
