### PR TITLE
fix: harden develop sync serialization (#743)

### DIFF
--- a/.github/workflows/commit-integrity.yml
+++ b/.github/workflows/commit-integrity.yml
@@ -1,0 +1,75 @@
+name: commit-integrity
+
+on:
+  pull_request:
+    branches: [main, develop]
+  merge_group:
+    branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: 'Pull request number to evaluate (required for workflow_dispatch)'
+        required: true
+        type: string
+      enforce:
+        description: 'Fail workflow on violations (true) or run observe-only (false)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: commit-integrity-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commit-integrity:
+    name: commit-integrity
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Run commit integrity checks
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMIT_INTEGRITY_ENFORCE: ${{ vars.COMMIT_INTEGRITY_ENFORCE || '0' }}
+          DISPATCH_PR: ${{ inputs.pull_request || '' }}
+          DISPATCH_ENFORCE: ${{ inputs.enforce || false }}
+        run: |
+          $reportPath = 'tests/results/_agent/commit-integrity/commit-integrity-report.json'
+          $args = @(
+            'tools/priority/commit-integrity.mjs',
+            '--report', $reportPath
+          )
+
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            if ([string]::IsNullOrWhiteSpace($env:DISPATCH_PR)) {
+              throw "workflow_dispatch requires input 'pull_request'."
+            }
+            $args += @('--pr', $env:DISPATCH_PR)
+            if ($env:DISPATCH_ENFORCE -ne 'true') {
+              $args += '--observe-only'
+            }
+          } elseif ($env:COMMIT_INTEGRITY_ENFORCE -ne '1') {
+            $args += '--observe-only'
+          }
+
+          node @args
+
+      - name: Upload commit integrity artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: commit-integrity-${{ github.run_id }}
+          path: tests/results/_agent/commit-integrity/commit-integrity-report.json
+          if-no-files-found: error

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -33,3 +33,7 @@ jobs:
         run: |
           pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-RequirementsVerificationCheckContract.ps1
 
+      - name: Assert commit-integrity contract
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-CommitIntegrityContract.ps1

--- a/docs/COMMIT_INTEGRITY_CHECK.md
+++ b/docs/COMMIT_INTEGRITY_CHECK.md
@@ -1,0 +1,83 @@
+# Commit Integrity Check
+
+Issue: `#743`
+
+This document defines the `commit-integrity` contract used to evaluate commit trust posture for PR/queue scopes.
+
+## Workflow Contract
+
+- Workflow: `.github/workflows/commit-integrity.yml`
+- Job/check target: `commit-integrity`
+- Deterministic artifact:
+  - `tests/results/_agent/commit-integrity/commit-integrity-report.json`
+  - Uploaded on every run via `if: always()`
+
+## Validation Coverage
+
+The checker evaluates all commits in scope and emits explicit violation categories:
+
+- `unverified-commit`
+  - Fails when `commit.verification.verified != true`.
+- `unknown-unverified-reason`
+  - Fails when an unverified commit has reason `unknown` and the policy toggle is enabled.
+- `missing-author-attribution`
+  - Fails when both author login and author email are absent and the policy toggle is enabled.
+- `missing-committer-attribution`
+  - Fails when both committer login and committer email are absent and the policy toggle is enabled.
+- `duplicate-commit-sha`
+  - Fails when the same commit SHA appears multiple times in scope and the policy toggle is enabled.
+- `empty-headline`
+  - Fails when commit message headline is empty and the policy toggle is enabled.
+- `headline-too-long`
+  - Fails when commit headline length exceeds policy maximum.
+- `missing-signature-material`
+  - Optional strict mode: fails when a commit is marked verified but signature/payload fields are absent.
+
+The report emits deterministic commit ordering (`sha-asc`) so repeated runs over the same commit set preserve output
+shape and pass/fail decisions.
+
+## Policy Seam
+
+Policy file: `tools/policy/commit-integrity-policy.json`
+
+- No repository-owner hardcoding is used in runtime logic.
+- Bot/source classification is policy-driven by regex:
+  - `source_resolution.bot_login_patterns`
+  - `source_resolution.bot_email_patterns`
+- Additional coverage toggles:
+  - `checks.require_author_attribution`
+  - `checks.require_committer_attribution`
+  - `checks.require_non_unknown_reason_for_unverified`
+  - `checks.require_unique_shas`
+  - `checks.require_non_empty_headline`
+  - `checks.max_headline_length`
+  - `checks.require_signature_material_for_verified`
+
+## Drift Guard
+
+- Contract guard script: `tools/Assert-CommitIntegrityContract.ps1`
+- Enforced in:
+  - `tools/PrePush-Checks.ps1`
+  - `.github/workflows/workflows-lint.yml`
+- Guard verifies:
+  - workflow/job/check naming
+  - deterministic report path contract
+  - observed-check entries in policy manifests
+  - defork-safe runtime/policy content (no hardcoded owner slugs)
+
+## Rollout Flags
+
+- Repo variable: `COMMIT_INTEGRITY_ENFORCE`
+  - `0` (default): observe-only mode (`report.result` still indicates pass/fail; workflow exit remains non-blocking)
+  - `1`: enforcing mode (violations fail the job)
+- `workflow_dispatch` input `enforce` can override mode for manual runs.
+
+## Local Usage
+
+```bash
+node tools/npm/run-script.mjs priority:commit-integrity -- --pr 744 --observe-only
+```
+
+```bash
+node tools/npm/run-script.mjs priority:commit-integrity -- --pr 744
+```

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -312,6 +312,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   `Authorization unavailable` or `authenticated-no-admin`, rotate `GH_TOKEN`/`GITHUB_TOKEN` secrets in upstream.
 - Use `node tools/npm/run-script.mjs priority:policy:apply` only with admin token scope when you intentionally need to
   sync GitHub protections/rulesets back to `tools/priority/policy.json`.
+- Run `node tools/npm/run-script.mjs priority:commit-integrity -- --pr <number>` to evaluate commit trust posture
+  locally. Add `--observe-only` to mirror staged rollout mode. See `docs/COMMIT_INTEGRITY_CHECK.md` for full contract
+  and rollout flags (`COMMIT_INTEGRITY_ENFORCE`).
 - Prefer opening PRs from your fork with `node tools/npm/run-script.mjs priority:pr`; the helper ensures `origin` targets your fork (creating
   it via `gh repo fork` if needed), pushes the current branch, and calls
   `gh pr create --fill --repo <upstream> --base develop --head <fork>:branch`.

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-05T05:55:00Z",
+  "updated": "2026-03-06T01:15:00Z",
   "entries": [
     {
       "name": "Root Playbooks",
@@ -61,6 +61,7 @@
         "docs/adr/0003-test-decision.md",
         "docs/adr/README.md",
         "docs/CI_ORCHESTRATION_REDESIGN.md",
+        "docs/COMMIT_INTEGRITY_CHECK.md",
         "docs/COMPARE_LOOP_MODULE.md",
         "docs/COMPARE_REPORT_CAPTURE_PLAN.md",
         "docs/DEV_DASHBOARD_PLAN.md",

--- a/docs/schemas/commit-integrity-report-v1.schema.json
+++ b/docs/schemas/commit-integrity-report-v1.schema.json
@@ -1,0 +1,374 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "commit-integrity/report@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAt",
+    "repository",
+    "scope",
+    "policy",
+    "enforcement",
+    "checks",
+    "summary",
+    "commits",
+    "violations",
+    "issues",
+    "result",
+    "errors",
+    "exitCode"
+  ],
+  "properties": {
+    "schema": {
+      "const": "commit-integrity/report@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "pullRequest",
+        "baseSha",
+        "headSha"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "pullRequest": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "baseSha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headSha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "path",
+        "failOnUnverified",
+        "checks",
+        "sourceResolution"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "failOnUnverified": {
+          "type": "boolean"
+        },
+        "checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requireAuthorAttribution",
+            "requireCommitterAttribution",
+            "requireKnownReasonForUnverified",
+            "requireUniqueShas",
+            "requireNonEmptyHeadline",
+            "maxHeadlineLength",
+            "requireSignatureMaterialForVerified"
+          ],
+          "properties": {
+            "requireAuthorAttribution": {
+              "type": "boolean"
+            },
+            "requireCommitterAttribution": {
+              "type": "boolean"
+            },
+            "requireKnownReasonForUnverified": {
+              "type": "boolean"
+            },
+            "requireUniqueShas": {
+              "type": "boolean"
+            },
+            "requireNonEmptyHeadline": {
+              "type": "boolean"
+            },
+            "maxHeadlineLength": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "requireSignatureMaterialForVerified": {
+              "type": "boolean"
+            }
+          }
+        },
+        "sourceResolution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "botLoginPatternCount",
+            "botEmailPatternCount"
+          ],
+          "properties": {
+            "botLoginPatternCount": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "botEmailPatternCount": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "enforcement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observeOnly",
+        "blocking"
+      ],
+      "properties": {
+        "observeOnly": {
+          "type": "boolean"
+        },
+        "blocking": {
+          "type": "boolean"
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "enabled",
+          "passed",
+          "failureCount"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "failureCount": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commitCount",
+        "verifiedCount",
+        "unverifiedCount",
+        "violationCount",
+        "deterministicOrder"
+      ],
+      "properties": {
+        "commitCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "verifiedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unverifiedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "violationCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deterministicOrder": {
+          "const": "sha-asc"
+        }
+      }
+    },
+    "commits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sha",
+          "url",
+          "messageHeadline",
+          "verified",
+          "verificationReason",
+          "verificationSignaturePresent",
+          "verificationPayloadPresent",
+          "authorLogin",
+          "committerLogin",
+          "authorEmail",
+          "committerEmail",
+          "sourceKind"
+        ],
+        "properties": {
+          "sha": {
+            "type": "string"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "messageHeadline": {
+            "type": "string"
+          },
+          "verified": {
+            "type": "boolean"
+          },
+          "verificationReason": {
+            "type": "string"
+          },
+          "verificationSignaturePresent": {
+            "type": "boolean"
+          },
+          "verificationPayloadPresent": {
+            "type": "boolean"
+          },
+          "authorLogin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "committerLogin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "authorEmail": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "committerEmail": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceKind": {
+            "enum": [
+              "human",
+              "bot"
+            ]
+          }
+        }
+      }
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "category",
+          "sha",
+          "reason",
+          "messageHeadline",
+          "sourceKind",
+          "authorLogin",
+          "committerLogin"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "messageHeadline": {
+            "type": "string"
+          },
+          "sourceKind": {
+            "enum": [
+              "human",
+              "bot"
+            ]
+          },
+          "authorLogin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "committerLogin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "result": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exitCode": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "priority:health-snapshot": "pwsh -NoLogo -NoProfile -File tools/priority/Write-HealthSnapshot.ps1",
     "priority:queue:supervisor": "node tools/priority/queue-supervisor.mjs",
     "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
