### PR TITLE
feat(priority): add safe-git reliability telemetry and trend rollups (#736)

### DIFF
--- a/docs/schemas/safe-git-reliability-trend-v1.schema.json
+++ b/docs/schemas/safe-git-reliability-trend-v1.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comparevi.dev/schemas/safe-git-reliability-trend-v1.schema.json",
+  "title": "Safe Git Reliability Trend v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "windowSize",
+    "sampleCount",
+    "metrics",
+    "trend"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/safe-git-reliability-trend@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "windowSize": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "sampleCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "totalRuns",
+        "successfulRuns",
+        "failedRuns",
+        "failureRatio",
+        "lockDetections",
+        "repairAttempts",
+        "repairSuccesses",
+        "repairFailures",
+        "runtimeLockConflicts",
+        "killedProcessCount",
+        "meanRecoveryMs"
+      ],
+      "properties": {
+        "totalRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "successfulRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failureRatio": {
+          "type": "number",
+          "minimum": 0
+        },
+        "lockDetections": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repairAttempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repairSuccesses": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repairFailures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "runtimeLockConflicts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "killedProcessCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "meanRecoveryMs": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "trend": {
+      "type": "object",
+      "required": [
+        "previousFailureRatio",
+        "currentFailureRatio",
+        "failureRatioDelta",
+        "previousMeanRecoveryMs",
+        "currentMeanRecoveryMs",
+        "meanRecoveryDeltaMs"
+      ],
+      "properties": {
+        "previousFailureRatio": {
+          "type": "number"
+        },
+        "currentFailureRatio": {
+          "type": "number"
+        },
+        "failureRatioDelta": {
+          "type": "number"
+        },
+        "previousMeanRecoveryMs": {
+          "type": "number"
+        },
+        "currentMeanRecoveryMs": {
+          "type": "number"
+        },
+        "meanRecoveryDeltaMs": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/safe-git-run-telemetry-v1.schema.json
+++ b/docs/schemas/safe-git-run-telemetry-v1.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comparevi.dev/schemas/safe-git-run-telemetry-v1.schema.json",
+  "title": "Safe Git Run Telemetry v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "startedAt",
+    "finishedAt",
+    "status",
+    "reason",
+    "command",
+    "cwd",
+    "attemptCount",
+    "counters",
+    "events"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/safe-git-run-telemetry@v1"
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "finishedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "durationMs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "status": {
+      "type": "string"
+    },
+    "reason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "message": {
+      "type": "string"
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "cwd": {
+      "type": "string"
+    },
+    "gitDir": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "maxAttempts": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "maxRetries": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "retryDelayMs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "staleLockAgeMs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "allowProcessKill": {
+      "type": "boolean"
+    },
+    "attemptCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "recoveryElapsedMs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "counters": {
+      "type": "object",
+      "required": [
+        "lockDetections",
+        "repairAttempts",
+        "repairSuccesses",
+        "repairFailures",
+        "killedProcessCount",
+        "runtimeLockConflicts"
+      ],
+      "properties": {
+        "lockDetections": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repairAttempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repairSuccesses": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repairFailures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "killedProcessCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "runtimeLockConflicts": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "type",
+          "at"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "priority:release": "pwsh -NoLogo -NoProfile -File tools/priority/Simulate-Release.ps1",
     "priority:schema": "node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/standing-priority-issue-v1.schema.json --data tests/results/_agent/issue/[0-9]*.json --optional",
     "priority:show": "node -e \"console.log(require('fs').readFileSync('tests/results/_agent/issue/router.json','utf8'))\"",
+    "priority:safe-git:trend": "node tools/priority/summarize-safe-git-telemetry.mjs",
     "priority:sync": "node tools/priority/sync-standing-priority.mjs",
     "priority:sync:strict": "node tools/priority/sync-standing-priority.mjs --fail-on-missing",
     "priority:sync:lane": "node tools/priority/sync-standing-priority.mjs --fail-on-missing --fail-on-multiple",

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -125,6 +125,30 @@ function Invoke-WorkspaceHealthGate([string]$repoRoot){
   Write-Host '[pre-push] workspace health gate OK' -ForegroundColor Green
 }
 
+function Invoke-SafeGitReliabilitySummary([string]$repoRoot){
+  $scriptPath = Join-Path $repoRoot 'tools' 'priority' 'summarize-safe-git-telemetry.mjs'
+  if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+    throw ("safe-git reliability summary script not found: {0}" -f $scriptPath)
+  }
+
+  $inputPath = Join-Path $repoRoot 'tests' 'results' '_agent' 'reliability' 'safe-git-events.jsonl'
+  $outputPath = Join-Path $repoRoot 'tests' 'results' '_agent' 'reliability' 'safe-git-trend-summary.json'
+  Write-Host '[pre-push] Summarizing safe-git reliability telemetry' -ForegroundColor Cyan
+  $args = @(
+    $scriptPath,
+    '--input', $inputPath,
+    '--output', $outputPath
+  )
+  if ($env:GITHUB_STEP_SUMMARY) {
+    $args += @('--step-summary', $env:GITHUB_STEP_SUMMARY)
+  }
+  & node @args
+  if ($LASTEXITCODE -ne 0) {
+    throw ("safe-git reliability summary failed (exit={0})." -f $LASTEXITCODE)
+  }
+  Write-Host '[pre-push] safe-git reliability summary OK' -ForegroundColor Green
+}
+
 $root = (Get-RepoRoot).Path
 Invoke-WorkspaceHealthGate -repoRoot $root
 $guardScript = Join-Path (Split-Path -Parent $PSCommandPath) 'Assert-NoAmbiguousRemoteRefs.ps1'
@@ -196,6 +220,8 @@ if (Test-Path -LiteralPath $commitIntegrityContractScript -PathType Leaf) {
   }
   Write-Host '[pre-push] commit-integrity contract OK' -ForegroundColor Green
 }
+
+Invoke-SafeGitReliabilitySummary -repoRoot $root
 
 $skipNiImageChecks = $SkipNiImageFlagScenarios `
   -or $SkipIconEditorFixtureChecks `

--- a/tools/priority/__tests__/safe-git-telemetry-contract.test.mjs
+++ b/tools/priority/__tests__/safe-git-telemetry-contract.test.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('branch-utils routes mutating git calls through safe-git telemetry path', () => {
+  const content = readRepoFile('tools/priority/lib/branch-utils.mjs');
+  assert.match(content, /resolveSafeGitTelemetryPath/);
+  assert.match(content, /telemetryPath:\s*resolveSafeGitTelemetryPath/);
+});
+
+test('run-handoff-tests routes mutating git calls through safe-git telemetry path', () => {
+  const content = readRepoFile('tools/priority/run-handoff-tests.mjs');
+  assert.match(content, /safeGitTelemetryPath/);
+  assert.match(content, /telemetryPath:\s*safeGitTelemetryPath/);
+});
+
+test('pre-push checks summarize safe-git reliability telemetry', () => {
+  const content = readRepoFile('tools/PrePush-Checks.ps1');
+  assert.match(content, /Invoke-SafeGitReliabilitySummary/);
+  assert.match(content, /summarize-safe-git-telemetry\.mjs/);
+  assert.match(content, /safe-git-trend-summary\.json/);
+});
+
+test('bootstrap summarizes safe-git reliability telemetry', () => {
+  const content = readRepoFile('tools/priority/bootstrap.ps1');
+  assert.match(content, /Invoke-SafeGitReliabilitySummary/);
+  assert.match(content, /summarize-safe-git-telemetry\.mjs/);
+  assert.match(content, /safe-git-trend-summary\.json/);
+});
+

--- a/tools/priority/__tests__/safe-git-telemetry-summary.test.mjs
+++ b/tools/priority/__tests__/safe-git-telemetry-summary.test.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { computeTrendSummary, runCli } from '../summarize-safe-git-telemetry.mjs';
+
+function sampleRun({ status = 'success', recoveryElapsedMs = 0, counters = {} } = {}) {
+  return {
+    schema: 'priority/safe-git-run-telemetry@v1',
+    startedAt: new Date('2026-03-06T00:00:00Z').toISOString(),
+    finishedAt: new Date('2026-03-06T00:00:01Z').toISOString(),
+    status,
+    reason: status === 'success' ? 'ok' : 'git-nonzero',
+    recoveryElapsedMs,
+    counters: {
+      lockDetections: 0,
+      repairAttempts: 0,
+      repairSuccesses: 0,
+      repairFailures: 0,
+      runtimeLockConflicts: 0,
+      killedProcessCount: 0,
+      ...counters
+    }
+  };
+}
+
+test('computeTrendSummary aggregates reliability counters and trend deltas', () => {
+  const runs = [
+    sampleRun({
+      status: 'success',
+      recoveryElapsedMs: 100,
+      counters: { lockDetections: 1, repairAttempts: 1, repairSuccesses: 1 }
+    }),
+    sampleRun({
+      status: 'blocked',
+      recoveryElapsedMs: 0,
+      counters: { lockDetections: 2, repairAttempts: 1, repairFailures: 1, runtimeLockConflicts: 1 }
+    }),
+    sampleRun({
+      status: 'success',
+      recoveryElapsedMs: 200,
+      counters: { lockDetections: 1, repairAttempts: 1, repairSuccesses: 1, killedProcessCount: 1 }
+    }),
+    sampleRun({
+      status: 'command-error',
+      recoveryElapsedMs: 0,
+      counters: { lockDetections: 0, repairAttempts: 0, repairFailures: 0 }
+    })
+  ];
+
+  const summary = computeTrendSummary(runs, 4);
+  assert.equal(summary.schema, 'priority/safe-git-reliability-trend@v1');
+  assert.equal(summary.metrics.totalRuns, 4);
+  assert.equal(summary.metrics.failedRuns, 2);
+  assert.equal(summary.metrics.lockDetections, 4);
+  assert.equal(summary.metrics.repairAttempts, 3);
+  assert.equal(summary.metrics.repairSuccesses, 2);
+  assert.equal(summary.metrics.repairFailures, 1);
+  assert.equal(summary.metrics.runtimeLockConflicts, 1);
+  assert.equal(summary.metrics.killedProcessCount, 1);
+  assert.equal(summary.metrics.meanRecoveryMs, 150);
+  assert.ok(typeof summary.trend.failureRatioDelta === 'number');
+  assert.ok(typeof summary.trend.meanRecoveryDeltaMs === 'number');
+});
+
+test('summarize-safe-git-telemetry CLI writes summary from jsonl input', async () => {
+  const work = await mkdtemp(path.join(tmpdir(), 'safe-git-summary-'));
+  const input = path.join(work, 'safe-git-events.jsonl');
+  const output = path.join(work, 'safe-git-trend-summary.json');
+
+  const rows = [
+    sampleRun({
+      status: 'success',
+      recoveryElapsedMs: 50,
+      counters: { lockDetections: 1, repairAttempts: 1, repairSuccesses: 1 }
+    }),
+    sampleRun({
+      status: 'blocked',
+      recoveryElapsedMs: 0,
+      counters: { lockDetections: 1, repairAttempts: 1, repairFailures: 1 }
+    })
+  ];
+
+  await writeFile(input, `${rows.map((entry) => JSON.stringify(entry)).join('\n')}\n`, 'utf8');
+
+  const code = await runCli(['--input', input, '--output', output, '--window', '10']);
+  assert.equal(code, 0);
+
+  const summary = JSON.parse(await readFile(output, 'utf8'));
+  assert.equal(summary.schema, 'priority/safe-git-reliability-trend@v1');
+  assert.equal(summary.metrics.totalRuns, 2);
+  assert.equal(summary.metrics.lockDetections, 2);
+  assert.equal(summary.metrics.failedRuns, 1);
+});
+

--- a/tools/priority/__tests__/safe-git.test.mjs
+++ b/tools/priority/__tests__/safe-git.test.mjs
@@ -176,3 +176,44 @@ test('runGitWithSafety kills stale git process when allowed and proceeds', () =>
   assert.deepEqual(removed, [indexLock]);
 });
 
