### PR TITLE
#728 Remove hardcoded owner slugs from runtime automation

### DIFF
--- a/.github/workflows/agent-review-policy.yml
+++ b/.github/workflows/agent-review-policy.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Enforce required reviewer for agent-authored PRs
         uses: actions/github-script@v8
+        env:
+          REQUIRED_AGENT_REVIEWER: ${{ vars.REQUIRED_AGENT_REVIEWER || github.repository_owner }}
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -40,7 +42,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pull_number = pr.number;
-            const requiredReviewer = 'svelderrainruiz';
+            const requiredReviewer = (process.env.REQUIRED_AGENT_REVIEWER || owner).trim();
             const prAuthor = pr.user?.login || '';
 
             // GitHub does not allow self-approval, so skip enforcement when the PR author

--- a/.github/workflows/pr-agent-review-routing.yml
+++ b/.github/workflows/pr-agent-review-routing.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Route reviewer for agent-authored PRs
         uses: actions/github-script@v8
+        env:
+          REQUIRED_AGENT_REVIEWER: ${{ vars.REQUIRED_AGENT_REVIEWER || github.repository_owner }}
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -33,7 +35,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pull_number = pr.number;
-            const requiredReviewer = 'svelderrainruiz';
+            const requiredReviewer = (process.env.REQUIRED_AGENT_REVIEWER || owner).trim();
 
             // Skip if the required reviewer is the PR author (can't request review from yourself)
             if (pr.user && pr.user.login === requiredReviewer) {

--- a/.github/workflows/runbook-validation.yml
+++ b/.github/workflows/runbook-validation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   runbook-check:
-    if: ${{ github.repository_owner == 'LabVIEW-Community-CI-CD' && !startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.event.repository.fork != true && !startsWith(github.ref, 'refs/tags/') }}
     runs-on: [self-hosted, Windows, X64]
     timeout-minutes: 3
     steps:
@@ -54,7 +54,7 @@ jobs:
           if (-not $json.phases) { throw 'No phases in runbook output' }
 
   runbook-check-container:
-    if: ${{ github.repository_owner == 'LabVIEW-Community-CI-CD' && !startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.event.repository.fork != true && !startsWith(github.ref, 'refs/tags/') }}
     needs: runbook-check
     runs-on: [self-hosted, Windows, X64]
     timeout-minutes: 15

--- a/.github/workflows/standing-priority-hygiene.yml
+++ b/.github/workflows/standing-priority-hygiene.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Fetch parity refs
         shell: bash
         run: |
-          git remote add upstream https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action.git 2>/dev/null || true
+          git remote add upstream "https://github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null || true
           git fetch --no-tags --prune --depth=1 origin develop
           git fetch --no-tags --prune --depth=1 upstream develop
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -819,8 +819,9 @@ jobs:
       run: |
         $res = Join-Path $env:RUNNER_TEMP 'sessionindex'
         $parityPath = Join-Path $res 'origin-upstream-parity.json'
+        $repoSlug = '${{ github.repository }}'
         try {
-          git remote add upstream 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action.git' 2>$null | Out-Null
+          git remote add upstream ("https://github.com/{0}.git" -f $repoSlug) 2>$null | Out-Null
         } catch { }
         try { git fetch --no-tags --prune --depth=1 origin develop | Out-Null } catch { Write-Host ("::notice::origin/develop fetch skipped: {0}" -f $_.Exception.Message) }
         try { git fetch --no-tags --prune --depth=1 upstream develop | Out-Null } catch { Write-Host ("::notice::upstream/develop fetch skipped: {0}" -f $_.Exception.Message) }
@@ -900,7 +901,7 @@ jobs:
     if: >
       needs.smoke-gate.outputs.skip != 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.repository != 'LabVIEW-Community-CI-CD/compare-vi-cli-action' &&
+      github.event.repository.fork == true &&
       github.event.inputs.allow_noncanonical_vi_history != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -923,7 +924,7 @@ jobs:
       needs.smoke-gate.outputs.skip != 'true' &&
       github.event_name == 'workflow_dispatch' &&
       (
-        github.repository == 'LabVIEW-Community-CI-CD/compare-vi-cli-action' ||
+        github.event.repository.fork != true ||
         github.event.inputs.allow_noncanonical_vi_history == 'true'
       )
     runs-on: [self-hosted, Windows, X64, self-hosted-docker-windows]
@@ -972,15 +973,15 @@ jobs:
             throw ("Unsupported history_scenario_set '{0}'. Allowed: {1}" -f $setRaw, ($allowed -join ', '))
           }
           $repo = '${{ github.repository }}'
-          $isCanonical = $repo -eq 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+          $isForkRepository = '${{ github.event.repository.fork }}' -eq 'true'
           $allowNonCanonical = '${{ github.event.inputs.allow_noncanonical_vi_history }}' -eq 'true'
           $allowNonCanonicalHistoryCore = '${{ github.event.inputs.allow_noncanonical_history_core }}' -eq 'true'
 
-          if (-not $isCanonical -and -not $allowNonCanonical) {
+          if ($isForkRepository -and -not $allowNonCanonical) {
             throw ("vi-history-scenarios non-canonical execution is disabled for '{0}'. Set allow_noncanonical_vi_history=true." -f $repo)
           }
 
-          if (-not $isCanonical -and $set -eq 'history-core' -and -not $allowNonCanonicalHistoryCore) {
+          if ($isForkRepository -and $set -eq 'history-core' -and -not $allowNonCanonicalHistoryCore) {
             Write-Host "::warning::history-core is disabled on non-canonical repos unless allow_noncanonical_history_core=true. Downgrading to smoke."
             $set = 'smoke'
           }
@@ -1058,7 +1059,7 @@ jobs:
       needs.smoke-gate.outputs.skip != 'true' &&
       github.event_name == 'workflow_dispatch' &&
       (
-        github.repository == 'LabVIEW-Community-CI-CD/compare-vi-cli-action' ||
+        github.event.repository.fork != true ||
         github.event.inputs.allow_noncanonical_vi_history == 'true'
       )
     runs-on: ubuntu-latest

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -175,6 +175,12 @@ Quick reference for building, testing, and releasing the LVCompare composite act
   Emits an auto-link snippet (defaults to `Fixes #531`) you can drop into PR descriptions so GitHub auto-closes the issue.
 - `node tools/priority/standing-priority-handoff.mjs [--dry-run] <next-issue>`  
   Removes the `standing-priority` label from the current issue (if any), applies it to `<next-issue>`, and re-runs the cache sync (`tools/priority/sync-standing-priority.mjs`). Use `--dry-run` to preview the actions without mutating labels.
+- Standing-priority repository resolution is owner-agnostic. Order:
+  1. `GITHUB_REPOSITORY`
+  2. git remotes (`upstream`, then `origin`)
+  3. package repository metadata.
+  Use `AGENT_PRIORITY_UPSTREAM_REPOSITORY=<owner/repo>` (or `AGENT_UPSTREAM_REPOSITORY`) when you need to force
+  upstream lookup in deforked or custom-remote environments.
 
 ```bash
 node tools/npm/run-script.mjs build
@@ -406,6 +412,8 @@ pwsh -File scripts/CompareVI.ps1 `
 - Auto-approve still requires `AUTO_APPROVE_TOKEN`, optional `AUTO_APPROVE_LABEL` (defaults to `auto-approve`), and
   optional `AUTO_APPROVE_ALLOWED`. The label lifecycle is now fully automated so contributors do not need to toggle it
   manually.
+- Agent reviewer routing/policy is owner-agnostic: set repository variable `REQUIRED_AGENT_REVIEWER` to pin a specific
+  login; when unset it defaults to `github.repository_owner`.
 - Manual `/vi-stage` and `/vi-history` workflows accept an optional `fetch_depth` input (default `20`). Increase it when
   you need additional commit history before running compares.
 - Use `tools/Test-ForkSimulation.ps1` when validating fork automation. Run it in three passes: `-DryRun` prints the

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -24,6 +24,9 @@ standing GitHub protection rules (including queue-managed `develop` and `main`).
 ### Local helpers
 - `tools/priority/create-pr.mjs` refuses PRs opened from `develop`/`main`, forcing contributors onto feature/issue
   branches.
+- Standing-priority repo/upstream detection is owner-agnostic (uses `GITHUB_REPOSITORY`, then git remotes).
+  Set `AGENT_PRIORITY_UPSTREAM_REPOSITORY=<owner/repo>` (or `AGENT_UPSTREAM_REPOSITORY`) to force upstream lookup
+  when remotes are non-standard.
 - Dry-run helpers (`node tools/npm/run-script.mjs feature:branch:dry`, `node tools/npm/run-script.mjs feature:finalize:dry`) rehearse branch creation/finalization
   and emit metadata under `tests/results/_agent/feature/`.
 - `node tools/npm/run-script.mjs priority:pr` pushes the current branch to your fork and opens a PR targeting `develop`, keeping the linear

--- a/tools/Test-ForkSimulation.ps1
+++ b/tools/Test-ForkSimulation.ps1
@@ -110,19 +110,28 @@ function Get-RemoteInfo {
     )
 
     if ($DryRun) {
+        $fallbackSlug = if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY)) {
+            $env:GITHUB_REPOSITORY.Trim()
+        } else {
+            'upstream-owner/compare-vi-cli-action'
+        }
+        $slugParts = $fallbackSlug.Split('/', 2)
+        $fallbackOwner = if ($slugParts.Count -ge 1 -and $slugParts[0]) { $slugParts[0] } else { 'upstream-owner' }
+        $fallbackRepo = if ($slugParts.Count -ge 2 -and $slugParts[1]) { $slugParts[1] } else { 'compare-vi-cli-action' }
+
         switch ($RemoteName) {
             'upstream' {
                 return [PSCustomObject]@{
-                    Owner      = 'LabVIEW-Community-CI-CD'
-                    Repository = 'compare-vi-cli-action'
-                    Slug       = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+                    Owner      = $fallbackOwner
+                    Repository = $fallbackRepo
+                    Slug       = "$fallbackOwner/$fallbackRepo"
                 }
             }
             'origin' {
                 return [PSCustomObject]@{
                     Owner      = 'fork-owner'
-                    Repository = 'compare-vi-cli-action'
-                    Slug       = 'fork-owner/compare-vi-cli-action'
+                    Repository = $fallbackRepo
+                    Slug       = "fork-owner/$fallbackRepo"
                 }
             }
             default {

--- a/tools/Test-SessionIndexV2Contract.ps1
+++ b/tools/Test-SessionIndexV2Contract.ps1
@@ -4,8 +4,8 @@ param(
 
   [string]$Branch = 'develop',
   [string]$PolicyPath = 'tools/policy/branch-required-checks.json',
-  [string]$Owner = 'LabVIEW-Community-CI-CD',
-  [string]$Repository = 'compare-vi-cli-action',
+  [string]$Owner,
+  [string]$Repository,
   [string]$WorkflowFileName = 'validate.yml',
   [int]$BurnInThreshold = 10,
   [switch]$Enforce
@@ -13,6 +13,70 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+function Convert-GitRemoteUrlToSlug {
+  param([string]$RemoteUrl)
+
+  if ([string]::IsNullOrWhiteSpace($RemoteUrl)) {
+    return $null
+  }
+
+  $trimmed = $RemoteUrl.Trim()
+  if ($trimmed -match '^(?:git@|ssh://git@)?github\.com[:/](?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$') {
+    return "$($Matches.owner)/$($Matches.repo)"
+  }
+
+  if ($trimmed -match '^https://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$') {
+    return "$($Matches.owner)/$($Matches.repo)"
+  }
+
+  if ($trimmed -match '^(?<owner>[^/]+)/(?<repo>[^/]+)$') {
+    return "$($Matches.owner)/$($Matches.repo)"
+  }
+
+  return $null
+}
+
+function Resolve-RepositoryContext {
+  param(
+    [string]$Owner,
+    [string]$Repository
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($Owner) -and -not [string]::IsNullOrWhiteSpace($Repository)) {
+    return [pscustomobject]@{
+      Owner = $Owner
+      Repository = $Repository
+    }
+  }
+
+  $slug = $null
+  if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY)) {
+    $slug = Convert-GitRemoteUrlToSlug -RemoteUrl $env:GITHUB_REPOSITORY
+  }
+
+  if (-not $slug) {
+    foreach ($remoteName in @('upstream', 'origin')) {
+      $url = (& git remote get-url $remoteName 2>$null | Out-String).Trim()
+      if (-not $url) { continue }
+      $slug = Convert-GitRemoteUrlToSlug -RemoteUrl $url
+      if ($slug) { break }
+    }
+  }
+
+  if ($slug -and $slug -match '/') {
+    $parts = $slug.Split('/', 2)
+    return [pscustomobject]@{
+      Owner = $parts[0]
+      Repository = $parts[1]
+    }
+  }
+
+  return [pscustomobject]@{
+    Owner = if ($Owner) { $Owner } else { 'unknown-owner' }
+    Repository = if ($Repository) { $Repository } else { 'unknown-repository' }
+  }
+}
 
 function Add-Failure {
   param(
@@ -23,6 +87,10 @@ function Add-Failure {
   $Failures.Value += $Message
   Write-Host ("::warning::{0}" -f $Message)
 }
+
+$repoContext = Resolve-RepositoryContext -Owner $Owner -Repository $Repository
+$Owner = $repoContext.Owner
+$Repository = $repoContext.Repository
 
 function Get-ApiHeaders {
   param([string]$Token)

--- a/tools/priority/Write-HealthSnapshot.ps1
+++ b/tools/priority/Write-HealthSnapshot.ps1
@@ -3,8 +3,8 @@
 param(
   [string]$ResultsRoot = 'tests/results',
   [string]$OutputDir = 'tests/results/_agent/health-snapshot',
-  [string]$Owner = 'LabVIEW-Community-CI-CD',
-  [string]$Repository = 'compare-vi-cli-action',
+  [string]$Owner,
+  [string]$Repository,
   [string]$Branch = 'develop',
   [string]$BaseRef = 'upstream/develop',
   [string]$HeadRef = 'origin/develop',
@@ -43,6 +43,78 @@ function Invoke-GitText {
   $output = & git @Arguments 2>$null
   if ($LASTEXITCODE -ne 0) { return $null }
   return ($output | Out-String).Trim()
+}
+
+function Convert-GitRemoteUrlToSlug {
+  param([string]$RemoteUrl)
+
+  if ([string]::IsNullOrWhiteSpace($RemoteUrl)) {
+    return $null
+  }
+
+  $trimmed = $RemoteUrl.Trim()
+  if ($trimmed -match '^(?:git@|ssh://git@)?github\.com[:/](?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$') {
+    return "$($Matches.owner)/$($Matches.repo)"
+  }
+
+  if ($trimmed -match '^https://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?$') {
+    return "$($Matches.owner)/$($Matches.repo)"
+  }
+
+  if ($trimmed -match '^(?<owner>[^/]+)/(?<repo>[^/]+)$') {
+    return "$($Matches.owner)/$($Matches.repo)"
+  }
+
+  return $null
+}
+
+function Resolve-RepositoryContext {
+  param(
+    [string]$Owner,
+    [string]$Repository
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($Owner) -and -not [string]::IsNullOrWhiteSpace($Repository)) {
+    return [pscustomobject]@{
+      Owner = $Owner
+      Repository = $Repository
+      Source = 'parameters'
+    }
+  }
+
+  $slug = $null
+  if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY)) {
+    $slug = Convert-GitRemoteUrlToSlug -RemoteUrl $env:GITHUB_REPOSITORY
+  }
+
+  if (-not $slug) {
+    foreach ($remoteName in @('upstream', 'origin')) {
+      $remoteUrl = Invoke-GitText -Arguments @('remote', 'get-url', $remoteName)
+      $slug = Convert-GitRemoteUrlToSlug -RemoteUrl $remoteUrl
+      if ($slug) {
+        break
+      }
+    }
+  }
+
+  if (-not $slug -and -not [string]::IsNullOrWhiteSpace($Owner) -and -not [string]::IsNullOrWhiteSpace($Repository)) {
+    $slug = "$Owner/$Repository"
+  }
+
+  if (-not $slug -or $slug -notmatch '/') {
+    return [pscustomobject]@{
+      Owner = if ($Owner) { $Owner } else { 'unknown-owner' }
+      Repository = if ($Repository) { $Repository } else { 'unknown-repository' }
+      Source = 'fallback'
+    }
+  }
+
+  $parts = $slug.Split('/', 2)
+  return [pscustomobject]@{
+    Owner = $parts[0]
+    Repository = $parts[1]
+    Source = 'auto'
+  }
 }
 
 function Get-PreferredSessionIndex {
@@ -296,6 +368,13 @@ if (-not (Test-Path -LiteralPath $OutputDir -PathType Container)) {
 
 $token = Get-Token
 $degradedNotes = @()
+
+$repoContext = Resolve-RepositoryContext -Owner $Owner -Repository $Repository
+$Owner = $repoContext.Owner
+$Repository = $repoContext.Repository
+if ($repoContext.Source -eq 'fallback') {
+  $degradedNotes += 'Repository owner/name auto-resolution failed; using fallback placeholders.'
+}
 
 # Keep refs fresh where possible.
 & git fetch upstream develop --quiet 2>$null | Out-Null

--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -137,13 +137,27 @@ test('buildNoStandingPriorityState clears router/cache deterministically', () =>
   assert.equal(state.result.fetchSource, 'none');
 });
 
-test('resolveStandingPriorityLabels prefers fork-standing-priority for non-canonical owners', () => {
+test('resolveStandingPriorityLabels prefers fork-standing-priority when configured upstream differs', () => {
   const labels = resolveStandingPriorityLabels(
     '/tmp/repo',
-    'svelderrainruiz/compare-vi-cli-action',
-    {}
+    'fork-owner/compare-vi-cli-action',
+    {
+      AGENT_PRIORITY_UPSTREAM_REPOSITORY: 'upstream-owner/compare-vi-cli-action'
+    }
   );
   assert.deepEqual(labels, ['fork-standing-priority', 'standing-priority']);
+});
+
+test('resolveStandingPriorityLabels defaults to standing-priority when upstream matches current repository', () => {
+  const currentSlug = 'repo-owner/compare-vi-cli-action';
+  const labels = resolveStandingPriorityLabels(
+    '/tmp/repo',
+    currentSlug,
+    {
+      AGENT_PRIORITY_UPSTREAM_REPOSITORY: currentSlug
+    }
+  );
+  assert.deepEqual(labels, ['standing-priority']);
 });
 
 test('resolveStandingPriorityLabels honors explicit env override order', () => {
@@ -176,7 +190,7 @@ test('resolveUpstreamRepositorySlug prefers upstream remote when fork slug is ac
   assert.equal(upstream, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
 });
 
-test('resolveUpstreamRepositorySlug falls back to canonical owner when upstream remote is missing', async (t) => {
+test('resolveUpstreamRepositorySlug returns null when upstream remote is missing', async (t) => {
   const repoRoot = await mkdtemp(path.join(tmpdir(), 'standing-upstream-fallback-'));
   t.after(() => rm(repoRoot, { recursive: true, force: true }));
 
@@ -189,7 +203,19 @@ test('resolveUpstreamRepositorySlug falls back to canonical owner when upstream 
   );
 
   const upstream = resolveUpstreamRepositorySlug(repoRoot, 'svelderrainruiz/compare-vi-cli-action');
-  assert.equal(upstream, 'labview-community-ci-cd/compare-vi-cli-action');
+  assert.equal(upstream, null);
+});
+
+test('resolveUpstreamRepositorySlug honors explicit env override', async (t) => {
+  const repoRoot = await mkdtemp(path.join(tmpdir(), 'standing-upstream-env-'));
+  t.after(() => rm(repoRoot, { recursive: true, force: true }));
+
+  const upstream = resolveUpstreamRepositorySlug(
+    repoRoot,
+    'fork-owner/compare-vi-cli-action',
+    { AGENT_PRIORITY_UPSTREAM_REPOSITORY: 'upstream-owner/compare-vi-cli-action' }
+  );
+  assert.equal(upstream, 'upstream-owner/compare-vi-cli-action');
 });
 
 test('resolveStandingPriorityLookupPlan checks upstream when fork lookup reports empty', async () => {

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -13,7 +13,6 @@ let GH_AUTH_TOKEN_CACHE;
 let WARNED_NO_GITHUB_TOKEN_FOR_REST = false;
 const DEFAULT_STANDING_PRIORITY_LABEL = 'standing-priority';
 const FORK_STANDING_PRIORITY_LABEL = 'fork-standing-priority';
-const CANONICAL_PRIORITY_OWNER = 'labview-community-ci-cd';
 const MODULE_FILE_PATH = fileURLToPath(import.meta.url);
 const MODULE_REPO_ROOT = path.resolve(path.dirname(MODULE_FILE_PATH), '../..');
 
@@ -641,28 +640,43 @@ function resolveRepositorySlug(repoRoot) {
   return null;
 }
 
-export function resolveUpstreamRepositorySlug(repoRoot, slug) {
-  const resolvedSlug = slug || resolveRepositorySlug(repoRoot);
-  if (!resolvedSlug || !resolvedSlug.includes('/')) {
-    return null;
-  }
+function normalizeRepositorySlug(slug) {
+  return typeof slug === 'string' ? slug.trim().toLowerCase() : '';
+}
 
-  const [owner, repoName] = resolvedSlug.split('/');
-  if (!owner || owner.toLowerCase() === CANONICAL_PRIORITY_OWNER) {
-    return null;
+function resolveConfiguredUpstreamRepositorySlug(env = process.env) {
+  const candidates = [
+    env.AGENT_PRIORITY_UPSTREAM_REPOSITORY,
+    env.AGENT_UPSTREAM_REPOSITORY
+  ];
+  for (const candidate of candidates) {
+    const parsed = parseGitRemoteUrl(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function resolveUpstreamRepositorySlug(repoRoot, slug, env = process.env) {
+  const resolvedSlug = slug || resolveRepositorySlug(repoRoot);
+  const normalizedResolvedSlug = normalizeRepositorySlug(resolvedSlug);
+
+  const configuredUpstream = resolveConfiguredUpstreamRepositorySlug(env);
+  if (configuredUpstream) {
+    if (normalizeRepositorySlug(configuredUpstream) === normalizedResolvedSlug) {
+      return null;
+    }
+    return configuredUpstream;
   }
 
   const upstreamUrl = resolveGitRemoteUrl(repoRoot, 'upstream');
   const upstreamSlug = parseGitRemoteUrl(upstreamUrl);
-  if (upstreamSlug) {
+  if (upstreamSlug && normalizeRepositorySlug(upstreamSlug) !== normalizedResolvedSlug) {
     return upstreamSlug;
   }
 
-  if (!repoName) {
-    return null;
-  }
-
-  return `${CANONICAL_PRIORITY_OWNER}/${repoName}`;
+  return null;
 }
 
 export function resolveStandingPriorityLabels(repoRoot, slug, env = process.env) {
@@ -678,9 +692,12 @@ export function resolveStandingPriorityLabels(repoRoot, slug, env = process.env)
     return explicitLabels;
   }
 
-  const resolvedSlug = (slug || resolveRepositorySlug(repoRoot) || '').toLowerCase();
-  const owner = resolvedSlug.includes('/') ? resolvedSlug.split('/')[0] : '';
-  if (owner && owner !== CANONICAL_PRIORITY_OWNER) {
+  const resolvedSlug = slug || resolveRepositorySlug(repoRoot);
+  const upstreamSlug = resolveUpstreamRepositorySlug(repoRoot, resolvedSlug, env);
+  if (
+    upstreamSlug &&
+    normalizeRepositorySlug(upstreamSlug) !== normalizeRepositorySlug(resolvedSlug)
+  ) {
     return [FORK_STANDING_PRIORITY_LABEL, DEFAULT_STANDING_PRIORITY_LABEL];
   }
 
@@ -995,18 +1012,21 @@ export async function resolveStandingPriorityLookupPlan({
   }
 
   const resolvedSlug = slug || resolveRepositorySlug(repoRoot);
-  const primaryOwner = (resolvedSlug || '').split('/')[0].toLowerCase();
-  const shouldCheckUpstream = Boolean(primaryOwner) && primaryOwner !== CANONICAL_PRIORITY_OWNER;
+  const upstreamSlug = resolveUpstreamSlug(repoRoot, resolvedSlug);
+  const shouldCheckUpstream = Boolean(
+    upstreamSlug &&
+      normalizeRepositorySlug(upstreamSlug) !== normalizeRepositorySlug(resolvedSlug)
+  );
 
   let cacheSource = primary;
   let cacheLabels = standingPriorityLabels;
   let cacheRepoSlug = primary.repoSlug || resolvedSlug || null;
 
   if (shouldCheckUpstream) {
-    const upstreamSlug = resolveUpstreamSlug(repoRoot, resolvedSlug);
-    if (upstreamSlug && upstreamSlug.toLowerCase() !== (resolvedSlug || '').toLowerCase()) {
+    if (upstreamSlug && normalizeRepositorySlug(upstreamSlug) !== normalizeRepositorySlug(resolvedSlug)) {
       if (didReportNoStandingPriority(primary)) {
-        warn(`[priority] No standing-priority issue found in ${resolvedSlug}; checking upstream ${upstreamSlug}.`);
+        const primaryTarget = resolvedSlug || 'current repository';
+        warn(`[priority] No standing-priority issue found in ${primaryTarget}; checking upstream ${upstreamSlug}.`);
       }
 
       const upstreamAttempt = await resolveForRepo(repoRoot, upstreamSlug, [DEFAULT_STANDING_PRIORITY_LABEL]);


### PR DESCRIPTION
## Summary
- remove runtime owner hardcoding from standing-priority resolution paths (`sync-standing-priority.mjs`) by deriving upstream from env override or remote config (no canonical-owner fallback)
- make workflow gates owner-agnostic by switching canonical/fork checks to repository fork-state logic and dynamic repository slug wiring
- make reviewer routing owner-agnostic using `REQUIRED_AGENT_REVIEWER` (fallback: `github.repository_owner`)
- make session-index/health snapshot/fork simulation utilities auto-resolve owner/repo from `GITHUB_REPOSITORY` or git remotes
- add tests covering upstream override behavior and no-remote fallback semantics

## Why
Closes #728 by removing hardcoded owner assumptions (`LabVIEW-Community-CI-CD`, `svelderrainruiz`) in runtime automation paths so deforked repositories can run priority/policy tooling without source edits.

## Validation
- `node --test tools/priority/__tests__/standing-priority-resolution.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `node tools/npm/run-script.mjs lint:md:changed`

## Links
- Closes #728
- Related: #721