+    "priority:commit-integrity": "node tools/priority/commit-integrity.mjs",
     "priority:deployment:assert": "node tools/priority/assert-validation-deployment-determinism.mjs",
     "priority:develop:sync": "pwsh -NoLogo -NoProfile -File tools/priority/Sync-OriginUpstreamDevelop.ps1",
     "priority:policy": "node tools/priority/check-policy.mjs",

--- a/tests/CommitIntegrityContract.Tests.ps1
+++ b/tests/CommitIntegrityContract.Tests.ps1
@@ -1,0 +1,120 @@
+Describe 'Commit integrity contract' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools/Assert-CommitIntegrityContract.ps1'
+
+    function Invoke-ContractScript {
+      param(
+        [Parameter(Mandatory)][string]$WorkflowPath,
+        [Parameter(Mandatory)][string]$BranchPolicyPath,
+        [Parameter(Mandatory)][string]$PriorityPolicyPath,
+        [Parameter(Mandatory)][string]$PolicyPath,
+        [Parameter(Mandatory)][string]$SchemaPath,
+        [Parameter(Mandatory)][string]$RuntimeScriptPath
+      )
+
+      $psi = [System.Diagnostics.ProcessStartInfo]::new()
+      $psi.FileName = 'pwsh'
+      $psi.Arguments = ('-NoLogo -NoProfile -NonInteractive -File "{0}" -WorkflowPath "{1}" -BranchRequiredChecksPath "{2}" -PriorityPolicyPath "{3}" -PolicyPath "{4}" -SchemaPath "{5}" -RuntimeScriptPath "{6}"' -f $scriptPath, $WorkflowPath, $BranchPolicyPath, $PriorityPolicyPath, $PolicyPath, $SchemaPath, $RuntimeScriptPath)
+      $psi.WorkingDirectory = $repoRoot
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+      $psi.UseShellExecute = $false
+      $psi.CreateNoWindow = $true
+
+      $proc = [System.Diagnostics.Process]::Start($psi)
+      $stdout = $proc.StandardOutput.ReadToEnd()
+      $stderr = $proc.StandardError.ReadToEnd()
+      $proc.WaitForExit()
+
+      return [pscustomobject]@{
+        ExitCode = $proc.ExitCode
+        StdOut = $stdout
+        StdErr = $stderr
+      }
+    }
+
+    function Write-JsonFile {
+      param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][object]$Data
+      )
+      $Data | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8
+    }
+  }
+
+  It 'passes against repository contract files' {
+    $workflowPath = Join-Path $repoRoot '.github/workflows/commit-integrity.yml'
+    $branchPolicyPath = Join-Path $repoRoot 'tools/policy/branch-required-checks.json'
+    $priorityPolicyPath = Join-Path $repoRoot 'tools/priority/policy.json'
+    $policyPath = Join-Path $repoRoot 'tools/policy/commit-integrity-policy.json'
+    $schemaPath = Join-Path $repoRoot 'docs/schemas/commit-integrity-report-v1.schema.json'
+    $runtimeScriptPath = Join-Path $repoRoot 'tools/priority/commit-integrity.mjs'
+
+    $run = Invoke-ContractScript -WorkflowPath $workflowPath -BranchPolicyPath $branchPolicyPath -PriorityPolicyPath $priorityPolicyPath -PolicyPath $policyPath -SchemaPath $schemaPath -RuntimeScriptPath $runtimeScriptPath
+    $run.ExitCode | Should -Be 0
+    ($run.StdOut + $run.StdErr) | Should -Match 'commit-integrity-contract'
+  }
+
+  It 'fails when observed check contract drifts' {
+    $tmpWorkflow = Join-Path $TestDrive 'commit-integrity.yml'
+    $tmpBranchPolicy = Join-Path $TestDrive 'branch-required-checks.json'
+    $tmpPriorityPolicy = Join-Path $TestDrive 'policy.json'
+    $tmpPolicy = Join-Path $TestDrive 'commit-integrity-policy.json'
+    $tmpSchema = Join-Path $TestDrive 'commit-integrity-report-v1.schema.json'
+    $tmpRuntime = Join-Path $TestDrive 'commit-integrity.mjs'
+
+    @'
+name: commit-integrity
+on:
+  workflow_dispatch:
+jobs:
+  commit-integrity:
+    name: commit-integrity
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo noop
+'@ | Set-Content -LiteralPath $tmpWorkflow -Encoding utf8
+
+    Write-JsonFile -Path $tmpBranchPolicy -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branches = @{
+        develop = @('lint')
+        main = @('lint')
+      }
+      observed = @{
+        develop = @('wrong-check')
+        main = @('wrong-check')
+      }
+    }
+
+    Write-JsonFile -Path $tmpPriorityPolicy -Data @{
+      branches = @{
+        develop = @{ observed_status_checks = @('wrong-check') }
+        main = @{ observed_status_checks = @('wrong-check') }
+      }
+      rulesets = @{
+        '8811898' = @{ observed_status_checks = @('wrong-check') }
+        '8614140' = @{ observed_status_checks = @('wrong-check') }
+      }
+    }
+
+    Write-JsonFile -Path $tmpPolicy -Data @{
+      schema = 'commit-integrity-policy/v1'
+      source_resolution = @{ bot_login_patterns = @('\[bot\]$') }
+      verification = @{ fail_on_unverified = $true }
+      checks = @{
+        require_author_attribution = $true
+        require_committer_attribution = $true
+        require_non_unknown_reason_for_unverified = $true
+      }
+    }
+    '{}' | Set-Content -LiteralPath $tmpSchema -Encoding utf8
+    'export {}' | Set-Content -LiteralPath $tmpRuntime -Encoding utf8
+
+    $run = Invoke-ContractScript -WorkflowPath $tmpWorkflow -BranchPolicyPath $tmpBranchPolicy -PriorityPolicyPath $tmpPriorityPolicy -PolicyPath $tmpPolicy -SchemaPath $tmpSchema -RuntimeScriptPath $tmpRuntime
+    $run.ExitCode | Should -Be 1
+    ($run.StdOut + $run.StdErr) | Should -Match 'expected report path|Observed branch checks'
+  }
+}