+test('runGitWithSafety emits deterministic telemetry for repair flow', () => {
+  let lockExists = true;
+  const writes = [];
+  let nowMs = 10_000;
+
+  const result = runGitWithSafety(
+    ['push', 'origin', 'feature/x'],
+    { cwd: repoRoot, env: {} },
+    makeCommonBroker({
+      telemetryPath: path.join(repoRoot, 'tests', 'results', '_agent', 'reliability', 'safe-git-events.jsonl'),
+      nowFn: () => {
+        nowMs += 50;
+        return nowMs;
+      },
+      existsSyncFn: (target) => target === indexLock && lockExists,
+      rmSyncFn: () => {
+        lockExists = false;
+      },
+      spawnSyncFn: () => ({ status: 0, stdout: 'ok', stderr: '' }),
+      mkdirSyncFn: () => {},
+      appendFileSyncFn: (_targetPath, payload) => {
+        writes.push(String(payload));
+      }
+    })
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(writes.length, 1);
+
+  const telemetry = JSON.parse(writes[0].trim());
+  assert.equal(telemetry.schema, 'priority/safe-git-run-telemetry@v1');
+  assert.equal(telemetry.status, 'success');
+  assert.equal(telemetry.reason, 'ok');
+  assert.equal(telemetry.counters.lockDetections, 1);
+  assert.equal(telemetry.counters.repairAttempts, 1);
+  assert.equal(telemetry.counters.repairSuccesses, 1);
+  assert.ok(Array.isArray(telemetry.events));
+  assert.ok(telemetry.events.some((event) => event.type === 'lock-detected'));
+  assert.ok(telemetry.events.some((event) => event.type === 'repair-attempt'));
+  assert.ok(telemetry.events.some((event) => event.type === 'repair-result' && event.outcome === 'success'));
+});

--- a/tools/priority/bootstrap.ps1
+++ b/tools/priority/bootstrap.ps1
@@ -142,6 +142,50 @@ function Invoke-SemVerCheck {
   }
 }
 
