### PR TITLE
[P1][release-platform] package-first CompareVi.Shared migration shim (#714)

### DIFF
--- a/.github/workflows/dotnet-shared.yml
+++ b/.github/workflows/dotnet-shared.yml
@@ -4,10 +4,14 @@ on:
   push:
     paths:
       - 'src/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
       - '.github/workflows/dotnet-shared.yml'
   pull_request:
     paths:
       - 'src/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
       - '.github/workflows/dotnet-shared.yml'
   workflow_dispatch:
     inputs:
@@ -27,7 +31,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shared_source: [project, package]
+        include:
+          - shared_source: package-first
+            expected_resolved: package
+          - shared_source: package
+            expected_resolved: package
+          - shared_source: project
+            expected_resolved: project
     steps:
       - uses: actions/checkout@v5
 
@@ -67,14 +77,29 @@ jobs:
           dotnet restore src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
           -p:CompareViSharedSource=${{ matrix.shared_source }}
           -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }}
+          -p:CompareViSharedPackageFeed=${{ github.workspace }}/artifacts
           --source "${{ github.workspace }}/artifacts"
           --source "https://api.nuget.org/v3/index.json"
+
+      - name: Assert shared-source resolution
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$(dotnet msbuild src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj \
+            -nologo \
+            -t:PrintCompareViSharedSource \
+            -p:CompareViSharedSource=${{ matrix.shared_source }} \
+            -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }} \
+            -p:CompareViSharedPackageFeed=${{ github.workspace }}/artifacts)"
+          echo "$output"
+          echo "$output" | grep -F "CompareViSharedResolvedSource=${{ matrix.expected_resolved }}"
 
       - name: Build CompareVi CLI
         run: >
           dotnet build -c Release src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
           -p:CompareViSharedSource=${{ matrix.shared_source }}
           -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }}
+          -p:CompareViSharedPackageFeed=${{ github.workspace }}/artifacts
           --no-restore
 
       - name: CLI smoke (version/tokenize/procs)
@@ -85,7 +110,8 @@ jobs:
           run_cli() {
             dotnet run --project src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj -c Release --no-build \
               -p:CompareViSharedSource=${{ matrix.shared_source }} \
-              -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }} -- "$@"
+              -p:CompareViSharedPackageVersion=${{ steps.shared.outputs.version }} \
+              -p:CompareViSharedPackageFeed=${{ github.workspace }}/artifacts -- "$@"
           }
 
           ver_json="$(run_cli version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,22 @@ jobs:
 
       - name: Publish CLI artifacts
         shell: pwsh
-        run: pwsh -File tools/Publish-Cli.ps1
+        run: pwsh -NoLogo -NoProfile -File tools/Publish-Cli.ps1 -CompareViSharedSource package-first -PrepareSharedPackageFeed -FailOnSharedFallback
+
+      - name: Validate shared-source resolution schema
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 \
+            -JsonPath tests/results/_agent/release/shared-source-resolution.json \
+            -SchemaPath docs/schemas/release-shared-source-resolution-v1.schema.json
+
+      - name: Upload shared-source resolution artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: release-shared-source-resolution-${{ github.run_id }}
+          path: tests/results/_agent/release/shared-source-resolution.json
+          if-no-files-found: error
 
       - name: Generate SBOM (SPDX)
         shell: pwsh
@@ -130,6 +145,7 @@ jobs:
             artifacts/cli/SHA256SUMS.txt
             artifacts/cli/sbom.spdx.json
             artifacts/cli/provenance.json
+            tests/results/_agent/release/shared-source-resolution.json
           if-no-files-found: error
 
       - name: Attest release assets provenance
@@ -374,6 +390,12 @@ jobs:
           name: release-supply-chain-trust-${{ github.run_id }}
           path: tests/results/_agent/supply-chain
 
+      - name: Download shared-source resolution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-shared-source-resolution-${{ github.run_id }}
+          path: tests/results/_agent/release
+
       - name: Download rollback drill health artifact
         uses: actions/download-artifact@v4
         with:
@@ -526,4 +548,5 @@ jobs:
             tests/results/_agent/certification/release-certification-matrix.json
             tests/results/_agent/supply-chain/release-trust-gate.json
             tests/results/_agent/release/rollback-drill-health.json
+            tests/results/_agent/release/shared-source-resolution.json
           if-no-files-found: error

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,10 @@
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>0.1.0.0</FileVersion>
     <InformationalVersion>0.1.0+local</InformationalVersion>
-    <CompareViSharedSource Condition="'$(CompareViSharedSource)' == ''">project</CompareViSharedSource>
+    <CompareViSharedSource Condition="'$(CompareViSharedSource)' == ''">package-first</CompareViSharedSource>
+    <CompareViSharedFallbackSource Condition="'$(CompareViSharedFallbackSource)' == ''">project</CompareViSharedFallbackSource>
     <CompareViSharedPackageVersion Condition="'$(CompareViSharedPackageVersion)' == ''">0.1.0</CompareViSharedPackageVersion>
+    <CompareViSharedPackageFeed Condition="'$(CompareViSharedPackageFeed)' == ''">$(MSBuildThisFileDirectory)artifacts/shared-feed</CompareViSharedPackageFeed>
   </PropertyGroup>
 </Project>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,22 @@
+<Project>
+  <PropertyGroup>
+    <CompareViSharedResolvedSource Condition="'$(CompareViSharedSource)' == ''">project</CompareViSharedResolvedSource>
+    <CompareViSharedResolvedSource Condition="'$(CompareViSharedSource)' == 'project'">project</CompareViSharedResolvedSource>
+    <CompareViSharedResolvedSource Condition="'$(CompareViSharedSource)' == 'package'">package</CompareViSharedResolvedSource>
+
+    <CompareViSharedPackageCandidate Condition="'$(CompareViSharedPackageFeed)' != '' and '$(CompareViSharedPackageVersion)' != ''">
+      $(CompareViSharedPackageFeed)/CompareVi.Shared.$(CompareViSharedPackageVersion).nupkg
+    </CompareViSharedPackageCandidate>
+    <CompareViSharedPackageAvailable Condition="'$(CompareViSharedPackageCandidate)' != '' and Exists('$(CompareViSharedPackageCandidate)')">true</CompareViSharedPackageAvailable>
+    <CompareViSharedPackageAvailable Condition="'$(CompareViSharedPackageAvailable)' == ''">false</CompareViSharedPackageAvailable>
+
+    <CompareViSharedResolvedSource Condition="'$(CompareViSharedSource)' == 'package-first' and '$(CompareViSharedPackageAvailable)' == 'true'">package</CompareViSharedResolvedSource>
+    <CompareViSharedResolvedSource Condition="'$(CompareViSharedSource)' == 'package-first' and '$(CompareViSharedPackageAvailable)' != 'true'">$(CompareViSharedFallbackSource)</CompareViSharedResolvedSource>
+  </PropertyGroup>
+
+  <Target Name="PrintCompareViSharedSource">
+    <Message
+      Importance="High"
+      Text="CompareViSharedSource=$(CompareViSharedSource);CompareViSharedResolvedSource=$(CompareViSharedResolvedSource);CompareViSharedFallbackSource=$(CompareViSharedFallbackSource);CompareViSharedPackageVersion=$(CompareViSharedPackageVersion);CompareViSharedPackageFeed=$(CompareViSharedPackageFeed);CompareViSharedPackageAvailable=$(CompareViSharedPackageAvailable)" />
+  </Target>
+</Project>

--- a/docs/COMPAREVI_SHARED_PACKAGE_MIGRATION.md
+++ b/docs/COMPAREVI_SHARED_PACKAGE_MIGRATION.md
@@ -1,0 +1,73 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# CompareVi.Shared Package-First Migration
+
+This runbook defines the package-first cutover for `CompareVi.Shared` and the compatibility fallback behavior used by
+`CompareVi.Tools.Cli`.
+
+## Package-first contract
+
+- Default source mode is `package-first` (`Directory.Build.props`).
+- Compatibility fallback source is `project`.
+- Resolution is deterministic in `Directory.Build.targets`:
+  - use package when `CompareVi.Shared.<version>.nupkg` exists in `CompareViSharedPackageFeed`
+  - otherwise fallback to `CompareViSharedFallbackSource`
+- Effective mode can be inspected with:
+
+```bash
+dotnet msbuild src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj \
+  -nologo -t:PrintCompareViSharedSource
+```
+
+## Downstream adoption (no source coupling)
+
+Consumers that do not have `src/CompareVi.Shared` should pin package mode explicitly:
+
+```bash
+dotnet restore src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj \
+  -p:CompareViSharedSource=package \
+  -p:CompareViSharedPackageVersion=<x.y.z> \
+  --source <nuget-feed-url>
+```
+
+Recommended settings:
+
+- `CompareViSharedSource=package`
+- `CompareViSharedPackageVersion=<published version>`
+- `CompareViSharedPackageFeed=<optional local mirror>`
+
+`package-first` remains available for repositories that keep both source and package lanes during migration.
+
+## CI parity gate
+
+`.github/workflows/dotnet-shared.yml` validates three lanes:
+
+- `package-first` (expected resolved source: `package`)
+- `package`
+- `project`
+
+All lanes run `version`, `tokenize`, and `procs` smoke checks to enforce behavior parity.
+
+## Release cutover behavior
+
+`tools/Publish-Cli.ps1` now:
+
+- defaults to `CompareViSharedSource=package-first`
+- prepares a local feed (`artifacts/shared-feed`) when needed
+- emits `tests/results/_agent/release/shared-source-resolution.json`
+- supports `-FailOnSharedFallback` to hard-fail if package resolution regresses to `project`
+
+`release.yml` enforces this in the release job.
+
+## Rollback playbook
+
+If package resolution causes a blocking regression:
+
+1. Switch source mode to `project` for the affected run:
+   - local: `pwsh -File tools/Publish-Cli.ps1 -CompareViSharedSource project`
+   - CI: set release invocation to project mode in workflow patch PR.
+2. Re-run smoke checks and Validate.
+3. Keep `package-first` default intact unless incident severity requires temporary policy rollback.
+4. Open a remediation issue with:
+   - `shared-source-resolution.json`
+   - failing restore/build logs
+   - package version + feed details.

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -5,6 +5,8 @@
 Define a deterministic operating model for release and promotion events so execution does not depend on a single
 operator.
 
+Related migration playbook: `docs/COMPAREVI_SHARED_PACKAGE_MIGRATION.md`.
+
 ## Scope
 
 - Promotion events (`rc -> stable -> lts`) and monthly stability cuts.
@@ -145,3 +147,4 @@ matching remediation path:
 - `tests/results/_agent/supply-chain/release-trust-gate.json`
 - `tests/results/_agent/release/rollback-drill-health.json`
 - `tests/results/_agent/release/rollback-drill-report.json`
+- `tests/results/_agent/release/shared-source-resolution.json`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -19,6 +19,8 @@ alignment, and evidence ledger expectations.
 - Rollback policy: `tools/policy/release-rollback-policy.json`
 - Rollback command: `tools/priority/rollback-release.mjs`
 - Rollback drill health gate: `tools/priority/rollback-drill-health.mjs`
+- CompareVi.Shared migration playbook: `docs/COMPAREVI_SHARED_PACKAGE_MIGRATION.md`
+- Shared-source resolution schema: `docs/schemas/release-shared-source-resolution-v1.schema.json`
 - Rollback report schemas:
   - `docs/schemas/release-rollback-v1.schema.json`
   - `docs/schemas/release-rollback-drill-health-v1.schema.json`
@@ -120,6 +122,14 @@ Policy thresholds are sourced from `tools/policy/release-rollback-policy.json`:
 - maximum hours since latest successful drill
 
 If the health gate fails, promotion pauses (fail-closed) until drill health is restored.
+
+## Shared-source resolution evidence
+
+Release tags also emit a CompareVi.Shared source-resolution artifact to prove package-first selection:
+
+- Artifact: `tests/results/_agent/release/shared-source-resolution.json`
+- Source: `tools/Publish-Cli.ps1` (`release/shared-source-resolution@v1`)
+- Policy: `shared-source-resolution` is required evidence for `rc`, `stable`, and `lts`.
 
 ## Gate outcomes
 

--- a/docs/schemas/release-shared-source-resolution-v1.schema.json
+++ b/docs/schemas/release-shared-source-resolution-v1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/release-shared-source-resolution-v1.schema.json",
+  "title": "Release Shared Source Resolution v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "requestedSource",
+    "resolvedSource",
+    "packageAvailable",
+    "packageVersion",
+    "packageFeed",
+    "prepareSharedPackageFeed",
+    "failOnSharedFallback"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "release/shared-source-resolution@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "requestedSource": {
+      "type": "string",
+      "enum": [
+        "project",
+        "package",
+        "package-first"
+      ]
+    },
+    "resolvedSource": {
+      "type": "string",
+      "enum": [
+        "project",
+        "package"
+      ]
+    },
+    "packageAvailable": {
+      "type": "string"
+    },
+    "packageVersion": {
+      "type": "string"
+    },
+    "packageFeed": {
+      "type": "string"
+    },
+    "prepareSharedPackageFeed": {
+      "type": "boolean"
+    },
+    "failOnSharedFallback": {
+      "type": "boolean"
+    }
+  }
+}

--- a/src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
+++ b/src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj
@@ -12,10 +12,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CompareVi.Shared\CompareVi.Shared.csproj"
-                      Condition="'$(CompareViSharedSource)' == 'project'" />
+                      Condition="'$(CompareViSharedResolvedSource)' == 'project'" />
     <PackageReference Include="CompareVi.Shared"
                       Version="$(CompareViSharedPackageVersion)"
-                      Condition="'$(CompareViSharedSource)' == 'package'" />
+                      Condition="'$(CompareViSharedResolvedSource)' == 'package'" />
   </ItemGroup>
 </Project>
 

--- a/tools/Publish-Cli.ps1
+++ b/tools/Publish-Cli.ps1
@@ -1,8 +1,16 @@
 param(
   [string]$ProjectPath = "src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj",
+  [string]$SharedProjectPath = "src/CompareVi.Shared/CompareVi.Shared.csproj",
   [string]$Configuration = "Release",
   [string[]]$Rids = @("win-x64","linux-x64","osx-x64"),
   [string]$OutputRoot = "artifacts/cli",
+  [ValidateSet("project","package","package-first")]
+  [string]$CompareViSharedSource = "package-first",
+  [string]$CompareViSharedPackageVersion = "",
+  [string]$CompareViSharedPackageFeed = "artifacts/shared-feed",
+  [switch]$PrepareSharedPackageFeed = $true,
+  [switch]$FailOnSharedFallback = $false,
+  [string]$SharedSourceReportPath = "tests/results/_agent/release/shared-source-resolution.json",
   [switch]$FrameworkDependent = $true,
   [switch]$SelfContained = $true,
   [switch]$SingleFile = $true
@@ -16,6 +24,16 @@ function Get-VersionFromProps {
   $ver = $xml.Project.PropertyGroup.Version
   if ([string]::IsNullOrWhiteSpace($ver)) { return '0.0.0' }
   return $ver
+}
+
+function Get-SharedPackageVersion {
+  param([string]$CsprojPath)
+  [xml]$xml = Get-Content -Raw $CsprojPath
+  $packageVersion = $xml.Project.PropertyGroup.PackageVersion | Select-Object -First 1
+  if (-not [string]::IsNullOrWhiteSpace($packageVersion)) { return [string]$packageVersion }
+  $version = $xml.Project.PropertyGroup.Version | Select-Object -First 1
+  if (-not [string]::IsNullOrWhiteSpace($version)) { return [string]$version }
+  throw "Unable to resolve CompareVi.Shared package version from $CsprojPath"
 }
 
 function Ensure-Dir($path) {
@@ -44,19 +62,150 @@ function Copy-Docs($destDir) {
   }
 }
 
+function Resolve-SharedSourceSelection {
+  param(
+    [string]$ProjectFullPath,
+    [string]$RequestedSourceMode,
+    [string]$SharedPackageVersion,
+    [string]$SharedPackageFeedPath
+  )
+
+  $output = dotnet msbuild $ProjectFullPath -nologo -t:PrintCompareViSharedSource `
+    "-p:CompareViSharedSource=$RequestedSourceMode" `
+    "-p:CompareViSharedPackageVersion=$SharedPackageVersion" `
+    "-p:CompareViSharedPackageFeed=$SharedPackageFeedPath" 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "Unable to evaluate CompareVi.Shared source resolution."
+  }
+
+  $text = ($output | Out-String)
+  $resolved = [regex]::Match($text, 'CompareViSharedResolvedSource=([^;]+);').Groups[1].Value
+  $resolved = ($resolved -replace '\s+', '').Trim()
+  $packageAvailable = [regex]::Match($text, 'CompareViSharedPackageAvailable=([A-Za-z0-9._-]+)').Groups[1].Value
+  if ([string]::IsNullOrWhiteSpace($resolved)) {
+    throw "Failed to parse CompareViSharedResolvedSource from msbuild output."
+  }
+
+  return [pscustomobject]@{
+    RequestedSourceMode = $RequestedSourceMode
+    ResolvedSource = $resolved
+    PackageAvailable = $packageAvailable
+    Raw = $text.Trim()
+  }
+}
+
+function Write-JsonReport {
+  param(
+    [string]$Path,
+    [object]$Data
+  )
+
+  $dir = Split-Path -Parent $Path
+  if ($dir) { Ensure-Dir $dir }
+  $Data | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Invoke-CliPublish {
+  param(
+    [string]$ProjectFullPath,
+    [string]$Rid,
+    [string]$OutDir,
+    [bool]$IsSelfContained,
+    [bool]$EnableSingleFile,
+    [string]$BuildConfig,
+    [string]$SharedSourceMode,
+    [string]$SharedPackageVersion,
+    [string]$SharedPackageFeedPath
+  )
+
+  $args = @(
+    'publish',
+    $ProjectFullPath,
+    '-c', $BuildConfig,
+    '-r', $Rid,
+    '--self-contained', ($IsSelfContained ? 'true' : 'false'),
+    '-p:PublishTrimmed=false',
+    "-p:CompareViSharedSource=$SharedSourceMode",
+    "-p:CompareViSharedPackageVersion=$SharedPackageVersion",
+    "-p:CompareViSharedPackageFeed=$SharedPackageFeedPath",
+    '-o', $OutDir
+  )
+  if ($IsSelfContained -and $EnableSingleFile) {
+    $args += '-p:PublishSingleFile=true'
+    $args += '-p:IncludeNativeLibrariesForSelfExtract=true'
+  }
+  if ($SharedSourceMode -ne 'project') {
+    $args += '--source'
+    $args += $SharedPackageFeedPath
+    $args += '--source'
+    $args += 'https://api.nuget.org/v3/index.json'
+  }
+  dotnet @args
+}
+
 $version = Get-VersionFromProps
 Write-Host "Publishing comparevi-cli version $version" -ForegroundColor Cyan
 
 $projFull = Resolve-Path $ProjectPath | Select-Object -ExpandProperty Path
+$sharedProjFull = Resolve-Path $SharedProjectPath | Select-Object -ExpandProperty Path
 $root = Resolve-Path '.' | Select-Object -ExpandProperty Path
 $outRoot = Join-Path $root $OutputRoot
 Ensure-Dir $outRoot
+
+$sharedFeed = if ([System.IO.Path]::IsPathRooted($CompareViSharedPackageFeed)) {
+  $CompareViSharedPackageFeed
+} else {
+  Join-Path $root $CompareViSharedPackageFeed
+}
+Ensure-Dir $sharedFeed
+
+if ([string]::IsNullOrWhiteSpace($CompareViSharedPackageVersion)) {
+  $CompareViSharedPackageVersion = Get-SharedPackageVersion -CsprojPath $sharedProjFull
+}
+
+if ($CompareViSharedSource -ne 'project' -and $PrepareSharedPackageFeed) {
+  Write-Host "Preparing CompareVi.Shared feed at $sharedFeed (version $CompareViSharedPackageVersion)" -ForegroundColor Cyan
+  dotnet restore $sharedProjFull
+  dotnet build -c $Configuration $sharedProjFull --no-restore
+  dotnet pack -c $Configuration $sharedProjFull -o $sharedFeed --no-build `
+    -p:PackageVersion=$CompareViSharedPackageVersion `
+    -p:Version=$CompareViSharedPackageVersion
+}
+
+$sharedSourceSelection = Resolve-SharedSourceSelection -ProjectFullPath $projFull `
+  -RequestedSourceMode $CompareViSharedSource `
+  -SharedPackageVersion $CompareViSharedPackageVersion `
+  -SharedPackageFeedPath $sharedFeed
+
+Write-Host ("CompareVi.Shared source requested={0} resolved={1} packageAvailable={2}" -f
+  $sharedSourceSelection.RequestedSourceMode,
+  $sharedSourceSelection.ResolvedSource,
+  $sharedSourceSelection.PackageAvailable) -ForegroundColor Cyan
+
+$sharedSourceReport = [ordered]@{
+  schema = 'release/shared-source-resolution@v1'
+  generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  requestedSource = $sharedSourceSelection.RequestedSourceMode
+  resolvedSource = $sharedSourceSelection.ResolvedSource
+  packageAvailable = $sharedSourceSelection.PackageAvailable
+  packageVersion = $CompareViSharedPackageVersion
+  packageFeed = $sharedFeed
+  prepareSharedPackageFeed = [bool]$PrepareSharedPackageFeed
+  failOnSharedFallback = [bool]$FailOnSharedFallback
+}
+Write-JsonReport -Path $SharedSourceReportPath -Data $sharedSourceReport
+
+if ($FailOnSharedFallback -and $CompareViSharedSource -ne 'project' -and $sharedSourceSelection.ResolvedSource -ne 'package') {
+  throw "CompareVi.Shared source fallback detected: requested=$CompareViSharedSource resolved=$($sharedSourceSelection.ResolvedSource)"
+}
 
 foreach ($rid in $Rids) {
   if ($FrameworkDependent) {
     $out = Join-Path $outRoot "fxdependent/$rid"
     Ensure-Dir $out
-    dotnet publish $projFull -c $Configuration -r $rid --self-contained false -p:PublishTrimmed=false -o $out
+    Invoke-CliPublish -ProjectFullPath $projFull -Rid $rid -OutDir $out -IsSelfContained:$false `
+      -EnableSingleFile:$false -BuildConfig $Configuration -SharedSourceMode $CompareViSharedSource `
+      -SharedPackageVersion $CompareViSharedPackageVersion -SharedPackageFeedPath $sharedFeed
     Copy-Docs $out
     if ($rid -like 'win-*') {
       $zip = Join-Path $outRoot ("comparevi-cli-v{0}-{1}-fxdependent.zip" -f $version,$rid)
@@ -70,10 +219,9 @@ foreach ($rid in $Rids) {
   if ($SelfContained) {
     $out = Join-Path $outRoot "selfcontained/$rid"
     Ensure-Dir $out
-    $props = @('PublishTrimmed=false')
-    if ($SingleFile) { $props += 'PublishSingleFile=true'; $props += 'IncludeNativeLibrariesForSelfExtract=true' }
-    $propArgs = $props | ForEach-Object { "-p:$_" }
-    dotnet publish $projFull -c $Configuration -r $rid --self-contained true @propArgs -o $out
+    Invoke-CliPublish -ProjectFullPath $projFull -Rid $rid -OutDir $out -IsSelfContained:$true `
+      -EnableSingleFile:$SingleFile -BuildConfig $Configuration -SharedSourceMode $CompareViSharedSource `
+      -SharedPackageVersion $CompareViSharedPackageVersion -SharedPackageFeedPath $sharedFeed
     Copy-Docs $out
     if ($rid -like 'win-*') {
       $zip = Join-Path $outRoot ("comparevi-cli-v{0}-{1}-selfcontained.zip" -f $version,$rid)

--- a/tools/policy/promotion-contract.json
+++ b/tools/policy/promotion-contract.json
@@ -13,7 +13,8 @@
         "promotion-evidence-ledger",
         "certification-matrix",
         "supply-chain-trust-gate",
-        "rollback-drill-health"
+        "rollback-drill-health",
+        "shared-source-resolution"
       ]
     },
     "stable": {
@@ -25,7 +26,8 @@
         "promotion-evidence-ledger",
         "certification-matrix",
         "supply-chain-trust-gate",
-        "rollback-drill-health"
+        "rollback-drill-health",
+        "shared-source-resolution"
       ]
     },
     "lts": {
@@ -37,7 +39,8 @@
         "promotion-evidence-ledger",
         "certification-matrix",
         "supply-chain-trust-gate",
-        "rollback-drill-health"
+        "rollback-drill-health",
+        "shared-source-resolution"
       ]
     }
   },

--- a/tools/priority/__tests__/shared-package-migration-contract.test.mjs
+++ b/tools/priority/__tests__/shared-package-migration-contract.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(process.cwd());
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('Directory.Build.props defaults CompareVi.Shared to package-first with project fallback', () => {
+  const props = read('Directory.Build.props');
+  assert.match(props, /<CompareViSharedSource[^>]*>\s*package-first\s*<\/CompareViSharedSource>/i);
+  assert.match(props, /<CompareViSharedFallbackSource[^>]*>\s*project\s*<\/CompareViSharedFallbackSource>/i);
+  assert.match(props, /<CompareViSharedPackageFeed[^>]*>/i);
+});
+
+test('Directory.Build.targets resolves package-first and exposes print target seam', () => {
+  const targets = read('Directory.Build.targets');
+  assert.ok(targets.includes('CompareViSharedResolvedSource'));
+  assert.ok(targets.includes("'$(CompareViSharedSource)' == 'package-first'"));
+  assert.ok(targets.includes('<Target Name="PrintCompareViSharedSource">'));
+  assert.ok(targets.includes('CompareViSharedPackageAvailable='));
+});
+
+test('CLI csproj references resolved CompareVi.Shared source seam', () => {
+  const cliCsproj = read('src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj');
+  assert.ok(cliCsproj.includes("'$(CompareViSharedResolvedSource)' == 'project'"));
+  assert.ok(cliCsproj.includes("'$(CompareViSharedResolvedSource)' == 'package'"));
+});
+
+test('dotnet-shared workflow enforces package-first parity lane', () => {
+  const workflow = read('.github/workflows/dotnet-shared.yml');
+  assert.match(workflow, /shared_source:\s*package-first/i);
+  assert.match(workflow, /expected_resolved:\s*package/i);
+  assert.match(workflow, /Assert shared-source resolution/i);
+});


### PR DESCRIPTION
## Summary
- switch `CompareVi.Shared` to package-first default with an MSBuild compatibility shim (`package-first -> package|project`) in `Directory.Build.props/targets`
- update release + dotnet-shared workflows to assert and enforce package resolution, including shared-source evidence artifact/schema
- add migration + rollback playbook for downstream package adoption without source coupling

## Testing
- node --test tools/priority/__tests__/shared-package-migration-contract.test.mjs
- node --test tools/priority/__tests__/*.mjs
- ./bin/actionlint -color
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios
- pwsh -NoLogo -NoProfile -File tools/Publish-Cli.ps1 -Rids win-x64 -SelfContained:$false -FrameworkDependent:$true -SingleFile:$false -CompareViSharedSource package-first -PrepareSharedPackageFeed -FailOnSharedFallback -OutputRoot tests/results/_agent/tmp-cli-publish -SharedSourceReportPath tests/results/_agent/release/shared-source-resolution-smoke.json
- pwsh -NoLogo -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 -JsonPath tests/results/_agent/release/shared-source-resolution-smoke.json -SchemaPath docs/schemas/release-shared-source-resolution-v1.schema.json

## Queue Metadata
- Coupling: independent
- Depends-On:

Refs: #714