--- a/tools/Assert-CommitIntegrityContract.ps1
+++ b/tools/Assert-CommitIntegrityContract.ps1
@@ -1,0 +1,131 @@
+[CmdletBinding()]
+param(
+  [string]$WorkflowPath = '.github/workflows/commit-integrity.yml',
+  [string]$BranchRequiredChecksPath = 'tools/policy/branch-required-checks.json',
+  [string]$PriorityPolicyPath = 'tools/priority/policy.json',
+  [string]$PolicyPath = 'tools/policy/commit-integrity-policy.json',
+  [string]$SchemaPath = 'docs/schemas/commit-integrity-report-v1.schema.json',
+  [string]$RuntimeScriptPath = 'tools/priority/commit-integrity.mjs',
+  [string]$WorkflowName = 'commit-integrity',
+  [string]$JobId = 'commit-integrity',
+  [string]$JobName = 'commit-integrity',
+  [string]$DevelopBranch = 'develop',
+  [string]$MainBranch = 'main',
+  [string]$DevelopRulesetId = '8811898',
+  [string]$MainRulesetId = '8614140',
+  [string]$ExpectedObservedCheck = 'commit-integrity / commit-integrity',
+  [string]$ExpectedReportPath = 'tests/results/_agent/commit-integrity/commit-integrity-report.json'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$errors = New-Object System.Collections.Generic.List[string]
+
+function Add-ContractError {
+  param([string]$Message)
+  $errors.Add($Message) | Out-Null
+}
+
+function Read-JsonFile {
+  param([Parameter(Mandatory)][string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "File not found: $Path"
+  }
+  return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 20)
+}
+
+if (-not (Test-Path -LiteralPath $WorkflowPath -PathType Leaf)) {
+  throw "Workflow file not found: $WorkflowPath"
+}
+if (-not (Test-Path -LiteralPath $SchemaPath -PathType Leaf)) {
+  Add-ContractError "Schema file missing: $SchemaPath"
+}
+if (-not (Test-Path -LiteralPath $PolicyPath -PathType Leaf)) {
+  Add-ContractError "Policy file missing: $PolicyPath"
+}
+if (-not (Test-Path -LiteralPath $RuntimeScriptPath -PathType Leaf)) {
+  Add-ContractError "Runtime script missing: $RuntimeScriptPath"
+}
+
+$workflowContent = Get-Content -LiteralPath $WorkflowPath -Raw
+
+$workflowNamePattern = '(?m)^name:\s*' + [regex]::Escape($WorkflowName) + '\s*$'
+if (-not [regex]::IsMatch($workflowContent, $workflowNamePattern)) {
+  Add-ContractError "Workflow name mismatch in $WorkflowPath (expected '$WorkflowName')."
+}
+
+$jobIdPattern = '(?m)^\s{2}' + [regex]::Escape($JobId) + ':\s*$'
+if (-not [regex]::IsMatch($workflowContent, $jobIdPattern)) {
+  Add-ContractError "Workflow job id '$JobId' is missing in $WorkflowPath."
+}
+
+$jobNamePattern = '(?m)^\s{4}name:\s*' + [regex]::Escape($JobName) + '\s*$'
+if (-not [regex]::IsMatch($workflowContent, $jobNamePattern)) {
+  Add-ContractError "Workflow job name mismatch in $WorkflowPath (expected '$JobName')."
+}
+
+$reportPathPattern = '(?m)' + [regex]::Escape($ExpectedReportPath)
+if (-not [regex]::IsMatch($workflowContent, $reportPathPattern)) {
+  Add-ContractError "Workflow does not reference expected report path '$ExpectedReportPath'."
+}
+
+$branchPolicy = Read-JsonFile -Path $BranchRequiredChecksPath
+$branchObserved = $branchPolicy.observed
+if (-not $branchObserved) {
+  Add-ContractError "Missing observed node in $BranchRequiredChecksPath."
+} else {
+  foreach ($branchName in @($DevelopBranch, $MainBranch)) {
+    $checks = @($branchObserved.$branchName)
+    if ($checks.Count -eq 0) {
+      Add-ContractError "Missing observed checks for branch '$branchName' in $BranchRequiredChecksPath."
+      continue
+    }
+    if (-not ($checks -contains $ExpectedObservedCheck)) {
+      Add-ContractError "Observed branch checks for '$branchName' missing '$ExpectedObservedCheck' in $BranchRequiredChecksPath."
+    }
+  }
+}
+
+$priorityPolicy = Read-JsonFile -Path $PriorityPolicyPath
+foreach ($branchName in @($DevelopBranch, $MainBranch)) {
+  $checks = @($priorityPolicy.branches.$branchName.observed_status_checks)
+  if ($checks.Count -eq 0) {
+    Add-ContractError "Priority policy branch '$branchName' missing observed_status_checks."
+    continue
+  }
+  if (-not ($checks -contains $ExpectedObservedCheck)) {
+    Add-ContractError "Priority policy branch '$branchName' observed_status_checks missing '$ExpectedObservedCheck'."
+  }
+}
+
+foreach ($rulesetId in @($DevelopRulesetId, $MainRulesetId)) {
+  $checks = @($priorityPolicy.rulesets.$rulesetId.observed_status_checks)
+  if ($checks.Count -eq 0) {
+    Add-ContractError "Priority policy ruleset '$rulesetId' missing observed_status_checks."
+    continue
+  }
+  if (-not ($checks -contains $ExpectedObservedCheck)) {
+    Add-ContractError "Priority policy ruleset '$rulesetId' observed_status_checks missing '$ExpectedObservedCheck'."
+  }
+}
+
+$ownerHardcodePattern = '(?i)LabVIEW-Community-CI-CD|svelderrainruiz'
+foreach ($pathToScan in @($RuntimeScriptPath, $PolicyPath)) {
+  if (-not (Test-Path -LiteralPath $pathToScan -PathType Leaf)) {
+    continue
+  }
+  $content = Get-Content -LiteralPath $pathToScan -Raw
+  if ([regex]::IsMatch($content, $ownerHardcodePattern)) {
+    Add-ContractError "Owner hardcode detected in $pathToScan. Runtime/policy must remain defork-safe."
+  }
+}
+
+if ($errors.Count -gt 0) {
+  foreach ($errorMessage in $errors) {
+    Write-Error $errorMessage
+  }
+  exit 1
+}
+
+Write-Host "[commit-integrity-contract] OK: $ExpectedObservedCheck" -ForegroundColor Green

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -148,6 +148,21 @@ if (Test-Path -LiteralPath $verificationContractScript -PathType Leaf) {
   Write-Host '[pre-push] requirements-verification check contract OK' -ForegroundColor Green
 }
 
+$commitIntegrityContractScript = Join-Path $root 'tools' 'Assert-CommitIntegrityContract.ps1'
+if (Test-Path -LiteralPath $commitIntegrityContractScript -PathType Leaf) {
+  Write-Host '[pre-push] Verifying commit-integrity contract' -ForegroundColor Cyan
+  Push-Location $root
+  try {
+    pwsh -NoLogo -NonInteractive -NoProfile -File $commitIntegrityContractScript
+    if ($LASTEXITCODE -ne 0) {
+      throw "Assert-CommitIntegrityContract.ps1 failed (exit=$LASTEXITCODE)."
+    }
+  } finally {
+    Pop-Location | Out-Null
+  }
+  Write-Host '[pre-push] commit-integrity contract OK' -ForegroundColor Green
+}
+
 $updateReportScript = Join-Path $root 'tools' 'icon-editor' 'Update-IconEditorFixtureReport.ps1'
 if (Test-Path -LiteralPath $updateReportScript -PathType Leaf) {
   $skipLegacyFixtureChecks = $SkipIconEditorFixtureChecks `
@@ -268,5 +283,4 @@ if (Test-Path -LiteralPath $updateReportScript -PathType Leaf) {
     Pop-Location | Out-Null
   }
 }
-
 

--- a/tools/policy/branch-required-checks.json
+++ b/tools/policy/branch-required-checks.json
@@ -29,5 +29,13 @@
       "mock-cli",
       "Policy Guard (Upstream) / policy-guard"
     ]
+  },
+  "observed": {
+    "develop": [
+      "commit-integrity / commit-integrity"
+    ],
+    "main": [
+      "commit-integrity / commit-integrity"
+    ]
   }
 }

--- a/tools/policy/commit-integrity-policy.json
+++ b/tools/policy/commit-integrity-policy.json
@@ -1,0 +1,25 @@
+{
+  "schema": "commit-integrity-policy/v1",
+  "schemaVersion": "1.0.0",
+  "source_resolution": {
+    "bot_login_patterns": [
+      "\\[bot\\]$"
+    ],
+    "bot_email_patterns": [
+      "\\[bot\\]@users\\.noreply\\.github\\.com$",
+      "@users\\.noreply\\.github\\.com$"
+    ]
+  },
+  "verification": {
+    "fail_on_unverified": true
+  },
+  "checks": {
+    "require_author_attribution": true,
+    "require_committer_attribution": true,
+    "require_non_unknown_reason_for_unverified": true,
+    "require_unique_shas": true,
+    "require_non_empty_headline": true,
+    "max_headline_length": 120,
+    "require_signature_material_for_verified": false
+  }
+}

--- a/tools/priority/__tests__/commit-integrity-schema.test.mjs
+++ b/tools/priority/__tests__/commit-integrity-schema.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { __test } from '../commit-integrity.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function makeCommit({
+  sha,
+  verified = true,
+  reason = 'valid',
+  sourceKind = 'human'
+}) {
+  return {
+    sha,
+    url: `https://github.com/example/repo/commit/${sha}`,
+    messageHeadline: `commit-${sha}`,
+    verified,
+    verificationReason: reason,
+    verificationSignaturePresent: verified,
+    verificationPayloadPresent: verified,
+    authorLogin: sourceKind === 'bot' ? 'dependabot[bot]' : 'alice',
+    committerLogin: sourceKind === 'bot' ? 'dependabot[bot]' : 'alice',
+    authorEmail:
+      sourceKind === 'bot' ? '49699333+dependabot[bot]@users.noreply.github.com' : 'alice@example.com',
+    committerEmail:
+      sourceKind === 'bot' ? '49699333+dependabot[bot]@users.noreply.github.com' : 'alice@example.com',
+    sourceKind
+  };
+}
+
+test('commit integrity report schema validates generated report payload', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'commit-integrity-report-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const commits = [makeCommit({ sha: 'aa', verified: true }), makeCommit({ sha: 'bb', verified: false, reason: 'unsigned' })];
+  const evaluation = __test.evaluateCommitIntegrity(commits, {
+    checks: {
+      requireAuthorAttribution: true,
+      requireCommitterAttribution: true,
+      requireKnownReasonForUnverified: true
+    }
+  });
+
+  const report = __test.buildReport({
+    repository: 'example/repo',
+    scope: {
+      mode: 'pull_request',
+      pullRequest: 123,
+      baseSha: null,
+      headSha: null
+    },
+    policy: {
+      schema: 'commit-integrity-policy/v1',
+      path: path.join(repoRoot, 'tools', 'policy', 'commit-integrity-policy.json'),
+      failOnUnverified: true,
+      checks: {
+        requireAuthorAttribution: true,
+        requireCommitterAttribution: true,
+        requireKnownReasonForUnverified: true,
+        requireUniqueShas: true,
+        requireNonEmptyHeadline: true,
+        maxHeadlineLength: 120,
+        requireSignatureMaterialForVerified: false
+      },
+      sourceResolution: {
+        botLoginRegexes: [/\[bot\]$/i],
+        botEmailRegexes: [/\[bot\]@users\.noreply\.github\.com$/i]
+      }
+    },
+    observeOnly: false,
+    commits,
+    evaluation,
+    generatedAt: '2026-03-06T00:00:00.000Z'
+  });
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/commit-integrity.test.mjs
+++ b/tools/priority/__tests__/commit-integrity.test.mjs
@@ -1,0 +1,209 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { __test, evaluateCommitIntegrity, normalizeCommitRecords, parseArgs } from '../commit-integrity.mjs';
+
+function createRawCommit({
+  sha,
+  verified = true,
+  reason = 'valid',
+  authorLogin = 'octocat',
+  committerLogin = 'octocat',
+  authorEmail = 'octocat@example.com',
+  committerEmail = 'octocat@example.com',
+  message = 'test commit'
+}) {
+  return {
+    sha,
+    html_url: `https://github.com/example/repo/commit/${sha}`,
+    author: authorLogin ? { login: authorLogin } : null,
+    committer: committerLogin ? { login: committerLogin } : null,
+    commit: {
+      message,
+      author: authorEmail ? { email: authorEmail } : null,
+      committer: committerEmail ? { email: committerEmail } : null,
+      verification: {
+        verified,
+        reason,
+        signature: verified ? 'sig' : null,
+        payload: verified ? 'payload' : null
+      }
+    }
+  };
+}
+
+const sourceResolution = {
+  botLoginRegexes: [/\[bot\]$/i],
+  botEmailRegexes: [/\[bot\]@users\.noreply\.github\.com$/i]
+};
+
+test('parseArgs supports observe-only and pull-request selection', () => {
+  const options = parseArgs([
+    'node',
+    'tools/priority/commit-integrity.mjs',
+    '--pr',
+    '42',
+    '--observe-only'
+  ]);
+  assert.equal(options.pr, 42);
+  assert.equal(options.observeOnly, true);
+});
+
+test('normalizeCommitRecords applies deterministic sha ordering', () => {
+  const commits = normalizeCommitRecords(
+    [
+      createRawCommit({ sha: 'bb', message: 'second' }),
+      createRawCommit({ sha: 'aa', message: 'first' })
+    ],
+    sourceResolution
+  );
+  assert.deepEqual(
+    commits.map((entry) => entry.sha),
+    ['aa', 'bb']
+  );
+});
+
+test('classifySourceKind honors policy-driven bot patterns', () => {
+  const human = __test.normalizeCommitRecord(
+    createRawCommit({ sha: 'aa01', authorLogin: 'alice', authorEmail: 'alice@example.com' }),
+    sourceResolution
+  );
+  const bot = __test.normalizeCommitRecord(
+    createRawCommit({
+      sha: 'aa02',
+      authorLogin: 'dependabot[bot]',
+      authorEmail: '49699333+dependabot[bot]@users.noreply.github.com'
+    }),
+    sourceResolution
+  );
+  assert.equal(human.sourceKind, 'human');
+  assert.equal(bot.sourceKind, 'bot');
+});
+
+test('evaluateCommitIntegrity fails on unverified commits with explicit categories', () => {
+  const commits = normalizeCommitRecords(
+    [createRawCommit({ sha: 'cc', verified: false, reason: 'unsigned' })],
+    sourceResolution
+  );
+  const evaluation = evaluateCommitIntegrity(commits);
+  assert.equal(evaluation.result, 'fail');
+  assert.ok(
+    evaluation.violations.some((violation) => violation.category === 'unverified-commit' && violation.reason === 'unsigned')
+  );
+});
+
+test('evaluateCommitIntegrity detects attribution and unknown-reason gaps when enabled', () => {
+  const commits = normalizeCommitRecords(
+    [
+      createRawCommit({
+        sha: 'dd',
+        verified: false,
+        reason: 'unknown',
+        authorLogin: null,
+        committerLogin: null,
+        authorEmail: null,
+        committerEmail: null
+      })
+    ],
+    sourceResolution
+  );
+  const evaluation = evaluateCommitIntegrity(commits, {
+    checks: {
+      requireAuthorAttribution: true,
+      requireCommitterAttribution: true,
+      requireKnownReasonForUnverified: true
+    }
+  });
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'unknown-unverified-reason'));
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'missing-author-attribution'));
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'missing-committer-attribution'));
+});
+
+test('evaluateCommitIntegrity detects duplicate SHAs and headline quality issues', () => {
+  const commits = [
+    {
+      sha: 'ee',
+      url: 'https://github.com/example/repo/commit/ee',
+      messageHeadline: '',
+      verified: true,
+      verificationReason: 'valid',
+      verificationSignaturePresent: true,
+      verificationPayloadPresent: true,
+      authorLogin: 'alice',
+      committerLogin: 'alice',
+      authorEmail: 'alice@example.com',
+      committerEmail: 'alice@example.com',
+      sourceKind: 'human'
+    },
+    {
+      sha: 'ee',
+      url: 'https://github.com/example/repo/commit/ee',
+      messageHeadline: 'x'.repeat(130),
+      verified: true,
+      verificationReason: 'valid',
+      verificationSignaturePresent: true,
+      verificationPayloadPresent: true,
+      authorLogin: 'alice',
+      committerLogin: 'alice',
+      authorEmail: 'alice@example.com',
+      committerEmail: 'alice@example.com',
+      sourceKind: 'human'
+    }
+  ];
+
+  const evaluation = evaluateCommitIntegrity(commits, {
+    checks: {
+      requireUniqueShas: true,
+      requireNonEmptyHeadline: true,
+      maxHeadlineLength: 120
+    }
+  });
+
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'duplicate-commit-sha'));
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'empty-headline'));
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'headline-too-long'));
+});
+
+test('evaluateCommitIntegrity checks signature material for verified commits when enabled', () => {
+  const commits = [
+    {
+      sha: 'ff',
+      url: 'https://github.com/example/repo/commit/ff',
+      messageHeadline: 'verified commit',
+      verified: true,
+      verificationReason: 'valid',
+      verificationSignaturePresent: false,
+      verificationPayloadPresent: false,
+      authorLogin: 'alice',
+      committerLogin: 'alice',
+      authorEmail: 'alice@example.com',
+      committerEmail: 'alice@example.com',
+      sourceKind: 'human'
+    }
+  ];
+
+  const evaluation = evaluateCommitIntegrity(commits, {
+    checks: {
+      requireSignatureMaterialForVerified: true
+    }
+  });
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'missing-signature-material'));
+});
+
+test('resolveScope supports pull_request and merge_group payloads', () => {
+  const pullRequestScope = __test.resolveScope(
+    { pr: null, baseSha: null, headSha: null },
+    { GITHUB_EVENT_NAME: 'pull_request' },
+    { pull_request: { number: 77 } }
+  );
+  assert.equal(pullRequestScope.mode, 'pull_request');
+  assert.equal(pullRequestScope.pullRequest, 77);
+
+  const mergeGroupScope = __test.resolveScope(
+    { pr: null, baseSha: null, headSha: null },
+    { GITHUB_EVENT_NAME: 'merge_group' },
+    { merge_group: { base_sha: 'abc123', head_sha: 'def456' } }
+  );
+  assert.equal(mergeGroupScope.mode, 'compare');
+  assert.equal(mergeGroupScope.baseSha, 'abc123');
+  assert.equal(mergeGroupScope.headSha, 'def456');
+});