+function Invoke-SafeGitReliabilitySummary {
+  $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $nodeCmd) {
+    Write-Warning 'node not found; skipping safe-git reliability summary.'
+    return
+  }
+
+  $scriptPath = Join-Path (Resolve-Path '.').Path 'tools/priority/summarize-safe-git-telemetry.mjs'
+  if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+    Write-Warning "safe-git reliability summary script not found at $scriptPath"
+    return
+  }
+
+  $inputPath = Join-Path (Resolve-Path '.').Path 'tests/results/_agent/reliability/safe-git-events.jsonl'
+  $outputPath = Join-Path (Resolve-Path '.').Path 'tests/results/_agent/reliability/safe-git-trend-summary.json'
+  $arguments = @(
+    $scriptPath,
+    '--input', $inputPath,
+    '--output', $outputPath
+  )
+  if ($env:GITHUB_STEP_SUMMARY) {
+    $arguments += @('--step-summary', $env:GITHUB_STEP_SUMMARY)
+  }
+
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = $nodeCmd.Source
+  foreach ($arg in $arguments) { $psi.ArgumentList.Add([string]$arg) }
+  $psi.WorkingDirectory = (Resolve-Path '.').Path
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  $proc = [System.Diagnostics.Process]::Start($psi)
+  $stdout = $proc.StandardOutput.ReadToEnd()
+  $stderr = $proc.StandardError.ReadToEnd()
+  $proc.WaitForExit()
+
+  if ($stdout) { Write-Host $stdout.TrimEnd() }
+  if ($stderr) { Write-Warning $stderr.TrimEnd() }
+  if ($proc.ExitCode -ne 0) {
+    throw "safe-git reliability summary failed (exit=$($proc.ExitCode))"
+  }
+}
+
 function Invoke-AgentWriterLeaseAcquire {
   if ($env:AGENT_WRITER_LEASE_ENABLED -eq '0') {
     Write-Host '[bootstrap] Agent writer lease disabled (AGENT_WRITER_LEASE_ENABLED=0).'
@@ -452,6 +496,9 @@ if (-not $PreflightOnly) {
     }
     Write-ReleaseSummary -SemVerResult $placeholder | Out-Null
   }
+
+  Write-Host '[bootstrap] Summarizing safe-git reliability telemetry…'
+  Invoke-SafeGitReliabilitySummary
 }
 
 Write-Host '[bootstrap] Bootstrapping complete.'

