### PR TITLE
[P1][commit-integrity] hard-fail signature verification unavailable states (#771)

### DIFF
--- a/docs/COMMIT_INTEGRITY_CHECK.md
+++ b/docs/COMMIT_INTEGRITY_CHECK.md
@@ -20,6 +20,9 @@ The checker evaluates all commits in scope and emits explicit violation categori
   - Fails when `commit.verification.verified != true`.
 - `unknown-unverified-reason`
   - Fails when an unverified commit has reason `unknown` and the policy toggle is enabled.
+- `signature-verification-unavailable`
+  - Fails when GitHub reports signature verification service unavailability (`gpgverify_error`,
+    `gpgverify_unavailable`) and strict availability is enabled.
 - `missing-author-attribution`
   - Fails when both author login and author email are absent and the policy toggle is enabled.
 - `missing-committer-attribution`
@@ -52,6 +55,7 @@ Policy file: `tools/policy/commit-integrity-policy.json`
   - `checks.require_author_attribution`
   - `checks.require_committer_attribution`
   - `checks.require_non_unknown_reason_for_unverified`
+  - `checks.require_signature_verification_available`
   - `checks.require_unique_shas`
   - `checks.require_non_empty_headline`
   - `checks.max_headline_length`

--- a/docs/schemas/commit-integrity-report-v1.schema.json
+++ b/docs/schemas/commit-integrity-report-v1.schema.json
@@ -98,6 +98,7 @@
             "requireAuthorAttribution",
             "requireCommitterAttribution",
             "requireKnownReasonForUnverified",
+            "requireSignatureVerificationAvailable",
             "requireUniqueShas",
             "requireNonEmptyHeadline",
             "maxHeadlineLength",
@@ -112,6 +113,9 @@
               "type": "boolean"
             },
             "requireKnownReasonForUnverified": {
+              "type": "boolean"
+            },
+            "requireSignatureVerificationAvailable": {
               "type": "boolean"
             },
             "requireUniqueShas": {

--- a/tools/policy/commit-integrity-policy.json
+++ b/tools/policy/commit-integrity-policy.json
@@ -17,6 +17,7 @@
     "require_author_attribution": true,
     "require_committer_attribution": true,
     "require_non_unknown_reason_for_unverified": true,
+    "require_signature_verification_available": true,
     "require_unique_shas": true,
     "require_non_empty_headline": true,
     "max_headline_length": 120,

--- a/tools/priority/__tests__/commit-integrity-schema.test.mjs
+++ b/tools/priority/__tests__/commit-integrity-schema.test.mjs
@@ -63,6 +63,7 @@ test('commit integrity report schema validates generated report payload', async 
         requireAuthorAttribution: true,
         requireCommitterAttribution: true,
         requireKnownReasonForUnverified: true,
+        requireSignatureVerificationAvailable: true,
         requireUniqueShas: true,
         requireNonEmptyHeadline: true,
         maxHeadlineLength: 120,

--- a/tools/priority/__tests__/commit-integrity.test.mjs
+++ b/tools/priority/__tests__/commit-integrity.test.mjs
@@ -95,6 +95,38 @@ test('evaluateCommitIntegrity fails on unverified commits with explicit categori
   );
 });
 
+test('evaluateCommitIntegrity covers verified, unsigned, unknown, and signature-unavailable reasons', () => {
+  const commits = normalizeCommitRecords(
+    [
+      createRawCommit({ sha: 'sig1', verified: true, reason: 'valid', message: 'feat: verified\n\nIssue: #771' }),
+      createRawCommit({ sha: 'sig2', verified: false, reason: 'unsigned', message: 'feat: unsigned\n\nIssue: #771' }),
+      createRawCommit({ sha: 'sig3', verified: false, reason: 'unknown', message: 'feat: unknown\n\nIssue: #771' }),
+      createRawCommit({
+        sha: 'sig4',
+        verified: false,
+        reason: 'gpgverify_unavailable',
+        message: 'feat: service unavailable\n\nIssue: #771'
+      })
+    ],
+    sourceResolution
+  );
+  const evaluation = evaluateCommitIntegrity(commits, {
+    checks: {
+      requireKnownReasonForUnverified: true,
+      requireSignatureVerificationAvailable: true
+    }
+  });
+
+  assert.ok(!evaluation.violations.some((violation) => violation.sha === 'sig1' && violation.category === 'unverified-commit'));
+  assert.ok(evaluation.violations.some((violation) => violation.sha === 'sig2' && violation.category === 'unverified-commit'));
+  assert.ok(evaluation.violations.some((violation) => violation.sha === 'sig3' && violation.category === 'unknown-unverified-reason'));
+  assert.ok(
+    evaluation.violations.some(
+      (violation) => violation.sha === 'sig4' && violation.category === 'signature-verification-unavailable'
+    )
+  );
+});
+
 test('evaluateCommitIntegrity detects attribution and unknown-reason gaps when enabled', () => {
   const commits = normalizeCommitRecords(
     [

--- a/tools/priority/commit-integrity.mjs
+++ b/tools/priority/commit-integrity.mjs
@@ -18,6 +18,7 @@ const DEFAULT_POLICY_CHECKS = Object.freeze({
   requireAuthorAttribution: true,
   requireCommitterAttribution: true,
   requireKnownReasonForUnverified: true,
+  requireSignatureVerificationAvailable: true,
   requireUniqueShas: true,
   requireNonEmptyHeadline: true,
   maxHeadlineLength: 120,
@@ -25,6 +26,7 @@ const DEFAULT_POLICY_CHECKS = Object.freeze({
   requireRequiredTrailer: false,
   requiredTrailerRules: Object.freeze([])
 });
+const SIGNATURE_UNAVAILABLE_REASONS = new Set(['gpgverify_error', 'gpgverify_unavailable']);
 
 function extractCommitTrailers(message) {
   const normalizedMessage = normalizeOptionalString(message) ?? '';
@@ -451,6 +453,10 @@ function normalizeChecks(checks = {}) {
       checks.requireKnownReasonForUnverified !== undefined
         ? Boolean(checks.requireKnownReasonForUnverified)
         : DEFAULT_POLICY_CHECKS.requireKnownReasonForUnverified,
+    requireSignatureVerificationAvailable:
+      checks.requireSignatureVerificationAvailable !== undefined
+        ? Boolean(checks.requireSignatureVerificationAvailable)
+        : DEFAULT_POLICY_CHECKS.requireSignatureVerificationAvailable,
     requireUniqueShas:
       checks.requireUniqueShas !== undefined
         ? Boolean(checks.requireUniqueShas)
@@ -581,6 +587,12 @@ export function evaluateCommitIntegrity(commits, { checks = {} } = {}) {
     }
     if (!commit.verified) {
       addViolation(violations, commit, 'unverified-commit', commit.verificationReason);
+      if (
+        effectiveChecks.requireSignatureVerificationAvailable &&
+        SIGNATURE_UNAVAILABLE_REASONS.has(commit.verificationReason)
+      ) {
+        addViolation(violations, commit, 'signature-verification-unavailable', commit.verificationReason);
+      }
       if (effectiveChecks.requireKnownReasonForUnverified && commit.verificationReason === 'unknown') {
         addViolation(violations, commit, 'unknown-unverified-reason', 'unknown verification reason');
       }
@@ -616,6 +628,14 @@ export function evaluateCommitIntegrity(commits, { checks = {} } = {}) {
       !effectiveChecks.requireKnownReasonForUnverified ||
       !violations.some((violation) => violation.category === 'unknown-unverified-reason'),
     failureCount: violations.filter((violation) => violation.category === 'unknown-unverified-reason').length
+  });
+  checkResults.push({
+    name: 'signature-verification-unavailable',
+    enabled: effectiveChecks.requireSignatureVerificationAvailable,
+    passed:
+      !effectiveChecks.requireSignatureVerificationAvailable ||
+      !violations.some((violation) => violation.category === 'signature-verification-unavailable'),
+    failureCount: violations.filter((violation) => violation.category === 'signature-verification-unavailable').length
   });
   checkResults.push({
     name: 'author-attribution',
@@ -771,6 +791,7 @@ async function loadPolicy(policyPath) {
       requireAuthorAttribution: checkSettings.require_author_attribution,
       requireCommitterAttribution: checkSettings.require_committer_attribution,
       requireKnownReasonForUnverified: checkSettings.require_non_unknown_reason_for_unverified,
+      requireSignatureVerificationAvailable: checkSettings.require_signature_verification_available,
       requireUniqueShas: checkSettings.require_unique_shas,
       requireNonEmptyHeadline: checkSettings.require_non_empty_headline,
       maxHeadlineLength: checkSettings.max_headline_length,
@@ -828,6 +849,7 @@ function buildReport({
         requireAuthorAttribution: policy.checks.requireAuthorAttribution,
         requireCommitterAttribution: policy.checks.requireCommitterAttribution,
         requireKnownReasonForUnverified: policy.checks.requireKnownReasonForUnverified,
+        requireSignatureVerificationAvailable: policy.checks.requireSignatureVerificationAvailable,
         requireUniqueShas: policy.checks.requireUniqueShas,
         requireNonEmptyHeadline: policy.checks.requireNonEmptyHeadline,
         maxHeadlineLength: policy.checks.maxHeadlineLength,
@@ -939,6 +961,7 @@ export async function runCommitIntegrity({
             requireAuthorAttribution: DEFAULT_POLICY_CHECKS.requireAuthorAttribution,
             requireCommitterAttribution: DEFAULT_POLICY_CHECKS.requireCommitterAttribution,
           requireKnownReasonForUnverified: DEFAULT_POLICY_CHECKS.requireKnownReasonForUnverified,
+          requireSignatureVerificationAvailable: DEFAULT_POLICY_CHECKS.requireSignatureVerificationAvailable,
           requireUniqueShas: DEFAULT_POLICY_CHECKS.requireUniqueShas,
           requireNonEmptyHeadline: DEFAULT_POLICY_CHECKS.requireNonEmptyHeadline,
           maxHeadlineLength: DEFAULT_POLICY_CHECKS.maxHeadlineLength,


### PR DESCRIPTION
## Summary
Implements `#771` by hardening commit signature verification diagnostics in `commit-integrity`.

## What Changed
- Added explicit `signature-verification-unavailable` violation category for:
  - `gpgverify_error`
  - `gpgverify_unavailable`
- Added policy seam:
  - `checks.require_signature_verification_available`
- Extended report schema and docs with the new strict availability check.
- Added unit coverage for verified, unsigned, unknown, and signature-unavailable paths.

## Validation
- `node --test tools/priority/__tests__/commit-integrity.test.mjs tools/priority/__tests__/commit-integrity-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`

Coupling: independent

Parent: #742
Issue: #771