--- a/tools/priority/commit-integrity.mjs
+++ b/tools/priority/commit-integrity.mjs
@@ -1,0 +1,845 @@
+#!/usr/bin/env node
+
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'commit-integrity',
+  'commit-integrity-report.json'
+);
+const DEFAULT_POLICY_PATH = path.join('tools', 'policy', 'commit-integrity-policy.json');
+const DEFAULT_POLICY_CHECKS = Object.freeze({
+  requireAuthorAttribution: true,
+  requireCommitterAttribution: true,
+  requireKnownReasonForUnverified: true,
+  requireUniqueShas: true,
+  requireNonEmptyHeadline: true,
+  maxHeadlineLength: 120,
+  requireSignatureMaterialForVerified: false
+});
+
+function printUsage() {
+  console.log('Usage: node tools/priority/commit-integrity.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --repo <owner/repo>    Target repository (default: GITHUB_REPOSITORY or git remote).');
+  console.log('  --pr <number>          Pull request number to evaluate.');
+  console.log('  --base-sha <sha>       Base SHA for compare mode.');
+  console.log('  --head-sha <sha>       Head SHA for compare mode.');
+  console.log(`  --policy <path>        Policy path (default: ${DEFAULT_POLICY_PATH}).`);
+  console.log(`  --report <path>        Report path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log('  --observe-only         Do not fail the process when violations are present.');
+  console.log('  -h, --help             Show usage.');
+}
+
+function parsePositiveInteger(value, { label }) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label} value '${value}'. Expected a positive integer.`);
+  }
+  return parsed;
+}
+
+function normalizeSha(value) {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase();
+  return normalized || null;
+}
+
+function normalizeOptionalString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function firstLine(value) {
+  const normalized = normalizeOptionalString(value) ?? '';
+  if (!normalized) {
+    return '';
+  }
+  const idx = normalized.indexOf('\n');
+  if (idx === -1) {
+    return normalized;
+  }
+  return normalized.slice(0, idx).trim();
+}
+
+function parseRemoteUrl(url) {
+  if (!url) {
+    return null;
+  }
+  const sshMatch = url.match(/:(?<repoPath>[^/]+\/[^/]+)(?:\.git)?$/);
+  const httpsMatch = url.match(/github\.com\/(?<repoPath>[^/]+\/[^/]+)(?:\.git)?$/);
+  const repoPath = sshMatch?.groups?.repoPath ?? httpsMatch?.groups?.repoPath;
+  if (!repoPath) {
+    return null;
+  }
+  const [owner, repoRaw] = repoPath.split('/');
+  if (!owner || !repoRaw) {
+    return null;
+  }
+  const repo = repoRaw.endsWith('.git') ? repoRaw.slice(0, -4) : repoRaw;
+  return { owner, repo };
+}
+
+function resolveRepoFromGit(execSyncFn = execSync) {
+  for (const remoteName of ['upstream', 'origin']) {
+    try {
+      const remoteUrl = execSyncFn(`git config --get remote.${remoteName}.url`, {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+        .toString()
+        .trim();
+      const parsed = parseRemoteUrl(remoteUrl);
+      if (parsed) {
+        return `${parsed.owner}/${parsed.repo}`;
+      }
+    } catch {
+      // ignore missing remote
+    }
+  }
+  return '';
+}
+
+function resolveRepository(options, env = process.env, execSyncFn = execSync) {
+  const fromArgs = normalizeOptionalString(options.repo);
+  if (fromArgs) {
+    if (!fromArgs.includes('/')) {
+      throw new Error(`Invalid --repo value '${fromArgs}'. Expected owner/repo.`);
+    }
+    return fromArgs;
+  }
+
+  const fromEnv = normalizeOptionalString(env.GITHUB_REPOSITORY);
+  if (fromEnv && fromEnv.includes('/')) {
+    return fromEnv;
+  }
+
+  const fromGit = resolveRepoFromGit(execSyncFn);
+  if (fromGit) {
+    return fromGit;
+  }
+
+  throw new Error('Unable to determine repository. Pass --repo or set GITHUB_REPOSITORY.');
+}
+
+async function resolveToken(env = process.env, { readFileFn = readFile, accessFn = access } = {}) {
+  const envCandidates = [env.GH_TOKEN, env.GITHUB_TOKEN, env.GH_ENTERPRISE_TOKEN];
+  for (const candidate of envCandidates) {
+    const token = normalizeOptionalString(candidate);
+    if (token) {
+      return token;
+    }
+  }
+
+  const fileCandidates = [env.GH_TOKEN_FILE];
+  if (process.platform === 'win32') {
+    fileCandidates.push('C:\\github_token.txt');
+  }
+  for (const filePath of fileCandidates) {
+    const normalizedPath = normalizeOptionalString(filePath);
+    if (!normalizedPath) {
+      continue;
+    }
+    try {
+      await accessFn(normalizedPath);
+      const token = normalizeOptionalString(await readFileFn(normalizedPath, 'utf8'));
+      if (token) {
+        return token;
+      }
+    } catch {
+      // ignore file read failures
+    }
+  }
+
+  throw new Error('GitHub token not found. Set GITHUB_TOKEN, GH_TOKEN, or GH_TOKEN_FILE.');
+}
+
+async function loadEventPayload(env = process.env, { readFileFn = readFile } = {}) {
+  const eventPath = normalizeOptionalString(env.GITHUB_EVENT_PATH);
+  if (!eventPath) {
+    return null;
+  }
+  try {
+    const raw = await readFileFn(eventPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function resolveScope(options, env = process.env, eventPayload = null) {
+  if (options.pr !== null) {
+    return {
+      mode: 'pull_request',
+      pullRequest: options.pr,
+      baseSha: null,
+      headSha: null
+    };
+  }
+
+  if (options.baseSha && options.headSha) {
+    return {
+      mode: 'compare',
+      pullRequest: null,
+      baseSha: options.baseSha,
+      headSha: options.headSha
+    };
+  }
+
+  if (env.GITHUB_EVENT_NAME === 'pull_request') {
+    const prNumber = Number(eventPayload?.pull_request?.number);
+    if (Number.isInteger(prNumber) && prNumber > 0) {
+      return {
+        mode: 'pull_request',
+        pullRequest: prNumber,
+        baseSha: null,
+        headSha: null
+      };
+    }
+  }
+
+  if (env.GITHUB_EVENT_NAME === 'merge_group') {
+    const baseSha = normalizeSha(eventPayload?.merge_group?.base_sha);
+    const headSha = normalizeSha(eventPayload?.merge_group?.head_sha);
+    if (baseSha && headSha) {
+      return {
+        mode: 'compare',
+        pullRequest: null,
+        baseSha,
+        headSha
+      };
+    }
+  }
+
+  throw new Error(
+    'Unable to resolve commit scope. Provide --pr <number> or --base-sha/--head-sha (required for workflow_dispatch).'
+  );
+}
+
+function compileRegexList(values, { label }) {
+  const compiled = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const pattern = normalizeOptionalString(value);
+    if (!pattern) {
+      continue;
+    }
+    try {
+      compiled.push(new RegExp(pattern, 'i'));
+    } catch (error) {
+      throw new Error(`Invalid ${label} regex '${pattern}': ${error.message}`);
+    }
+  }
+  return compiled;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    repo: '',
+    pr: null,
+    baseSha: null,
+    headSha: null,
+    policyPath: DEFAULT_POLICY_PATH,
+    reportPath: DEFAULT_REPORT_PATH,
+    observeOnly: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === '--observe-only') {
+      options.observeOnly = true;
+      continue;
+    }
+    if (arg === '--repo' || arg === '--pr' || arg === '--base-sha' || arg === '--head-sha' || arg === '--policy' || arg === '--report') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${arg}.`);
+      }
+      index += 1;
+      if (arg === '--repo') {
+        options.repo = String(next).trim();
+      } else if (arg === '--pr') {
+        options.pr = parsePositiveInteger(next, { label: '--pr' });
+      } else if (arg === '--base-sha') {
+        options.baseSha = normalizeSha(next);
+      } else if (arg === '--head-sha') {
+        options.headSha = normalizeSha(next);
+      } else if (arg === '--policy') {
+        options.policyPath = next;
+      } else if (arg === '--report') {
+        options.reportPath = next;
+      }
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if ((options.baseSha && !options.headSha) || (!options.baseSha && options.headSha)) {
+    throw new Error('Both --base-sha and --head-sha are required for compare mode.');
+  }
+
+  return options;
+}
+
+export function classifySourceKind(commit, sourceResolution) {
+  const authorLogin = normalizeOptionalString(commit.authorLogin);
+  const committerLogin = normalizeOptionalString(commit.committerLogin);
+  const authorEmail = normalizeOptionalString(commit.authorEmail);
+  const committerEmail = normalizeOptionalString(commit.committerEmail);
+
+  for (const regex of sourceResolution.botLoginRegexes) {
+    if ((authorLogin && regex.test(authorLogin)) || (committerLogin && regex.test(committerLogin))) {
+      return 'bot';
+    }
+  }
+  for (const regex of sourceResolution.botEmailRegexes) {
+    if ((authorEmail && regex.test(authorEmail)) || (committerEmail && regex.test(committerEmail))) {
+      return 'bot';
+    }
+  }
+
+  return 'human';
+}
+
+export function normalizeCommitRecord(rawRecord, sourceResolution) {
+  const sha = normalizeSha(rawRecord?.sha);
+  if (!sha) {
+    return null;
+  }
+
+  const commit = rawRecord?.commit ?? {};
+  const verification = commit?.verification ?? {};
+  const verificationReason = normalizeOptionalString(verification?.reason) ?? 'unknown';
+  const normalized = {
+    sha,
+    url: normalizeOptionalString(rawRecord?.html_url),
+    messageHeadline: firstLine(commit?.message),
+    verified: verification?.verified === true,
+    verificationReason,
+    verificationSignaturePresent: Boolean(normalizeOptionalString(verification?.signature)),
+    verificationPayloadPresent: Boolean(normalizeOptionalString(verification?.payload)),
+    authorLogin: normalizeOptionalString(rawRecord?.author?.login),
+    committerLogin: normalizeOptionalString(rawRecord?.committer?.login),
+    authorEmail: normalizeOptionalString(commit?.author?.email),
+    committerEmail: normalizeOptionalString(commit?.committer?.email)
+  };
+  normalized.sourceKind = classifySourceKind(normalized, sourceResolution);
+  return normalized;
+}
+
+function commitSort(left, right) {
+  if (left.sha !== right.sha) {
+    return left.sha.localeCompare(right.sha);
+  }
+  const leftUrl = left.url ?? '';
+  const rightUrl = right.url ?? '';
+  if (leftUrl !== rightUrl) {
+    return leftUrl.localeCompare(rightUrl);
+  }
+  return (left.messageHeadline ?? '').localeCompare(right.messageHeadline ?? '');
+}
+
+export function normalizeCommitRecords(rawRecords, sourceResolution) {
+  const normalized = [];
+  for (const rawRecord of Array.isArray(rawRecords) ? rawRecords : []) {
+    const record = normalizeCommitRecord(rawRecord, sourceResolution);
+    if (!record) {
+      continue;
+    }
+    normalized.push(record);
+  }
+  normalized.sort(commitSort);
+  return normalized;
+}
+
+function normalizeChecks(checks = {}) {
+  const rawMaxHeadlineLength = Number(checks.maxHeadlineLength);
+  const normalizedMaxHeadlineLength =
+    Number.isInteger(rawMaxHeadlineLength) && rawMaxHeadlineLength > 0
+      ? rawMaxHeadlineLength
+      : DEFAULT_POLICY_CHECKS.maxHeadlineLength;
+  return {
+    requireAuthorAttribution:
+      checks.requireAuthorAttribution !== undefined
+        ? Boolean(checks.requireAuthorAttribution)
+        : DEFAULT_POLICY_CHECKS.requireAuthorAttribution,
+    requireCommitterAttribution:
+      checks.requireCommitterAttribution !== undefined
+        ? Boolean(checks.requireCommitterAttribution)
+        : DEFAULT_POLICY_CHECKS.requireCommitterAttribution,
+    requireKnownReasonForUnverified:
+      checks.requireKnownReasonForUnverified !== undefined
+        ? Boolean(checks.requireKnownReasonForUnverified)
+        : DEFAULT_POLICY_CHECKS.requireKnownReasonForUnverified,
+    requireUniqueShas:
+      checks.requireUniqueShas !== undefined
+        ? Boolean(checks.requireUniqueShas)
+        : DEFAULT_POLICY_CHECKS.requireUniqueShas,
+    requireNonEmptyHeadline:
+      checks.requireNonEmptyHeadline !== undefined
+        ? Boolean(checks.requireNonEmptyHeadline)
+        : DEFAULT_POLICY_CHECKS.requireNonEmptyHeadline,
+    maxHeadlineLength: normalizedMaxHeadlineLength,
+    requireSignatureMaterialForVerified:
+      checks.requireSignatureMaterialForVerified !== undefined
+        ? Boolean(checks.requireSignatureMaterialForVerified)
+        : DEFAULT_POLICY_CHECKS.requireSignatureMaterialForVerified
+  };
+}
+
+function hasAuthorAttribution(commit) {
+  return Boolean(commit.authorLogin || commit.authorEmail);
+}
+
+function hasCommitterAttribution(commit) {
+  return Boolean(commit.committerLogin || commit.committerEmail);
+}
+
+function addViolation(violations, commit, category, reason) {
+  violations.push({
+    category,
+    sha: commit.sha,
+    reason,
+    messageHeadline: commit.messageHeadline,
+    sourceKind: commit.sourceKind,
+    authorLogin: commit.authorLogin,
+    committerLogin: commit.committerLogin
+  });
+}
+
+export function evaluateCommitIntegrity(commits, { checks = {} } = {}) {
+  const list = Array.isArray(commits) ? commits : [];
+  const effectiveChecks = normalizeChecks(checks);
+  const issues = [];
+  const violations = [];
+  const checkResults = [];
+  const duplicateShas = new Set();
+  const seenShas = new Set();
+
+  if (effectiveChecks.requireUniqueShas) {
+    for (const commit of list) {
+      if (seenShas.has(commit.sha)) {
+        duplicateShas.add(commit.sha);
+      } else {
+        seenShas.add(commit.sha);
+      }
+    }
+    for (const duplicateSha of duplicateShas) {
+      const example = list.find((commit) => commit.sha === duplicateSha);
+      addViolation(violations, example ?? { sha: duplicateSha }, 'duplicate-commit-sha', 'duplicate commit SHA in scope');
+    }
+  }
+
+  for (const commit of list) {
+    if (effectiveChecks.requireNonEmptyHeadline && !commit.messageHeadline) {
+      addViolation(violations, commit, 'empty-headline', 'commit headline is empty');
+    }
+    if (effectiveChecks.maxHeadlineLength > 0 && (commit.messageHeadline?.length ?? 0) > effectiveChecks.maxHeadlineLength) {
+      addViolation(
+        violations,
+        commit,
+        'headline-too-long',
+        `commit headline exceeds ${effectiveChecks.maxHeadlineLength} characters`
+      );
+    }
+    if (
+      effectiveChecks.requireSignatureMaterialForVerified &&
+      commit.verified &&
+      (!commit.verificationSignaturePresent || !commit.verificationPayloadPresent)
+    ) {
+      addViolation(violations, commit, 'missing-signature-material', 'verified commit missing signature or payload');
+    }
+    if (!commit.verified) {
+      addViolation(violations, commit, 'unverified-commit', commit.verificationReason);
+      if (effectiveChecks.requireKnownReasonForUnverified && commit.verificationReason === 'unknown') {
+        addViolation(violations, commit, 'unknown-unverified-reason', 'unknown verification reason');
+      }
+    }
+    if (effectiveChecks.requireAuthorAttribution && !hasAuthorAttribution(commit)) {
+      addViolation(violations, commit, 'missing-author-attribution', 'author login/email missing');
+    }
+    if (effectiveChecks.requireCommitterAttribution && !hasCommitterAttribution(commit)) {
+      addViolation(violations, commit, 'missing-committer-attribution', 'committer login/email missing');
+    }
+  }
+
+  if (list.length === 0) {
+    issues.push('no-commits-found');
+  }
+
+  checkResults.push({
+    name: 'unverified-commit',
+    enabled: true,
+    passed: !violations.some((violation) => violation.category === 'unverified-commit'),
+    failureCount: violations.filter((violation) => violation.category === 'unverified-commit').length
+  });
+  checkResults.push({
+    name: 'unknown-unverified-reason',
+    enabled: effectiveChecks.requireKnownReasonForUnverified,
+    passed:
+      !effectiveChecks.requireKnownReasonForUnverified ||
+      !violations.some((violation) => violation.category === 'unknown-unverified-reason'),
+    failureCount: violations.filter((violation) => violation.category === 'unknown-unverified-reason').length
+  });
+  checkResults.push({
+    name: 'author-attribution',
+    enabled: effectiveChecks.requireAuthorAttribution,
+    passed:
+      !effectiveChecks.requireAuthorAttribution ||
+      !violations.some((violation) => violation.category === 'missing-author-attribution'),
+    failureCount: violations.filter((violation) => violation.category === 'missing-author-attribution').length
+  });
+  checkResults.push({
+    name: 'committer-attribution',
+    enabled: effectiveChecks.requireCommitterAttribution,
+    passed:
+      !effectiveChecks.requireCommitterAttribution ||
+      !violations.some((violation) => violation.category === 'missing-committer-attribution'),
+    failureCount: violations.filter((violation) => violation.category === 'missing-committer-attribution').length
+  });
+  checkResults.push({
+    name: 'duplicate-commit-sha',
+    enabled: effectiveChecks.requireUniqueShas,
+    passed:
+      !effectiveChecks.requireUniqueShas ||
+      !violations.some((violation) => violation.category === 'duplicate-commit-sha'),
+    failureCount: violations.filter((violation) => violation.category === 'duplicate-commit-sha').length
+  });
+  checkResults.push({
+    name: 'empty-headline',
+    enabled: effectiveChecks.requireNonEmptyHeadline,
+    passed:
+      !effectiveChecks.requireNonEmptyHeadline ||
+      !violations.some((violation) => violation.category === 'empty-headline'),
+    failureCount: violations.filter((violation) => violation.category === 'empty-headline').length
+  });
+  checkResults.push({
+    name: 'headline-too-long',
+    enabled: effectiveChecks.maxHeadlineLength > 0,
+    passed:
+      effectiveChecks.maxHeadlineLength <= 0 ||
+      !violations.some((violation) => violation.category === 'headline-too-long'),
+    failureCount: violations.filter((violation) => violation.category === 'headline-too-long').length
+  });
+  checkResults.push({
+    name: 'missing-signature-material',
+    enabled: effectiveChecks.requireSignatureMaterialForVerified,
+    passed:
+      !effectiveChecks.requireSignatureMaterialForVerified ||
+      !violations.some((violation) => violation.category === 'missing-signature-material'),
+    failureCount: violations.filter((violation) => violation.category === 'missing-signature-material').length
+  });
+
+  const summary = {
+    commitCount: list.length,
+    verifiedCount: list.filter((commit) => commit.verified).length,
+    unverifiedCount: list.filter((commit) => !commit.verified).length,
+    violationCount: violations.length,
+    deterministicOrder: 'sha-asc'
+  };
+
+  return {
+    result: issues.length === 0 && violations.length === 0 ? 'pass' : 'fail',
+    issues,
+    checks: checkResults,
+    violations,
+    summary
+  };
+}
+
+function createHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'commit-integrity-check',
+    'X-GitHub-Api-Version': '2022-11-28'
+  };
+}
+
+async function requestJson(url, token, { fetchFn = globalThis.fetch } = {}) {
+  if (typeof fetchFn !== 'function') {
+    throw new Error('Global fetch is unavailable.');
+  }
+  const response = await fetchFn(url, {
+    method: 'GET',
+    headers: createHeaders(token)
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText} -> ${text}`);
+  }
+  return response.json();
+}
+
+async function listPullRequestCommits(repo, pullRequest, token, { fetchFn = globalThis.fetch } = {}) {
+  const commits = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const url = `https://api.github.com/repos/${repo}/pulls/${pullRequest}/commits?per_page=100&page=${page}`;
+    const payload = await requestJson(url, token, { fetchFn });
+    const pageItems = Array.isArray(payload) ? payload : [];
+    if (pageItems.length === 0) {
+      break;
+    }
+    commits.push(...pageItems);
+    if (pageItems.length < 100) {
+      break;
+    }
+  }
+  return commits;
+}
+
+async function listCompareCommits(repo, baseSha, headSha, token, { fetchFn = globalThis.fetch } = {}) {
+  const url = `https://api.github.com/repos/${repo}/compare/${baseSha}...${headSha}`;
+  const payload = await requestJson(url, token, { fetchFn });
+  return Array.isArray(payload?.commits) ? payload.commits : [];
+}
+
+async function loadPolicy(policyPath) {
+  const resolved = path.resolve(policyPath);
+  const raw = await readFile(resolved, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  const sourceResolution = parsed?.source_resolution ?? {};
+  const checkSettings = parsed?.checks ?? {};
+  const policy = {
+    path: resolved,
+    schema: normalizeOptionalString(parsed?.schema) ?? 'commit-integrity-policy/v1',
+    failOnUnverified: parsed?.verification?.fail_on_unverified !== false,
+    checks: normalizeChecks({
+      requireAuthorAttribution: checkSettings.require_author_attribution,
+      requireCommitterAttribution: checkSettings.require_committer_attribution,
+      requireKnownReasonForUnverified: checkSettings.require_non_unknown_reason_for_unverified,
+      requireUniqueShas: checkSettings.require_unique_shas,
+      requireNonEmptyHeadline: checkSettings.require_non_empty_headline,
+      maxHeadlineLength: checkSettings.max_headline_length,
+      requireSignatureMaterialForVerified: checkSettings.require_signature_material_for_verified
+    }),
+    sourceResolution: {
+      botLoginRegexes: compileRegexList(sourceResolution.bot_login_patterns, {
+        label: 'source_resolution.bot_login_patterns'
+      }),
+      botEmailRegexes: compileRegexList(sourceResolution.bot_email_patterns, {
+        label: 'source_resolution.bot_email_patterns'
+      })
+    }
+  };
+  return policy;
+}
+
+async function writeReport(reportPath, report) {
+  const resolvedPath = path.resolve(reportPath);
+  await mkdir(path.dirname(resolvedPath), { recursive: true });
+  await writeFile(resolvedPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+function buildReport({
+  repository,
+  scope,
+  policy,
+  observeOnly,
+  commits,
+  evaluation,
+  errors = [],
+  generatedAt = new Date().toISOString()
+}) {
+  const blocking = !observeOnly && policy.failOnUnverified;
+  const shouldFailProcess = blocking && evaluation.result === 'fail';
+  return {
+    schema: 'commit-integrity/report@v1',
+    schemaVersion: '1.0.0',
+    generatedAt,
+    repository,
+    scope: {
+      mode: scope.mode,
+      pullRequest: scope.pullRequest ?? null,
+      baseSha: scope.baseSha ?? null,
+      headSha: scope.headSha ?? null
+    },
+    policy: {
+      schema: policy.schema,
+      path: policy.path,
+      failOnUnverified: policy.failOnUnverified,
+      checks: {
+        requireAuthorAttribution: policy.checks.requireAuthorAttribution,
+        requireCommitterAttribution: policy.checks.requireCommitterAttribution,
+        requireKnownReasonForUnverified: policy.checks.requireKnownReasonForUnverified,
+        requireUniqueShas: policy.checks.requireUniqueShas,
+        requireNonEmptyHeadline: policy.checks.requireNonEmptyHeadline,
+        maxHeadlineLength: policy.checks.maxHeadlineLength,
+        requireSignatureMaterialForVerified: policy.checks.requireSignatureMaterialForVerified
+      },
+      sourceResolution: {
+        botLoginPatternCount: policy.sourceResolution.botLoginRegexes.length,
+        botEmailPatternCount: policy.sourceResolution.botEmailRegexes.length
+      }
+    },
+    enforcement: {
+      observeOnly,
+      blocking
+    },
+    checks: evaluation.checks,
+    summary: evaluation.summary,
+    commits,
+    violations: evaluation.violations,
+    issues: evaluation.issues,
+    result: evaluation.result,
+    errors: Array.isArray(errors) ? errors : [],
+    exitCode: shouldFailProcess ? 1 : 0
+  };
+}
+
+export async function runCommitIntegrity({
+  argv = process.argv,
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  readFileFn = readFile,
+  accessFn = access,
+  execSyncFn = execSync,
+  log = console.log,
+  warn = console.warn
+} = {}) {
+  let options = {
+    reportPath: DEFAULT_REPORT_PATH
+  };
+  let report = null;
+
+  try {
+    options = parseArgs(argv);
+    const repository = resolveRepository(options, env, execSyncFn);
+    const eventPayload = await loadEventPayload(env, { readFileFn });
+    const scope = resolveScope(options, env, eventPayload);
+    const token = await resolveToken(env, { readFileFn, accessFn });
+    const policy = await loadPolicy(options.policyPath);
+
+    const rawCommits =
+      scope.mode === 'pull_request'
+        ? await listPullRequestCommits(repository, scope.pullRequest, token, { fetchFn })
+        : await listCompareCommits(repository, scope.baseSha, scope.headSha, token, { fetchFn });
+    const commits = normalizeCommitRecords(rawCommits, policy.sourceResolution);
+    const evaluation = evaluateCommitIntegrity(commits, {
+      checks: policy.checks
+    });
+
+    report = buildReport({
+      repository,
+      scope,
+      policy,
+      observeOnly: options.observeOnly,
+      commits,
+      evaluation
+    });
+
+    const resolvedReportPath = await writeReport(options.reportPath, report);
+    log(`[commit-integrity] report: ${resolvedReportPath}`);
+    if (report.result === 'fail' && report.exitCode === 1) {
+      throw new Error(
+        `Commit integrity validation failed: ${report.violations.length} violation(s), ${report.issues.length} issue(s).`
+      );
+    }
+    if (report.result === 'fail' && options.observeOnly) {
+      warn(
+        `[commit-integrity] observe-only mode: ${report.violations.length} violation(s), ${report.issues.length} issue(s).`
+      );
+    } else {
+      log(
+        `[commit-integrity] PASS commits=${report.summary.commitCount} verified=${report.summary.verifiedCount} unverified=${report.summary.unverifiedCount}`
+      );
+    }
+    return report.exitCode;
+  } catch (error) {
+    if (!report) {
+      report = {
+        schema: 'commit-integrity/report@v1',
+        schemaVersion: '1.0.0',
+        generatedAt: new Date().toISOString(),
+        repository: normalizeOptionalString(env.GITHUB_REPOSITORY),
+        scope: {
+          mode: 'unknown',
+          pullRequest: null,
+          baseSha: null,
+          headSha: null
+        },
+        policy: {
+          schema: 'commit-integrity-policy/v1',
+          path: path.resolve(options.policyPath ?? DEFAULT_POLICY_PATH),
+          failOnUnverified: true,
+          checks: {
+            requireAuthorAttribution: DEFAULT_POLICY_CHECKS.requireAuthorAttribution,
+            requireCommitterAttribution: DEFAULT_POLICY_CHECKS.requireCommitterAttribution,
+            requireKnownReasonForUnverified: DEFAULT_POLICY_CHECKS.requireKnownReasonForUnverified,
+            requireUniqueShas: DEFAULT_POLICY_CHECKS.requireUniqueShas,
+            requireNonEmptyHeadline: DEFAULT_POLICY_CHECKS.requireNonEmptyHeadline,
+            maxHeadlineLength: DEFAULT_POLICY_CHECKS.maxHeadlineLength,
+            requireSignatureMaterialForVerified: DEFAULT_POLICY_CHECKS.requireSignatureMaterialForVerified
+          },
+          sourceResolution: {
+            botLoginPatternCount: 0,
+            botEmailPatternCount: 0
+          }
+        },
+        enforcement: {
+          observeOnly: Boolean(options.observeOnly),
+          blocking: true
+        },
+        checks: [],
+        summary: {
+          commitCount: 0,
+          verifiedCount: 0,
+          unverifiedCount: 0,
+          violationCount: 0,
+          deterministicOrder: 'sha-asc'
+        },
+        commits: [],
+        violations: [],
+        issues: ['runtime-error'],
+        result: 'fail',
+        errors: [],
+        exitCode: 1
+      };
+    }
+    report.errors = [...(Array.isArray(report.errors) ? report.errors : []), error.message ?? String(error)];
+    report.result = 'fail';
+    report.exitCode = 1;
+    await writeReport(options.reportPath ?? DEFAULT_REPORT_PATH, report);
+    throw error;
+  }
+}
+
+export const __test = Object.freeze({
+  resolveScope,
+  classifySourceKind,
+  normalizeCommitRecord,
+  normalizeCommitRecords,
+  evaluateCommitIntegrity,
+  buildReport
+});
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  runCommitIntegrity()
+    .then((exitCode) => {
+      if (exitCode !== 0) {
+        process.exitCode = exitCode;
+      }
+    })
+    .catch((error) => {
+      console.error(error.message || error);
+      process.exitCode = 1;
+    });
+}

--- a/tools/priority/policy.json
+++ b/tools/priority/policy.json
@@ -20,6 +20,9 @@
         "hook-parity (ubuntu-latest)",
         "vi-history-scenarios-linux"
       ],
+      "observed_status_checks": [
+        "commit-integrity / commit-integrity"
+      ],
       "required_linear_history": true,
       "enforce_admins": false,
       "required_pull_request_reviews": null,
@@ -39,6 +42,9 @@
         "vi-binary-check",
         "vi-compare",
         "Policy Guard (Upstream) / policy-guard"
+      ],
+      "observed_status_checks": [
+        "commit-integrity / commit-integrity"
       ],
       "required_linear_history": true,
       "enforce_admins": false,
