### PR TITLE
[P1][#742] Enforce signed release-tag verification in trust gate (#773)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,7 @@ jobs:
             --checksums artifacts/cli/SHA256SUMS.txt \
             --sbom artifacts/cli/sbom.spdx.json \
             --provenance artifacts/cli/provenance.json \
+            --tag-ref "${{ github.ref_name }}" \
             --signer-workflow "${{ github.repository }}/.github/workflows/release.yml" \
             --report tests/results/_agent/supply-chain/release-trust-gate.json
 

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -126,6 +126,12 @@ matching remediation path:
 
 - `missing-artifacts-root`, `missing-required-file`, `no-distribution-artifacts`
   - Re-run publish steps and confirm artifacts exist under `artifacts/cli`.
+- `tag-ref-missing`, `tag-ref-lookup-failed`, `tag-object-lookup-failed`, `tag-signature-parse-failed`
+  - Confirm release workflow was triggered from a tag push and rerun with GitHub CLI/API access intact.
+- `tag-signature-cli-unavailable`
+  - Restore GitHub CLI availability on runner and retry release.
+- `tag-not-annotated`, `tag-signature-unverified`
+  - Recreate release tag as a signed annotated tag and rerun release.
 - `checksum-invalid-line`, `checksum-empty`, `checksum-entry-missing-file`, `checksum-missing-artifact`, `checksum-mismatch`
   - Regenerate `SHA256SUMS.txt` from fresh artifacts and ensure no post-pack mutation occurred.
 - `sbom-parse-failed`, `sbom-invalid`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -99,6 +99,7 @@ Release tags must pass the supply-chain trust gate before GitHub Release publica
 - Gate script: `node tools/priority/supply-chain-trust-gate.mjs`
 - Report artifact: `tests/results/_agent/supply-chain/release-trust-gate.json`
 - Enforced checks:
+  - signed annotated release tag verification (GitHub API `git/tags` verification must be `verified=true`)
   - required artifact presence (`*.zip/*.tar.gz`, `SHA256SUMS.txt`, `sbom.spdx.json`, `provenance.json`)
   - checksum integrity
   - SBOM/provenance contract validity

--- a/docs/schemas/supply-chain-trust-gate-v1.schema.json
+++ b/docs/schemas/supply-chain-trust-gate-v1.schema.json
@@ -8,6 +8,7 @@
     "generatedAt",
     "repository",
     "policy",
+    "tagSignature",
     "artifacts",
     "attestations",
     "failures",
@@ -34,12 +35,23 @@
     "policy": {
       "type": "object",
       "required": [
+        "verifyTagSignature",
+        "tagRef",
         "signerWorkflow",
         "verifyAttestations",
         "attestationAttempts",
         "attestationRetrySeconds"
       ],
       "properties": {
+        "verifyTagSignature": {
+          "type": "boolean"
+        },
+        "tagRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "signerWorkflow": {
           "type": "string"
         },
@@ -55,6 +67,20 @@
           "minimum": 0
         }
       }
+    },
+    "tagSignature": {
+      "type": "object",
+      "required": [
+        "refName",
+        "checked",
+        "exists",
+        "annotated",
+        "objectType",
+        "objectSha",
+        "verified",
+        "reason",
+        "verifiedAt"
+      ]
     },
     "artifacts": {
       "type": "object",

--- a/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
+++ b/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
@@ -10,6 +10,7 @@ import {
   parseArgs,
   parseChecksumManifest,
   shouldRetryAttestationVerify,
+  verifyReleaseTagSignature,
   verifyAttestationForArtifact,
   verifyAttestations
 } from '../supply-chain-trust-gate.mjs';
@@ -27,6 +28,8 @@ test('parseArgs applies defaults and explicit overrides', () => {
   const defaults = parseArgs(['node', 'supply-chain-trust-gate.mjs']);
   assert.equal(defaults.artifactsRoot, path.join('artifacts', 'cli'));
   assert.equal(defaults.reportPath, DEFAULT_REPORT_PATH);
+  assert.equal(defaults.tagRef, process.env.GITHUB_REF_NAME || null);
+  assert.equal(defaults.verifyTagSignature, true);
   assert.equal(defaults.verifyAttestations, true);
   assert.equal(defaults.attestationAttempts, 6);
 
@@ -43,6 +46,8 @@ test('parseArgs applies defaults and explicit overrides', () => {
     'out/release/sbom.json',
     '--provenance',
     'out/release/prov.json',
+    '--tag-ref',
+    'v1.2.3',
     '--report',
     'out/report.json',
     '--signer-workflow',
@@ -51,14 +56,17 @@ test('parseArgs applies defaults and explicit overrides', () => {
     '2',
     '--attestation-retry-seconds',
     '1',
+    '--skip-tag-signature',
     '--skip-attestations'
   ]);
   assert.equal(parsed.repo, 'owner/repo');
   assert.equal(parsed.artifactsRoot, 'out/release');
+  assert.equal(parsed.tagRef, 'v1.2.3');
   assert.equal(parsed.reportPath, 'out/report.json');
   assert.equal(parsed.signerWorkflow, 'owner/repo/.github/workflows/release.yml');
   assert.equal(parsed.attestationAttempts, 2);
   assert.equal(parsed.attestationRetrySeconds, 1);
+  assert.equal(parsed.verifyTagSignature, false);
   assert.equal(parsed.verifyAttestations, false);
 });
 
@@ -221,4 +229,124 @@ test('verifyAttestations reports gh unavailable and retry classifier catches tra
   assert.ok(result.failures.some((failure) => failure.code === 'attestation-cli-unavailable'));
   assert.equal(result.results.length, 1);
   assert.equal(result.results[0].verified, false);
+});
+
+test('verifyReleaseTagSignature passes for verified annotated tag', async () => {
+  const runner = (_command, args) => {
+    if (args[0] === '--version') {
+      return { status: 0, stdout: 'gh version 2.x', stderr: '' };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/git/ref/tags/')) {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          object: {
+            type: 'tag',
+            sha: 'abc123'
+          }
+        }),
+        stderr: ''
+      };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/git/tags/')) {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          verification: {
+            verified: true,
+            reason: 'valid',
+            verified_at: '2026-03-06T00:00:00Z'
+          }
+        }),
+        stderr: ''
+      };
+    }
+    return { status: 1, stdout: '', stderr: 'unexpected' };
+  };
+
+  const result = await verifyReleaseTagSignature({
+    repository: 'owner/repo',
+    tagRef: 'v1.2.3',
+    runner
+  });
+
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.status.checked, true);
+  assert.equal(result.status.annotated, true);
+  assert.equal(result.status.verified, true);
+  assert.equal(result.status.reason, 'valid');
+});
+
+test('verifyReleaseTagSignature fails for unsigned tag', async () => {
+  const runner = (_command, args) => {
+    if (args[0] === '--version') {
+      return { status: 0, stdout: 'gh version 2.x', stderr: '' };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/git/ref/tags/')) {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          object: {
+            type: 'tag',
+            sha: 'abc123'
+          }
+        }),
+        stderr: ''
+      };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/git/tags/')) {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          verification: {
+            verified: false,
+            reason: 'unsigned'
+          }
+        }),
+        stderr: ''
+      };
+    }
+    return { status: 1, stdout: '', stderr: 'unexpected' };
+  };
+
+  const result = await verifyReleaseTagSignature({
+    repository: 'owner/repo',
+    tagRef: 'v1.2.3',
+    runner
+  });
+
+  assert.ok(result.failures.some((failure) => failure.code === 'tag-signature-unverified'));
+  assert.equal(result.status.verified, false);
+  assert.equal(result.status.reason, 'unsigned');
+});
+
+test('verifyReleaseTagSignature fails for lightweight tag', async () => {
+  const runner = (_command, args) => {
+    if (args[0] === '--version') {
+      return { status: 0, stdout: 'gh version 2.x', stderr: '' };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/git/ref/tags/')) {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          object: {
+            type: 'commit',
+            sha: 'deadbeef'
+          }
+        }),
+        stderr: ''
+      };
+    }
+    return { status: 1, stdout: '', stderr: 'unexpected' };
+  };
+
+  const result = await verifyReleaseTagSignature({
+    repository: 'owner/repo',
+    tagRef: 'v1.2.3',
+    runner
+  });
+
+  assert.ok(result.failures.some((failure) => failure.code === 'tag-not-annotated'));
+  assert.equal(result.status.annotated, false);
+  assert.equal(result.status.reason, 'not-annotated');
 });

--- a/tools/priority/supply-chain-trust-gate.mjs
+++ b/tools/priority/supply-chain-trust-gate.mjs
@@ -27,6 +27,13 @@ const FAILURE_HINTS = {
   'sbom-invalid': 'SBOM content is missing required SPDX fields or artifact references. Regenerate SBOM.',
   'provenance-parse-failed': 'Provenance JSON is unreadable. Re-run Generate-ReleaseProvenance.ps1 and validate output.',
   'provenance-invalid': 'Provenance payload failed contract checks (schema/asset hash/identity). Regenerate provenance.',
+  'tag-ref-missing': 'Release tag ref is unavailable. Ensure trust gate runs from a tag-triggered release event.',
+  'tag-signature-cli-unavailable': 'GitHub CLI is unavailable. Install/enable gh on runner before tag signature verification.',
+  'tag-ref-lookup-failed': 'Unable to resolve release tag via GitHub API. Confirm tag exists and token has repo read access.',
+  'tag-object-lookup-failed': 'Unable to resolve annotated tag object via GitHub API. Confirm tag object availability.',
+  'tag-signature-parse-failed': 'Tag signature payload could not be parsed. Re-run and inspect gh api output.',
+  'tag-not-annotated': 'Release tag is lightweight/non-annotated. Create a signed annotated tag for release.',
+  'tag-signature-unverified': 'Release tag signature is not verified. Sign the tag and re-run the release.',
   'attestation-cli-unavailable': 'GitHub CLI is unavailable. Install/enable gh on runner before trust gate.',
   'attestation-output-parse-failed': 'Attestation verification output was not valid JSON. Re-run verification and inspect gh logs.',
   'attestation-unverified': 'Artifact attestation verification failed. Confirm attest-build-provenance step and signer workflow.',
@@ -42,10 +49,12 @@ export function printUsage() {
   console.log('  --checksums <path>                SHA256SUMS path (default: artifacts/cli/SHA256SUMS.txt).');
   console.log('  --sbom <path>                     SBOM path (default: artifacts/cli/sbom.spdx.json).');
   console.log('  --provenance <path>               Provenance path (default: artifacts/cli/provenance.json).');
+  console.log('  --tag-ref <name>                  Release tag ref name (default: GITHUB_REF_NAME).');
   console.log(`  --report <path>                   Report output path (default: ${DEFAULT_REPORT_PATH}).`);
   console.log('  --signer-workflow <value>         Attestation signer workflow identity.');
   console.log('  --attestation-attempts <n>        Retry attempts for attestation verify (default: 6).');
   console.log('  --attestation-retry-seconds <n>   Retry delay in seconds (default: 10).');
+  console.log('  --skip-tag-signature              Skip release tag signature verification (local/debug only).');
   console.log('  --skip-attestations               Skip gh attestation verification (local/debug only).');
   console.log('  -h, --help                        Show this message and exit.');
 }
@@ -58,10 +67,12 @@ export function parseArgs(argv = process.argv) {
     checksumsPath: path.join('artifacts', 'cli', 'SHA256SUMS.txt'),
     sbomPath: path.join('artifacts', 'cli', 'sbom.spdx.json'),
     provenancePath: path.join('artifacts', 'cli', 'provenance.json'),
+    tagRef: process.env.GITHUB_REF_NAME || null,
     reportPath: DEFAULT_REPORT_PATH,
     signerWorkflow: null,
     attestationAttempts: 6,
     attestationRetrySeconds: 10,
+    verifyTagSignature: true,
     verifyAttestations: true,
     help: false
   };
@@ -77,6 +88,10 @@ export function parseArgs(argv = process.argv) {
       options.verifyAttestations = false;
       continue;
     }
+    if (token === '--skip-tag-signature') {
+      options.verifyTagSignature = false;
+      continue;
+    }
 
     if (
       token === '--repo' ||
@@ -84,6 +99,7 @@ export function parseArgs(argv = process.argv) {
       token === '--checksums' ||
       token === '--sbom' ||
       token === '--provenance' ||
+      token === '--tag-ref' ||
       token === '--report' ||
       token === '--signer-workflow'
     ) {
@@ -96,6 +112,7 @@ export function parseArgs(argv = process.argv) {
       if (token === '--checksums') options.checksumsPath = next;
       if (token === '--sbom') options.sbomPath = next;
       if (token === '--provenance') options.provenancePath = next;
+      if (token === '--tag-ref') options.tagRef = next;
       if (token === '--report') options.reportPath = next;
       if (token === '--signer-workflow') options.signerWorkflow = next;
       continue;
@@ -521,6 +538,116 @@ function defaultCommandRunner(command, args) {
   };
 }
 
+function parseJsonFromCommandPayload(raw, description, failures) {
+  try {
+    return JSON.parse(String(raw || '').trim() || '{}');
+  } catch (error) {
+    addFailure(failures, 'tag-signature-parse-failed', `Failed to parse ${description}: ${error.message}`);
+    return null;
+  }
+}
+
+function formatCommandError(result) {
+  return String(result?.stderr || result?.stdout || `exit code ${result?.status ?? 1}`).trim();
+}
+
+export function createDefaultTagSignatureStatus(tagRef = null, reason = null) {
+  return {
+    refName: tagRef || null,
+    checked: false,
+    exists: false,
+    annotated: false,
+    objectType: null,
+    objectSha: null,
+    verified: false,
+    reason: reason || null,
+    verifiedAt: null
+  };
+}
+
+export async function verifyReleaseTagSignature({ repository, tagRef, runner = defaultCommandRunner }) {
+  const failures = [];
+  const normalizedTagRef = String(tagRef || '').trim();
+  const status = createDefaultTagSignatureStatus(normalizedTagRef || null);
+
+  if (!normalizedTagRef) {
+    addFailure(failures, 'tag-ref-missing', 'Release tag ref is unavailable (GITHUB_REF_NAME/--tag-ref missing).');
+    return { failures, status };
+  }
+
+  const cliCheck = await Promise.resolve(runner('gh', ['--version']));
+  if (cliCheck.status !== 0) {
+    addFailure(failures, 'tag-signature-cli-unavailable', 'Unable to execute gh api for tag signature verification.');
+    return { failures, status };
+  }
+
+  const refPath = `repos/${repository}/git/ref/tags/${encodeURIComponent(normalizedTagRef)}`;
+  const refResult = await Promise.resolve(runner('gh', ['api', refPath]));
+  if (refResult.status !== 0) {
+    addFailure(
+      failures,
+      'tag-ref-lookup-failed',
+      `Failed to query release tag ref '${normalizedTagRef}': ${formatCommandError(refResult)}.`,
+      normalizedTagRef
+    );
+    return { failures, status };
+  }
+
+  const refPayload = parseJsonFromCommandPayload(refResult.stdout, 'tag ref payload', failures);
+  if (!refPayload) {
+    return { failures, status };
+  }
+
+  status.checked = true;
+  status.exists = true;
+  status.objectType = typeof refPayload?.object?.type === 'string' ? refPayload.object.type : null;
+  status.objectSha = typeof refPayload?.object?.sha === 'string' ? refPayload.object.sha : null;
+  if (status.objectType !== 'tag' || !status.objectSha) {
+    status.reason = 'not-annotated';
+    addFailure(
+      failures,
+      'tag-not-annotated',
+      `Release tag '${normalizedTagRef}' is not an annotated tag (object.type=${status.objectType || '<empty>'}).`,
+      normalizedTagRef
+    );
+    return { failures, status };
+  }
+  status.annotated = true;
+
+  const tagPath = `repos/${repository}/git/tags/${status.objectSha}`;
+  const tagResult = await Promise.resolve(runner('gh', ['api', tagPath]));
+  if (tagResult.status !== 0) {
+    addFailure(
+      failures,
+      'tag-object-lookup-failed',
+      `Failed to query tag object for '${normalizedTagRef}': ${formatCommandError(tagResult)}.`,
+      normalizedTagRef
+    );
+    return { failures, status };
+  }
+
+  const tagPayload = parseJsonFromCommandPayload(tagResult.stdout, 'tag object payload', failures);
+  if (!tagPayload) {
+    return { failures, status };
+  }
+
+  const verification = tagPayload?.verification || {};
+  status.verified = verification?.verified === true;
+  status.reason = typeof verification?.reason === 'string' ? verification.reason : null;
+  status.verifiedAt = typeof verification?.verified_at === 'string' ? verification.verified_at : null;
+
+  if (!status.verified) {
+    addFailure(
+      failures,
+      'tag-signature-unverified',
+      `Release tag '${normalizedTagRef}' signature not verified (reason=${status.reason || 'unknown'}).`,
+      normalizedTagRef
+    );
+  }
+
+  return { failures, status };
+}
+
 export function shouldRetryAttestationVerify(message) {
   const text = String(message || '').toLowerCase();
   return (
@@ -677,6 +804,7 @@ function appendSummary(report, reportPath) {
     `- Status: \`${report.summary.status}\``,
     `- Failures: \`${report.summary.failureCount}\``,
     `- Artifacts evaluated: \`${report.summary.artifactCount}\``,
+    `- Tag signature: \`${report.tagSignature.verified ? 'verified' : report.tagSignature.reason || 'unverified'}\` (\`${report.tagSignature.refName || 'n/a'}\`)`,
     `- Attestations verified: \`${report.summary.attestationVerifiedCount}/${report.summary.attestationTotal}\``,
     `- Report: \`${reportPath}\``
   ];
@@ -700,6 +828,17 @@ export async function run(options, dependencies = {}) {
   const repository = resolveRepositorySlug(options.repo);
   const signerWorkflow = options.signerWorkflow || `${repository}/.github/workflows/release.yml`;
   const repoRoot = process.cwd();
+
+  const tagSignature = options.verifyTagSignature
+    ? await verifyReleaseTagSignature({
+        repository,
+        tagRef: options.tagRef || process.env.GITHUB_REF_NAME || null,
+        runner: dependencies.runner || defaultCommandRunner
+      })
+    : {
+        failures: [],
+        status: createDefaultTagSignatureStatus(options.tagRef || process.env.GITHUB_REF_NAME || null, 'skipped')
+      };
 
   const local = evaluateLocalIntegrity({
     repoRoot,
@@ -735,7 +874,7 @@ export async function run(options, dependencies = {}) {
     });
   }
 
-  const failures = [...local.failures, ...attestation.failures];
+  const failures = [...tagSignature.failures, ...local.failures, ...attestation.failures];
   const summary = {
     status: failures.length === 0 ? 'pass' : 'fail',
     failureCount: failures.length,
@@ -759,11 +898,14 @@ export async function run(options, dependencies = {}) {
       sha: process.env.GITHUB_SHA || null
     },
     policy: {
+      verifyTagSignature: options.verifyTagSignature,
+      tagRef: options.tagRef || process.env.GITHUB_REF_NAME || null,
       signerWorkflow,
       verifyAttestations: options.verifyAttestations,
       attestationAttempts: options.attestationAttempts,
       attestationRetrySeconds: options.attestationRetrySeconds
     },
+    tagSignature: tagSignature.status,
     artifacts: {
       root: path.resolve(options.artifactsRoot),
       distribution: local.artifactRecords,
@@ -813,6 +955,7 @@ if (invokedPath && invokedPath === modulePath) {
           attestationVerifiedCount: 0,
           attestationTotal: 0
         },
+        tagSignature: createDefaultTagSignatureStatus(process.env.GITHUB_REF_NAME || null, 'execution-error'),
         failures: [
           {
             code: 'execution-error',


### PR DESCRIPTION
## Summary
- enforce signed annotated release-tag verification in `tools/priority/supply-chain-trust-gate.mjs`
- fail trust gate for missing tag ref, lightweight tags, API lookup failures, and unverified/unsigned tag signatures
- extend trust-gate report/schema/docs and wire explicit `--tag-ref` from `release.yml`

## Validation
- `node --test tools/priority/__tests__/supply-chain-trust-gate.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`

Coupling: independent
Depends-On: 
Refs #773
Parent #742
