### PR TITLE
[P1][supply-chain] Enforce release trust gate policy (#712)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup Node 20
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
       - name: Build release notes from CHANGELOG
         id: notes
         shell: bash
@@ -136,6 +141,37 @@ jobs:
             artifacts/cli/SHA256SUMS.txt
             artifacts/cli/sbom.spdx.json
             artifacts/cli/provenance.json
+
+      - name: Enforce supply-chain trust gate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node tools/priority/supply-chain-trust-gate.mjs \
+            --repo "${{ github.repository }}" \
+            --artifacts-root artifacts/cli \
+            --checksums artifacts/cli/SHA256SUMS.txt \
+            --sbom artifacts/cli/sbom.spdx.json \
+            --provenance artifacts/cli/provenance.json \
+            --signer-workflow "${{ github.repository }}/.github/workflows/release.yml" \
+            --report tests/results/_agent/supply-chain/release-trust-gate.json
+
+      - name: Validate supply-chain trust report schema
+        if: always()
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 \
+            -JsonPath tests/results/_agent/supply-chain/release-trust-gate.json \
+            -SchemaPath docs/schemas/supply-chain-trust-gate-v1.schema.json
+
+      - name: Upload supply-chain trust artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: release-supply-chain-trust-${{ github.run_id }}
+          path: tests/results/_agent/supply-chain/release-trust-gate.json
+          if-no-files-found: error
 
       - name: Create GitHub Release with assets (CHANGELOG)
         if: steps.notes.outputs.fallback == 'false'
@@ -305,6 +341,12 @@ jobs:
           name: certification-matrix-${{ github.run_id }}
           path: tests/results/_agent/certification
 
+      - name: Download supply-chain trust artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-supply-chain-trust-${{ github.run_id }}
+          path: tests/results/_agent/supply-chain
+
       - name: Assert promotion contract alignment
         shell: pwsh
         run: |
@@ -449,4 +491,5 @@ jobs:
             tests/results/promotion-contract/release-ledger.json
             tests/results/_agent/slo/release-slo-metrics.json
             tests/results/_agent/certification/release-certification-matrix.json
+            tests/results/_agent/supply-chain/release-trust-gate.json
           if-no-files-found: error

--- a/docs/RELEASE_ASSET_VERIFICATION.md
+++ b/docs/RELEASE_ASSET_VERIFICATION.md
@@ -56,3 +56,12 @@ gh attestation verify <asset-file> \
 ```
 
 The verification must pass before promoting release artifacts.
+
+## Automated trust gate
+
+`Release on tag` enforces these checks through:
+
+- `node tools/priority/supply-chain-trust-gate.mjs`
+- report artifact: `tests/results/_agent/supply-chain/release-trust-gate.json`
+
+The release fails closed if this gate reports any failure class.

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -87,6 +87,25 @@ Configuration path: `Settings -> Environments -> <environment> -> Required revie
    - evidence artifacts are linked
    - follow-up remediation issues are created when needed
 
+## Supply-chain trust remediation classes
+
+When the release trust gate fails, inspect `tests/results/_agent/supply-chain/release-trust-gate.json` and follow the
+matching remediation path:
+
+- `missing-artifacts-root`, `missing-required-file`, `no-distribution-artifacts`
+  - Re-run publish steps and confirm artifacts exist under `artifacts/cli`.
+- `checksum-invalid-line`, `checksum-empty`, `checksum-entry-missing-file`, `checksum-missing-artifact`, `checksum-mismatch`
+  - Regenerate `SHA256SUMS.txt` from fresh artifacts and ensure no post-pack mutation occurred.
+- `sbom-parse-failed`, `sbom-invalid`
+  - Re-run `tools/Generate-ReleaseSbom.ps1` and validate content/coverage for all distribution archives.
+- `provenance-parse-failed`, `provenance-invalid`
+  - Re-run `tools/Generate-ReleaseProvenance.ps1`; verify repository/run/sha identity fields.
+- `attestation-cli-unavailable`
+  - Restore GitHub CLI availability on runner and retry release.
+- `attestation-output-parse-failed`, `attestation-empty-result`, `attestation-unverified`
+  - Re-run attestation and verify with:
+    - `gh attestation verify <artifact> --repo <owner/repo> --signer-workflow <owner/repo/.github/workflows/release.yml>`
+
 ## Rehearsal contract (testable, repeatable)
 
 - Weekly operator rehearsal (non-destructive):
@@ -105,3 +124,4 @@ Configuration path: `Settings -> Environments -> <environment> -> Required revie
 - `tests/results/_agent/release/release-<tag>-finalize.json`
 - `tests/results/_agent/policy/policy-drift-report.json`
 - `tests/results/_agent/health-snapshot/health-snapshot.json`
+- `tests/results/_agent/supply-chain/release-trust-gate.json`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -14,6 +14,8 @@ alignment, and evidence ledger expectations.
 - Certification matrix policy: `tools/policy/certification-matrix.json`
 - Certification matrix schema: `docs/schemas/certification-matrix-v1.schema.json`
 - Certification runbook: `docs/CERTIFICATION_MATRIX.md`
+- Supply-chain trust gate script: `tools/priority/supply-chain-trust-gate.mjs`
+- Supply-chain trust gate schema: `docs/schemas/supply-chain-trust-gate-v1.schema.json`
 
 ## Channels
 
@@ -81,6 +83,20 @@ Release tags must generate a compatibility certification matrix artifact before 
   - `stable`: block when required lanes are stale, missing, incomplete, or failed.
 
 Lane lifecycle (add/remove/update) is documented in `docs/CERTIFICATION_MATRIX.md`.
+
+## Supply-chain trust gate
+
+Release tags must pass the supply-chain trust gate before GitHub Release publication:
+
+- Gate script: `node tools/priority/supply-chain-trust-gate.mjs`
+- Report artifact: `tests/results/_agent/supply-chain/release-trust-gate.json`
+- Enforced checks:
+  - required artifact presence (`*.zip/*.tar.gz`, `SHA256SUMS.txt`, `sbom.spdx.json`, `provenance.json`)
+  - checksum integrity
+  - SBOM/provenance contract validity
+  - artifact attestation verification via `gh attestation verify`
+
+If the trust gate fails, release publication is blocked (fail-closed) and the report artifact must be used for remediation.
 
 ## Gate outcomes
 

--- a/docs/schemas/supply-chain-trust-gate-v1.schema.json
+++ b/docs/schemas/supply-chain-trust-gate-v1.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/supply-chain-trust-gate-v1.schema.json",
+  "title": "Supply Chain Trust Gate v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "repository",
+    "policy",
+    "artifacts",
+    "attestations",
+    "failures",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "priority/supply-chain-trust-gate@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "channel": {
+      "type": "string"
+    },
+    "workflow": {
+      "type": "object"
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "signerWorkflow",
+        "verifyAttestations",
+        "attestationAttempts",
+        "attestationRetrySeconds"
+      ],
+      "properties": {
+        "signerWorkflow": {
+          "type": "string"
+        },
+        "verifyAttestations": {
+          "type": "boolean"
+        },
+        "attestationAttempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "attestationRetrySeconds": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "root",
+        "distribution",
+        "checksums",
+        "sbom",
+        "provenance"
+      ],
+      "properties": {
+        "root": {
+          "type": "string"
+        },
+        "distribution": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "path",
+              "sizeBytes",
+              "sha256",
+              "checksum"
+            ]
+          }
+        },
+        "checksums": {
+          "type": "object",
+          "required": [
+            "path",
+            "exists",
+            "entryCount",
+            "invalidLineCount"
+          ]
+        },
+        "sbom": {
+          "type": "object",
+          "required": [
+            "path",
+            "exists",
+            "valid",
+            "spdxVersion",
+            "fileCount"
+          ]
+        },
+        "provenance": {
+          "type": "object",
+          "required": [
+            "path",
+            "exists",
+            "valid",
+            "schema",
+            "releaseAssetCount"
+          ]
+        }
+      }
+    },
+    "attestations": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "results"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "artifactPath",
+              "verified",
+              "attempts",
+              "attestationCount",
+              "error"
+            ]
+          }
+        }
+      }
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "status",
+        "failureCount",
+        "failureCodes",
+        "artifactCount",
+        "attestationVerifiedCount",
+        "attestationTotal"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "fail"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "priority:policy": "node tools/priority/check-policy.mjs",
     "priority:policy:snapshot": "node tools/priority/policy-snapshot.mjs",
     "priority:certification:matrix": "node tools/priority/certification-matrix.mjs",
+    "priority:trust:gate": "node tools/priority/supply-chain-trust-gate.mjs",
     "priority:slo": "node tools/priority/slo-metrics.mjs",
     "priority:operator-status": "pwsh -NoLogo -NoProfile -File tools/priority/Write-OperatorStatusSummary.ps1",
     "priority:parity": "node tools/priority/report-origin-upstream-parity.mjs",

--- a/tools/policy/promotion-contract.json
+++ b/tools/policy/promotion-contract.json
@@ -11,7 +11,8 @@
       "required_evidence": [
         "contract-alignment",
         "promotion-evidence-ledger",
-        "certification-matrix"
+        "certification-matrix",
+        "supply-chain-trust-gate"
       ]
     },
     "stable": {
@@ -21,7 +22,8 @@
       "required_evidence": [
         "contract-alignment",
         "promotion-evidence-ledger",
-        "certification-matrix"
+        "certification-matrix",
+        "supply-chain-trust-gate"
       ]
     },
     "lts": {
@@ -31,7 +33,8 @@
       "required_evidence": [
         "contract-alignment",
         "promotion-evidence-ledger",
-        "certification-matrix"
+        "certification-matrix",
+        "supply-chain-trust-gate"
       ]
     }
   },

--- a/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
+++ b/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
@@ -1,0 +1,224 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_REPORT_PATH,
+  evaluateLocalIntegrity,
+  parseArgs,
+  parseChecksumManifest,
+  shouldRetryAttestationVerify,
+  verifyAttestationForArtifact,
+  verifyAttestations
+} from '../supply-chain-trust-gate.mjs';
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+test('parseArgs applies defaults and explicit overrides', () => {
+  const defaults = parseArgs(['node', 'supply-chain-trust-gate.mjs']);
+  assert.equal(defaults.artifactsRoot, path.join('artifacts', 'cli'));
+  assert.equal(defaults.reportPath, DEFAULT_REPORT_PATH);
+  assert.equal(defaults.verifyAttestations, true);
+  assert.equal(defaults.attestationAttempts, 6);
+
+  const parsed = parseArgs([
+    'node',
+    'supply-chain-trust-gate.mjs',
+    '--repo',
+    'owner/repo',
+    '--artifacts-root',
+    'out/release',
+    '--checksums',
+    'out/release/SHA256SUMS.txt',
+    '--sbom',
+    'out/release/sbom.json',
+    '--provenance',
+    'out/release/prov.json',
+    '--report',
+    'out/report.json',
+    '--signer-workflow',
+    'owner/repo/.github/workflows/release.yml',
+    '--attestation-attempts',
+    '2',
+    '--attestation-retry-seconds',
+    '1',
+    '--skip-attestations'
+  ]);
+  assert.equal(parsed.repo, 'owner/repo');
+  assert.equal(parsed.artifactsRoot, 'out/release');
+  assert.equal(parsed.reportPath, 'out/report.json');
+  assert.equal(parsed.signerWorkflow, 'owner/repo/.github/workflows/release.yml');
+  assert.equal(parsed.attestationAttempts, 2);
+  assert.equal(parsed.attestationRetrySeconds, 1);
+  assert.equal(parsed.verifyAttestations, false);
+});
+
+test('parseChecksumManifest parses valid entries and invalid lines', () => {
+  const a = 'a'.repeat(64);
+  const b = 'b'.repeat(64);
+  const parsed = parseChecksumManifest(
+    `${a}  ./artifacts/cli/file-a.tar.gz\n` +
+      `invalid-line\n` +
+      `${b}  .\\artifacts\\cli\\file-b.zip\n`
+  );
+  assert.equal(parsed.entries.length, 2);
+  assert.equal(parsed.invalidLines.length, 1);
+  assert.equal(parsed.entries[0].name, 'file-a.tar.gz');
+  assert.equal(parsed.entries[1].name, 'file-b.zip');
+});
+
+test('evaluateLocalIntegrity passes for valid release payload', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'trust-gate-pass-'));
+  const artifactsRoot = path.join(root, 'artifacts', 'cli');
+  fs.mkdirSync(artifactsRoot, { recursive: true });
+
+  const linuxArchive = path.join(artifactsRoot, 'comparevi-cli-v1-linux-x64-selfcontained.tar.gz');
+  const winArchive = path.join(artifactsRoot, 'comparevi-cli-v1-win-x64-selfcontained.zip');
+  writeFile(linuxArchive, 'linux-archive-content');
+  writeFile(winArchive, 'windows-archive-content');
+
+  const linuxHash = sha256('linux-archive-content');
+  const winHash = sha256('windows-archive-content');
+  const checksumText =
+    `${linuxHash}  ./comparevi-cli-v1-linux-x64-selfcontained.tar.gz\n` +
+    `${winHash}  ./comparevi-cli-v1-win-x64-selfcontained.zip\n`;
+  writeFile(path.join(artifactsRoot, 'SHA256SUMS.txt'), checksumText);
+
+  const sbomPayload = {
+    spdxVersion: 'SPDX-2.3',
+    files: [
+      { fileName: './comparevi-cli-v1-linux-x64-selfcontained.tar.gz' },
+      { fileName: './comparevi-cli-v1-win-x64-selfcontained.zip' }
+    ]
+  };
+  writeFile(path.join(artifactsRoot, 'sbom.spdx.json'), JSON.stringify(sbomPayload));
+
+  const checksumHash = sha256(checksumText);
+  const sbomHash = sha256(JSON.stringify(sbomPayload));
+  const provenancePayload = {
+    schema: 'run-provenance/v1',
+    repository: 'owner/repo',
+    runId: '123',
+    headSha: 'abc123',
+    releaseAssets: [
+      { name: path.basename(linuxArchive), sha256: linuxHash },
+      { name: path.basename(winArchive), sha256: winHash },
+      { name: 'SHA256SUMS.txt', sha256: checksumHash },
+      { name: 'sbom.spdx.json', sha256: sbomHash }
+    ]
+  };
+  writeFile(path.join(artifactsRoot, 'provenance.json'), JSON.stringify(provenancePayload));
+
+  const result = evaluateLocalIntegrity({
+    repoRoot: root,
+    artifactsRoot: path.join('artifacts', 'cli'),
+    checksumsPath: path.join('artifacts', 'cli', 'SHA256SUMS.txt'),
+    sbomPath: path.join('artifacts', 'cli', 'sbom.spdx.json'),
+    provenancePath: path.join('artifacts', 'cli', 'provenance.json'),
+    expectedRepository: 'owner/repo',
+    expectedRunId: '123',
+    expectedHeadSha: 'abc123'
+  });
+
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.artifactRecords.length, 2);
+  assert.equal(result.sbom.valid, true);
+  assert.equal(result.provenance.valid, true);
+});
+
+test('evaluateLocalIntegrity reports checksum mismatch failures', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'trust-gate-fail-'));
+  const artifactsRoot = path.join(root, 'artifacts', 'cli');
+  fs.mkdirSync(artifactsRoot, { recursive: true });
+
+  const archive = path.join(artifactsRoot, 'comparevi-cli-v1-linux-x64-selfcontained.tar.gz');
+  writeFile(archive, 'archive-content');
+  writeFile(path.join(artifactsRoot, 'SHA256SUMS.txt'), `${'0'.repeat(64)}  ./comparevi-cli-v1-linux-x64-selfcontained.tar.gz\n`);
+  writeFile(
+    path.join(artifactsRoot, 'sbom.spdx.json'),
+    JSON.stringify({ spdxVersion: 'SPDX-2.3', files: [{ fileName: './comparevi-cli-v1-linux-x64-selfcontained.tar.gz' }] })
+  );
+  writeFile(
+    path.join(artifactsRoot, 'provenance.json'),
+    JSON.stringify({
+      schema: 'run-provenance/v1',
+      repository: 'owner/repo',
+      runId: '123',
+      headSha: 'abc123',
+      releaseAssets: [{ name: 'comparevi-cli-v1-linux-x64-selfcontained.tar.gz', sha256: sha256('archive-content') }]
+    })
+  );
+
+  const result = evaluateLocalIntegrity({
+    repoRoot: root,
+    artifactsRoot: path.join('artifacts', 'cli'),
+    checksumsPath: path.join('artifacts', 'cli', 'SHA256SUMS.txt'),
+    sbomPath: path.join('artifacts', 'cli', 'sbom.spdx.json'),
+    provenancePath: path.join('artifacts', 'cli', 'provenance.json'),
+    expectedRepository: 'owner/repo',
+    expectedRunId: '123',
+    expectedHeadSha: 'abc123'
+  });
+
+  assert.ok(result.failures.some((failure) => failure.code === 'checksum-mismatch'));
+});
+
+test('verifyAttestationForArtifact retries on transient error and then succeeds', async () => {
+  const calls = [];
+  const runner = (_command, _args) => {
+    calls.push(1);
+    if (calls.length === 1) {
+      return {
+        status: 1,
+        stdout: '',
+        stderr: 'no attestations found for subject'
+      };
+    }
+    return {
+      status: 0,
+      stdout: '[{"verificationResult":{"statement":{"subject":[]}}}]',
+      stderr: ''
+    };
+  };
+  const result = await verifyAttestationForArtifact({
+    artifactPath: '/tmp/file.zip',
+    repository: 'owner/repo',
+    signerWorkflow: 'owner/repo/.github/workflows/release.yml',
+    maxAttempts: 3,
+    retrySeconds: 0,
+    runner,
+    sleepFn: async () => {}
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.attempts, 2);
+  assert.equal(result.attestationCount, 1);
+});
+
+test('verifyAttestations reports gh unavailable and retry classifier catches transient messages', async () => {
+  assert.equal(shouldRetryAttestationVerify('no attestations found'), true);
+  assert.equal(shouldRetryAttestationVerify('HTTP 429 rate limit exceeded'), true);
+  assert.equal(shouldRetryAttestationVerify('permission denied'), false);
+
+  const result = await verifyAttestations({
+    artifactPaths: ['/tmp/a.zip'],
+    repository: 'owner/repo',
+    signerWorkflow: 'owner/repo/.github/workflows/release.yml',
+    maxAttempts: 1,
+    retrySeconds: 0,
+    runner: () => ({ status: 1, stdout: '', stderr: 'gh missing' }),
+    sleepFn: async () => {}
+  });
+
+  assert.ok(result.failures.some((failure) => failure.code === 'attestation-cli-unavailable'));
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0].verified, false);
+});

--- a/tools/priority/supply-chain-trust-gate.mjs
+++ b/tools/priority/supply-chain-trust-gate.mjs
@@ -1,0 +1,833 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'supply-chain',
+  'release-trust-gate.json'
+);
+
+const FAILURE_HINTS = {
+  'missing-artifacts-root': 'Verify Publish CLI output path and ensure artifacts are generated before trust verification.',
+  'missing-required-file': 'Regenerate release artifacts and ensure required files are present in artifacts/cli.',
+  'no-distribution-artifacts': 'No .zip/.tar.gz assets were found. Re-run publish and verify RID packaging outputs.',
+  'checksum-invalid-line': 'Regenerate SHA256SUMS.txt to restore valid "<sha256>  <path>" formatting.',
+  'checksum-empty': 'SHA256SUMS.txt parsed as empty. Re-run Publish-Cli and ensure checksums are written.',
+  'checksum-entry-missing-file': 'Checksum manifest references a file that does not exist. Regenerate artifacts/checksums together.',
+  'checksum-missing-artifact': 'A published archive is missing from SHA256SUMS.txt. Re-run checksum generation.',
+  'checksum-mismatch': 'Artifact hash does not match SHA256SUMS entry. Rebuild artifacts from a clean workspace.',
+  'sbom-parse-failed': 'SBOM JSON is unreadable. Re-run Generate-ReleaseSbom.ps1 and validate output.',
+  'sbom-invalid': 'SBOM content is missing required SPDX fields or artifact references. Regenerate SBOM.',
+  'provenance-parse-failed': 'Provenance JSON is unreadable. Re-run Generate-ReleaseProvenance.ps1 and validate output.',
+  'provenance-invalid': 'Provenance payload failed contract checks (schema/asset hash/identity). Regenerate provenance.',
+  'attestation-cli-unavailable': 'GitHub CLI is unavailable. Install/enable gh on runner before trust gate.',
+  'attestation-output-parse-failed': 'Attestation verification output was not valid JSON. Re-run verification and inspect gh logs.',
+  'attestation-unverified': 'Artifact attestation verification failed. Confirm attest-build-provenance step and signer workflow.',
+  'attestation-empty-result': 'No attestation records were returned. Confirm attestation publication and retry.'
+};
+
+export function printUsage() {
+  console.log('Usage: node tools/priority/supply-chain-trust-gate.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --repo <owner/repo>               Target repository (default: env/remotes).');
+  console.log('  --artifacts-root <path>           Release artifact root (default: artifacts/cli).');
+  console.log('  --checksums <path>                SHA256SUMS path (default: artifacts/cli/SHA256SUMS.txt).');
+  console.log('  --sbom <path>                     SBOM path (default: artifacts/cli/sbom.spdx.json).');
+  console.log('  --provenance <path>               Provenance path (default: artifacts/cli/provenance.json).');
+  console.log(`  --report <path>                   Report output path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log('  --signer-workflow <value>         Attestation signer workflow identity.');
+  console.log('  --attestation-attempts <n>        Retry attempts for attestation verify (default: 6).');
+  console.log('  --attestation-retry-seconds <n>   Retry delay in seconds (default: 10).');
+  console.log('  --skip-attestations               Skip gh attestation verification (local/debug only).');
+  console.log('  -h, --help                        Show this message and exit.');
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    repo: null,
+    artifactsRoot: path.join('artifacts', 'cli'),
+    checksumsPath: path.join('artifacts', 'cli', 'SHA256SUMS.txt'),
+    sbomPath: path.join('artifacts', 'cli', 'sbom.spdx.json'),
+    provenancePath: path.join('artifacts', 'cli', 'provenance.json'),
+    reportPath: DEFAULT_REPORT_PATH,
+    signerWorkflow: null,
+    attestationAttempts: 6,
+    attestationRetrySeconds: 10,
+    verifyAttestations: true,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--skip-attestations') {
+      options.verifyAttestations = false;
+      continue;
+    }
+
+    if (
+      token === '--repo' ||
+      token === '--artifacts-root' ||
+      token === '--checksums' ||
+      token === '--sbom' ||
+      token === '--provenance' ||
+      token === '--report' ||
+      token === '--signer-workflow'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--repo') options.repo = next;
+      if (token === '--artifacts-root') options.artifactsRoot = next;
+      if (token === '--checksums') options.checksumsPath = next;
+      if (token === '--sbom') options.sbomPath = next;
+      if (token === '--provenance') options.provenancePath = next;
+      if (token === '--report') options.reportPath = next;
+      if (token === '--signer-workflow') options.signerWorkflow = next;
+      continue;
+    }
+
+    if (token === '--attestation-attempts' || token === '--attestation-retry-seconds') {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      const parsed = Number.parseInt(next, 10);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(`Invalid value for ${token}: ${next}`);
+      }
+      if (token === '--attestation-attempts') options.attestationAttempts = parsed;
+      if (token === '--attestation-retry-seconds') options.attestationRetrySeconds = parsed;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+function parseRemoteUrl(url) {
+  if (!url) return null;
+  const sshMatch = url.match(/:(?<repoPath>[^/]+\/[^/]+)(?:\.git)?$/);
+  const httpsMatch = url.match(/github\.com\/(?<repoPath>[^/]+\/[^/]+)(?:\.git)?$/);
+  const repoPath = sshMatch?.groups?.repoPath ?? httpsMatch?.groups?.repoPath;
+  if (!repoPath) return null;
+  const [owner, rawRepo] = repoPath.split('/');
+  if (!owner || !rawRepo) return null;
+  const repo = rawRepo.endsWith('.git') ? rawRepo.slice(0, -4) : rawRepo;
+  return `${owner}/${repo}`;
+}
+
+export function resolveRepositorySlug(explicitRepo) {
+  if (explicitRepo) return explicitRepo;
+  const envRepo = process.env.GITHUB_REPOSITORY?.trim();
+  if (envRepo && envRepo.includes('/')) return envRepo;
+  for (const remoteName of ['upstream', 'origin']) {
+    try {
+      const raw = execSync(`git config --get remote.${remoteName}.url`, {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+        .toString()
+        .trim();
+      const parsed = parseRemoteUrl(raw);
+      if (parsed) return parsed;
+    } catch {
+      // ignore missing remotes
+    }
+  }
+  throw new Error('Unable to resolve repository slug. Set GITHUB_REPOSITORY or pass --repo.');
+}
+
+function normalizePathValue(value) {
+  if (!value) return '';
+  return String(value).replace(/\\/g, '/').replace(/^\.\/+/, '').replace(/^\/+/, '');
+}
+
+function hashFileSha256(filePath) {
+  const data = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function walkFilesRecursive(rootPath) {
+  const files = [];
+  if (!fs.existsSync(rootPath)) return files;
+  for (const entry of fs.readdirSync(rootPath, { withFileTypes: true })) {
+    const fullPath = path.join(rootPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFilesRecursive(fullPath));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function addFailure(failures, code, message, target = null) {
+  const payload = {
+    code,
+    message,
+    hint: FAILURE_HINTS[code] || null
+  };
+  if (target) payload.target = target;
+  failures.push(payload);
+}
+
+export function parseChecksumManifest(text) {
+  const entries = [];
+  const invalidLines = [];
+  const lines = String(text || '').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([0-9a-fA-F]{64})\s+(.+)$/);
+    if (!match) {
+      invalidLines.push(trimmed);
+      continue;
+    }
+    entries.push({
+      sha256: match[1].toLowerCase(),
+      rawPath: match[2],
+      normalizedPath: normalizePathValue(match[2]),
+      name: path.basename(normalizePathValue(match[2]))
+    });
+  }
+  return { entries, invalidLines };
+}
+
+function buildFileIndex(files, repoRoot, artifactsRoot) {
+  const byNormalizedPath = new Map();
+  const byName = new Map();
+  for (const absolutePath of files) {
+    const relRepo = normalizePathValue(path.relative(repoRoot, absolutePath));
+    const relArtifacts = normalizePathValue(path.relative(artifactsRoot, absolutePath));
+    if (relRepo) byNormalizedPath.set(relRepo, absolutePath);
+    if (relArtifacts) byNormalizedPath.set(relArtifacts, absolutePath);
+    const name = path.basename(absolutePath);
+    if (!byName.has(name)) byName.set(name, []);
+    byName.get(name).push(absolutePath);
+  }
+  return { byNormalizedPath, byName };
+}
+
+function resolveChecksumTarget(entry, index) {
+  const direct = index.byNormalizedPath.get(entry.normalizedPath);
+  if (direct) return direct;
+  const sameName = index.byName.get(entry.name) || [];
+  if (sameName.length === 1) return sameName[0];
+  return null;
+}
+
+function validateSbomPayload(sbom, archiveFiles, failures) {
+  if (!sbom || typeof sbom !== 'object') {
+    addFailure(failures, 'sbom-invalid', 'SBOM payload is not an object.');
+    return { valid: false, spdxVersion: null, fileCount: 0 };
+  }
+  const spdxVersion = String(sbom.spdxVersion || '');
+  if (spdxVersion !== 'SPDX-2.3') {
+    addFailure(failures, 'sbom-invalid', `Expected spdxVersion=SPDX-2.3. Received: ${spdxVersion || '<empty>'}.`);
+  }
+  const sbomFiles = Array.isArray(sbom.files) ? sbom.files : [];
+  if (sbomFiles.length === 0) {
+    addFailure(failures, 'sbom-invalid', 'SBOM files array is empty.');
+  }
+  const sbomNames = new Set(
+    sbomFiles.map((entry) => path.basename(normalizePathValue(entry?.fileName || '')).toLowerCase()).filter(Boolean)
+  );
+  for (const archivePath of archiveFiles) {
+    const name = path.basename(archivePath).toLowerCase();
+    if (!sbomNames.has(name)) {
+      addFailure(failures, 'sbom-invalid', `SBOM does not reference distribution artifact '${name}'.`, name);
+    }
+  }
+  return {
+    valid: failures.filter((failure) => failure.code === 'sbom-invalid' || failure.code === 'sbom-parse-failed').length === 0,
+    spdxVersion,
+    fileCount: sbomFiles.length
+  };
+}
+
+function validateProvenancePayload(provenance, context, archiveFiles, failures) {
+  if (!provenance || typeof provenance !== 'object') {
+    addFailure(failures, 'provenance-invalid', 'Provenance payload is not an object.');
+    return { valid: false, schema: null, releaseAssetCount: 0 };
+  }
+  const schema = String(provenance.schema || '');
+  if (schema !== 'run-provenance/v1') {
+    addFailure(failures, 'provenance-invalid', `Expected schema=run-provenance/v1. Received: ${schema || '<empty>'}.`);
+  }
+  if (context.expectedRepository && provenance.repository && provenance.repository !== context.expectedRepository) {
+    addFailure(
+      failures,
+      'provenance-invalid',
+      `Provenance repository mismatch. expected=${context.expectedRepository} actual=${provenance.repository}.`
+    );
+  }
+  if (context.expectedRunId && provenance.runId && String(provenance.runId) !== String(context.expectedRunId)) {
+    addFailure(
+      failures,
+      'provenance-invalid',
+      `Provenance runId mismatch. expected=${context.expectedRunId} actual=${provenance.runId}.`
+    );
+  }
+  if (context.expectedHeadSha && provenance.headSha && String(provenance.headSha) !== String(context.expectedHeadSha)) {
+    addFailure(
+      failures,
+      'provenance-invalid',
+      `Provenance headSha mismatch. expected=${context.expectedHeadSha} actual=${provenance.headSha}.`
+    );
+  }
+
+  const releaseAssets = Array.isArray(provenance.releaseAssets) ? provenance.releaseAssets : [];
+  if (releaseAssets.length === 0) {
+    addFailure(failures, 'provenance-invalid', 'Provenance releaseAssets array is empty.');
+  }
+
+  const expectedNames = new Set([
+    ...archiveFiles.map((filePath) => path.basename(filePath)),
+    'SHA256SUMS.txt',
+    'sbom.spdx.json'
+  ]);
+  const releaseByName = new Map();
+  for (const entry of releaseAssets) {
+    const name = String(entry?.name || '').trim();
+    if (!name) continue;
+    releaseByName.set(name, entry);
+  }
+  for (const expectedName of expectedNames) {
+    if (!releaseByName.has(expectedName)) {
+      addFailure(
+        failures,
+        'provenance-invalid',
+        `Provenance releaseAssets does not include '${expectedName}'.`,
+        expectedName
+      );
+    }
+  }
+
+  return {
+    valid: failures.filter((failure) => failure.code === 'provenance-invalid' || failure.code === 'provenance-parse-failed').length === 0,
+    schema,
+    releaseAssetCount: releaseAssets.length
+  };
+}
+
+export function evaluateLocalIntegrity({
+  repoRoot,
+  artifactsRoot,
+  checksumsPath,
+  sbomPath,
+  provenancePath,
+  expectedRepository = null,
+  expectedRunId = null,
+  expectedHeadSha = null
+}) {
+  const failures = [];
+  const resolvedRoot = path.resolve(repoRoot, artifactsRoot);
+  const resolvedChecksums = path.resolve(repoRoot, checksumsPath);
+  const resolvedSbom = path.resolve(repoRoot, sbomPath);
+  const resolvedProvenance = path.resolve(repoRoot, provenancePath);
+
+  if (!fs.existsSync(resolvedRoot)) {
+    addFailure(failures, 'missing-artifacts-root', `Artifacts root not found: ${resolvedRoot}`, resolvedRoot);
+    return {
+      failures,
+      artifactRecords: [],
+      archiveFiles: [],
+      checksums: { path: resolvedChecksums, exists: false, entryCount: 0, invalidLineCount: 0 },
+      sbom: { path: resolvedSbom, exists: false, valid: false, spdxVersion: null, fileCount: 0 },
+      provenance: { path: resolvedProvenance, exists: false, valid: false, schema: null, releaseAssetCount: 0 }
+    };
+  }
+
+  const files = walkFilesRecursive(resolvedRoot);
+  const archiveFiles = files.filter((filePath) => /\.(zip|tar\.gz)$/i.test(filePath));
+  if (archiveFiles.length === 0) {
+    addFailure(failures, 'no-distribution-artifacts', `No distribution archives found under ${resolvedRoot}.`);
+  }
+
+  for (const required of [
+    { key: 'checksums', path: resolvedChecksums },
+    { key: 'sbom', path: resolvedSbom },
+    { key: 'provenance', path: resolvedProvenance }
+  ]) {
+    if (!fs.existsSync(required.path)) {
+      addFailure(failures, 'missing-required-file', `Required file missing: ${required.path}`, required.path);
+    }
+  }
+
+  const index = buildFileIndex(files, repoRoot, resolvedRoot);
+
+  let checksumEntries = [];
+  let invalidChecksumLines = [];
+  if (fs.existsSync(resolvedChecksums)) {
+    const parsedChecksums = parseChecksumManifest(fs.readFileSync(resolvedChecksums, 'utf8'));
+    checksumEntries = parsedChecksums.entries;
+    invalidChecksumLines = parsedChecksums.invalidLines;
+    for (const invalidLine of invalidChecksumLines) {
+      addFailure(failures, 'checksum-invalid-line', `Invalid checksum line: ${invalidLine}`);
+    }
+    if (checksumEntries.length === 0) {
+      addFailure(failures, 'checksum-empty', 'No checksum entries parsed from SHA256SUMS.txt.');
+    }
+  }
+
+  const checksumByFile = new Map();
+  for (const entry of checksumEntries) {
+    const target = resolveChecksumTarget(entry, index);
+    if (!target) {
+      addFailure(
+        failures,
+        'checksum-entry-missing-file',
+        `Checksum entry references missing/ambiguous file: ${entry.rawPath}`,
+        entry.rawPath
+      );
+      continue;
+    }
+    const actual = hashFileSha256(target);
+    const match = actual === entry.sha256;
+    checksumByFile.set(target, {
+      expected: entry.sha256,
+      actual,
+      match,
+      source: entry.rawPath
+    });
+    if (!match) {
+      addFailure(
+        failures,
+        'checksum-mismatch',
+        `Checksum mismatch for ${path.basename(target)} expected=${entry.sha256} actual=${actual}.`,
+        target
+      );
+    }
+  }
+
+  for (const archivePath of archiveFiles) {
+    if (!checksumByFile.has(archivePath)) {
+      addFailure(
+        failures,
+        'checksum-missing-artifact',
+        `Distribution artifact missing from checksum manifest: ${path.basename(archivePath)}.`,
+        archivePath
+      );
+    }
+  }
+
+  const artifactRecords = archiveFiles
+    .map((archivePath) => {
+      const checksum = checksumByFile.get(archivePath) || null;
+      return {
+        name: path.basename(archivePath),
+        path: archivePath,
+        sizeBytes: fs.statSync(archivePath).size,
+        sha256: hashFileSha256(archivePath),
+        checksum: {
+          present: Boolean(checksum),
+          match: checksum ? Boolean(checksum.match) : false,
+          expected: checksum?.expected ?? null,
+          actual: checksum?.actual ?? null
+        }
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  let sbomStatus = { path: resolvedSbom, exists: fs.existsSync(resolvedSbom), valid: false, spdxVersion: null, fileCount: 0 };
+  if (fs.existsSync(resolvedSbom)) {
+    try {
+      const payload = JSON.parse(fs.readFileSync(resolvedSbom, 'utf8'));
+      const validation = validateSbomPayload(payload, archiveFiles, failures);
+      sbomStatus = {
+        path: resolvedSbom,
+        exists: true,
+        valid: validation.valid,
+        spdxVersion: validation.spdxVersion,
+        fileCount: validation.fileCount
+      };
+    } catch (error) {
+      addFailure(failures, 'sbom-parse-failed', `Failed to parse SBOM: ${error.message}`);
+    }
+  }
+
+  let provenanceStatus = {
+    path: resolvedProvenance,
+    exists: fs.existsSync(resolvedProvenance),
+    valid: false,
+    schema: null,
+    releaseAssetCount: 0
+  };
+  if (fs.existsSync(resolvedProvenance)) {
+    try {
+      const payload = JSON.parse(fs.readFileSync(resolvedProvenance, 'utf8'));
+      const validation = validateProvenancePayload(
+        payload,
+        {
+          expectedRepository,
+          expectedRunId,
+          expectedHeadSha
+        },
+        archiveFiles,
+        failures
+      );
+      provenanceStatus = {
+        path: resolvedProvenance,
+        exists: true,
+        valid: validation.valid,
+        schema: validation.schema,
+        releaseAssetCount: validation.releaseAssetCount
+      };
+    } catch (error) {
+      addFailure(failures, 'provenance-parse-failed', `Failed to parse provenance payload: ${error.message}`);
+    }
+  }
+
+  return {
+    failures,
+    artifactRecords,
+    archiveFiles,
+    checksums: {
+      path: resolvedChecksums,
+      exists: fs.existsSync(resolvedChecksums),
+      entryCount: checksumEntries.length,
+      invalidLineCount: invalidChecksumLines.length
+    },
+    sbom: sbomStatus,
+    provenance: provenanceStatus
+  };
+}
+
+function defaultCommandRunner(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  return {
+    status: Number.isInteger(result.status) ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+export function shouldRetryAttestationVerify(message) {
+  const text = String(message || '').toLowerCase();
+  return (
+    text.includes('no attestations found') ||
+    text.includes('not found') ||
+    text.includes('429') ||
+    text.includes('rate limit') ||
+    text.includes('temporarily unavailable')
+  );
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function verifyAttestationForArtifact({
+  artifactPath,
+  repository,
+  signerWorkflow,
+  maxAttempts,
+  retrySeconds,
+  runner = defaultCommandRunner,
+  sleepFn = sleep
+}) {
+  let attempts = 0;
+  let lastError = '';
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    attempts = attempt;
+    const args = [
+      'attestation',
+      'verify',
+      artifactPath,
+      '--repo',
+      repository,
+      '--signer-workflow',
+      signerWorkflow,
+      '--format',
+      'json'
+    ];
+    if (process.env.GITHUB_REF) {
+      args.push('--source-ref', process.env.GITHUB_REF);
+    }
+
+    const result = await Promise.resolve(runner('gh', args));
+    const stderr = String(result.stderr || '').trim();
+    const stdout = String(result.stdout || '').trim();
+    if (result.status === 0) {
+      try {
+        const parsed = stdout ? JSON.parse(stdout) : [];
+        if (!Array.isArray(parsed) || parsed.length === 0) {
+          lastError = 'attestation verify returned empty result array';
+          if (attempt < maxAttempts) {
+            await sleepFn(retrySeconds * 1000);
+            continue;
+          }
+          return {
+            artifactPath,
+            verified: false,
+            attempts,
+            attestationCount: 0,
+            error: lastError
+          };
+        }
+        return {
+          artifactPath,
+          verified: true,
+          attempts,
+          attestationCount: parsed.length,
+          error: null
+        };
+      } catch (error) {
+        lastError = `attestation output parse failed: ${error.message}`;
+      }
+    } else {
+      lastError = stderr || stdout || `gh exited with code ${result.status}`;
+    }
+
+    if (attempt < maxAttempts && shouldRetryAttestationVerify(lastError)) {
+      await sleepFn(retrySeconds * 1000);
+      continue;
+    }
+    break;
+  }
+
+  return {
+    artifactPath,
+    verified: false,
+    attempts,
+    attestationCount: 0,
+    error: lastError
+  };
+}
+
+export async function verifyAttestations({
+  artifactPaths,
+  repository,
+  signerWorkflow,
+  maxAttempts,
+  retrySeconds,
+  runner = defaultCommandRunner,
+  sleepFn = sleep
+}) {
+  const failures = [];
+  const check = await Promise.resolve(runner('gh', ['--version']));
+  if (check.status !== 0) {
+    addFailure(failures, 'attestation-cli-unavailable', 'Unable to execute gh attestation verify.');
+    return {
+      failures,
+      results: artifactPaths.map((artifactPath) => ({
+        artifactPath,
+        verified: false,
+        attempts: 0,
+        attestationCount: 0,
+        error: 'gh-not-available'
+      }))
+    };
+  }
+
+  const results = [];
+  for (const artifactPath of artifactPaths) {
+    const record = await verifyAttestationForArtifact({
+      artifactPath,
+      repository,
+      signerWorkflow,
+      maxAttempts,
+      retrySeconds,
+      runner,
+      sleepFn
+    });
+    results.push(record);
+    if (!record.verified) {
+      const code =
+        record.error && record.error.toLowerCase().includes('parse failed')
+          ? 'attestation-output-parse-failed'
+          : record.error && record.error.toLowerCase().includes('empty result')
+            ? 'attestation-empty-result'
+            : 'attestation-unverified';
+      addFailure(
+        failures,
+        code,
+        `Attestation verify failed for ${path.basename(record.artifactPath)} after ${record.attempts} attempt(s): ${record.error}`,
+        record.artifactPath
+      );
+    }
+  }
+  return { failures, results };
+}
+
+function appendSummary(report, reportPath) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const lines = [
+    '### Supply-Chain Trust Gate',
+    `- Status: \`${report.summary.status}\``,
+    `- Failures: \`${report.summary.failureCount}\``,
+    `- Artifacts evaluated: \`${report.summary.artifactCount}\``,
+    `- Attestations verified: \`${report.summary.attestationVerifiedCount}/${report.summary.attestationTotal}\``,
+    `- Report: \`${reportPath}\``
+  ];
+  if (report.failures.length > 0) {
+    lines.push('', '| Code | Target | Message |', '| --- | --- | --- |');
+    for (const failure of report.failures) {
+      lines.push(`| \`${failure.code}\` | \`${failure.target || 'n/a'}\` | ${failure.message.replace(/\|/g, '\\|')} |`);
+    }
+  }
+  fs.appendFileSync(summaryPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function writeReport(filePath, payload) {
+  const resolved = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export async function run(options, dependencies = {}) {
+  const repository = resolveRepositorySlug(options.repo);
+  const signerWorkflow = options.signerWorkflow || `${repository}/.github/workflows/release.yml`;
+  const repoRoot = process.cwd();
+
+  const local = evaluateLocalIntegrity({
+    repoRoot,
+    artifactsRoot: options.artifactsRoot,
+    checksumsPath: options.checksumsPath,
+    sbomPath: options.sbomPath,
+    provenancePath: options.provenancePath,
+    expectedRepository: repository,
+    expectedRunId: process.env.GITHUB_RUN_ID || null,
+    expectedHeadSha: process.env.GITHUB_SHA || null
+  });
+
+  const attestationArtifactPaths = [
+    ...local.archiveFiles,
+    local.checksums.path,
+    local.sbom.path,
+    local.provenance.path
+  ].filter((value, index, self) => self.indexOf(value) === index && fs.existsSync(value));
+
+  let attestation = {
+    failures: [],
+    results: []
+  };
+  if (options.verifyAttestations) {
+    attestation = await verifyAttestations({
+      artifactPaths: attestationArtifactPaths,
+      repository,
+      signerWorkflow,
+      maxAttempts: Math.max(1, options.attestationAttempts),
+      retrySeconds: Math.max(0, options.attestationRetrySeconds),
+      runner: dependencies.runner || defaultCommandRunner,
+      sleepFn: dependencies.sleepFn || sleep
+    });
+  }
+
+  const failures = [...local.failures, ...attestation.failures];
+  const summary = {
+    status: failures.length === 0 ? 'pass' : 'fail',
+    failureCount: failures.length,
+    failureCodes: [...new Set(failures.map((failure) => failure.code))].sort(),
+    artifactCount: local.artifactRecords.length,
+    attestationVerifiedCount: attestation.results.filter((entry) => entry.verified).length,
+    attestationTotal: attestation.results.length
+  };
+
+  return {
+    schema: 'priority/supply-chain-trust-gate@v1',
+    generatedAt: new Date().toISOString(),
+    repository,
+    channel: /-rc\./i.test(process.env.GITHUB_REF_NAME || '') ? 'rc' : 'stable',
+    workflow: {
+      name: process.env.GITHUB_WORKFLOW || null,
+      runId: process.env.GITHUB_RUN_ID || null,
+      runAttempt: process.env.GITHUB_RUN_ATTEMPT || null,
+      event: process.env.GITHUB_EVENT_NAME || null,
+      ref: process.env.GITHUB_REF || null,
+      sha: process.env.GITHUB_SHA || null
+    },
+    policy: {
+      signerWorkflow,
+      verifyAttestations: options.verifyAttestations,
+      attestationAttempts: options.attestationAttempts,
+      attestationRetrySeconds: options.attestationRetrySeconds
+    },
+    artifacts: {
+      root: path.resolve(options.artifactsRoot),
+      distribution: local.artifactRecords,
+      checksums: local.checksums,
+      sbom: local.sbom,
+      provenance: local.provenance
+    },
+    attestations: {
+      enabled: options.verifyAttestations,
+      results: attestation.results
+    },
+    failures,
+    summary
+  };
+}
+
+export async function main(argv = process.argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+
+  const report = await run(options);
+  const outputPath = writeReport(options.reportPath, report);
+  appendSummary(report, options.reportPath);
+  console.log(`[supply-chain-trust-gate] wrote ${outputPath} (status=${report.summary.status}, failures=${report.summary.failureCount})`);
+  return report.summary.status === 'pass' ? 0 : 1;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((code) => {
+      if (code !== 0) process.exitCode = code;
+    })
+    .catch((error) => {
+      const fallback = {
+        schema: 'priority/supply-chain-trust-gate@v1',
+        generatedAt: new Date().toISOString(),
+        summary: {
+          status: 'fail',
+          failureCount: 1,
+          failureCodes: ['execution-error'],
+          artifactCount: 0,
+          attestationVerifiedCount: 0,
+          attestationTotal: 0
+        },
+        failures: [
+          {
+            code: 'execution-error',
+            message: error?.stack || error?.message || String(error),
+            hint: 'Inspect script logs and rerun trust gate.'
+          }
+        ]
+      };
+      try {
+        const options = parseArgs(process.argv);
+        writeReport(options.reportPath, fallback);
+      } catch {
+        // no-op
+      }
+      console.error(error?.stack ?? error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- add a fail-closed release trust gate (`tools/priority/supply-chain-trust-gate.mjs`) that validates:
  - required release artifacts exist
  - checksum integrity matches `SHA256SUMS.txt`
  - SBOM and provenance contracts are valid
  - GitHub artifact attestations verify with `gh attestation verify`
- wire trust gate into `.github/workflows/release.yml` before GitHub Release publication and emit deterministic report artifact:
  - `tests/results/_agent/supply-chain/release-trust-gate.json`
- add trust report schema + unit tests + npm script:
  - `docs/schemas/supply-chain-trust-gate-v1.schema.json`
  - `tools/priority/__tests__/supply-chain-trust-gate.test.mjs`
  - `priority:trust:gate`
- update promotion/runbook docs and promotion-contract evidence list to include `supply-chain-trust-gate`

## Validation
- `node --test tools/priority/__tests__/supply-chain-trust-gate.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`

Closes #712