@@ -82,6 +88,9 @@
         "hook-parity (ubuntu-latest)",
         "vi-history-scenarios-linux"
       ],
+      "observed_status_checks": [
+        "commit-integrity / commit-integrity"
+      ],
       "merge_queue": {
         "merge_method": "SQUASH",
         "grouping_strategy": "ALLGREEN",
@@ -114,6 +123,9 @@
         "vi-binary-check",
         "vi-compare",
         "Policy Guard (Upstream) / policy-guard"
+      ],
+      "observed_status_checks": [
+        "commit-integrity / commit-integrity"
       ],
       "merge_queue": {
         "merge_method": "SQUASH",


### PR DESCRIPTION
## Summary
- implement `commit-integrity` checker at `tools/priority/commit-integrity.mjs` with deterministic commit ordering (`sha-asc`)
- evaluate all PR-scope commits and fail on unverified commits with explicit per-commit reasons/categories
- expand coverage with policy-driven checks:
  - unknown unverified reason
  - author/committer attribution completeness
  - duplicate SHA detection
  - headline quality (empty / max length)
  - optional signature-material check for verified commits
- add defork-safe policy seam (`tools/policy/commit-integrity-policy.json`) with no hardcoded owner assumptions in runtime logic
- add workflow `.github/workflows/commit-integrity.yml` with observe-only/enforce rollout control (`COMMIT_INTEGRITY_ENFORCE`)
- add deterministic artifact + schema contract:
  - artifact: `tests/results/_agent/commit-integrity/commit-integrity-report.json`
  - schema: `docs/schemas/commit-integrity-report-v1.schema.json`
- wire observe-only entries into policy manifests:
  - `tools/policy/branch-required-checks.json` (`observed`)
  - `tools/priority/policy.json` (`observed_status_checks`)
- add governance drift guard:
  - `tools/Assert-CommitIntegrityContract.ps1`
  - CI/local enforcement in `.github/workflows/workflows-lint.yml` and `tools/PrePush-Checks.ps1`

## Verification
- `node --test tools/priority/__tests__/commit-integrity.test.mjs tools/priority/__tests__/commit-integrity-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/CommitIntegrityContract.Tests.ps1 -Output Detailed -CI"`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `node tools/npm/run-script.mjs docs:manifest:validate`

## Rollout
- Phase 1 (this PR): observe-only mode by default via `COMMIT_INTEGRITY_ENFORCE=0`.
- Enable enforcement by setting `COMMIT_INTEGRITY_ENFORCE=1` once stability window criteria are met.

Closes #743.
