### PR TITLE
feat(priority): enforce workspace health gates across automation (#735)

### DIFF
--- a/.github/workflows/policy-guard-upstream.yml
+++ b/.github/workflows/policy-guard-upstream.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Workspace health gate
+        run: |
+          node tools/priority/check-workspace-health.mjs --repo-root . --lease-mode ignore --report tests/results/_agent/health/policy-guard-workspace-health.json
+
       - name: Prepare policy guard token
         shell: pwsh
         env:
@@ -62,5 +66,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: policy-drift-${{ github.run_id }}
-          path: tests/results/_agent/policy/policy-drift-report.json
+          path: |
+            tests/results/_agent/policy/policy-drift-report.json
+            tests/results/_agent/health/policy-guard-workspace-health.json
           if-no-files-found: error

--- a/.github/workflows/policy-sync.yml
+++ b/.github/workflows/policy-sync.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Workspace health gate
+        run: |
+          node tools/priority/check-workspace-health.mjs --repo-root . --lease-mode ignore --report tests/results/_agent/health/policy-sync-workspace-health.json
+
       - name: Prepare policy sync token
         shell: pwsh
         env:
@@ -48,5 +52,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: policy-sync-${{ github.run_id }}
-          path: tests/results/_agent/policy/policy-drift-report.json
+          path: |
+            tests/results/_agent/policy/policy-drift-report.json
+            tests/results/_agent/health/policy-sync-workspace-health.json
           if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "priority:sync:lane": "node tools/priority/sync-standing-priority.mjs --fail-on-missing --fail-on-multiple",
     "priority:sync:docker": "pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -ToolsImageTag comparevi-tools:local -UseToolsImage -PrioritySync -SkipActionlint -SkipMarkdown -SkipDocs -SkipWorkflow -SkipDotnetCliBuild",
     "priority:test": "node --test tools/priority/__tests__/*.mjs",
+    "priority:workspace-health": "node tools/priority/check-workspace-health.mjs",
     "safe-watch:contract": "node --test tools/priority/__tests__/safe-watch-task-contract.test.mjs",
     "priority:validate": "node tools/priority/dispatch-validate.mjs",
     "publish:cli": "pwsh -NoLogo -NoProfile -File tools/Publish-Cli.ps1",

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -107,7 +107,26 @@ function Invoke-Actionlint([string]$repoRoot){
   }
 }
 
+function Invoke-WorkspaceHealthGate([string]$repoRoot){
+  $scriptPath = Join-Path $repoRoot 'tools' 'priority' 'check-workspace-health.mjs'
+  if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+    throw ("workspace health gate script not found: {0}" -f $scriptPath)
+  }
+
+  $reportPath = Join-Path $repoRoot 'tests' 'results' '_agent' 'health' 'pre-push-workspace-health.json'
+  Write-Host '[pre-push] Verifying workspace health gate' -ForegroundColor Cyan
+  & node $scriptPath `
+    --repo-root $repoRoot `
+    --report $reportPath `
+    --lease-mode optional
+  if ($LASTEXITCODE -ne 0) {
+    throw ("workspace health gate failed (exit={0}). See {1}" -f $LASTEXITCODE, $reportPath)
+  }
+  Write-Host '[pre-push] workspace health gate OK' -ForegroundColor Green
+}
+
 $root = (Get-RepoRoot).Path
+Invoke-WorkspaceHealthGate -repoRoot $root
 $guardScript = Join-Path (Split-Path -Parent $PSCommandPath) 'Assert-NoAmbiguousRemoteRefs.ps1'
 
 Push-Location $root

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('bootstrap enforces workspace health gate before and after lease acquisition', () => {
+  const content = readRepoFile('tools/priority/bootstrap.ps1');
+  assert.match(content, /Invoke-WorkspaceHealthGate -LeaseMode 'optional' -ReportName 'bootstrap-preflight-workspace-health\.json'/);
+  assert.match(content, /Invoke-WorkspaceHealthGate -LeaseMode 'required' -ReportName 'bootstrap-postlease-workspace-health\.json'/);
+});
+
+test('PrePush-Checks invokes workspace health gate in optional lease mode', () => {
+  const content = readRepoFile('tools/PrePush-Checks.ps1');
+  assert.match(content, /check-workspace-health\.mjs/);
+  assert.match(content, /--lease-mode optional/);
+  assert.match(content, /pre-push-workspace-health\.json/);
+});
+
+test('policy workflows enforce workspace health gate and publish health artifacts', () => {
+  const guardWorkflow = readRepoFile('.github/workflows/policy-guard-upstream.yml');
+  assert.match(guardWorkflow, /Workspace health gate/);
+  assert.match(guardWorkflow, /check-workspace-health\.mjs --repo-root \. --lease-mode ignore --report tests\/results\/_agent\/health\/policy-guard-workspace-health\.json/);
+  assert.match(guardWorkflow, /tests\/results\/_agent\/health\/policy-guard-workspace-health\.json/);
+
+  const syncWorkflow = readRepoFile('.github/workflows/policy-sync.yml');
+  assert.match(syncWorkflow, /Workspace health gate/);
+  assert.match(syncWorkflow, /check-workspace-health\.mjs --repo-root \. --lease-mode ignore --report tests\/results\/_agent\/health\/policy-sync-workspace-health\.json/);
+  assert.match(syncWorkflow, /tests\/results\/_agent\/health\/policy-sync-workspace-health\.json/);
+});
+

--- a/tools/priority/__tests__/workspace-health.test.mjs
+++ b/tools/priority/__tests__/workspace-health.test.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { evaluateWorkspaceHealth } from '../lib/workspace-health.mjs';
+import { runCli } from '../check-workspace-health.mjs';
+
+const repoRoot = path.resolve(path.sep, 'tmp', 'workspace-health-repo');
+const gitDir = path.join(repoRoot, '.git');
+const indexPath = path.join(gitDir, 'index');
+const rebasePath = path.join(gitDir, 'rebase-merge');
+const indexLockPath = path.join(gitDir, 'index.lock');
+const leasePath = path.join(gitDir, 'agent-writer-leases', 'workspace.json');
+
+function normalize(value) {
+  return path.normalize(value);
+}
+
+function makeDeps({
+  existing = [],
+  writable = [],
+  files = {},
+  mtimes = {},
+  nowMs = 100_000
+} = {}) {
+  const existingSet = new Set(existing.map((entry) => normalize(entry)));
+  const writableSet = new Set(writable.map((entry) => normalize(entry)));
+  const fileMap = new Map(
+    Object.entries(files).map(([filePath, content]) => [normalize(filePath), String(content)])
+  );
+  const mtimeMap = new Map(
+    Object.entries(mtimes).map(([filePath, mtimeMs]) => [normalize(filePath), Number(mtimeMs)])
+  );
+
+  return {
+    spawnSyncFn: () => ({ status: 0, stdout: '.git\n', stderr: '' }),
+    existsSyncFn: (filePath) => existingSet.has(normalize(filePath)),
+    accessSyncFn: (filePath) => {
+      if (!writableSet.has(normalize(filePath))) {
+        const error = new Error('EACCES');
+        error.code = 'EACCES';
+        throw error;
+      }
+    },
+    readFileSyncFn: (filePath) => {
+      const key = normalize(filePath);
+      if (!fileMap.has(key)) {
+        const error = new Error('ENOENT');
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return fileMap.get(key);
+    },
+    statSyncFn: (filePath) => ({ mtimeMs: mtimeMap.get(normalize(filePath)) ?? nowMs }),
+    readdirSyncFn: () => [],
+    nowFn: () => nowMs
+  };
+}
+
+test('evaluateWorkspaceHealth passes for a clean workspace when lease is optional', () => {
+  const report = evaluateWorkspaceHealth(
+    {
+      repoRoot,
+      leaseMode: 'optional'
+    },
+    makeDeps({
+      existing: [indexPath],
+      writable: [indexPath]
+    })
+  );
+
+  assert.equal(report.status, 'pass');
+  assert.equal(report.failures.length, 0);
+});
+
+test('evaluateWorkspaceHealth fails when git index is not writable', () => {
+  const report = evaluateWorkspaceHealth(
+    {
+      repoRoot,
+      leaseMode: 'ignore'
+    },
+    makeDeps({
+      existing: [indexPath]
+    })
+  );
+
+  assert.equal(report.status, 'fail');
+  assert.ok(report.failures.some((entry) => entry.id === 'index-not-writable'));
+});
+
+test('evaluateWorkspaceHealth fails when rebase state marker exists', () => {
+  const report = evaluateWorkspaceHealth(
+    {
+      repoRoot,
+      leaseMode: 'ignore'
+    },
+    makeDeps({
+      existing: [indexPath, rebasePath],
+      writable: [indexPath]
+    })
+  );
+
+  assert.equal(report.status, 'fail');
+  assert.ok(report.failures.some((entry) => entry.id === 'git-operation-in-progress'));
+});
+
+test('evaluateWorkspaceHealth fails when stale lock file exists', () => {
+  const report = evaluateWorkspaceHealth(
+    {
+      repoRoot,
+      leaseMode: 'ignore',
+      lockStaleSeconds: 30
+    },
+    makeDeps({
+      existing: [indexPath, indexLockPath],
+      writable: [indexPath],
+      mtimes: {
+        [indexLockPath]: 0
+      },
+      nowMs: 120_000
+    })
+  );
+
+  assert.equal(report.status, 'fail');
+  assert.ok(report.failures.some((entry) => entry.id === 'stale-lock-file'));
+});
+
+test('evaluateWorkspaceHealth fails when required lease owner mismatches', () => {
+  const report = evaluateWorkspaceHealth(
+    {
+      repoRoot,
+      leaseMode: 'required',
+      expectedLeaseOwner: 'agent-a@host:default'
+    },
+    makeDeps({
+      existing: [indexPath, leasePath],
+      writable: [indexPath],
+      files: {
+        [leasePath]: JSON.stringify({ owner: 'agent-b@host:default', leaseId: 'abc123' })
+      }
+    })
+  );
+
+  assert.equal(report.status, 'fail');
+  assert.ok(report.failures.some((entry) => entry.id === 'lease-owner-mismatch'));
+});
+
+test('workspace health CLI writes report even when failing', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'workspace-health-cli-'));
+  const tempGitDir = path.join(tempRoot, '.git');
+  const reportPath = path.join(tempRoot, 'tests', 'results', '_agent', 'health', 'cli-report.json');
+
+  const init = spawnSync('git', ['init', '-q'], { cwd: tempRoot, encoding: 'utf8' });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
+  await mkdir(tempGitDir, { recursive: true });
+  await writeFile(path.join(tempGitDir, 'index'), 'index\n', 'utf8');
+  await writeFile(path.join(tempGitDir, 'MERGE_HEAD'), '1234\n', 'utf8');
+
+  const code = await runCli([
+    '--repo-root',
+    tempRoot,
+    '--report',
+    reportPath,
+    '--lease-mode',
+    'ignore',
+    '--quiet'
+  ]);
+
+  assert.equal(code, 1);
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(report.status, 'fail');
+  assert.ok(report.failures.some((entry) => entry.id === 'git-operation-in-progress'));
+});

--- a/tools/priority/bootstrap.ps1
+++ b/tools/priority/bootstrap.ps1
@@ -48,6 +48,57 @@ function Invoke-Npm {
   }
 }
 
+function Invoke-WorkspaceHealthGate {
+  param(
+    [ValidateSet('ignore','optional','required')][string]$LeaseMode = 'optional',
+    [Parameter(Mandatory=$true)][string]$ReportName
+  )
+
+  $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $nodeCmd) {
+    throw 'node not found; cannot run workspace health gate.'
+  }
+
+  $scriptPath = Join-Path (Resolve-Path '.').Path 'tools/priority/check-workspace-health.mjs'
+  if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+    throw "workspace health gate script not found at $scriptPath"
+  }
+
+  $reportPath = Join-Path (Resolve-Path '.').Path ("tests/results/_agent/health/{0}" -f $ReportName)
+  $arguments = @(
+    $scriptPath,
+    '--repo-root', (Resolve-Path '.').Path,
+    '--report', $reportPath,
+    '--lease-mode', $LeaseMode
+  )
+  if (-not [string]::IsNullOrWhiteSpace($env:AGENT_WRITER_LEASE_OWNER)) {
+    $arguments += @('--expected-owner', $env:AGENT_WRITER_LEASE_OWNER)
+  }
+  if ($LeaseMode -eq 'required' -and -not [string]::IsNullOrWhiteSpace($env:AGENT_WRITER_LEASE_ID)) {
+    $arguments += @('--expected-lease-id', $env:AGENT_WRITER_LEASE_ID)
+  }
+
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = $nodeCmd.Source
+  foreach ($arg in $arguments) { $psi.ArgumentList.Add([string]$arg) }
+  $psi.WorkingDirectory = (Resolve-Path '.').Path
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  $proc = [System.Diagnostics.Process]::Start($psi)
+  $stdout = $proc.StandardOutput.ReadToEnd()
+  $stderr = $proc.StandardError.ReadToEnd()
+  $proc.WaitForExit()
+
+  if ($stdout) { Write-Host $stdout.TrimEnd() }
+  if ($stderr) { Write-Warning $stderr.TrimEnd() }
+
+  if ($proc.ExitCode -ne 0) {
+    throw "Workspace health gate failed (lease-mode=$LeaseMode). See $reportPath"
+  }
+}
+
 function Invoke-SemVerCheck {
   $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
   if (-not $nodeCmd) {
@@ -356,6 +407,9 @@ Write-Host '[bootstrap] Detecting hook plane…'
 Ensure-DevelopBranch
 Invoke-Npm -Script 'hooks:plane' -AllowFailure
 
+Write-Host '[bootstrap] Running workspace health gate (preflight)…'
+Invoke-WorkspaceHealthGate -LeaseMode 'optional' -ReportName 'bootstrap-preflight-workspace-health.json'
+
 Write-Host '[bootstrap] Running hook preflight…'
 Invoke-Npm -Script 'hooks:preflight' -AllowFailure
 
@@ -369,6 +423,9 @@ if ($VerboseHooks) {
 if (-not $PreflightOnly) {
   Write-Host '[bootstrap] Acquiring agent writer lease…'
   Invoke-AgentWriterLeaseAcquire | Out-Null
+
+  Write-Host '[bootstrap] Running workspace health gate (post-lease)…'
+  Invoke-WorkspaceHealthGate -LeaseMode 'required' -ReportName 'bootstrap-postlease-workspace-health.json'
 
   Write-Host '[bootstrap] Syncing standing priority snapshot…'
   Invoke-Npm -Script 'priority:sync:lane'

--- a/tools/priority/check-workspace-health.mjs
+++ b/tools/priority/check-workspace-health.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { evaluateWorkspaceHealth } from './lib/workspace-health.mjs';
+
+const DEFAULT_REPORT_PATH = path.join(
+  process.cwd(),
+  'tests',
+  'results',
+  '_agent',
+  'health',
+  'workspace-health-report.json'
+);
+
+function printUsage() {
+  console.log(`Usage:
+  node tools/priority/check-workspace-health.mjs [options]
+
+Options:
+  --repo-root <path>         Repository root to evaluate (default: current working directory)
+  --report <path>            JSON report output path
+  --lock-stale-seconds <n>   Lock stale threshold in seconds (default: 30)
+  --lease-mode <mode>        Lease validation mode: ignore|optional|required (default: optional)
+  --expected-owner <value>   Expected lease owner (default: computed current owner)
+  --expected-lease-id <id>   Expected lease id (default: AGENT_WRITER_LEASE_ID)
+  --lease-root <path>        Lease directory override (relative to repo root allowed)
+  --quiet                    Suppress JSON report echo
+  --help                     Show this help text
+`);
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const parsed = {
+    repoRoot: process.cwd(),
+    report: DEFAULT_REPORT_PATH,
+    lockStaleSeconds: 30,
+    leaseMode: 'optional',
+    expectedLeaseOwner: process.env.AGENT_WRITER_LEASE_OWNER ?? '',
+    expectedLeaseId: process.env.AGENT_WRITER_LEASE_ID ?? '',
+    leaseRoot: '',
+    quiet: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (token === '--quiet') {
+      parsed.quiet = true;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next) {
+      throw new Error(`Missing value for ${token}`);
+    }
+
+    if (token === '--repo-root') {
+      parsed.repoRoot = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    if (token === '--report') {
+      parsed.report = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    if (token === '--lock-stale-seconds') {
+      const value = Number.parseInt(next, 10);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`Invalid --lock-stale-seconds value: ${next}`);
+      }
+      parsed.lockStaleSeconds = value;
+      index += 1;
+      continue;
+    }
+    if (token === '--lease-mode') {
+      parsed.leaseMode = String(next).trim().toLowerCase();
+      index += 1;
+      continue;
+    }
+    if (token === '--expected-owner') {
+      parsed.expectedLeaseOwner = next;
+      index += 1;
+      continue;
+    }
+    if (token === '--expected-lease-id') {
+      parsed.expectedLeaseId = next;
+      index += 1;
+      continue;
+    }
+    if (token === '--lease-root') {
+      parsed.leaseRoot = next;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return parsed;
+}
+
+async function writeReport(reportPath, payload) {
+  await fs.mkdir(path.dirname(reportPath), { recursive: true });
+  await fs.writeFile(reportPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function printFailureSummary(report) {
+  console.error(`[workspace-health] FAIL (${report.failures.length} violation(s))`);
+  for (const failure of report.failures) {
+    const metadata = [];
+    if (failure.path) metadata.push(`path=${failure.path}`);
+    if (failure.expectedOwner) metadata.push(`expectedOwner=${failure.expectedOwner}`);
+    if (failure.actualOwner) metadata.push(`actualOwner=${failure.actualOwner}`);
+    if (failure.message) metadata.push(`message=${failure.message}`);
+    if (failure.states) {
+      metadata.push(`states=${failure.states.map((entry) => entry.description).join(',')}`);
+    }
+    if (failure.locks) {
+      metadata.push(`locks=${failure.locks.map((entry) => path.basename(entry.path)).join(',')}`);
+    }
+    const suffix = metadata.length > 0 ? ` (${metadata.join('; ')})` : '';
+    console.error(`  - ${failure.id}${suffix}`);
+  }
+  for (const hint of report.hints) {
+    console.error(`  hint: ${hint}`);
+  }
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printUsage();
+    return 0;
+  }
+
+  const report = evaluateWorkspaceHealth({
+    repoRoot: args.repoRoot,
+    lockStaleSeconds: args.lockStaleSeconds,
+    leaseMode: args.leaseMode,
+    expectedLeaseOwner: args.expectedLeaseOwner || undefined,
+    expectedLeaseId: args.expectedLeaseId || undefined,
+    leaseRoot: args.leaseRoot || undefined
+  });
+
+  await writeReport(args.report, report);
+
+  if (!args.quiet) {
+    console.log(`[workspace-health] report: ${args.report}`);
+  }
+
+  if (report.status === 'pass') {
+    console.log(`[workspace-health] PASS (checks=${report.checks.length})`);
+    return 0;
+  }
+
+  printFailureSummary(report);
+  return 1;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+if (invokedPath && invokedPath === modulePath) {
+  try {
+    const exitCode = await runCli();
+    process.exit(exitCode);
+  } catch (error) {
+    console.error(`[workspace-health] ${error?.message || error}`);
+    process.exit(1);
+  }
+}

--- a/tools/priority/lib/workspace-health.mjs
+++ b/tools/priority/lib/workspace-health.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { accessSync, constants, existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { defaultOwner } from '../agent-writer-lease.mjs';
+
+const DEFAULT_LOCK_STALE_SECONDS = 30;
+const LOCK_FILENAMES = ['index.lock', 'HEAD.lock', 'packed-refs.lock', 'shallow.lock'];
+
+const IN_PROGRESS_MARKERS = [
+  { key: 'merge', marker: 'MERGE_HEAD', description: 'merge in progress' },
+  { key: 'cherry-pick', marker: 'CHERRY_PICK_HEAD', description: 'cherry-pick in progress' },
+  { key: 'revert', marker: 'REVERT_HEAD', description: 'revert in progress' },
+  { key: 'rebase', marker: 'rebase-apply', description: 'rebase in progress' },
+  { key: 'rebase', marker: 'rebase-merge', description: 'rebase in progress' }
+];
+
+const HINTS = {
+  'git-dir-unresolved':
+    'Run from a valid git worktree and verify `.git` is accessible before running automation.',
+  'index-missing':
+    'Ensure the repository worktree is initialized and `.git/index` exists.',
+  'index-not-writable':
+    'Ensure the workspace is writable and `.git/index` is not read-only or locked by another process.',
+  'git-operation-in-progress':
+    'Resolve in-progress git operations (`git status`, then `--continue` or `--abort`) before retrying.',
+  'active-lock-file':
+    'Another git operation may still be running. Wait for it to finish or clear the conflicting lock safely.',
+  'stale-lock-file':
+    'Remove stale lock files after confirming no git process is active, then re-run the workflow.',
+  'lease-missing':
+    'Acquire the writer lease (`tools/priority/bootstrap.ps1`) before running mutating automation.',
+  'lease-read-error':
+    'Repair or remove the corrupted lease file under `.git/agent-writer-leases/` and re-run bootstrap.',
+  'lease-owner-mismatch':
+    'Only the active lease owner may proceed. Reacquire lease or hand off ownership first.',
+  'lease-id-mismatch':
+    'Lease id changed; rerun bootstrap to refresh `AGENT_WRITER_LEASE_ID` for this session.'
+};
+
+function normalizeLeaseMode(raw) {
+  const value = String(raw ?? 'optional').trim().toLowerCase();
+  if (value === 'ignore' || value === 'optional' || value === 'required') {
+    return value;
+  }
+  throw new Error(`Unsupported lease mode: ${raw}`);
+}
+
+function createDeps(overrides = {}) {
+  return {
+    spawnSyncFn: overrides.spawnSyncFn ?? spawnSync,
+    accessSyncFn: overrides.accessSyncFn ?? accessSync,
+    existsSyncFn: overrides.existsSyncFn ?? existsSync,
+    readdirSyncFn: overrides.readdirSyncFn ?? readdirSync,
+    readFileSyncFn: overrides.readFileSyncFn ?? readFileSync,
+    statSyncFn: overrides.statSyncFn ?? statSync,
+    nowFn: overrides.nowFn ?? (() => Date.now())
+  };
+}
+
+function resolveGitDir(repoRoot, deps, explicitGitDir = '') {
+  if (explicitGitDir) {
+    return path.isAbsolute(explicitGitDir)
+      ? path.normalize(explicitGitDir)
+      : path.normalize(path.resolve(repoRoot, explicitGitDir));
+  }
+
+  const probe = deps.spawnSyncFn('git', ['rev-parse', '--git-dir'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (probe.status !== 0) {
+    const stderr = String(probe.stderr ?? '').trim();
+    throw new Error(stderr || 'git rev-parse --git-dir failed');
+  }
+
+  const raw = String(probe.stdout ?? '').trim();
+  if (!raw) {
+    throw new Error('git rev-parse returned empty git-dir');
+  }
+
+  return path.isAbsolute(raw) ? path.normalize(raw) : path.normalize(path.resolve(repoRoot, raw));
+}
+
+function safeMtimeMs(filePath, deps, nowMs) {
+  try {
+    const stat = deps.statSyncFn(filePath);
+    return Number.isFinite(stat?.mtimeMs) ? Number(stat.mtimeMs) : nowMs;
+  } catch {
+    return nowMs;
+  }
+}
+
+function listRefLockFiles(refRoot, deps, output) {
+  let entries = [];
+  try {
+    entries = deps.readdirSyncFn(refRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(refRoot, entry.name);
+    if (entry.isDirectory()) {
+      listRefLockFiles(fullPath, deps, output);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.lock')) {
+      output.push(fullPath);
+    }
+  }
+}
+
+function collectLockFiles(gitDir, deps, nowMs) {
+  const candidates = [];
+  for (const lockName of LOCK_FILENAMES) {
+    const lockPath = path.join(gitDir, lockName);
+    if (deps.existsSyncFn(lockPath)) {
+      candidates.push(lockPath);
+    }
+  }
+
+  listRefLockFiles(path.join(gitDir, 'refs'), deps, candidates);
+
+  const dedupe = new Set();
+  const locks = [];
+  for (const candidate of candidates) {
+    const normalized = path.normalize(candidate);
+    if (dedupe.has(normalized)) {
+      continue;
+    }
+    dedupe.add(normalized);
+    locks.push({
+      path: normalized,
+      mtimeMs: safeMtimeMs(normalized, deps, nowMs)
+    });
+  }
+
+  return locks.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function collectInProgressStates(gitDir, deps) {
+  const states = [];
+  const seen = new Set();
+
+  for (const marker of IN_PROGRESS_MARKERS) {
+    const markerPath = path.join(gitDir, marker.marker);
+    if (!deps.existsSyncFn(markerPath)) {
+      continue;
+    }
+    if (seen.has(marker.key)) {
+      continue;
+    }
+    seen.add(marker.key);
+    states.push({
+      key: marker.key,
+      description: marker.description,
+      markerPath
+    });
+  }
+
+  return states;
+}
+
+function pushCheck(checks, id, status, detail = {}) {
+  checks.push({ id, status, ...detail });
+}
+
+function pushFailure(failures, id, detail = {}) {
+  failures.push({ id, ...detail });
+}
+
+function maybeReadLease(leasePath, deps) {
+  if (!deps.existsSyncFn(leasePath)) {
+    return { status: 'missing', lease: null };
+  }
+
+  try {
+    const raw = String(deps.readFileSyncFn(leasePath, 'utf8') ?? '');
+    const lease = JSON.parse(raw);
+    return { status: 'present', lease };
+  } catch (error) {
+    return { status: 'error', error: error?.message || String(error), lease: null };
+  }
+}
+
+export function evaluateWorkspaceHealth(options = {}, depOverrides = {}) {
+  const deps = createDeps(depOverrides);
+  const nowMs = deps.nowFn();
+  const lockStaleSeconds = Number.isFinite(options.lockStaleSeconds)
+    ? Math.max(0, Number(options.lockStaleSeconds))
+    : DEFAULT_LOCK_STALE_SECONDS;
+  const staleThresholdMs = lockStaleSeconds * 1000;
+
+  const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
+  const leaseMode = normalizeLeaseMode(options.leaseMode);
+  const expectedLeaseOwner = options.expectedLeaseOwner ?? defaultOwner();
+  const expectedLeaseId = options.expectedLeaseId ?? process.env.AGENT_WRITER_LEASE_ID ?? '';
+  const leaseScope = options.leaseScope ?? 'workspace';
+
+  const checks = [];
+  const failures = [];
+  let gitDir = '';
+
+  try {
+    gitDir = resolveGitDir(repoRoot, deps, options.gitDir ?? '');
+  } catch (error) {
+    pushCheck(checks, 'git-dir', 'fail', { message: String(error?.message || error) });
+    pushFailure(failures, 'git-dir-unresolved', { message: String(error?.message || error) });
+    return buildReport({
+      repoRoot,
+      gitDir: null,
+      leaseMode,
+      lockStaleSeconds,
+      checks,
+      failures,
+      checkedAt: new Date(nowMs).toISOString()
+    });
+  }
+
+  const indexPath = path.join(gitDir, 'index');
+  if (!deps.existsSyncFn(indexPath)) {
+    pushCheck(checks, 'git-index-writable', 'fail', { path: indexPath, reason: 'missing' });
+    pushFailure(failures, 'index-missing', { path: indexPath });
+  } else {
+    try {
+      deps.accessSyncFn(indexPath, constants.W_OK);
+      pushCheck(checks, 'git-index-writable', 'pass', { path: indexPath });
+    } catch (error) {
+      pushCheck(checks, 'git-index-writable', 'fail', {
+        path: indexPath,
+        reason: 'not-writable',
+        message: String(error?.message || error)
+      });
+      pushFailure(failures, 'index-not-writable', {
+        path: indexPath,
+        message: String(error?.message || error)
+      });
+    }
+  }
+
+  const inProgress = collectInProgressStates(gitDir, deps);
+  if (inProgress.length > 0) {
+    pushCheck(checks, 'git-in-progress', 'fail', { states: inProgress });
+    pushFailure(failures, 'git-operation-in-progress', { states: inProgress });
+  } else {
+    pushCheck(checks, 'git-in-progress', 'pass', { states: [] });
+  }
+
+  const locks = collectLockFiles(gitDir, deps, nowMs);
+  const staleLocks = [];
+  const activeLocks = [];
+  for (const lock of locks) {
+    const ageMs = Math.max(0, Math.trunc(nowMs - lock.mtimeMs));
+    const payload = { ...lock, ageMs };
+    if (ageMs >= staleThresholdMs) {
+      staleLocks.push(payload);
+    } else {
+      activeLocks.push(payload);
+    }
+  }
+
+  if (staleLocks.length > 0) {
+    pushFailure(failures, 'stale-lock-file', { locks: staleLocks });
+  }
+  if (activeLocks.length > 0) {
+    pushFailure(failures, 'active-lock-file', { locks: activeLocks });
+  }
+  if (staleLocks.length > 0 || activeLocks.length > 0) {
+    pushCheck(checks, 'git-lock-files', 'fail', {
+      lockCount: locks.length,
+      staleLocks,
+      activeLocks
+    });
+  } else {
+    pushCheck(checks, 'git-lock-files', 'pass', { lockCount: 0 });
+  }
+
+  const leaseRoot = options.leaseRoot
+    ? path.resolve(repoRoot, options.leaseRoot)
+    : path.join(gitDir, 'agent-writer-leases');
+  const leasePath = path.join(leaseRoot, `${leaseScope}.json`);
+  if (leaseMode === 'ignore') {
+    pushCheck(checks, 'writer-lease', 'skipped', { mode: leaseMode, path: leasePath });
+  } else {
+    const leaseRead = maybeReadLease(leasePath, deps);
+    if (leaseRead.status === 'missing') {
+      if (leaseMode === 'required') {
+        pushCheck(checks, 'writer-lease', 'fail', {
+          mode: leaseMode,
+          path: leasePath,
+          reason: 'missing'
+        });
+        pushFailure(failures, 'lease-missing', { path: leasePath });
+      } else {
+        pushCheck(checks, 'writer-lease', 'pass', {
+          mode: leaseMode,
+          path: leasePath,
+          reason: 'missing-allowed'
+        });
+      }
+    } else if (leaseRead.status === 'error') {
+      pushCheck(checks, 'writer-lease', 'fail', {
+        mode: leaseMode,
+        path: leasePath,
+        reason: 'read-error',
+        message: leaseRead.error
+      });
+      pushFailure(failures, 'lease-read-error', { path: leasePath, message: leaseRead.error });
+    } else {
+      const lease = leaseRead.lease ?? {};
+      const owner = String(lease.owner ?? '');
+      const leaseId = String(lease.leaseId ?? '');
+      const ownerMismatch =
+        expectedLeaseOwner &&
+        owner &&
+        owner.trim().toLowerCase() !== String(expectedLeaseOwner).trim().toLowerCase();
+
+      if (ownerMismatch) {
+        pushFailure(failures, 'lease-owner-mismatch', {
+          expectedOwner: expectedLeaseOwner,
+          actualOwner: owner,
+          path: leasePath
+        });
+      }
+      if (expectedLeaseId && leaseId && leaseId !== expectedLeaseId) {
+        pushFailure(failures, 'lease-id-mismatch', {
+          expectedLeaseId,
+          actualLeaseId: leaseId,
+          path: leasePath
+        });
+      }
+
+      const leaseFailures = failures.filter((entry) => entry.id.startsWith('lease-'));
+      if (leaseFailures.length > 0) {
+        pushCheck(checks, 'writer-lease', 'fail', {
+          mode: leaseMode,
+          path: leasePath,
+          owner,
+          leaseId
+        });
+      } else {
+        pushCheck(checks, 'writer-lease', 'pass', {
+          mode: leaseMode,
+          path: leasePath,
+          owner,
+          leaseId
+        });
+      }
+    }
+  }
+
+  return buildReport({
+    repoRoot,
+    gitDir,
+    leaseMode,
+    lockStaleSeconds,
+    checks,
+    failures,
+    checkedAt: new Date(nowMs).toISOString()
+  });
+}
+
+function buildReport({ repoRoot, gitDir, leaseMode, lockStaleSeconds, checks, failures, checkedAt }) {
+  const hints = [];
+  const seen = new Set();
+  for (const failure of failures) {
+    const hint = HINTS[failure.id];
+    if (!hint || seen.has(hint)) {
+      continue;
+    }
+    seen.add(hint);
+    hints.push(hint);
+  }
+
+  return {
+    schema: 'priority/workspace-health@v1',
+    checkedAt,
+    repoRoot,
+    gitDir,
+    leaseMode,
+    lockStaleSeconds,
+    status: failures.length === 0 ? 'pass' : 'fail',
+    checks,
+    failures,
+    hints
+  };
+}


### PR DESCRIPTION
Implements #735 by adding a shared workspace health gate and enforcing it in bootstrap, pre-push, and policy workflows. Validation run: node --test tools/priority/__tests__/workspace-health.test.mjs tools/priority/__tests__/workspace-health-contract.test.mjs; node --test tools/priority/__tests__/*.mjs; ./bin/actionlint -color; pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios.