### PR TITLE
feat: add deterministic agent single-writer lease manager (#733)

### DIFF
--- a/docs/SESSION_LOCK_HANDOFF.md
+++ b/docs/SESSION_LOCK_HANDOFF.md
@@ -27,6 +27,27 @@ tools/SessionLock-Takeover.ps1 -Group pester-selfhosted
 | `SESSION_LOCK_FORCE` | Force takeover when stale |
 | `SESSION_LOCK_STRICT` | Fail run if lock cannot be acquired |
 
+## Agent writer lease (`#733`)
+
+Repository-wide single-writer coordination for agent sessions now uses `tools/priority/agent-writer-lease.mjs`.
+
+```bash
+# Acquire lease for workspace mutations
+node tools/npm/run-script.mjs priority:lease -- --action acquire --scope workspace
+
+# Inspect / heartbeat / release
+node tools/npm/run-script.mjs priority:lease -- --action inspect --scope workspace
+node tools/npm/run-script.mjs priority:lease -- --action heartbeat --scope workspace
+node tools/npm/run-script.mjs priority:lease -- --action release --scope workspace
+```
+
+Default lease root is `.git/agent-writer-leases/` (keeps workspaces clean). Useful controls:
+
+- `AGENT_WRITER_LEASE_ENABLED=0` disables bootstrap acquisition.
+- `AGENT_WRITER_LEASE_STALE_SECONDS=<n>` adjusts stale threshold.
+- `AGENT_WRITER_LEASE_FORCE_TAKEOVER=1` allows stale takeover.
+- `AGENT_WRITER_LEASE_MAX_ATTEMPTS=<n>` + `AGENT_WRITER_LEASE_WAIT_MS=<n>` tune contention retry behavior.
+
 ## Handoff checklist
 
 1. Read `AGENT_HANDOFF.txt` for context.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "priority:handoff": "pwsh -NoLogo -NoProfile -File tools/priority/Import-HandoffState.ps1",
     "priority:handoff-tests": "node tools/priority/run-handoff-tests.mjs",
     "priority:health-snapshot": "pwsh -NoLogo -NoProfile -File tools/priority/Write-HealthSnapshot.ps1",
+    "priority:lease": "node tools/priority/agent-writer-lease.mjs",
     "priority:queue:supervisor": "node tools/priority/queue-supervisor.mjs",
     "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
     "priority:commit-integrity": "node tools/priority/commit-integrity.mjs",

--- a/tools/priority/__tests__/agent-writer-lease.test.mjs
+++ b/tools/priority/__tests__/agent-writer-lease.test.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  acquireWriterLease,
+  heartbeatWriterLease,
+  inspectWriterLease,
+  releaseWriterLease
+} from '../agent-writer-lease.mjs';
+
+function randomTempRoot(prefix) {
+  return path.join(
+    os.tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`
+  );
+}
+
+test('acquire blocks second owner while lease is active', async () => {
+  const leaseRoot = randomTempRoot('agent-writer-lease-active');
+  const first = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a',
+    staleSeconds: 600
+  });
+  assert.equal(first.status, 'acquired');
+
+  const second = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-b',
+    staleSeconds: 600,
+    maxAttempts: 0
+  });
+  assert.equal(second.status, 'busy');
+  assert.equal(second.holder, 'owner-a');
+
+  const release = await releaseWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a'
+  });
+  assert.equal(release.status, 'released');
+});
+
+test('acquire can renew heartbeat for same owner', async () => {
+  const leaseRoot = randomTempRoot('agent-writer-lease-renew');
+  const first = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a'
+  });
+  assert.equal(first.status, 'acquired');
+
+  const renewed = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a'
+  });
+  assert.equal(renewed.status, 'renewed');
+  assert.equal(renewed.lease.owner, 'owner-a');
+  assert.equal(renewed.lease.leaseId, first.lease.leaseId);
+});
+
+test('stale lease requires explicit takeover and supports force takeover', async () => {
+  const leaseRoot = randomTempRoot('agent-writer-lease-stale');
+  const first = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a',
+    staleSeconds: 600
+  });
+  assert.equal(first.status, 'acquired');
+
+  const leasePath = path.join(leaseRoot, 'workspace.json');
+  const stale = { ...first.lease, heartbeatAt: new Date(Date.now() - 3_600_000).toISOString() };
+  await fs.mkdir(path.dirname(leasePath), { recursive: true });
+  await fs.writeFile(leasePath, `${JSON.stringify(stale, null, 2)}\n`, 'utf8');
+
+  const blocked = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-b',
+    staleSeconds: 300,
+    forceTakeover: false
+  });
+  assert.equal(blocked.status, 'stale');
+  assert.equal(blocked.holder, 'owner-a');
+
+  const takeover = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-b',
+    staleSeconds: 300,
+    forceTakeover: true
+  });
+  assert.equal(takeover.status, 'takeover');
+  assert.equal(takeover.lease.owner, 'owner-b');
+  assert.equal(takeover.previousLease.owner, 'owner-a');
+});
+
+test('release and heartbeat enforce owner or lease-id matching', async () => {
+  const leaseRoot = randomTempRoot('agent-writer-lease-ownership');
+  const acquired = await acquireWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a'
+  });
+  assert.equal(acquired.status, 'acquired');
+
+  const mismatch = await releaseWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-b'
+  });
+  assert.equal(mismatch.status, 'mismatch');
+
+  const heartbeat = await heartbeatWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-b',
+    leaseId: acquired.lease.leaseId
+  });
+  assert.equal(heartbeat.status, 'renewed');
+
+  const released = await releaseWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-b',
+    leaseId: acquired.lease.leaseId
+  });
+  assert.equal(released.status, 'released');
+
+  const inspect = await inspectWriterLease({
+    leaseRoot,
+    scope: 'workspace',
+    owner: 'owner-a'
+  });
+  assert.equal(inspect.status, 'not-found');
+});

--- a/tools/priority/__tests__/standing-priority-handoff.test.mjs
+++ b/tools/priority/__tests__/standing-priority-handoff.test.mjs
@@ -6,6 +6,7 @@ import { handoffStandingPriority } from '../standing-priority-handoff.mjs';
 
 test('handoffStandingPriority removes old label, adds new, and syncs cache', async () => {
   const calls = [];
+  let leaseReleaseCount = 0;
   const ghRunner = (args) => {
     calls.push(args);
     if (args[0] === 'issue' && args[1] === 'list') {
@@ -17,18 +18,24 @@ test('handoffStandingPriority removes old label, adds new, and syncs cache', asy
   const syncFn = async () => {
     syncCount += 1;
   };
+  const leaseReleaseFn = async () => {
+    leaseReleaseCount += 1;
+    return { status: 'released' };
+  };
 
-  await handoffStandingPriority(529, { ghRunner, syncFn, logger: () => {} });
+  await handoffStandingPriority(529, { ghRunner, syncFn, leaseReleaseFn, logger: () => {} });
 
   assert.deepEqual(calls, [
     ['issue', 'list', '--label', 'standing-priority', '--state', 'open', '--limit', '20', '--json', 'number'],
     ['issue', 'edit', '528', '--remove-label', 'standing-priority']
   ]);
   assert.equal(syncCount, 1);
+  assert.equal(leaseReleaseCount, 1);
 });
 
 test('handoffStandingPriority adds label when none present', async () => {
   const calls = [];
+  let leaseReleaseCount = 0;
   const ghRunner = (args) => {
     calls.push(args);
     if (args[0] === 'issue' && args[1] === 'list') {
@@ -40,18 +47,24 @@ test('handoffStandingPriority adds label when none present', async () => {
   const syncFn = async () => {
     syncCount += 1;
   };
+  const leaseReleaseFn = async () => {
+    leaseReleaseCount += 1;
+    return { status: 'not-found' };
+  };
 
-  await handoffStandingPriority('530', { ghRunner, syncFn, logger: () => {} });
+  await handoffStandingPriority('530', { ghRunner, syncFn, leaseReleaseFn, logger: () => {} });
 
   assert.deepEqual(calls, [
     ['issue', 'list', '--label', 'standing-priority', '--state', 'open', '--limit', '20', '--json', 'number'],
     ['issue', 'edit', '530', '--add-label', 'standing-priority']
   ]);
   assert.equal(syncCount, 1);
+  assert.equal(leaseReleaseCount, 1);
 });
 
 test('dry-run only inspects current issues', async () => {
   const calls = [];
+  let leaseReleaseCount = 0;
   const ghRunner = (args) => {
     calls.push(args);
     if (args[0] === 'issue' && args[1] === 'list') {
@@ -59,10 +72,15 @@ test('dry-run only inspects current issues', async () => {
     }
     return '';
   };
+  const leaseReleaseFn = async () => {
+    leaseReleaseCount += 1;
+    return { status: 'released' };
+  };
 
-  await handoffStandingPriority(532, { ghRunner, dryRun: true, logger: () => {} });
+  await handoffStandingPriority(532, { ghRunner, dryRun: true, leaseReleaseFn, logger: () => {} });
 
   assert.deepEqual(calls, [
     ['issue', 'list', '--label', 'standing-priority', '--state', 'open', '--limit', '20', '--json', 'number']
   ]);
+  assert.equal(leaseReleaseCount, 0);
 });

--- a/tools/priority/agent-writer-lease.mjs
+++ b/tools/priority/agent-writer-lease.mjs
@@ -1,0 +1,472 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(MODULE_DIR, '..', '..');
+const DEFAULT_SCOPE = 'workspace';
+const DEFAULT_STALE_SECONDS = 900;
+const DEFAULT_WAIT_MS = 250;
+const DEFAULT_MAX_ATTEMPTS = 0;
+
+const STATUS = Object.freeze({
+  acquired: 'acquired',
+  renewed: 'renewed',
+  takeover: 'takeover',
+  busy: 'busy',
+  stale: 'stale',
+  released: 'released',
+  notFound: 'not-found',
+  mismatch: 'mismatch',
+  active: 'active'
+});
+
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function envBool(name, fallback = false) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  return raw === '1' || raw.toLowerCase() === 'true';
+}
+
+export function defaultLeaseRoot() {
+  return process.env.AGENT_WRITER_LEASE_ROOT || path.join(REPO_ROOT, '.git', 'agent-writer-leases');
+}
+
+export function defaultOwner() {
+  const actor =
+    process.env.AGENT_WRITER_LEASE_ACTOR ||
+    process.env.GITHUB_ACTOR ||
+    process.env.USERNAME ||
+    process.env.USER ||
+    'unknown';
+  const session = process.env.AGENT_SESSION_NAME || process.env.PS_SESSION_NAME || 'default';
+  return `${actor}@${os.hostname()}:${session}`;
+}
+
+export function leasePathForScope(scope, leaseRoot = defaultLeaseRoot()) {
+  return path.join(leaseRoot, `${scope}.json`);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function leaseAgeSeconds(lease, nowMs = Date.now()) {
+  const heartbeat = lease?.heartbeatAt || lease?.acquiredAt;
+  if (!heartbeat) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(heartbeat);
+  if (!Number.isFinite(parsed)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, (nowMs - parsed) / 1000);
+}
+
+async function ensureParentDir(filePath) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function readLease(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    if (!raw.trim()) return null;
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+async function writeJsonAtomic(filePath, payload, { createOnly = false } = {}) {
+  await ensureParentDir(filePath);
+  const body = `${JSON.stringify(payload, null, 2)}\n`;
+  if (createOnly) {
+    await fs.writeFile(filePath, body, { encoding: 'utf8', flag: 'wx' });
+    return;
+  }
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tempPath, body, { encoding: 'utf8' });
+  await fs.rename(tempPath, filePath);
+}
+
+function buildBaseResult(action, scope, leasePath, owner) {
+  return {
+    schema: 'agent/writer-lease-result@v1',
+    action,
+    scope,
+    leasePath,
+    owner,
+    checkedAt: nowIso()
+  };
+}
+
+function createLeaseRecord({ scope, owner, leaseId, takeoverFrom = null, takeoverReason = null }) {
+  const timestamp = nowIso();
+  const record = {
+    schema: 'agent/writer-lease@v1',
+    scope,
+    leaseId,
+    owner,
+    acquiredAt: timestamp,
+    heartbeatAt: timestamp
+  };
+  if (takeoverFrom) {
+    record.takeover = {
+      fromOwner: takeoverFrom,
+      reason: takeoverReason || 'stale-lease'
+    };
+  }
+  return record;
+}
+
+function normalizeAcquireOptions(options = {}) {
+  return {
+    scope: options.scope || DEFAULT_SCOPE,
+    owner: options.owner || defaultOwner(),
+    leaseRoot: options.leaseRoot || defaultLeaseRoot(),
+    staleSeconds: Number.isFinite(options.staleSeconds)
+      ? options.staleSeconds
+      : envInt('AGENT_WRITER_LEASE_STALE_SECONDS', DEFAULT_STALE_SECONDS),
+    waitMs: Number.isFinite(options.waitMs) ? options.waitMs : envInt('AGENT_WRITER_LEASE_WAIT_MS', DEFAULT_WAIT_MS),
+    maxAttempts: Number.isFinite(options.maxAttempts)
+      ? options.maxAttempts
+      : envInt('AGENT_WRITER_LEASE_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS),
+    forceTakeover: options.forceTakeover ?? envBool('AGENT_WRITER_LEASE_FORCE_TAKEOVER', false)
+  };
+}
+
+function normalizeReleaseOptions(options = {}) {
+  return {
+    scope: options.scope || DEFAULT_SCOPE,
+    owner: options.owner || defaultOwner(),
+    leaseRoot: options.leaseRoot || defaultLeaseRoot(),
+    leaseId: options.leaseId || process.env.AGENT_WRITER_LEASE_ID || ''
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+export async function inspectWriterLease(options = {}) {
+  const { scope, owner, leaseRoot, staleSeconds } = normalizeAcquireOptions(options);
+  const leasePath = leasePathForScope(scope, leaseRoot);
+  const base = buildBaseResult('inspect', scope, leasePath, owner);
+  const lease = await readLease(leasePath);
+  if (!lease) {
+    return { ...base, status: STATUS.notFound, lease: null };
+  }
+  const ageSeconds = leaseAgeSeconds(lease);
+  return {
+    ...base,
+    status: STATUS.active,
+    ageSeconds,
+    stale: ageSeconds > staleSeconds,
+    lease
+  };
+}
+
+export async function acquireWriterLease(options = {}) {
+  const normalized = normalizeAcquireOptions(options);
+  const { scope, owner, leaseRoot, staleSeconds, waitMs, maxAttempts, forceTakeover } = normalized;
+  const leasePath = leasePathForScope(scope, leaseRoot);
+  const base = buildBaseResult('acquire', scope, leasePath, owner);
+
+  let attempt = 0;
+  while (true) {
+    const leaseId = options.leaseId || `${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2, 10)}`;
+    const freshLease = createLeaseRecord({ scope, owner, leaseId });
+    try {
+      await writeJsonAtomic(leasePath, freshLease, { createOnly: true });
+      return { ...base, status: STATUS.acquired, attempt, lease: freshLease };
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+
+    const current = await readLease(leasePath);
+    if (!current) {
+      if (attempt >= maxAttempts) {
+        return { ...base, status: STATUS.busy, attempt, reason: 'lease-file-race', lease: null };
+      }
+      attempt += 1;
+      await sleep(waitMs);
+      continue;
+    }
+
+    const ageSeconds = leaseAgeSeconds(current);
+    const isStale = ageSeconds > staleSeconds;
+
+    if (current.owner === owner) {
+      const renewed = {
+        ...current,
+        heartbeatAt: nowIso()
+      };
+      await writeJsonAtomic(leasePath, renewed);
+      return { ...base, status: STATUS.renewed, attempt, ageSeconds, lease: renewed };
+    }
+
+    if (isStale) {
+      if (!forceTakeover) {
+        return {
+          ...base,
+          status: STATUS.stale,
+          attempt,
+          ageSeconds,
+          staleSeconds,
+          holder: current.owner,
+          lease: current
+        };
+      }
+      const takeover = createLeaseRecord({
+        scope,
+        owner,
+        leaseId,
+        takeoverFrom: current.owner,
+        takeoverReason: `stale>${staleSeconds}s`
+      });
+      await writeJsonAtomic(leasePath, takeover);
+      return {
+        ...base,
+        status: STATUS.takeover,
+        attempt,
+        ageSeconds,
+        staleSeconds,
+        previousLease: current,
+        lease: takeover
+      };
+    }
+
+    if (attempt >= maxAttempts) {
+      return {
+        ...base,
+        status: STATUS.busy,
+        attempt,
+        ageSeconds,
+        staleSeconds,
+        holder: current.owner,
+        lease: current
+      };
+    }
+
+    attempt += 1;
+    await sleep(waitMs);
+  }
+}
+
+export async function releaseWriterLease(options = {}) {
+  const { scope, owner, leaseRoot, leaseId } = normalizeReleaseOptions(options);
+  const leasePath = leasePathForScope(scope, leaseRoot);
+  const base = buildBaseResult('release', scope, leasePath, owner);
+  const current = await readLease(leasePath);
+  if (!current) {
+    return { ...base, status: STATUS.notFound, lease: null };
+  }
+
+  const ownerMatches = current.owner === owner;
+  const leaseIdMatches = leaseId && current.leaseId === leaseId;
+  if (!ownerMatches && !leaseIdMatches) {
+    return {
+      ...base,
+      status: STATUS.mismatch,
+      lease: current,
+      reason: 'owner-or-lease-id-mismatch'
+    };
+  }
+
+  await fs.rm(leasePath, { force: true });
+  return { ...base, status: STATUS.released, lease: current };
+}
+
+export async function heartbeatWriterLease(options = {}) {
+  const { scope, owner, leaseRoot, leaseId } = normalizeReleaseOptions(options);
+  const leasePath = leasePathForScope(scope, leaseRoot);
+  const base = buildBaseResult('heartbeat', scope, leasePath, owner);
+  const current = await readLease(leasePath);
+  if (!current) {
+    return { ...base, status: STATUS.notFound, lease: null };
+  }
+
+  const ownerMatches = current.owner === owner;
+  const leaseIdMatches = leaseId && current.leaseId === leaseId;
+  if (!ownerMatches && !leaseIdMatches) {
+    return {
+      ...base,
+      status: STATUS.mismatch,
+      lease: current,
+      reason: 'owner-or-lease-id-mismatch'
+    };
+  }
+
+  const next = { ...current, heartbeatAt: nowIso() };
+  await writeJsonAtomic(leasePath, next);
+  return { ...base, status: STATUS.renewed, lease: next };
+}
+
+async function maybeWriteReport(reportPath, payload) {
+  if (!reportPath) return;
+  await ensureParentDir(reportPath);
+  await fs.writeFile(reportPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const parsed = {
+    action: '',
+    scope: DEFAULT_SCOPE,
+    owner: '',
+    leaseRoot: '',
+    leaseId: '',
+    staleSeconds: undefined,
+    waitMs: undefined,
+    maxAttempts: undefined,
+    forceTakeover: false,
+    report: '',
+    quiet: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    switch (token) {
+      case '--action':
+        parsed.action = argv[++index] || '';
+        break;
+      case '--scope':
+        parsed.scope = argv[++index] || DEFAULT_SCOPE;
+        break;
+      case '--owner':
+        parsed.owner = argv[++index] || '';
+        break;
+      case '--lease-root':
+        parsed.leaseRoot = argv[++index] || '';
+        break;
+      case '--lease-id':
+        parsed.leaseId = argv[++index] || '';
+        break;
+      case '--stale-seconds':
+        parsed.staleSeconds = Number.parseInt(argv[++index] || '', 10);
+        break;
+      case '--wait-ms':
+        parsed.waitMs = Number.parseInt(argv[++index] || '', 10);
+        break;
+      case '--max-attempts':
+        parsed.maxAttempts = Number.parseInt(argv[++index] || '', 10);
+        break;
+      case '--force-takeover':
+        parsed.forceTakeover = true;
+        break;
+      case '--report':
+        parsed.report = argv[++index] || '';
+        break;
+      case '--quiet':
+        parsed.quiet = true;
+        break;
+      case '--help':
+      case '-h':
+        parsed.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  return parsed;
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node tools/priority/agent-writer-lease.mjs --action <acquire|release|heartbeat|inspect> [options]
+
+Options:
+  --scope <name>            Lease scope (default: workspace)
+  --owner <value>           Lease owner identity
+  --lease-root <path>       Lease root directory (default: .git/agent-writer-leases)
+  --lease-id <id>           Optional lease id matcher for release/heartbeat
+  --stale-seconds <n>       Stale threshold for acquire/inspect
+  --wait-ms <n>             Wait interval between retries (acquire)
+  --max-attempts <n>        Retry attempts before reporting busy (acquire)
+  --force-takeover          Allow stale lease takeover (acquire)
+  --report <path>           Write deterministic report JSON
+  --quiet                   Suppress stdout JSON output
+`);
+}
+
+function exitCodeForResult(result) {
+  if (!result) return 1;
+  switch (result.action) {
+    case 'acquire':
+      if ([STATUS.acquired, STATUS.renewed, STATUS.takeover].includes(result.status)) return 0;
+      if (result.status === STATUS.busy) return 10;
+      if (result.status === STATUS.stale) return 11;
+      return 1;
+    case 'release':
+      if ([STATUS.released, STATUS.notFound].includes(result.status)) return 0;
+      if (result.status === STATUS.mismatch) return 12;
+      return 1;
+    case 'heartbeat':
+      if (result.status === STATUS.renewed) return 0;
+      if (result.status === STATUS.notFound) return 13;
+      if (result.status === STATUS.mismatch) return 12;
+      return 1;
+    case 'inspect':
+      return result.status === STATUS.active ? 0 : 1;
+    default:
+      return 1;
+  }
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help || !options.action) {
+    printUsage();
+    return 0;
+  }
+
+  let result;
+  if (options.action === 'acquire') {
+    result = await acquireWriterLease(options);
+  } else if (options.action === 'release') {
+    result = await releaseWriterLease(options);
+  } else if (options.action === 'heartbeat') {
+    result = await heartbeatWriterLease(options);
+  } else if (options.action === 'inspect') {
+    result = await inspectWriterLease(options);
+  } else {
+    throw new Error(`Unsupported action '${options.action}'.`);
+  }
+
+  if (options.report) {
+    await maybeWriteReport(options.report, result);
+  }
+  if (!options.quiet) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }
+  return exitCodeForResult(result);
+}
+
+export const __test = {
+  leaseAgeSeconds,
+  parseArgs
+};
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  try {
+    const code = await runCli();
+    process.exit(code);
+  } catch (error) {
+    const failure = {
+      schema: 'agent/writer-lease-result@v1',
+      action: 'error',
+      status: 'error',
+      message: error?.message || String(error)
+    };
+    process.stderr.write(`${JSON.stringify(failure, null, 2)}\n`);
+    process.exit(1);
+  }
+}

