### PR TITLE
test(policy): add seams for deterministic policy snapshot audit (#724)

### DIFF
--- a/tools/priority/__tests__/policy-snapshot.test.mjs
+++ b/tools/priority/__tests__/policy-snapshot.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import {
+  parseArgs,
+  parseRemoteUrl,
+  resolveRepositorySlug,
+  collectPolicyState
+} from '../policy-snapshot.mjs';
+
+test('parseArgs applies defaults and accepts explicit repo/output', () => {
+  const defaults = parseArgs(['node', 'policy-snapshot.mjs']);
+  assert.equal(defaults.outputPath, path.join('tests', 'results', '_agent', 'policy', 'policy-state-snapshot.json'));
+  assert.equal(defaults.repo, null);
+  assert.equal(defaults.help, false);
+
+  const explicit = parseArgs([
+    'node',
+    'policy-snapshot.mjs',
+    '--repo',
+    'owner/repo',
+    '--output',
+    'tmp/snapshot.json'
+  ]);
+  assert.equal(explicit.repo, 'owner/repo');
+  assert.equal(explicit.outputPath, 'tmp/snapshot.json');
+});
+
+test('parseRemoteUrl normalizes ssh/https GitHub remote URLs', () => {
+  assert.equal(parseRemoteUrl('git@github.com:owner/repo.git'), 'owner/repo');
+  assert.equal(parseRemoteUrl('https://github.com/owner/repo.git'), 'owner/repo');
+  assert.equal(parseRemoteUrl('https://example.com/not-github/repo.git'), null);
+});
+
+test('resolveRepositorySlug prefers explicit, then env, then remotes', () => {
+  const fromExplicit = resolveRepositorySlug('explicit/repo');
+  assert.equal(fromExplicit, 'explicit/repo');
+
+  const fromEnv = resolveRepositorySlug(null, {
+    environment: { GITHUB_REPOSITORY: 'env/repo' },
+    commandRunner: () => {
+      throw new Error('should not call command runner when env is set');
+    }
+  });
+  assert.equal(fromEnv, 'env/repo');
+
+  const seenCommands = [];
+  const fromRemote = resolveRepositorySlug(null, {
+    environment: {},
+    commandRunner: (command) => {
+      seenCommands.push(command);
+      if (command.includes('remote.upstream.url')) {
+        return 'git@github.com:upstream-owner/compare-vi-cli-action.git';
+      }
+      throw new Error('missing remote');
+    }
+  });
+  assert.equal(fromRemote, 'upstream-owner/compare-vi-cli-action');
+  assert.ok(seenCommands.some((entry) => entry.includes('remote.upstream.url')));
+});
+
+test('collectPolicyState records branch protection and ruleset-by-id details', async () => {
+  const calls = [];
+  const manifest = {
+    branches: {
+      develop: {},
+      main: {},
+      'release/*': {}
+    },
+    rulesets: {
+      100: {},
+      abc: {}
+    }
+  };
+
+  const state = await collectPolicyState({
+    repo: 'owner/repo',
+    token: 'test-token',
+    manifest,
+    requestJsonFn: async (url) => {
+      calls.push(url);
+      if (url.endsWith('/repos/owner/repo')) {
+        return {
+          full_name: 'owner/repo',
+          allow_squash_merge: true,
+          allow_merge_commit: false,
+          allow_rebase_merge: false,
+          allow_auto_merge: true,
+          delete_branch_on_merge: true,
+          updated_at: '2026-03-06T00:00:00Z'
+        };
+      }
+      if (url.endsWith('/branches/develop/protection')) {
+        return { required_pull_request_reviews: { required_approving_review_count: 0 } };
+      }
+      if (url.endsWith('/branches/main/protection')) {
+        return { required_status_checks: { strict: true } };
+      }
+      if (url.endsWith('/rulesets/100')) {
+        return { id: 100, name: 'develop queue', rules: [{ type: 'merge_queue' }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }
+  });
+
+  assert.equal(state.repo.name, 'owner/repo');
+  assert.equal(state.repo.allow_squash_merge, true);
+  assert.equal(state.branches.develop.skipped, false);
+  assert.equal(state.branches.main.skipped, false);
+  assert.equal(state.branches['release/*'].skipped, true);
+  assert.equal(state.rulesets['100'].id, 100);
+  assert.equal(state.rulesets.abc.error, 'invalid-ruleset-id');
+  assert.ok(calls.some((entry) => entry.endsWith('/rulesets/100')));
+  assert.ok(calls.every((entry) => !entry.endsWith('/rulesets')));
+});

--- a/tools/priority/policy-snapshot.mjs
+++ b/tools/priority/policy-snapshot.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const manifestPath = new URL('./policy.json', import.meta.url);
-const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'policy', 'policy-state-snapshot.json');
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'policy', 'policy-state-snapshot.json');
 
 function printUsage() {
   console.log('Usage: node tools/priority/policy-snapshot.mjs [options]');
@@ -17,7 +17,7 @@ function printUsage() {
   console.log('  -h, --help        Show this help text and exit.');
 }
 
-function parseArgs(argv = process.argv) {
+export function parseArgs(argv = process.argv) {
   const args = argv.slice(2);
   const options = {
     outputPath: DEFAULT_OUTPUT_PATH,
@@ -48,7 +48,7 @@ function parseArgs(argv = process.argv) {
   return options;
 }
 
-function parseRemoteUrl(url) {
+export function parseRemoteUrl(url) {
   if (!url) return null;
   const sshMatch = url.match(/:(?<repoPath>[^/]+\/[^/]+)(?:\.git)?$/);
   const httpsMatch = url.match(/github\.com\/(?<repoPath>[^/]+\/[^/]+)(?:\.git)?$/);
@@ -62,20 +62,20 @@ function parseRemoteUrl(url) {
   return `${owner}/${repo}`;
 }
 
-function resolveRepositorySlug(explicitRepo) {
+export function resolveRepositorySlug(explicitRepo, options = {}) {
+  const environment = options.environment ?? process.env;
+  const commandRunner = options.commandRunner ?? ((command) => execSync(command, {
+    stdio: ['ignore', 'pipe', 'ignore']
+  }).toString().trim());
   if (explicitRepo) {
     return explicitRepo;
   }
-  if (process.env.GITHUB_REPOSITORY && process.env.GITHUB_REPOSITORY.includes('/')) {
-    return process.env.GITHUB_REPOSITORY.trim();
+  if (environment.GITHUB_REPOSITORY && environment.GITHUB_REPOSITORY.includes('/')) {
+    return environment.GITHUB_REPOSITORY.trim();
   }
   for (const remoteName of ['upstream', 'origin']) {
     try {
-      const url = execSync(`git config --get remote.${remoteName}.url`, {
-        stdio: ['ignore', 'pipe', 'ignore']
-      })
-        .toString()
-        .trim();
+      const url = commandRunner(`git config --get remote.${remoteName}.url`);
       const parsed = parseRemoteUrl(url);
       if (parsed) return parsed;
     } catch {
@@ -137,13 +137,14 @@ function isBranchPattern(branch) {
   return /[*?[\]]/.test(branch);
 }
 
-async function collectPolicyState({
+export async function collectPolicyState({
   repo,
   token,
-  manifest
+  manifest,
+  requestJsonFn = requestJson
 }) {
   const apiBase = `https://api.github.com/repos/${repo}`;
-  const repoState = await requestJson(apiBase, token);
+  const repoState = await requestJsonFn(apiBase, token);
 
   const branches = {};
   for (const branchName of Object.keys(manifest.branches ?? {})) {
@@ -154,7 +155,7 @@ async function collectPolicyState({
       };
       continue;
     }
-    const protection = await requestJson(`${apiBase}/branches/${encodeURIComponent(branchName)}/protection`, token);
+    const protection = await requestJsonFn(`${apiBase}/branches/${encodeURIComponent(branchName)}/protection`, token);
     branches[branchName] = {
       skipped: false,
       protection
@@ -170,7 +171,7 @@ async function collectPolicyState({
       };
       continue;
     }
-    const ruleset = await requestJson(`${apiBase}/rulesets/${numeric}`, token);
+    const ruleset = await requestJsonFn(`${apiBase}/rulesets/${numeric}`, token);
     rulesets[id] = ruleset;
   }
 


### PR DESCRIPTION
## Summary
- add unit-test seams to `tools/priority/policy-snapshot.mjs` (argument parsing, repo slug resolution, and policy-state collection)
- add `policy-snapshot` unit tests that verify deterministic branch protection capture and ruleset-by-id fetch behavior
- assert snapshot collection uses detailed `/rulesets/{id}` endpoints and does not regress to list-only inference

## Validation
- node --test tools/priority/__tests__/policy-snapshot.test.mjs
- node --test tools/priority/__tests__/*.mjs
- ./bin/actionlint -color
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios

Closes #724
