### PR TITLE
[P1][commit-integrity] enforce bot identity allowlist policy (#772)

### DIFF
--- a/docs/COMMIT_INTEGRITY_CHECK.md
+++ b/docs/COMMIT_INTEGRITY_CHECK.md
@@ -23,6 +23,8 @@ The checker evaluates all commits in scope and emits explicit violation categori
 - `signature-verification-unavailable`
   - Fails when GitHub reports signature verification service unavailability (`gpgverify_error`,
     `gpgverify_unavailable`) and strict availability is enabled.
+- `unauthorized-bot-identity`
+  - Fails when a bot-authored commit does not match the configured bot allowlist.
 - `missing-author-attribution`
   - Fails when both author login and author email are absent and the policy toggle is enabled.
 - `missing-committer-attribution`
@@ -52,6 +54,7 @@ Policy file: `tools/policy/commit-integrity-policy.json`
   - `source_resolution.bot_login_patterns`
   - `source_resolution.bot_email_patterns`
 - Additional coverage toggles:
+  - `checks.require_bot_allowlist`
   - `checks.require_author_attribution`
   - `checks.require_committer_attribution`
   - `checks.require_non_unknown_reason_for_unverified`
@@ -64,6 +67,10 @@ Policy file: `tools/policy/commit-integrity-policy.json`
 - Trailer schema contract:
   - `trailer_contract.required_any[].key`
   - `trailer_contract.required_any[].value_pattern`
+- Bot identity allowlist contract:
+  - `bot_identity_policy.require_allowlist_for_bot_commits`
+  - `bot_identity_policy.allowed_bot_logins[]`
+  - `bot_identity_policy.allowed_bot_email_patterns[]`
 
 ## Drift Guard
 

--- a/docs/schemas/commit-integrity-report-v1.schema.json
+++ b/docs/schemas/commit-integrity-report-v1.schema.json
@@ -79,6 +79,7 @@
         "failOnUnverified",
         "checks",
         "sourceResolution",
+        "botIdentityPolicy",
         "trailerContract"
       ],
       "properties": {
@@ -95,6 +96,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": [
+            "requireBotAllowlist",
             "requireAuthorAttribution",
             "requireCommitterAttribution",
             "requireKnownReasonForUnverified",
@@ -106,6 +108,9 @@
             "requireRequiredTrailer"
           ],
           "properties": {
+            "requireBotAllowlist": {
+              "type": "boolean"
+            },
             "requireAuthorAttribution": {
               "type": "boolean"
             },
@@ -151,6 +156,28 @@
             "botEmailPatternCount": {
               "type": "integer",
               "minimum": 0
+            }
+          }
+        },
+        "botIdentityPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "allowedBotLogins",
+            "allowedBotEmailPatterns"
+          ],
+          "properties": {
+            "allowedBotLogins": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowedBotEmailPatterns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/tools/policy/commit-integrity-policy.json
+++ b/tools/policy/commit-integrity-policy.json
@@ -10,6 +10,19 @@
       "@users\\.noreply\\.github\\.com$"
     ]
   },
+  "bot_identity_policy": {
+    "require_allowlist_for_bot_commits": true,
+    "allowed_bot_logins": [
+      "dependabot[bot]",
+      "github-actions[bot]",
+      "github-merge-queue[bot]"
+    ],
+    "allowed_bot_email_patterns": [
+      "^[0-9]+\\+dependabot\\[bot\\]@users\\.noreply\\.github\\.com$",
+      "^41898282\\+github-actions\\[bot\\]@users\\.noreply\\.github\\.com$",
+      "^[0-9]+\\+github-merge-queue\\[bot\\]@users\\.noreply\\.github\\.com$"
+    ]
+  },
   "verification": {
     "fail_on_unverified": true
   },

--- a/tools/priority/__tests__/commit-integrity-schema.test.mjs
+++ b/tools/priority/__tests__/commit-integrity-schema.test.mjs
@@ -60,6 +60,7 @@ test('commit integrity report schema validates generated report payload', async 
       path: path.join(repoRoot, 'tools', 'policy', 'commit-integrity-policy.json'),
       failOnUnverified: true,
       checks: {
+        requireBotAllowlist: true,
         requireAuthorAttribution: true,
         requireCommitterAttribution: true,
         requireKnownReasonForUnverified: true,
@@ -72,11 +73,23 @@ test('commit integrity report schema validates generated report payload', async 
         requiredTrailerRules: [
           { key: 'Issue', keyLower: 'issue', valuePattern: '^#\\d+$', valueRegex: /^#\d+$/ },
           { key: 'Refs', keyLower: 'refs', valuePattern: '^#\\d+$', valueRegex: /^#\d+$/ }
+        ],
+        allowedBotLogins: ['dependabot[bot]', 'github-actions[bot]'],
+        allowedBotEmailPatterns: [
+          '^[0-9]+\\+dependabot\\[bot\\]@users\\.noreply\\.github\\.com$',
+          '^41898282\\+github-actions\\[bot\\]@users\\.noreply\\.github\\.com$'
         ]
       },
       sourceResolution: {
         botLoginRegexes: [/\[bot\]$/i],
         botEmailRegexes: [/\[bot\]@users\.noreply\.github\.com$/i]
+      },
+      botIdentityPolicy: {
+        allowedBotLogins: ['dependabot[bot]', 'github-actions[bot]'],
+        allowedBotEmailPatterns: [
+          '^[0-9]+\\+dependabot\\[bot\\]@users\\.noreply\\.github\\.com$',
+          '^41898282\\+github-actions\\[bot\\]@users\\.noreply\\.github\\.com$'
+        ]
       },
       trailerContract: {
         requiredAny: [

--- a/tools/priority/__tests__/commit-integrity.test.mjs
+++ b/tools/priority/__tests__/commit-integrity.test.mjs
@@ -39,6 +39,11 @@ const requiredTrailerRules = [
   { key: 'Issue', valuePattern: '^#\\d+$' },
   { key: 'Refs', valuePattern: '^#\\d+$' }
 ];
+const allowedBotLogins = ['dependabot[bot]', 'github-actions[bot]'];
+const allowedBotEmailPatterns = [
+  '^[0-9]+\\+dependabot\\[bot\\]@users\\.noreply\\.github\\.com$',
+  '^41898282\\+github-actions\\[bot\\]@users\\.noreply\\.github\\.com$'
+];
 
 test('parseArgs supports observe-only and pull-request selection', () => {
   const options = parseArgs([
@@ -298,4 +303,60 @@ test('evaluateCommitIntegrity reports empty-range issue deterministically', () =
   });
   assert.equal(evaluation.result, 'fail');
   assert.ok(evaluation.issues.includes('no-commits-found'));
+});
+
+test('evaluateCommitIntegrity allows allowlisted bot identities', () => {
+  const commits = normalizeCommitRecords(
+    [
+      createRawCommit({
+        sha: 'bot01',
+        authorLogin: 'dependabot[bot]',
+        committerLogin: 'dependabot[bot]',
+        authorEmail: '49699333+dependabot[bot]@users.noreply.github.com',
+        committerEmail: '49699333+dependabot[bot]@users.noreply.github.com',
+        message: 'chore: update deps\n\nIssue: #772'
+      })
+    ],
+    sourceResolution
+  );
+  const evaluation = evaluateCommitIntegrity(commits, {
+    checks: {
+      requireBotAllowlist: true,
+      allowedBotLogins,
+      allowedBotEmailPatterns,
+      requireRequiredTrailer: true,
+      requiredTrailerRules
+    }
+  });
+
+  assert.equal(evaluation.result, 'pass');
+  assert.ok(!evaluation.violations.some((violation) => violation.category === 'unauthorized-bot-identity'));
+});
+
+test('evaluateCommitIntegrity fails on non-allowlisted bot identities', () => {
+  const commits = normalizeCommitRecords(
+    [
+      createRawCommit({
+        sha: 'bot02',
+        authorLogin: 'renovate[bot]',
+        committerLogin: 'renovate[bot]',
+        authorEmail: 'renovate[bot]@users.noreply.github.com',
+        committerEmail: 'renovate[bot]@users.noreply.github.com',
+        message: 'chore: update deps\n\nIssue: #772'
+      })
+    ],
+    sourceResolution
+  );
+  const evaluation = evaluateCommitIntegrity(commits, {
+    checks: {
+      requireBotAllowlist: true,
+      allowedBotLogins,
+      allowedBotEmailPatterns,
+      requireRequiredTrailer: true,
+      requiredTrailerRules
+    }
+  });
+
+  assert.equal(evaluation.result, 'fail');
+  assert.ok(evaluation.violations.some((violation) => violation.category === 'unauthorized-bot-identity'));
 });

--- a/tools/priority/commit-integrity.mjs
+++ b/tools/priority/commit-integrity.mjs
@@ -15,6 +15,9 @@ const DEFAULT_REPORT_PATH = path.join(
 );
 const DEFAULT_POLICY_PATH = path.join('tools', 'policy', 'commit-integrity-policy.json');
 const DEFAULT_POLICY_CHECKS = Object.freeze({
+  requireBotAllowlist: false,
+  allowedBotLogins: Object.freeze([]),
+  allowedBotEmailPatterns: Object.freeze([]),
   requireAuthorAttribution: true,
   requireCommitterAttribution: true,
   requireKnownReasonForUnverified: true,
@@ -440,7 +443,46 @@ function normalizeChecks(checks = {}) {
     }
   }
 
+  const normalizedAllowedBotLogins = Array.from(
+    new Set(
+      (Array.isArray(checks.allowedBotLogins) ? checks.allowedBotLogins : [])
+        .map((entry) => normalizeOptionalString(entry)?.toLowerCase())
+        .filter(Boolean)
+    )
+  );
+
+  const normalizedAllowedBotEmailPatterns = [];
+  const normalizedAllowedBotEmailRegexes = [];
+  for (const [index, rawPattern] of (Array.isArray(checks.allowedBotEmailPatterns) ? checks.allowedBotEmailPatterns : []).entries()) {
+    const pattern = normalizeOptionalString(rawPattern);
+    if (!pattern) {
+      continue;
+    }
+    try {
+      normalizedAllowedBotEmailPatterns.push(pattern);
+      normalizedAllowedBotEmailRegexes.push(new RegExp(pattern, 'i'));
+    } catch (error) {
+      throw new Error(`Invalid bot email pattern at index ${index}: ${error.message}`);
+    }
+  }
+
   return {
+    requireBotAllowlist:
+      checks.requireBotAllowlist !== undefined
+        ? Boolean(checks.requireBotAllowlist)
+        : DEFAULT_POLICY_CHECKS.requireBotAllowlist,
+    allowedBotLogins:
+      normalizedAllowedBotLogins.length > 0
+        ? normalizedAllowedBotLogins
+        : DEFAULT_POLICY_CHECKS.allowedBotLogins,
+    allowedBotEmailPatterns:
+      normalizedAllowedBotEmailPatterns.length > 0
+        ? normalizedAllowedBotEmailPatterns
+        : DEFAULT_POLICY_CHECKS.allowedBotEmailPatterns,
+    allowedBotEmailRegexes:
+      normalizedAllowedBotEmailRegexes.length > 0
+        ? normalizedAllowedBotEmailRegexes
+        : [],
     requireAuthorAttribution:
       checks.requireAuthorAttribution !== undefined
         ? Boolean(checks.requireAuthorAttribution)
@@ -499,6 +541,36 @@ function addViolation(violations, commit, category, reason) {
     authorLogin: commit.authorLogin,
     committerLogin: commit.committerLogin
   });
+}
+
+function evaluateBotIdentityAllowlist(commit, checks) {
+  if (!checks.requireBotAllowlist || commit.sourceKind !== 'bot') {
+    return {
+      passed: true,
+      reason: null
+    };
+  }
+
+  const loginCandidates = [commit.authorLogin, commit.committerLogin]
+    .map((entry) => normalizeOptionalString(entry)?.toLowerCase())
+    .filter(Boolean);
+  const emailCandidates = [commit.authorEmail, commit.committerEmail]
+    .map((entry) => normalizeOptionalString(entry))
+    .filter(Boolean);
+
+  const loginAllowed = loginCandidates.some((entry) => checks.allowedBotLogins.includes(entry));
+  const emailAllowed = emailCandidates.some((entry) => checks.allowedBotEmailRegexes.some((regex) => regex.test(entry)));
+  if (loginAllowed || emailAllowed) {
+    return {
+      passed: true,
+      reason: null
+    };
+  }
+
+  return {
+    passed: false,
+    reason: `bot identity not allowlisted (logins=${loginCandidates.join('|') || 'none'}, emails=${emailCandidates.join('|') || 'none'})`
+  };
 }
 
 function evaluateRequiredTrailer(commit, requiredTrailerRules) {
@@ -567,6 +639,10 @@ export function evaluateCommitIntegrity(commits, { checks = {} } = {}) {
   }
 
   for (const commit of list) {
+    const botAllowlistEvaluation = evaluateBotIdentityAllowlist(commit, effectiveChecks);
+    if (!botAllowlistEvaluation.passed) {
+      addViolation(violations, commit, 'unauthorized-bot-identity', botAllowlistEvaluation.reason);
+    }
     if (effectiveChecks.requireNonEmptyHeadline && !commit.messageHeadline) {
       addViolation(violations, commit, 'empty-headline', 'commit headline is empty');
     }
@@ -636,6 +712,14 @@ export function evaluateCommitIntegrity(commits, { checks = {} } = {}) {
       !effectiveChecks.requireSignatureVerificationAvailable ||
       !violations.some((violation) => violation.category === 'signature-verification-unavailable'),
     failureCount: violations.filter((violation) => violation.category === 'signature-verification-unavailable').length
+  });
+  checkResults.push({
+    name: 'bot-identity-allowlist',
+    enabled: effectiveChecks.requireBotAllowlist,
+    passed:
+      !effectiveChecks.requireBotAllowlist ||
+      !violations.some((violation) => violation.category === 'unauthorized-bot-identity'),
+    failureCount: violations.filter((violation) => violation.category === 'unauthorized-bot-identity').length
   });
   checkResults.push({
     name: 'author-attribution',
@@ -776,6 +860,7 @@ async function loadPolicy(policyPath) {
 
   const sourceResolution = parsed?.source_resolution ?? {};
   const checkSettings = parsed?.checks ?? {};
+  const botIdentityPolicy = parsed?.bot_identity_policy ?? {};
   const trailerContract = parsed?.trailer_contract ?? {};
   const requiredAnyTrailers = Array.isArray(trailerContract.required_any)
     ? trailerContract.required_any.map((entry) => ({
@@ -788,6 +873,9 @@ async function loadPolicy(policyPath) {
     schema: normalizeOptionalString(parsed?.schema) ?? 'commit-integrity-policy/v1',
     failOnUnverified: parsed?.verification?.fail_on_unverified !== false,
     checks: normalizeChecks({
+      requireBotAllowlist: botIdentityPolicy.require_allowlist_for_bot_commits,
+      allowedBotLogins: botIdentityPolicy.allowed_bot_logins,
+      allowedBotEmailPatterns: botIdentityPolicy.allowed_bot_email_patterns,
       requireAuthorAttribution: checkSettings.require_author_attribution,
       requireCommitterAttribution: checkSettings.require_committer_attribution,
       requireKnownReasonForUnverified: checkSettings.require_non_unknown_reason_for_unverified,
@@ -846,6 +934,7 @@ function buildReport({
       path: policy.path,
       failOnUnverified: policy.failOnUnverified,
       checks: {
+        requireBotAllowlist: policy.checks.requireBotAllowlist,
         requireAuthorAttribution: policy.checks.requireAuthorAttribution,
         requireCommitterAttribution: policy.checks.requireCommitterAttribution,
         requireKnownReasonForUnverified: policy.checks.requireKnownReasonForUnverified,
@@ -859,6 +948,10 @@ function buildReport({
       sourceResolution: {
         botLoginPatternCount: policy.sourceResolution.botLoginRegexes.length,
         botEmailPatternCount: policy.sourceResolution.botEmailRegexes.length
+      },
+      botIdentityPolicy: {
+        allowedBotLogins: policy.checks.allowedBotLogins,
+        allowedBotEmailPatterns: policy.checks.allowedBotEmailPatterns
       },
       trailerContract: {
         requiredAny: policy.checks.requiredTrailerRules.map((rule) => ({
@@ -958,6 +1051,7 @@ export async function runCommitIntegrity({
         path: path.resolve(options.policyPath ?? DEFAULT_POLICY_PATH),
         failOnUnverified: true,
         checks: {
+          requireBotAllowlist: DEFAULT_POLICY_CHECKS.requireBotAllowlist,
             requireAuthorAttribution: DEFAULT_POLICY_CHECKS.requireAuthorAttribution,
             requireCommitterAttribution: DEFAULT_POLICY_CHECKS.requireCommitterAttribution,
           requireKnownReasonForUnverified: DEFAULT_POLICY_CHECKS.requireKnownReasonForUnverified,
@@ -971,6 +1065,10 @@ export async function runCommitIntegrity({
         sourceResolution: {
           botLoginPatternCount: 0,
           botEmailPatternCount: 0
+        },
+        botIdentityPolicy: {
+          allowedBotLogins: [],
+          allowedBotEmailPatterns: []
         },
         trailerContract: {
           requiredAny: []


### PR DESCRIPTION
## Summary
Implements `#772` by enforcing bot identity allowlist policy in `commit-integrity`.

## What Changed
- Added bot identity policy seam:
  - `bot_identity_policy.require_allowlist_for_bot_commits`
  - `bot_identity_policy.allowed_bot_logins[]`
  - `bot_identity_policy.allowed_bot_email_patterns[]`
- Added `unauthorized-bot-identity` violation when bot commits are not allowlisted.
- Added `bot-identity-allowlist` check result in commit-integrity report.
- Extended report schema + docs for bot identity policy contract.
- Added unit tests for allowlisted and denied bot commit identities.

## Validation
- `node --test tools/priority/__tests__/commit-integrity.test.mjs tools/priority/__tests__/commit-integrity-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`

Coupling: independent

Parent: #742
Issue: #772