--- a/tools/priority/bootstrap.ps1
+++ b/tools/priority/bootstrap.ps1
@@ -91,6 +91,104 @@ function Invoke-SemVerCheck {
   }
 }
 
+function Invoke-AgentWriterLeaseAcquire {
+  if ($env:AGENT_WRITER_LEASE_ENABLED -eq '0') {
+    Write-Host '[bootstrap] Agent writer lease disabled (AGENT_WRITER_LEASE_ENABLED=0).'
+    return $null
+  }
+
+  if ($env:GITHUB_ACTIONS -eq 'true' -and $env:AGENT_WRITER_LEASE_ALLOW_CI -ne '1') {
+    Write-Host '[bootstrap] Skipping agent writer lease in GitHub Actions context.'
+    return $null
+  }
+
+  $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $nodeCmd) {
+    Write-Warning 'node not found; skipping agent writer lease.'
+    return $null
+  }
+
+  $leaseScript = Join-Path (Resolve-Path '.').Path 'tools/priority/agent-writer-lease.mjs'
+  if (-not (Test-Path -LiteralPath $leaseScript -PathType Leaf)) {
+    Write-Warning "Agent writer lease script not found at $leaseScript"
+    return $null
+  }
+
+  $owner = $env:AGENT_WRITER_LEASE_OWNER
+  if ([string]::IsNullOrWhiteSpace($owner)) {
+    $user = if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ACTOR)) { $env:GITHUB_ACTOR } elseif (-not [string]::IsNullOrWhiteSpace($env:USERNAME)) { $env:USERNAME } elseif (-not [string]::IsNullOrWhiteSpace($env:USER)) { $env:USER } else { 'unknown' }
+    $session = if (-not [string]::IsNullOrWhiteSpace($env:AGENT_SESSION_NAME)) { $env:AGENT_SESSION_NAME } elseif (-not [string]::IsNullOrWhiteSpace($env:PS_SESSION_NAME)) { $env:PS_SESSION_NAME } else { 'default' }
+    $owner = "{0}@{1}:{2}" -f $user, [System.Environment]::MachineName, $session
+  }
+
+  $reportPath = Join-Path (Resolve-Path '.').Path 'tests/results/_agent/lease/bootstrap-lease.json'
+  $arguments = @(
+    $leaseScript,
+    '--action', 'acquire',
+    '--scope', 'workspace',
+    '--owner', $owner,
+    '--report', $reportPath
+  )
+
+  if ($env:AGENT_WRITER_LEASE_FORCE_TAKEOVER -eq '1') {
+    $arguments += '--force-takeover'
+  }
+  if ($env:AGENT_WRITER_LEASE_STALE_SECONDS -match '^\d+$') {
+    $arguments += @('--stale-seconds', $env:AGENT_WRITER_LEASE_STALE_SECONDS)
+  }
+  if ($env:AGENT_WRITER_LEASE_WAIT_MS -match '^\d+$') {
+    $arguments += @('--wait-ms', $env:AGENT_WRITER_LEASE_WAIT_MS)
+  }
+  if ($env:AGENT_WRITER_LEASE_MAX_ATTEMPTS -match '^\d+$') {
+    $arguments += @('--max-attempts', $env:AGENT_WRITER_LEASE_MAX_ATTEMPTS)
+  }
+
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = $nodeCmd.Source
+  foreach ($arg in $arguments) { $psi.ArgumentList.Add([string]$arg) }
+  $psi.WorkingDirectory = (Resolve-Path '.').Path
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  $proc = [System.Diagnostics.Process]::Start($psi)
+  $stdout = $proc.StandardOutput.ReadToEnd()
+  $stderr = $proc.StandardError.ReadToEnd()
+  $proc.WaitForExit()
+
+  if ($stderr) {
+    Write-Warning $stderr.TrimEnd()
+  }
+
+  $result = $null
+  if ($stdout) {
+    try {
+      $result = $stdout | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+      Write-Warning '[bootstrap] Unable to parse agent writer lease JSON output.'
+    }
+  }
+
+  if ($result -and $result.PSObject.Properties['lease'] -and $result.lease -and $result.lease.PSObject.Properties['leaseId']) {
+    $env:AGENT_WRITER_LEASE_ID = [string]$result.lease.leaseId
+  }
+
+  if ($proc.ExitCode -ne 0) {
+    $statusLabel = if ($result -and $result.PSObject.Properties['status']) { [string]$result.status } else { 'unknown' }
+    $message = ("[bootstrap] Agent writer lease acquisition failed (status={0}, exit={1}). " +
+      "Use AGENT_WRITER_LEASE_FORCE_TAKEOVER=1 for stale takeovers or AGENT_WRITER_LEASE_ENABLED=0 to disable.") -f $statusLabel, $proc.ExitCode
+    throw $message
+  }
+
+  if ($result -and $result.PSObject.Properties['status']) {
+    Write-Host ("[bootstrap] Agent writer lease status: {0}" -f [string]$result.status)
+  } else {
+    Write-Host '[bootstrap] Agent writer lease acquired.'
+  }
+
+  return $result
+}
+
 function Invoke-GitCommand {
   param(
     [Parameter(Mandatory=$true)][string[]]$Arguments,
@@ -269,6 +367,9 @@ if ($VerboseHooks) {
 }
 
 if (-not $PreflightOnly) {
+  Write-Host '[bootstrap] Acquiring agent writer lease…'
+  Invoke-AgentWriterLeaseAcquire | Out-Null
+
   Write-Host '[bootstrap] Syncing standing priority snapshot…'
   Invoke-Npm -Script 'priority:sync:lane'
   Write-Host '[bootstrap] Showing router plan…'

--- a/tools/priority/standing-priority-handoff.mjs
+++ b/tools/priority/standing-priority-handoff.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 import { main as syncStandingPriority } from './sync-standing-priority.mjs';
+import { releaseWriterLease } from './agent-writer-lease.mjs';
 import { assertPresent } from './lib/github-text.mjs';
 
 function defaultGhRunner(args, { quiet = false } = {}) {
@@ -38,11 +39,19 @@ function parseIssueList(input) {
  * Rotate the standing-priority label to a new issue.
  *
  * @param {number|string} nextIssue
- * @param {{ dryRun?: boolean, ghRunner?: Function, syncFn?: Function, logger?: Function }} [options]
+ * @param {{ dryRun?: boolean, ghRunner?: Function, syncFn?: Function, logger?: Function, leaseReleaseFn?: Function, releaseLease?: boolean, leaseScope?: string }} [options]
  */
 export async function handoffStandingPriority(
   nextIssue,
-  { dryRun = false, ghRunner = defaultGhRunner, syncFn = syncStandingPriority, logger = console.log } = {}
+  {
+    dryRun = false,
+    ghRunner = defaultGhRunner,
+    syncFn = syncStandingPriority,
+    logger = console.log,
+    leaseReleaseFn = releaseWriterLease,
+    releaseLease = true,
+    leaseScope = 'workspace'
+  } = {}
 ) {
   const target = String(nextIssue ?? '').trim();
   assertPresent(target, 'Next standing priority issue number is required.');
@@ -69,6 +78,9 @@ export async function handoffStandingPriority(
     } else {
       logger(`[standing-handoff] Issue #${target} already carries the label (no add required).`);
     }
+    if (releaseLease) {
+      logger(`[standing-handoff] Would release writer lease for scope '${leaseScope}'.`);
+    }
     logger('[standing-handoff] Dry run complete – skipping sync.');
     return;
   }
@@ -87,6 +99,17 @@ export async function handoffStandingPriority(
 
   logger('[standing-handoff] Synchronising priority cache...');
   await syncFn();
+  if (releaseLease && typeof leaseReleaseFn === 'function') {
+    logger(`[standing-handoff] Releasing writer lease for scope '${leaseScope}'...`);
+    try {
+      const leaseResult = await leaseReleaseFn({ scope: leaseScope });
+      if (leaseResult?.status) {
+        logger(`[standing-handoff] Writer lease release status: ${leaseResult.status}.`);
+      }
+    } catch (error) {
+      logger(`[standing-handoff] Writer lease release failed: ${error.message}`);
+    }
+  }
   logger('[standing-handoff] Standing priority hand-off completed.');
 }
 


### PR DESCRIPTION
## Summary
- add a repository-scoped agent writer lease manager at `tools/priority/agent-writer-lease.mjs`
- implement deterministic lease actions (`acquire`, `release`, `heartbeat`, `inspect`) with stale takeover and contention states
- integrate lease acquisition into `tools/priority/bootstrap.ps1` for non-CI agent sessions
- integrate lease release into `tools/priority/standing-priority-handoff.mjs`
- add unit coverage for lease contention/stale takeover and update standing-handoff tests for lease release seam
- document operator usage and controls in `docs/SESSION_LOCK_HANDOFF.md`

## Validation
- `node --test tools/priority/__tests__/agent-writer-lease.test.mjs tools/priority/__tests__/standing-priority-handoff.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1 -PreflightOnly`
- `./bin/actionlint -color`

Refs #733