--- a/tools/priority/lib/branch-utils.mjs
+++ b/tools/priority/lib/branch-utils.mjs
@@ -1,10 +1,19 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
+import path from 'node:path';
 import process from 'node:process';
 import { isMutatingGitCommand, runGitWithSafety } from './safe-git.mjs';
 
 const IDENTIFIER_REGEX = /^[A-Za-z0-9._-]+$/;
+
+function resolveSafeGitTelemetryPath(cwd) {
+  const explicit = process.env.SAFE_GIT_TELEMETRY_PATH;
+  if (explicit) {
+    return path.isAbsolute(explicit) ? explicit : path.resolve(cwd, explicit);
+  }
+  return path.resolve(cwd, 'tests', 'results', '_agent', 'reliability', 'safe-git-events.jsonl');
+}
 
 export function run(command, args, options = {}) {
   const normalizedOptions = {
@@ -15,7 +24,9 @@ export function run(command, args, options = {}) {
 
   const result =
     command === 'git' && isMutatingGitCommand(args)
-      ? runGitWithSafety(args, normalizedOptions)
+      ? runGitWithSafety(args, normalizedOptions, {
+        telemetryPath: resolveSafeGitTelemetryPath(normalizedOptions.cwd ?? process.cwd())
+      })
       : spawnSync(command, args, normalizedOptions);
 
   if (result.status !== 0) {

--- a/tools/priority/lib/safe-git.mjs
+++ b/tools/priority/lib/safe-git.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -75,6 +75,13 @@ const IN_PROGRESS_PATTERNS = [
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_RETRY_DELAY_MS = 350;
 const DEFAULT_STALE_LOCK_AGE_MS = 30_000;
+const DEFAULT_TELEMETRY_RELATIVE_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'reliability',
+  'safe-git-events.jsonl'
+);
 
 function parseBooleanEnv(value, fallback = false) {
   if (value == null) {
@@ -454,12 +461,121 @@ function buildDeps(custom = {}) {
     readdirSyncFn: custom.readdirSyncFn ?? readdirSync,
     statSyncFn: custom.statSyncFn ?? statSync,
     rmSyncFn: custom.rmSyncFn ?? rmSync,
+    appendFileSyncFn: custom.appendFileSyncFn ?? appendFileSync,
+    mkdirSyncFn: custom.mkdirSyncFn ?? mkdirSync,
     nowFn: custom.nowFn ?? (() => Date.now()),
     logFn: custom.logFn ?? ((message) => console.warn(message)),
     resolveGitDirFn: custom.resolveGitDirFn,
     listGitProcessesFn: custom.listGitProcessesFn,
     killGitProcessFn: custom.killGitProcessFn
   };
+}
+
+function safeIsoTimestamp(nowMs) {
+  return new Date(Number.isFinite(nowMs) ? nowMs : Date.now()).toISOString();
+}
+
+function resolveTelemetryPath(cwd, spawnOptions, brokerOptions) {
+  const explicitPath = brokerOptions.telemetryPath ?? spawnOptions.env?.SAFE_GIT_TELEMETRY_PATH;
+  if (explicitPath) {
+    return path.isAbsolute(explicitPath) ? explicitPath : path.resolve(cwd, explicitPath);
+  }
+
+  const telemetryEnabled = parseBooleanEnv(
+    brokerOptions.telemetryEnabled ?? spawnOptions.env?.SAFE_GIT_TELEMETRY_ENABLED,
+    false
+  );
+  if (!telemetryEnabled) {
+    return null;
+  }
+
+  return path.resolve(cwd, DEFAULT_TELEMETRY_RELATIVE_PATH);
+}
+
+function buildTelemetryRun(args, cwd, gitDir, maxAttempts, maxRetries, retryDelayMs, staleLockAgeMs, allowProcessKill, deps) {
+  const startedAtMs = deps.nowFn();
+  return {
+    schema: 'priority/safe-git-run-telemetry@v1',
+    startedAt: safeIsoTimestamp(startedAtMs),
+    finishedAt: null,
+    durationMs: 0,
+    status: 'running',
+    reason: null,
+    command: [...args],
+    cwd,
+    gitDir,
+    maxAttempts,
+    maxRetries,
+    retryDelayMs,
+    staleLockAgeMs,
+    allowProcessKill,
+    attemptCount: 0,
+    recoveryElapsedMs: 0,
+    counters: {
+      lockDetections: 0,
+      repairAttempts: 0,
+      repairSuccesses: 0,
+      repairFailures: 0,
+      killedProcessCount: 0,
+      runtimeLockConflicts: 0
+    },
+    events: [],
+    _startedAtMs: startedAtMs,
+    _firstRepairAtMs: null,
+    _lastRepairAtMs: null
+  };
+}
+
+function pushTelemetryEvent(telemetry, deps, type, detail = {}) {
+  telemetry.events.push({
+    type,
+    at: safeIsoTimestamp(deps.nowFn()),
+    ...detail
+  });
+}
+
+function lockDetailsForTelemetry(gitDir, locks, nowMs, staleLockAgeMs) {
+  return locks.map((lock) => {
+    const ageMs = Math.max(0, Math.trunc(nowMs - lock.mtimeMs));
+    return {
+      path: formatGitPath(gitDir, lock.path),
+      ageMs,
+      stale: ageMs >= staleLockAgeMs
+    };
+  });
+}
+
+function finalizeTelemetry(telemetry, deps, status, reason, message = null) {
+  telemetry.status = status;
+  telemetry.reason = reason;
+  telemetry.finishedAt = safeIsoTimestamp(deps.nowFn());
+  const nowMs = deps.nowFn();
+  telemetry.durationMs = Math.max(0, Math.trunc(nowMs - telemetry._startedAtMs));
+  telemetry.recoveryElapsedMs =
+    telemetry._firstRepairAtMs != null && telemetry._lastRepairAtMs != null
+      ? Math.max(0, Math.trunc(telemetry._lastRepairAtMs - telemetry._firstRepairAtMs))
+      : 0;
+  if (message) {
+    telemetry.message = message;
+  }
+  delete telemetry._startedAtMs;
+  delete telemetry._firstRepairAtMs;
+  delete telemetry._lastRepairAtMs;
+}
+
+function persistTelemetry(telemetryPath, telemetry, deps) {
+  if (!telemetryPath) {
+    return;
+  }
+
+  try {
+    deps.mkdirSyncFn(path.dirname(telemetryPath), { recursive: true });
+    deps.appendFileSyncFn(telemetryPath, `${JSON.stringify(telemetry)}\n`, 'utf8');
+  } catch (error) {
+    deps.logFn(
+      `[safe-git] warning: failed to write telemetry to ${telemetryPath}: ${error?.message ?? String(error)}`
+    );
+  }
 }
 
 function shouldMutateTag(args) {
@@ -527,82 +643,219 @@ export function runGitWithSafety(args, spawnOptions = {}, brokerOptions = {}) {
     brokerOptions.allowProcessKill ?? normalizedSpawn.env?.SAFE_GIT_ALLOW_PROCESS_KILL,
     true
   );
-  const gitDir = resolveGitDir(cwd, normalizedSpawn, deps);
   const maxAttempts = Math.max(1, maxRetries + 1);
+  const telemetryPath = resolveTelemetryPath(cwd, normalizedSpawn, brokerOptions);
+  let gitDir = null;
+  let telemetry = buildTelemetryRun(
+    args,
+    cwd,
+    gitDir,
+    maxAttempts,
+    maxRetries,
+    retryDelayMs,
+    staleLockAgeMs,
+    allowProcessKill,
+    deps
+  );
+
+  let attemptCount = 0;
   let lastResult = null;
+  let telemetryFinalized = false;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const nowMs = deps.nowFn();
-    const locks = collectLockFiles(gitDir, deps, nowMs);
-    const inProgressStates = collectInProgressStates(gitDir, deps);
-    const blockedStates = evaluateBlockedStates(command, args, inProgressStates);
+  function finalize(status, reason, message = null) {
+    if (telemetryFinalized) {
+      return;
+    }
+    telemetry.attemptCount = attemptCount;
+    finalizeTelemetry(telemetry, deps, status, reason, message);
+    persistTelemetry(telemetryPath, telemetry, deps);
+    telemetryFinalized = true;
+  }
 
-    if (blockedStates.length > 0) {
-      throw buildStateError(args, blockedStates);
+  try {
+    try {
+      gitDir = resolveGitDir(cwd, normalizedSpawn, deps);
+      telemetry.gitDir = gitDir;
+    } catch (error) {
+      const message = error?.message ?? String(error);
+      pushTelemetryEvent(telemetry, deps, 'git-dir-unresolved', { message });
+      finalize('error', 'git-dir-unresolved', message);
+      throw error;
     }
 
-    if (locks.length > 0) {
-      const repair = repairLocks({
-        commandArgs: args,
-        gitDir,
-        locks,
-        staleLockAgeMs,
-        allowProcessKill,
-        deps,
-        nowMs,
-        logFn: deps.logFn
-      });
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      attemptCount = attempt;
+      pushTelemetryEvent(telemetry, deps, 'attempt-start', { attempt });
+      const nowMs = deps.nowFn();
+      const locks = collectLockFiles(gitDir, deps, nowMs);
+      const inProgressStates = collectInProgressStates(gitDir, deps);
+      const blockedStates = evaluateBlockedStates(command, args, inProgressStates);
 
-      if (repair.killedPids.length > 0) {
-        deps.logFn(
-          `[safe-git] terminated git process(es) ${repair.killedPids.join(', ')} while repairing lock(s) for git ${args.join(' ')}`
-        );
+      if (blockedStates.length > 0) {
+        pushTelemetryEvent(telemetry, deps, 'state-detected', {
+          attempt,
+          states: blockedStates.map((entry) => entry.description)
+        });
+        const error = buildStateError(args, blockedStates);
+        finalize('fail-fast', 'operation-in-progress', error.message);
+        throw error;
       }
 
-      if (repair.blocked.length > 0) {
-        if (attempt >= maxAttempts) {
-          throw buildLockError(args, repair.blocked, attempt, gitDir);
+      if (locks.length > 0) {
+        const lockDetails = lockDetailsForTelemetry(gitDir, locks, nowMs, staleLockAgeMs);
+        telemetry.counters.lockDetections += lockDetails.length;
+        pushTelemetryEvent(telemetry, deps, 'lock-detected', {
+          attempt,
+          lockCount: lockDetails.length,
+          locks: lockDetails
+        });
+
+        telemetry.counters.repairAttempts += 1;
+        if (telemetry._firstRepairAtMs == null) {
+          telemetry._firstRepairAtMs = nowMs;
         }
+        pushTelemetryEvent(telemetry, deps, 'repair-attempt', {
+          attempt,
+          allowProcessKill,
+          staleLockAgeMs
+        });
+
+        const repair = repairLocks({
+          commandArgs: args,
+          gitDir,
+          locks,
+          staleLockAgeMs,
+          allowProcessKill,
+          deps,
+          nowMs,
+          logFn: deps.logFn
+        });
+        telemetry._lastRepairAtMs = deps.nowFn();
+
+        if (repair.killedPids.length > 0) {
+          telemetry.counters.killedProcessCount += repair.killedPids.length;
+          deps.logFn(
+            `[safe-git] terminated git process(es) ${repair.killedPids.join(', ')} while repairing lock(s) for git ${args.join(' ')}`
+          );
+          for (const pid of repair.killedPids) {
+            pushTelemetryEvent(telemetry, deps, 'repair-result', {
+              attempt,
+              outcome: 'killed-process',
+              pid
+            });
+          }
+        }
+
+        for (const removed of repair.removed) {
+          telemetry.counters.repairSuccesses += 1;
+          pushTelemetryEvent(telemetry, deps, 'repair-result', {
+            attempt,
+            outcome: 'success',
+            lockPath: formatGitPath(gitDir, removed.path),
+            ageMs: removed.ageMs
+          });
+        }
+
+        for (const blocked of repair.blocked) {
+          telemetry.counters.repairFailures += 1;
+          pushTelemetryEvent(telemetry, deps, 'repair-result', {
+            attempt,
+            outcome: 'failure',
+            lockPath: formatGitPath(gitDir, blocked.path),
+            ageMs: blocked.ageMs,
+            reason: blocked.reason
+          });
+        }
+
+        if (repair.blocked.length > 0) {
+          if (attempt >= maxAttempts) {
+            const error = buildLockError(args, repair.blocked, attempt, gitDir);
+            finalize('blocked', 'lock-conflict', error.message);
+            throw error;
+          }
+          pushTelemetryEvent(telemetry, deps, 'retry-scheduled', {
+            attempt,
+            reason: 'lock-repair-incomplete',
+            retryDelayMs
+          });
+          sleepSync(retryDelayMs);
+          continue;
+        }
+      }
+
+      const result = deps.spawnSyncFn('git', args, normalizedSpawn);
+      lastResult = result;
+
+      if (result.status === 0) {
+        pushTelemetryEvent(telemetry, deps, 'command-result', {
+          attempt,
+          status: 'success'
+        });
+        finalize('success', 'ok');
+        return result;
+      }
+
+      if (looksLikeInProgressFailure(result)) {
+        const refreshed = evaluateBlockedStates(command, args, collectInProgressStates(gitDir, deps));
+        pushTelemetryEvent(telemetry, deps, 'command-result', {
+          attempt,
+          status: 'failure',
+          reason: 'operation-in-progress',
+          exitCode: result.status
+        });
+        if (refreshed.length > 0) {
+          const error = buildStateError(args, refreshed);
+          finalize('fail-fast', 'operation-in-progress', error.message);
+          throw error;
+        }
+        const error = new Error(
+          `[safe-git] git ${args.join(' ')} failed due to an in-progress operation state. Resolve the state and retry.`
+        );
+        finalize('fail-fast', 'operation-in-progress', error.message);
+        throw error;
+      }
+
+      if (looksLikeLockConflict(result) && attempt < maxAttempts) {
+        telemetry.counters.runtimeLockConflicts += 1;
+        pushTelemetryEvent(telemetry, deps, 'runtime-lock-conflict', {
+          attempt,
+          exitCode: result.status,
+          retryDelayMs
+        });
         sleepSync(retryDelayMs);
         continue;
       }
-    }
 
-    const result = deps.spawnSyncFn('git', args, normalizedSpawn);
-    lastResult = result;
-
-    if (result.status === 0) {
+      pushTelemetryEvent(telemetry, deps, 'command-result', {
+        attempt,
+        status: 'failure',
+        reason: 'non-zero',
+        exitCode: result.status
+      });
+      finalize('command-error', 'git-nonzero', String(result.stderr ?? '').trim() || null);
       return result;
     }
 
-    if (looksLikeInProgressFailure(result)) {
-      const refreshed = evaluateBlockedStates(command, args, collectInProgressStates(gitDir, deps));
-      if (refreshed.length > 0) {
-        throw buildStateError(args, refreshed);
-      }
-      throw new Error(
-        `[safe-git] git ${args.join(' ')} failed due to an in-progress operation state. Resolve the state and retry.`
-      );
+    if (lastResult) {
+      finalize('command-error', 'last-result-nonzero', String(lastResult.stderr ?? '').trim() || null);
+      return lastResult;
     }
 
-    if (looksLikeLockConflict(result) && attempt < maxAttempts) {
-      sleepSync(retryDelayMs);
-      continue;
+    const error = new Error(`[safe-git] git ${args.join(' ')} failed before execution.`);
+    finalize('error', 'pre-execution', error.message);
+    throw error;
+  } catch (error) {
+    if (!telemetryFinalized) {
+      finalize('error', 'exception', error?.message ?? String(error));
     }
-
-    return result;
+    throw error;
   }
-
-  if (lastResult) {
-    return lastResult;
-  }
-
-  throw new Error(`[safe-git] git ${args.join(' ')} failed before execution.`);
 }
 
 export const __test = {
   parseNumberEnv,
   parseBooleanEnv,
+  resolveTelemetryPath,
   collectLockFiles,
   collectInProgressStates,
   evaluateBlockedStates,
@@ -611,4 +864,3 @@ export const __test = {
   repairLocks,
   resolveGitDir
 };
-

--- a/tools/priority/run-handoff-tests.mjs
+++ b/tools/priority/run-handoff-tests.mjs
@@ -7,6 +7,11 @@ import { isMutatingGitCommand, runGitWithSafety } from './lib/safe-git.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..', '..');
+const safeGitTelemetryPath = process.env.SAFE_GIT_TELEMETRY_PATH
+  ? (path.isAbsolute(process.env.SAFE_GIT_TELEMETRY_PATH)
+    ? process.env.SAFE_GIT_TELEMETRY_PATH
+    : path.resolve(repoRoot, process.env.SAFE_GIT_TELEMETRY_PATH))
+  : path.join(repoRoot, 'tests', 'results', '_agent', 'reliability', 'safe-git-events.jsonl');
 
 const nodeExecPath = process.env.npm_node_execpath || process.execPath;
 const wrapperPath = path.join(repoRoot, 'tools', 'npm', 'run-script.mjs');
@@ -19,6 +24,8 @@ function runGit(args) {
         env: process.env,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe']
+      }, {
+        telemetryPath: safeGitTelemetryPath
       })
       : spawnSync('git', args, {
         cwd: repoRoot,

--- a/tools/priority/summarize-safe-git-telemetry.mjs
+++ b/tools/priority/summarize-safe-git-telemetry.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_INPUT_PATH = path.resolve(
+  'tests',
+  'results',
+  '_agent',
+  'reliability',
+  'safe-git-events.jsonl'
+);
+const DEFAULT_OUTPUT_PATH = path.resolve(
+  'tests',
+  'results',
+  '_agent',
+  'reliability',
+  'safe-git-trend-summary.json'
+);
+
+function printUsage() {
+  console.log(`Usage:
+  node tools/priority/summarize-safe-git-telemetry.mjs [options]
+
+Options:
+  --input <path>          JSONL run telemetry input path
+  --output <path>         Summary JSON output path
+  --window <n>            Number of most recent runs to analyze (default: 50)
+  --step-summary <path>   Optional GitHub step summary markdown path
+  --help                  Show this message and exit
+`);
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const parsed = {
+    input: DEFAULT_INPUT_PATH,
+    output: DEFAULT_OUTPUT_PATH,
+    window: 50,
+    stepSummary: process.env.GITHUB_STEP_SUMMARY || ''
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === '--input') {
+      parsed.input = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    if (arg === '--output') {
+      parsed.output = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    if (arg === '--window') {
+      const value = Number.parseInt(next, 10);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`Invalid --window value: ${next}`);
+      }
+      parsed.window = value;
+      index += 1;
+      continue;
+    }
+    if (arg === '--step-summary') {
+      parsed.stepSummary = path.resolve(next);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return parsed;
+}
+
+async function readJsonl(pathname) {
+  try {
+    const raw = await fs.readFile(pathname, 'utf8');
+    const lines = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const rows = [];
+    for (const line of lines) {
+      try {
+        rows.push(JSON.parse(line));
+      } catch {
+        // skip malformed line
+      }
+    }
+    return rows;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function toFixedNumber(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Number(value.toFixed(2));
+}
+
+export function computeTrendSummary(runs, windowSize = 50) {
+  const ordered = [...runs]
+    .filter((run) => run && typeof run === 'object')
+    .sort((left, right) => {
+      const l = Date.parse(left.startedAt || left.finishedAt || 0);
+      const r = Date.parse(right.startedAt || right.finishedAt || 0);
+      return l - r;
+    });
+
+  const window = ordered.slice(-windowSize);
+  const failures = window.filter((run) => run.status !== 'success');
+  const lockDetections = window.reduce((sum, run) => sum + Number(run?.counters?.lockDetections || 0), 0);
+  const repairAttempts = window.reduce((sum, run) => sum + Number(run?.counters?.repairAttempts || 0), 0);
+  const repairSuccesses = window.reduce((sum, run) => sum + Number(run?.counters?.repairSuccesses || 0), 0);
+  const repairFailures = window.reduce((sum, run) => sum + Number(run?.counters?.repairFailures || 0), 0);
+  const runtimeLockConflicts = window.reduce((sum, run) => sum + Number(run?.counters?.runtimeLockConflicts || 0), 0);
+  const killedProcessCount = window.reduce((sum, run) => sum + Number(run?.counters?.killedProcessCount || 0), 0);
+
+  const recoveryValues = window
+    .map((run) => Number(run?.recoveryElapsedMs || 0))
+    .filter((value) => Number.isFinite(value) && value > 0);
+  const meanRecoveryMs =
+    recoveryValues.length > 0
+      ? toFixedNumber(recoveryValues.reduce((sum, value) => sum + value, 0) / recoveryValues.length)
+      : 0;
+
+  const midpoint = Math.floor(window.length / 2);
+  const previousSegment = midpoint > 0 ? window.slice(0, midpoint) : [];
+  const currentSegment = midpoint > 0 ? window.slice(midpoint) : window;
+
+  function failureRatio(segment) {
+    if (!segment.length) {
+      return 0;
+    }
+    const segmentFailures = segment.filter((run) => run.status !== 'success').length;
+    return segmentFailures / segment.length;
+  }
+
+  function meanRecovery(segment) {
+    const values = segment
+      .map((run) => Number(run?.recoveryElapsedMs || 0))
+      .filter((value) => Number.isFinite(value) && value > 0);
+    if (!values.length) {
+      return 0;
+    }
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+  }
+
+  const previousFailureRatio = failureRatio(previousSegment);
+  const currentFailureRatio = failureRatio(currentSegment);
+  const previousMeanRecovery = meanRecovery(previousSegment);
+  const currentMeanRecovery = meanRecovery(currentSegment);
+
+  return {
+    schema: 'priority/safe-git-reliability-trend@v1',
+    generatedAt: new Date().toISOString(),
+    windowSize,
+    sampleCount: window.length,
+    metrics: {
+      totalRuns: window.length,
+      successfulRuns: window.length - failures.length,
+      failedRuns: failures.length,
+      failureRatio: toFixedNumber(currentFailureRatio),
+      lockDetections,
+      repairAttempts,
+      repairSuccesses,
+      repairFailures,
+      runtimeLockConflicts,
+      killedProcessCount,
+      meanRecoveryMs
+    },
+    trend: {
+      previousFailureRatio: toFixedNumber(previousFailureRatio),
+      currentFailureRatio: toFixedNumber(currentFailureRatio),
+      failureRatioDelta: toFixedNumber(currentFailureRatio - previousFailureRatio),
+      previousMeanRecoveryMs: toFixedNumber(previousMeanRecovery),
+      currentMeanRecoveryMs: toFixedNumber(currentMeanRecovery),
+      meanRecoveryDeltaMs: toFixedNumber(currentMeanRecovery - previousMeanRecovery)
+    }
+  };
+}
+
+async function writeSummary(pathname, summary) {
+  await fs.mkdir(path.dirname(pathname), { recursive: true });
+  await fs.writeFile(pathname, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+}
+
+async function appendStepSummary(pathname, summary) {
+  if (!pathname) {
+    return;
+  }
+  const lines = [
+    '### Safe Git Reliability',
+    '',
+    `- Runs analyzed: ${summary.metrics.totalRuns}`,
+    `- Failure ratio: ${summary.metrics.failureRatio}`,
+    `- Lock detections: ${summary.metrics.lockDetections}`,
+    `- Repair attempts: ${summary.metrics.repairAttempts}`,
+    `- Repair successes: ${summary.metrics.repairSuccesses}`,
+    `- Repair failures: ${summary.metrics.repairFailures}`,
+    `- Mean recovery (ms): ${summary.metrics.meanRecoveryMs}`,
+    `- Failure ratio delta: ${summary.trend.failureRatioDelta}`,
+    `- Mean recovery delta (ms): ${summary.trend.meanRecoveryDeltaMs}`,
+    ''
+  ];
+  await fs.appendFile(pathname, `${lines.join('\n')}\n`, 'utf8');
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printUsage();
+    return 0;
+  }
+
+  const runs = await readJsonl(args.input);
+  const summary = computeTrendSummary(runs, args.window);
+  await writeSummary(args.output, summary);
+  await appendStepSummary(args.stepSummary, summary);
+
+  console.log(
+    `[safe-git-trend] summary: ${args.output} (runs=${summary.metrics.totalRuns}, failureRatio=${summary.metrics.failureRatio})`
+  );
+
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+if (invokedPath && invokedPath === modulePath) {
+  try {
+    const exitCode = await runCli();
+    process.exit(exitCode);
+  } catch (error) {
+    console.error(`[safe-git-trend] ${error?.message || error}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Implements #736 by emitting structured safe-git run telemetry, documenting schemas, and adding trend rollups with step-summary counters. Wiring includes branch-utils/run-handoff-tests telemetry output, bootstrap/pre-push rollup generation, and regression/contract tests. Validation: node --test tools/priority/__tests__/safe-git.test.mjs tools/priority/__tests__/safe-git-telemetry-summary.test.mjs tools/priority/__tests__/safe-git-telemetry-contract.test.mjs; node --test tools/priority/__tests__/*.mjs; ./bin/actionlint -color; pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios.