### PR TITLE
feat(priority): safe git broker for mutating operations (#734)

### DIFF
--- a/.agent_priority_cache.json
+++ b/.agent_priority_cache.json
@@ -1,22 +1,20 @@
 {
-  "number": 732,
-  "title": "[Program][P0] Agent Runtime Reliability: single-writer + safe-git + self-heal",
-  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/732",
+  "number": 734,
+  "title": "[P1] Build safe git broker with lock detection, retries, and auto-repair",
+  "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/734",
   "state": "open",
   "labels": [
     "ci",
     "governance",
-    "program",
-    "slo",
     "standing-priority"
   ],
   "assignees": [],
   "milestone": "LabVIEW CI Platform v1 (2026Q2)",
   "commentCount": 0,
   "lastSeenUpdatedAt": null,
-  "issueDigest": "5b6c0f3a581217b1ecac30ca605afadcb72b1a964bcd993f4d7305c4f0e6b9c4",
-  "bodyDigest": "55e59ca5c79a8bf13e893f21c7fa6c49a071eca741d026681dd3f80c7f71c38f",
-  "cachedAtUtc": "2026-03-05T22:34:31.888Z",
+  "issueDigest": "b4a5e27d6a5f2b49fd5c616264394003ef3ea0e73cf05e92b7aa7fc88d7be4bd",
+  "bodyDigest": "15127c9d46d8bd048cdf2275714ebf62325bade6293fa4efe0d1b283763bcb2f",
+  "cachedAtUtc": "2026-03-06T05:53:55.060Z",
   "lastFetchSource": "live",
   "lastFetchError": null,
   "repository": "LabVIEW-Community-CI-CD/compare-vi-cli-action"

--- a/tests/results/_agent/issue/router.json
+++ b/tests/results/_agent/issue/router.json
@@ -1,6 +1,6 @@
 {
   "schema": "agent/priority-router@v1",
-  "issue": 732,
+  "issue": 734,
   "updatedAt": null,
   "actions": [
     {

--- a/tools/priority/__tests__/safe-git.test.mjs
+++ b/tools/priority/__tests__/safe-git.test.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { isMutatingGitCommand, runGitWithSafety } from '../lib/safe-git.mjs';
+
+const repoRoot = path.join(path.sep, 'tmp', 'safe-git-repo');
+const gitDir = path.join(repoRoot, '.git');
+const indexLock = path.join(gitDir, 'index.lock');
+const mergeHead = path.join(gitDir, 'MERGE_HEAD');
+
+function makeCommonBroker(overrides = {}) {
+  return {
+    resolveGitDirFn: () => gitDir,
+    readdirSyncFn: () => [],
+    statSyncFn: () => ({ mtimeMs: 0 }),
+    rmSyncFn: () => {},
+    listGitProcessesFn: () => [],
+    logFn: () => {},
+    nowFn: () => 1_000_000,
+    retryDelayMs: 0,
+    ...overrides
+  };
+}
+
+test('isMutatingGitCommand classifies mutating and non-mutating commands', () => {
+  assert.equal(isMutatingGitCommand(['push', 'origin', 'feature/x']), true);
+  assert.equal(isMutatingGitCommand(['commit', '-m', 'msg']), true);
+  assert.equal(isMutatingGitCommand(['branch', '-m', 'old', 'new']), true);
+  assert.equal(isMutatingGitCommand(['tag', 'v1.2.3']), true);
+
+  assert.equal(isMutatingGitCommand(['status']), false);
+  assert.equal(isMutatingGitCommand(['rev-parse', 'HEAD']), false);
+  assert.equal(isMutatingGitCommand(['branch', '--list']), false);
+  assert.equal(isMutatingGitCommand(['tag', '--list']), false);
+});
+
+test('runGitWithSafety fails fast when merge state is in progress', () => {
+  assert.throws(
+    () =>
+      runGitWithSafety(
+        ['push', 'origin', 'feature/x'],
+        { cwd: repoRoot, env: {} },
+        makeCommonBroker({
+          existsSyncFn: (target) => target === mergeHead,
+          spawnSyncFn: () => {
+            throw new Error('git command should not execute when merge state is blocked');
+          }
+        })
+      ),
+    /merge in progress/i
+  );
+});
+
+test('runGitWithSafety removes stale lock and executes command', () => {
+  let lockExists = true;
+  const removed = [];
+  let invocationCount = 0;
+
+  const result = runGitWithSafety(
+    ['push', 'origin', 'feature/x'],
+    { cwd: repoRoot, env: {} },
+    makeCommonBroker({
+      existsSyncFn: (target) => target === indexLock && lockExists,
+      rmSyncFn: (target) => {
+        removed.push(target);
+        lockExists = false;
+      },
+      spawnSyncFn: () => {
+        invocationCount += 1;
+        return { status: 0, stdout: 'ok', stderr: '' };
+      }
+    })
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(invocationCount, 1);
+  assert.deepEqual(removed, [indexLock]);
+});
+
+test('runGitWithSafety retries once after runtime lock conflict', () => {
+  let lockExists = false;
+  let callCount = 0;
+  let removedCount = 0;
+
+  const result = runGitWithSafety(
+    ['push', 'origin', 'feature/x'],
+    { cwd: repoRoot, env: {} },
+    makeCommonBroker({
+      maxRetries: 1,
+      existsSyncFn: (target) => target === indexLock && lockExists,
+      rmSyncFn: () => {
+        lockExists = false;
+        removedCount += 1;
+      },
+      spawnSyncFn: () => {
+        callCount += 1;
+        if (callCount === 1) {
+          lockExists = true;
+          return {
+            status: 128,
+            stdout: '',
+            stderr: "fatal: Unable to create '.git/index.lock': File exists."
+          };
+        }
+        return { status: 0, stdout: 'ok', stderr: '' };
+      }
+    })
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(callCount, 2);
+  assert.equal(removedCount, 1);
+});
+
+test('runGitWithSafety fails with bounded guidance when active lock cannot be repaired', () => {
+  let commandInvoked = false;
+
+  assert.throws(
+    () =>
+      runGitWithSafety(
+        ['push', 'origin', 'feature/x'],
+        { cwd: repoRoot, env: {} },
+        makeCommonBroker({
+          maxRetries: 1,
+          staleLockAgeMs: 60_000,
+          allowProcessKill: false,
+          nowFn: () => 100_000,
+          existsSyncFn: (target) => target === indexLock,
+          statSyncFn: () => ({ mtimeMs: 99_500 }),
+          listGitProcessesFn: () => [4567],
+          spawnSyncFn: () => {
+            commandInvoked = true;
+            return { status: 0, stdout: '', stderr: '' };
+          }
+        })
+      ),
+    /Auto-repair is bounded/i
+  );
+
+  assert.equal(commandInvoked, false);
+});
+
+test('runGitWithSafety kills stale git process when allowed and proceeds', () => {
+  let lockExists = true;
+  let activePids = [999];
+  const killed = [];
+  const removed = [];
+
+  const result = runGitWithSafety(
+    ['push', 'origin', 'feature/x'],
+    { cwd: repoRoot, env: {} },
+    makeCommonBroker({
+      allowProcessKill: true,
+      staleLockAgeMs: 1_000,
+      nowFn: () => 50_000,
+      existsSyncFn: (target) => target === indexLock && lockExists,
+      statSyncFn: () => ({ mtimeMs: 0 }),
+      listGitProcessesFn: () => activePids,
+      killGitProcessFn: (pid) => {
+        killed.push(pid);
+        activePids = [];
+        return true;
+      },
+      rmSyncFn: (target) => {
+        removed.push(target);
+        lockExists = false;
+      },
+      spawnSyncFn: () => ({ status: 0, stdout: 'ok', stderr: '' })
+    })
+  );
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(killed, [999]);
+  assert.deepEqual(removed, [indexLock]);
+});
+

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -380,12 +380,11 @@ async function main() {
       }
     }
     if (forcePushMain) {
-      const pushResult = spawnSync('git', ['push', '--force-with-lease', 'upstream', 'main'], {
-        cwd: repoRoot,
-        stdio: 'inherit',
-        encoding: 'utf8'
-      });
-      if (pushResult.status !== 0) {
+      try {
+        run('git', ['push', '--force-with-lease', 'upstream', 'main'], {
+          cwd: repoRoot
+        });
+      } catch {
         throw new Error('Failed to push main with --force-with-lease. Resolve the push error above.');
       }
     } else {

--- a/tools/priority/lib/branch-utils.mjs
+++ b/tools/priority/lib/branch-utils.mjs
@@ -2,15 +2,21 @@
 
 import { spawnSync } from 'node:child_process';
 import process from 'node:process';
+import { isMutatingGitCommand, runGitWithSafety } from './safe-git.mjs';
 
 const IDENTIFIER_REGEX = /^[A-Za-z0-9._-]+$/;
 
 export function run(command, args, options = {}) {
-  const result = spawnSync(command, args, {
+  const normalizedOptions = {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'inherit'],
     ...options
-  });
+  };
+
+  const result =
+    command === 'git' && isMutatingGitCommand(args)
+      ? runGitWithSafety(args, normalizedOptions)
+      : spawnSync(command, args, normalizedOptions);
 
   if (result.status !== 0) {
     throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);

--- a/tools/priority/lib/remote-utils.mjs
+++ b/tools/priority/lib/remote-utils.mjs
@@ -93,27 +93,21 @@ export function ensureOriginFork(repoRoot, upstream) {
 }
 
 export function pushBranch(repoRoot, branch) {
-  const pushResult = spawnSync(
-    'git',
-    ['push', '--set-upstream', 'origin', branch],
-    {
-      cwd: repoRoot,
-      stdio: 'inherit',
-      encoding: 'utf8'
-    }
-  );
-  if (pushResult.status !== 0) {
+  try {
+    run('git', ['push', '--set-upstream', 'origin', branch], {
+      cwd: repoRoot
+    });
+  } catch {
     throw new Error('Failed to push branch to origin. Resolve the push error above.');
   }
 }
 
 export function pushToRemote(repoRoot, remote, ref) {
-  const result = spawnSync('git', ['push', remote, ref], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-    encoding: 'utf8'
-  });
-  if (result.status !== 0) {
+  try {
+    run('git', ['push', remote, ref], {
+      cwd: repoRoot
+    });
+  } catch {
     throw new Error(`Failed to push ${ref} to ${remote}. Resolve the push error above.`);
   }
 }

--- a/tools/priority/lib/safe-git.mjs
+++ b/tools/priority/lib/safe-git.mjs
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const MUTATING_GIT_COMMANDS = new Set([
+  'add',
+  'am',
+  'apply',
+  'branch',
+  'checkout',
+  'cherry-pick',
+  'clean',
+  'commit',
+  'merge',
+  'mv',
+  'pull',
+  'push',
+  'rebase',
+  'reset',
+  'restore',
+  'revert',
+  'rm',
+  'switch',
+  'tag',
+  'worktree'
+]);
+
+const BRANCH_MUTATING_FLAGS = new Set([
+  '-c',
+  '-C',
+  '-d',
+  '-D',
+  '-m',
+  '-M',
+  '--copy',
+  '--delete',
+  '--move',
+  '--set-upstream-to',
+  '--unset-upstream'
+]);
+
+const TAG_READONLY_FLAGS = new Set([
+  '-l',
+  '--list',
+  '--contains',
+  '--merged',
+  '--no-merged',
+  '--points-at',
+  '--sort',
+  '--column',
+  '-n',
+  '--format'
+]);
+
+const LOCK_FILENAMES = ['index.lock', 'HEAD.lock', 'packed-refs.lock', 'shallow.lock'];
+
+const LOCK_CONFLICT_PATTERNS = [
+  /another git process seems to be running/i,
+  /unable to create '.*\.lock'/i,
+  /cannot lock ref/i,
+  /could not lock/i,
+  /index\.lock/i
+];
+
+const IN_PROGRESS_PATTERNS = [
+  /you have not concluded your merge/i,
+  /rebase in progress/i,
+  /cherry-pick is already in progress/i,
+  /revert is already in progress/i
+];
+
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_RETRY_DELAY_MS = 350;
+const DEFAULT_STALE_LOCK_AGE_MS = 30_000;
+
+function parseBooleanEnv(value, fallback = false) {
+  if (value == null) {
+    return fallback;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === '' || normalized === '0' || normalized === 'false' || normalized === 'no') {
+    return false;
+  }
+  if (normalized === '1' || normalized === 'true' || normalized === 'yes') {
+    return true;
+  }
+  return fallback;
+}
+
+function parseNumberEnv(value, fallback) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(0, Math.trunc(parsed));
+}
+
+function toSpawnOptions(options = {}) {
+  const normalized = {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options
+  };
+  return normalized;
+}
+
+function sleepSync(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return;
+  }
+  const view = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function normalizeGitDir(cwd, gitDirRaw) {
+  if (!gitDirRaw) {
+    throw new Error('Unable to resolve .git directory.');
+  }
+  return path.isAbsolute(gitDirRaw) ? path.normalize(gitDirRaw) : path.normalize(path.resolve(cwd, gitDirRaw));
+}
+
+function resolveGitDir(cwd, spawnOptions, deps) {
+  if (typeof deps.resolveGitDirFn === 'function') {
+    const custom = deps.resolveGitDirFn(cwd, spawnOptions);
+    return normalizeGitDir(cwd, custom);
+  }
+
+  const probe = deps.spawnSyncFn('git', ['rev-parse', '--git-dir'], {
+    cwd,
+    env: spawnOptions.env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  if (probe.status !== 0) {
+    const stderr = (probe.stderr ?? '').trim();
+    throw new Error(`Unable to resolve .git directory (git rev-parse --git-dir failed: ${stderr || probe.status}).`);
+  }
+
+  return normalizeGitDir(cwd, String(probe.stdout ?? '').trim());
+}
+
+function listRefLockFiles(refRoot, deps, output) {
+  let entries = [];
+  try {
+    entries = deps.readdirSyncFn(refRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(refRoot, entry.name);
+    if (entry.isDirectory()) {
+      listRefLockFiles(fullPath, deps, output);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.lock')) {
+      output.push(fullPath);
+    }
+  }
+}
+
+function safeStatMtimeMs(filePath, deps, nowMs) {
+  try {
+    const stat = deps.statSyncFn(filePath);
+    return Number.isFinite(stat.mtimeMs) ? stat.mtimeMs : nowMs;
+  } catch {
+    return nowMs;
+  }
+}
+
+function collectLockFiles(gitDir, deps, nowMs) {
+  const lockCandidates = [];
+
+  for (const name of LOCK_FILENAMES) {
+    const fullPath = path.join(gitDir, name);
+    if (deps.existsSyncFn(fullPath)) {
+      lockCandidates.push(fullPath);
+    }
+  }
+
+  listRefLockFiles(path.join(gitDir, 'refs'), deps, lockCandidates);
+
+  const deduped = new Set();
+  const locks = [];
+  for (const lockPath of lockCandidates) {
+    const normalized = path.normalize(lockPath);
+    if (deduped.has(normalized)) {
+      continue;
+    }
+    deduped.add(normalized);
+    locks.push({
+      path: normalized,
+      mtimeMs: safeStatMtimeMs(normalized, deps, nowMs)
+    });
+  }
+  return locks;
+}
+
+function collectInProgressStates(gitDir, deps) {
+  const states = [];
+  const markers = [
+    { key: 'merge', description: 'merge in progress', path: path.join(gitDir, 'MERGE_HEAD') },
+    { key: 'cherry-pick', description: 'cherry-pick in progress', path: path.join(gitDir, 'CHERRY_PICK_HEAD') },
+    { key: 'revert', description: 'revert in progress', path: path.join(gitDir, 'REVERT_HEAD') },
+    { key: 'rebase', description: 'rebase in progress', path: path.join(gitDir, 'rebase-apply') },
+    { key: 'rebase', description: 'rebase in progress', path: path.join(gitDir, 'rebase-merge') }
+  ];
+
+  const seen = new Set();
+  for (const marker of markers) {
+    if (!deps.existsSyncFn(marker.path)) {
+      continue;
+    }
+    if (seen.has(marker.key)) {
+      continue;
+    }
+    seen.add(marker.key);
+    states.push({
+      key: marker.key,
+      description: marker.description,
+      markerPath: marker.path
+    });
+  }
+
+  return states;
+}
+
+function commandAllowsState(command, args, stateKey) {
+  if (command !== stateKey) {
+    return false;
+  }
+
+  const normalized = args.slice(1);
+  if (stateKey === 'merge') {
+    return normalized.some((value) => ['--abort', '--continue', '--quit'].includes(value));
+  }
+  if (stateKey === 'rebase') {
+    return normalized.some((value) => ['--abort', '--continue', '--skip', '--quit', '--edit-todo'].includes(value));
+  }
+  if (stateKey === 'cherry-pick' || stateKey === 'revert') {
+    return normalized.some((value) => ['--abort', '--continue', '--skip', '--quit'].includes(value));
+  }
+  return false;
+}
+
+function evaluateBlockedStates(command, args, inProgressStates) {
+  return inProgressStates.filter((state) => !commandAllowsState(command, args, state.key));
+}
+
+function formatGitPath(gitDir, fullPath) {
+  const relative = path.relative(gitDir, fullPath).split(path.sep).join('/');
+  if (!relative || relative.startsWith('..')) {
+    return fullPath;
+  }
+  return `.git/${relative}`;
+}
+
+function parseTaskListCsvLine(line) {
+  const values = [];
+  let current = '';
+  let quoted = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (char === ',' && !quoted) {
+      values.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  values.push(current.trim());
+  return values;
+}
+
+function listGitProcesses(deps) {
+  if (typeof deps.listGitProcessesFn === 'function') {
+    return deps.listGitProcessesFn();
+  }
+
+  if (process.platform === 'win32') {
+    const result = deps.spawnSyncFn('tasklist', ['/FI', 'IMAGENAME eq git.exe', '/FO', 'CSV', '/NH'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    if (result.status !== 0) {
+      return [];
+    }
+    const rows = String(result.stdout ?? '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => !line.startsWith('INFO:'));
+    const pids = [];
+    for (const row of rows) {
+      const parts = parseTaskListCsvLine(row);
+      const pid = Number(parts[1]);
+      if (Number.isInteger(pid) && pid > 0) {
+        pids.push(pid);
+      }
+    }
+    return pids;
+  }
+
+  const result = deps.spawnSyncFn('pgrep', ['-x', 'git'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  });
+  if (result.status !== 0) {
+    return [];
+  }
+  return String(result.stdout ?? '')
+    .split(/\r?\n/)
+    .map((line) => Number(line.trim()))
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+function killGitProcess(pid, deps) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  if (typeof deps.killGitProcessFn === 'function') {
+    return deps.killGitProcessFn(pid);
+  }
+
+  if (process.platform === 'win32') {
+    const killed = deps.spawnSyncFn('taskkill', ['/PID', String(pid), '/F'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    return killed.status === 0;
+  }
+
+  const killed = deps.spawnSyncFn('kill', ['-9', String(pid)], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  return killed.status === 0;
+}
+
+function repairLocks({
+  commandArgs,
+  gitDir,
+  locks,
+  staleLockAgeMs,
+  allowProcessKill,
+  deps,
+  nowMs,
+  logFn
+}) {
+  const removed = [];
+  const blocked = [];
+  const killedPids = [];
+
+  let activePids = listGitProcesses(deps);
+  for (const lock of locks) {
+    const ageMs = Math.max(0, Math.trunc(nowMs - lock.mtimeMs));
+    const staleByAge = ageMs >= staleLockAgeMs;
+    const hasActivePids = activePids.length > 0;
+
+    if (hasActivePids && staleByAge && allowProcessKill) {
+      for (const pid of activePids) {
+        if (killGitProcess(pid, deps)) {
+          killedPids.push(pid);
+        }
+      }
+      activePids = listGitProcesses(deps);
+    }
+
+    const mayRemove = !hasActivePids || staleByAge;
+    if (!mayRemove || activePids.length > 0) {
+      const reason = hasActivePids && !staleByAge
+        ? 'active-git-process'
+        : hasActivePids && staleByAge && !allowProcessKill
+          ? 'stale-lock-process-kill-disabled'
+          : 'git-process-still-active';
+
+      blocked.push({
+        path: lock.path,
+        ageMs,
+        reason
+      });
+      continue;
+    }
+
+    try {
+      deps.rmSyncFn(lock.path, { force: true });
+      removed.push({
+        path: lock.path,
+        ageMs
+      });
+      logFn(
+        `[safe-git] removed lock ${formatGitPath(gitDir, lock.path)} before git ${commandArgs.join(' ')} (age=${ageMs}ms)`
+      );
+    } catch (error) {
+      blocked.push({
+        path: lock.path,
+        ageMs,
+        reason: `remove-failed:${error.message}`
+      });
+    }
+  }
+
+  return {
+    removed,
+    blocked,
+    killedPids
+  };
+}
+
+function looksLikeLockConflict(result) {
+  const combined = `${result?.stderr ?? ''}\n${result?.stdout ?? ''}`;
+  return LOCK_CONFLICT_PATTERNS.some((pattern) => pattern.test(combined));
+}
+
+function looksLikeInProgressFailure(result) {
+  const combined = `${result?.stderr ?? ''}\n${result?.stdout ?? ''}`;
+  return IN_PROGRESS_PATTERNS.some((pattern) => pattern.test(combined));
+}
+
+function buildStateError(commandArgs, blockedStates) {
+  const states = blockedStates.map((entry) => entry.description).join(', ');
+  return new Error(
+    `[safe-git] git ${commandArgs.join(' ')} blocked: ${states}. ` +
+      'Resolve operation state (for example git status + --abort/--continue) and retry.'
+  );
+}
+
+function buildLockError(commandArgs, blockedLocks, attemptCount, gitDir) {
+  const lockList = blockedLocks
+    .map((entry) => `${formatGitPath(gitDir, entry.path)} (${entry.reason}, age=${entry.ageMs}ms)`)
+    .join(', ');
+  return new Error(
+    `[safe-git] git ${commandArgs.join(' ')} blocked by lock(s) after ${attemptCount} attempt(s): ${lockList}. ` +
+      'Auto-repair is bounded; ensure no git process is running, clear stale lock(s), and retry.'
+  );
+}
+
+function buildDeps(custom = {}) {
+  return {
+    spawnSyncFn: custom.spawnSyncFn ?? spawnSync,
+    existsSyncFn: custom.existsSyncFn ?? existsSync,
+    readdirSyncFn: custom.readdirSyncFn ?? readdirSync,
+    statSyncFn: custom.statSyncFn ?? statSync,
+    rmSyncFn: custom.rmSyncFn ?? rmSync,
+    nowFn: custom.nowFn ?? (() => Date.now()),
+    logFn: custom.logFn ?? ((message) => console.warn(message)),
+    resolveGitDirFn: custom.resolveGitDirFn,
+    listGitProcessesFn: custom.listGitProcessesFn,
+    killGitProcessFn: custom.killGitProcessFn
+  };
+}
+
+function shouldMutateTag(args) {
+  const flags = args.slice(1);
+  if (flags.length === 0) {
+    return false;
+  }
+  if (flags.some((flag) => flag === '-d' || flag === '--delete')) {
+    return true;
+  }
+  if (flags.some((flag) => TAG_READONLY_FLAGS.has(flag) || flag.startsWith('--sort='))) {
+    return false;
+  }
+  return true;
+}
+
+export function isMutatingGitCommand(args = []) {
+  if (!Array.isArray(args) || args.length === 0) {
+    return false;
+  }
+  const command = String(args[0] ?? '').toLowerCase();
+  if (!MUTATING_GIT_COMMANDS.has(command)) {
+    return false;
+  }
+
+  if (command === 'branch') {
+    return args.slice(1).some((value) => BRANCH_MUTATING_FLAGS.has(value) || value.startsWith('--set-upstream-to='));
+  }
+
+  if (command === 'tag') {
+    return shouldMutateTag(args);
+  }
+
+  return true;
+}
+
+export function runGitWithSafety(args, spawnOptions = {}, brokerOptions = {}) {
+  if (!Array.isArray(args) || args.length === 0) {
+    throw new Error('runGitWithSafety requires at least one git argument.');
+  }
+
+  const command = String(args[0] ?? '').toLowerCase();
+  const mutate = isMutatingGitCommand(args);
+  const normalizedSpawn = toSpawnOptions(spawnOptions);
+  const deps = buildDeps(brokerOptions);
+
+  if (!mutate) {
+    return deps.spawnSyncFn('git', args, normalizedSpawn);
+  }
+
+  const cwd = normalizedSpawn.cwd ?? process.cwd();
+  const maxRetries = parseNumberEnv(
+    brokerOptions.maxRetries ?? normalizedSpawn.env?.SAFE_GIT_MAX_RETRIES,
+    DEFAULT_MAX_RETRIES
+  );
+  const retryDelayMs = parseNumberEnv(
+    brokerOptions.retryDelayMs ?? normalizedSpawn.env?.SAFE_GIT_RETRY_DELAY_MS,
+    DEFAULT_RETRY_DELAY_MS
+  );
+  const staleLockAgeMs = parseNumberEnv(
+    brokerOptions.staleLockAgeMs ?? normalizedSpawn.env?.SAFE_GIT_STALE_LOCK_AGE_MS,
+    DEFAULT_STALE_LOCK_AGE_MS
+  );
+  const allowProcessKill = parseBooleanEnv(
+    brokerOptions.allowProcessKill ?? normalizedSpawn.env?.SAFE_GIT_ALLOW_PROCESS_KILL,
+    true
+  );
+  const gitDir = resolveGitDir(cwd, normalizedSpawn, deps);
+  const maxAttempts = Math.max(1, maxRetries + 1);
+  let lastResult = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const nowMs = deps.nowFn();
+    const locks = collectLockFiles(gitDir, deps, nowMs);
+    const inProgressStates = collectInProgressStates(gitDir, deps);
+    const blockedStates = evaluateBlockedStates(command, args, inProgressStates);
+
+    if (blockedStates.length > 0) {
+      throw buildStateError(args, blockedStates);
+    }
+
+    if (locks.length > 0) {
+      const repair = repairLocks({
+        commandArgs: args,
+        gitDir,
+        locks,
+        staleLockAgeMs,
+        allowProcessKill,
+        deps,
+        nowMs,
+        logFn: deps.logFn
+      });
+
+      if (repair.killedPids.length > 0) {
+        deps.logFn(
+          `[safe-git] terminated git process(es) ${repair.killedPids.join(', ')} while repairing lock(s) for git ${args.join(' ')}`
+        );
+      }
+
+      if (repair.blocked.length > 0) {
+        if (attempt >= maxAttempts) {
+          throw buildLockError(args, repair.blocked, attempt, gitDir);
+        }
+        sleepSync(retryDelayMs);
+        continue;
+      }
+    }
+
+    const result = deps.spawnSyncFn('git', args, normalizedSpawn);
+    lastResult = result;
+
+    if (result.status === 0) {
+      return result;
+    }
+
+    if (looksLikeInProgressFailure(result)) {
+      const refreshed = evaluateBlockedStates(command, args, collectInProgressStates(gitDir, deps));
+      if (refreshed.length > 0) {
+        throw buildStateError(args, refreshed);
+      }
+      throw new Error(
+        `[safe-git] git ${args.join(' ')} failed due to an in-progress operation state. Resolve the state and retry.`
+      );
+    }
+
+    if (looksLikeLockConflict(result) && attempt < maxAttempts) {
+      sleepSync(retryDelayMs);
+      continue;
+    }
+
+    return result;
+  }
+
+  if (lastResult) {
+    return lastResult;
+  }
+
+  throw new Error(`[safe-git] git ${args.join(' ')} failed before execution.`);
+}
+
+export const __test = {
+  parseNumberEnv,
+  parseBooleanEnv,
+  collectLockFiles,
+  collectInProgressStates,
+  evaluateBlockedStates,
+  looksLikeLockConflict,
+  looksLikeInProgressFailure,
+  repairLocks,
+  resolveGitDir
+};
+

--- a/tools/priority/rename-issue-branch.mjs
+++ b/tools/priority/rename-issue-branch.mjs
@@ -162,23 +162,19 @@ function pushBranch(repoRoot, remote, branch, { setUpstream = false } = {}) {
   if (setUpstream) {
     args.splice(1, 0, '--set-upstream');
   }
-  const result = spawnSync('git', args, {
-    cwd: repoRoot,
-    stdio: 'inherit',
-    encoding: 'utf8'
-  });
-  if (result.status !== 0) {
-    throw new Error(`git push ${remote} ${branch} failed with exit code ${result.status}`);
+  try {
+    run('git', args, { cwd: repoRoot });
+  } catch {
+    throw new Error(`git push ${remote} ${branch} failed. Resolve the push error above.`);
   }
 }
 
 function deleteRemoteBranch(repoRoot, remote, branch) {
-  const result = spawnSync('git', ['push', remote, `:${branch}`], {
-    cwd: repoRoot,
-    stdio: 'inherit',
-    encoding: 'utf8'
-  });
-  if (result.status !== 0) {
+  try {
+    run('git', ['push', remote, `:${branch}`], {
+      cwd: repoRoot
+    });
+  } catch {
     throw new Error(`Failed to delete ${remote}/${branch}. Resolve the push error above.`);
   }
 }

--- a/tools/priority/run-handoff-tests.mjs
+++ b/tools/priority/run-handoff-tests.mjs
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMutatingGitCommand, runGitWithSafety } from './lib/safe-git.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,18 +12,33 @@ const nodeExecPath = process.env.npm_node_execpath || process.execPath;
 const wrapperPath = path.join(repoRoot, 'tools', 'npm', 'run-script.mjs');
 
 function runGit(args) {
-  const result = spawnSync('git', args, {
-    cwd: repoRoot,
-    env: process.env,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
+  try {
+    const result = isMutatingGitCommand(args)
+      ? runGitWithSafety(args, {
+        cwd: repoRoot,
+        env: process.env,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+      : spawnSync('git', args, {
+        cwd: repoRoot,
+        env: process.env,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
 
-  return {
-    status: result.status ?? (typeof result.signal === 'string' ? 128 : -1),
-    stdout: (result.stdout ?? '').trim(),
-    stderr: (result.stderr ?? '').trim()
-  };
+    return {
+      status: result.status ?? (typeof result.signal === 'string' ? 128 : -1),
+      stdout: (result.stdout ?? '').trim(),
+      stderr: (result.stderr ?? '').trim()
+    };
+  } catch (error) {
+    return {
+      status: 1,
+      stdout: '',
+      stderr: error instanceof Error ? error.message : String(error)
+    };
+  }
 }
 
 function gitRefExists(ref) {


### PR DESCRIPTION
## Summary
- add `tools/priority/lib/safe-git.mjs` as a bounded mutating git broker with preflight lock/in-progress detection
- route mutating git paths through the broker (`branch-utils`, release push paths, remote push helpers, rename flow, handoff helper)
- add unit coverage for lock repair, retry, fail-fast state blocking, and guarded stale-process kill behavior

## Testing
- `node --test tools/priority/__tests__/safe-git.test.mjs`
- `node --test tools/priority/__tests__/dispatch-validate.test.mjs`
- `node --test tools/priority/__tests__/rename-issue-branch.test.mjs tools/priority/__tests__/create-pr.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` *(fails at existing NI image known-flag step: `Run-NIWindowsContainerCompare.ps1` missing `-nofppos` parameter)*

Refs #734