### PR TITLE
[P2][#742] Commit-integrity drift monitor + SLO reporting (#774)

### DIFF
--- a/.github/workflows/commit-integrity-drift-monitor.yml
+++ b/.github/workflows/commit-integrity-drift-monitor.yml
@@ -1,0 +1,44 @@
+name: Commit Integrity Drift Monitor
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: commit-integrity-drift-monitor
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    name: monitor
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Emit commit-integrity drift report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node tools/npm/run-script.mjs priority:commit-integrity:drift -- \
+            --route-on-breach \
+            --route-labels slo,ci,governance,supply-chain \
+            --route-title-prefix "[SLO] Commit integrity breach"
+
+      - name: Upload commit-integrity drift artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: commit-integrity-drift-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tests/results/_agent/commit-integrity/commit-integrity-drift-report.json
+          if-no-files-found: error

--- a/docs/COMMIT_INTEGRITY_CHECK.md
+++ b/docs/COMMIT_INTEGRITY_CHECK.md
@@ -1,6 +1,6 @@
 # Commit Integrity Check
 
-Issue: `#743`
+Issues: `#743`, `#774`
 
 This document defines the `commit-integrity` contract used to evaluate commit trust posture for PR/queue scopes.
 
@@ -11,6 +11,10 @@ This document defines the `commit-integrity` contract used to evaluate commit tr
 - Deterministic artifact:
   - `tests/results/_agent/commit-integrity/commit-integrity-report.json`
   - Uploaded on every run via `if: always()`
+- Drift monitor workflow: `.github/workflows/commit-integrity-drift-monitor.yml`
+  - Deterministic artifact:
+    - `tests/results/_agent/commit-integrity/commit-integrity-drift-report.json`
+  - Runs every 6 hours and on manual dispatch.
 
 ## Validation Coverage
 
@@ -100,3 +104,15 @@ node tools/npm/run-script.mjs priority:commit-integrity -- --pr 744 --observe-on
 ```bash
 node tools/npm/run-script.mjs priority:commit-integrity -- --pr 744
 ```
+
+```bash
+node tools/npm/run-script.mjs priority:commit-integrity:drift
+```
+
+## Drift + SLO Monitoring
+
+- Drift/SLO report source: `tools/priority/slo-metrics.mjs` (workflow scoped to `commit-integrity.yml`).
+- Report includes pass/fail/skip telemetry plus MTTR/staleness/gate-regression metrics.
+- Breach routing:
+  - opens/comments an issue with labels `slo`, `ci`, `governance`, `supply-chain`
+  - title prefix: `[SLO] Commit integrity breach`

--- a/docs/schemas/priority-slo-metrics-v1.schema.json
+++ b/docs/schemas/priority-slo-metrics-v1.schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "priority/slo-metrics@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "repository",
+    "lookbackDays",
+    "thresholds",
+    "workflowSummaries",
+    "summary",
+    "breaches",
+    "route"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/slo-metrics@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "lookbackDays": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "thresholds": {
+      "$ref": "#/$defs/thresholds"
+    },
+    "workflowSummaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workflow",
+          "summary",
+          "runCount"
+        ],
+        "properties": {
+          "workflow": {
+            "type": "string",
+            "minLength": 1
+          },
+          "runCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "summary": {
+            "$ref": "#/$defs/summary"
+          }
+        }
+      }
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    },
+    "breaches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "none",
+            "create",
+            "comment",
+            "error"
+          ]
+        },
+        "issueNumber": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "failureRate",
+        "skipRate",
+        "mttrHours",
+        "staleHours",
+        "gateRegressions"
+      ],
+      "properties": {
+        "failureRate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "skipRate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "mttrHours": {
+          "type": "number",
+          "minimum": 0
+        },
+        "staleHours": {
+          "type": "number",
+          "minimum": 0
+        },
+        "gateRegressions": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "totals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalRuns",
+        "observedRuns",
+        "successRuns",
+        "failedRuns",
+        "skippedRuns",
+        "gateRegressions"
+      ],
+      "properties": {
+        "totalRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "observedRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "successRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skippedRuns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "gateRegressions": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "failureRate",
+        "skipRate",
+        "leadTimeP50Seconds",
+        "leadTimeP95Seconds",
+        "mttrSeconds",
+        "staleHours"
+      ],
+      "properties": {
+        "failureRate": {
+          "type": "number",
+          "minimum": 0
+        },
+        "skipRate": {
+          "type": "number",
+          "minimum": 0
+        },
+        "leadTimeP50Seconds": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "leadTimeP95Seconds": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "mttrSeconds": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "staleHours": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "unresolvedIncident": {
+          "type": "boolean"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totals",
+        "metrics"
+      ],
+      "properties": {
+        "totals": {
+          "$ref": "#/$defs/totals"
+        },
+        "metrics": {
+          "$ref": "#/$defs/metrics"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "priority:queue:supervisor": "node tools/priority/queue-supervisor.mjs",
     "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
     "priority:commit-integrity": "node tools/priority/commit-integrity.mjs",
+    "priority:commit-integrity:drift": "node tools/priority/slo-metrics.mjs --workflow commit-integrity.yml --lookback-days 30 --max-runs 200 --threshold-failure-rate 0.3 --threshold-skip-rate 0.25 --threshold-mttr-hours 24 --threshold-stale-hours 168 --threshold-gate-regressions 5 --output tests/results/_agent/commit-integrity/commit-integrity-drift-report.json",
     "priority:deployment:assert": "node tools/priority/assert-validation-deployment-determinism.mjs",
     "priority:onboard:downstream": "node tools/priority/downstream-onboarding.mjs",
     "priority:onboard:success": "node tools/priority/downstream-onboarding-success.mjs",

--- a/tools/priority/__tests__/slo-metrics-schema.test.mjs
+++ b/tools/priority/__tests__/slo-metrics-schema.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import {
+  summarizeWorkflowRuns,
+  buildSloSummary,
+  evaluateBreaches
+} from '../slo-metrics.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('slo metrics schema validates generated payload', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'priority-slo-metrics-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const now = new Date('2026-03-06T12:00:00Z');
+  const workflowSummary = summarizeWorkflowRuns(
+    [
+      {
+        created_at: '2026-03-06T08:00:00Z',
+        updated_at: '2026-03-06T08:10:00Z',
+        conclusion: 'failure'
+      },
+      {
+        created_at: '2026-03-06T09:00:00Z',
+        updated_at: '2026-03-06T09:12:00Z',
+        conclusion: 'success'
+      },
+      {
+        created_at: '2026-03-06T10:00:00Z',
+        updated_at: '2026-03-06T10:06:00Z',
+        conclusion: 'skipped'
+      }
+    ],
+    now
+  );
+
+  const workflowSummaries = [
+    {
+      workflow: 'commit-integrity.yml',
+      runCount: 3,
+      summary: workflowSummary
+    }
+  ];
+  const summary = buildSloSummary(workflowSummaries);
+  const thresholds = {
+    failureRate: 0.3,
+    skipRate: 0.25,
+    mttrHours: 24,
+    staleHours: 168,
+    gateRegressions: 3
+  };
+
+  const payload = {
+    schema: 'priority/slo-metrics@v1',
+    generatedAt: now.toISOString(),
+    repository: 'example/repo',
+    lookbackDays: 30,
+    thresholds,
+    workflowSummaries,
+    summary,
+    breaches: evaluateBreaches(summary, thresholds),
+    route: {
+      action: 'none'
+    }
+  };
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(payload);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/slo-metrics.test.mjs
+++ b/tools/priority/__tests__/slo-metrics.test.mjs
@@ -11,6 +11,7 @@ test('parseArgs applies defaults and supports explicit options', () => {
   const defaults = parseArgs(['node', 'slo-metrics.mjs']);
   assert.equal(defaults.lookbackDays, 45);
   assert.equal(defaults.maxRuns, 100);
+  assert.equal(defaults.thresholdSkipRate, 1);
   assert.equal(defaults.routeOnBreach, false);
   assert.deepEqual(defaults.workflows, [
     'release.yml',
@@ -60,14 +61,22 @@ test('summarizeWorkflowRuns computes lead time, failure rate, mttr, and stale ho
       created_at: '2026-03-06T02:00:00Z',
       updated_at: '2026-03-06T02:12:00Z',
       conclusion: 'success'
+    },
+    {
+      created_at: '2026-03-06T03:00:00Z',
+      updated_at: '2026-03-06T03:10:00Z',
+      conclusion: 'skipped'
     }
   ];
 
   const summary = summarizeWorkflowRuns(runs, now);
   assert.equal(summary.totals.totalRuns, 3);
+  assert.equal(summary.totals.observedRuns, 4);
   assert.equal(summary.totals.failedRuns, 1);
   assert.equal(summary.totals.successRuns, 2);
+  assert.equal(summary.totals.skippedRuns, 1);
   assert.equal(summary.metrics.failureRate, 1 / 3);
+  assert.equal(summary.metrics.skipRate, 1 / 4);
   assert.equal(summary.metrics.leadTimeP50Seconds, 720);
   assert.equal(summary.metrics.mttrSeconds, 4200);
   assert.equal(summary.metrics.staleHours, (now.getTime() - Date.parse('2026-03-06T02:12:00Z')) / 3_600_000);
@@ -78,9 +87,10 @@ test('buildSloSummary aggregates workflow summaries and breach evaluation trigge
     {
       workflow: 'release.yml',
       summary: {
-        totals: { totalRuns: 4, successRuns: 2, failedRuns: 2, gateRegressions: 2 },
+        totals: { totalRuns: 4, observedRuns: 5, successRuns: 2, failedRuns: 2, skippedRuns: 1, gateRegressions: 2 },
         metrics: {
           failureRate: 0.5,
+          skipRate: 0.2,
           leadTimeP50Seconds: 900,
           leadTimeP95Seconds: 1400,
           mttrSeconds: 3600,
@@ -91,9 +101,10 @@ test('buildSloSummary aggregates workflow summaries and breach evaluation trigge
     {
       workflow: 'publish-tools-image.yml',
       summary: {
-        totals: { totalRuns: 2, successRuns: 2, failedRuns: 0, gateRegressions: 0 },
+        totals: { totalRuns: 2, observedRuns: 2, successRuns: 2, failedRuns: 0, skippedRuns: 0, gateRegressions: 0 },
         metrics: {
           failureRate: 0,
+          skipRate: 0,
           leadTimeP50Seconds: 600,
           leadTimeP95Seconds: 600,
           mttrSeconds: null,
@@ -104,19 +115,23 @@ test('buildSloSummary aggregates workflow summaries and breach evaluation trigge
   ]);
 
   assert.equal(summary.totals.totalRuns, 6);
+  assert.equal(summary.totals.observedRuns, 7);
   assert.equal(summary.totals.failedRuns, 2);
+  assert.equal(summary.totals.skippedRuns, 1);
   assert.equal(summary.totals.gateRegressions, 2);
   assert.equal(summary.metrics.failureRate, 2 / 6);
+  assert.equal(summary.metrics.skipRate, 1 / 7);
   assert.equal(summary.metrics.staleHours, 1200);
 
   const breaches = evaluateBreaches(summary, {
     failureRate: 0.2,
+    skipRate: 0.1,
     mttrHours: 0.5,
     staleHours: 1000,
     gateRegressions: 1
   });
   assert.deepEqual(
     breaches.map((entry) => entry.code).sort(),
-    ['failure-rate', 'gate-regressions', 'mttr', 'stale-budget']
+    ['failure-rate', 'gate-regressions', 'mttr', 'skip-rate', 'stale-budget']
   );
 });

--- a/tools/priority/slo-metrics.mjs
+++ b/tools/priority/slo-metrics.mjs
@@ -25,6 +25,7 @@ function printUsage() {
   console.log('  --lookback-days <n>                Lookback window in days (default: 45).');
   console.log('  --max-runs <n>                     Max completed runs fetched per workflow (default: 100).');
   console.log('  --threshold-failure-rate <0..1>    Failure-rate breach threshold (default: 0.3).');
+  console.log('  --threshold-skip-rate <0..1>       Skip-rate breach threshold (default: 1).');
   console.log('  --threshold-mttr-hours <n>         MTTR breach threshold in hours (default: 24).');
   console.log('  --threshold-stale-hours <n>        Stale-budget breach threshold in hours (default: 1080).');
   console.log('  --threshold-gate-regressions <n>   Gate-regression breach threshold (default: 3).');
@@ -43,6 +44,7 @@ export function parseArgs(argv = process.argv) {
     lookbackDays: 45,
     maxRuns: 100,
     thresholdFailureRate: 0.3,
+    thresholdSkipRate: 1,
     thresholdMttrHours: 24,
     thresholdStaleHours: 1080,
     thresholdGateRegressions: 3,
@@ -105,7 +107,7 @@ export function parseArgs(argv = process.argv) {
       continue;
     }
 
-    if (token === '--threshold-failure-rate') {
+    if (token === '--threshold-failure-rate' || token === '--threshold-skip-rate') {
       if (!next || next.startsWith('-')) {
         throw new Error(`Missing value for ${token}.`);
       }
@@ -114,7 +116,11 @@ export function parseArgs(argv = process.argv) {
       if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
         throw new Error(`Invalid value for ${token}: ${next}`);
       }
-      options.thresholdFailureRate = parsed;
+      if (token === '--threshold-failure-rate') {
+        options.thresholdFailureRate = parsed;
+      } else {
+        options.thresholdSkipRate = parsed;
+      }
       continue;
     }
 
@@ -210,7 +216,8 @@ async function requestJson(url, token, method = 'GET', body = null) {
 
 function classifyConclusion(conclusion) {
   if (conclusion === 'success') return 'success';
-  if (!conclusion || conclusion === 'neutral' || conclusion === 'skipped') return 'ignored';
+  if (conclusion === 'neutral' || conclusion === 'skipped') return 'skipped';
+  if (!conclusion) return 'ignored';
   return 'failure';
 }
 
@@ -249,6 +256,8 @@ export function summarizeWorkflowRuns(runs, now = new Date()) {
   const considered = normalized.filter((entry) => entry.outcome !== 'ignored');
   const successes = considered.filter((entry) => entry.outcome === 'success');
   const failures = considered.filter((entry) => entry.outcome === 'failure');
+  const skipped = considered.filter((entry) => entry.outcome === 'skipped');
+  const effectiveRuns = considered.filter((entry) => entry.outcome !== 'skipped');
   const successDurations = successes
     .map((entry) => entry.durationSeconds)
     .filter((value) => Number.isFinite(value) && value >= 0);
@@ -277,13 +286,16 @@ export function summarizeWorkflowRuns(runs, now = new Date()) {
 
   return {
     totals: {
-      totalRuns: considered.length,
+      totalRuns: effectiveRuns.length,
+      observedRuns: considered.length,
       successRuns: successes.length,
       failedRuns: failures.length,
+      skippedRuns: skipped.length,
       gateRegressions: failures.length
     },
     metrics: {
-      failureRate: considered.length > 0 ? failures.length / considered.length : 0,
+      failureRate: effectiveRuns.length > 0 ? failures.length / effectiveRuns.length : 0,
+      skipRate: considered.length > 0 ? skipped.length / considered.length : 0,
       leadTimeP50Seconds: percentile(successDurations, 0.5),
       leadTimeP95Seconds: percentile(successDurations, 0.95),
       mttrSeconds: average(mttrDurations),
@@ -299,6 +311,12 @@ export function evaluateBreaches(summary, thresholds) {
     breaches.push({
       code: 'failure-rate',
       message: `failureRate ${summary.metrics.failureRate.toFixed(3)} exceeds threshold ${thresholds.failureRate}`
+    });
+  }
+  if (summary.metrics.skipRate > thresholds.skipRate) {
+    breaches.push({
+      code: 'skip-rate',
+      message: `skipRate ${summary.metrics.skipRate.toFixed(3)} exceeds threshold ${thresholds.skipRate}`
     });
   }
   if (
@@ -346,6 +364,7 @@ function renderBreachIssueBody(payload) {
     `- Repository: \`${payload.repository}\``,
     `- Generated at: \`${payload.generatedAt}\``,
     `- Failure rate: \`${formatNumber(payload.summary.metrics.failureRate, 3)}\``,
+    `- Skip rate: \`${formatNumber(payload.summary.metrics.skipRate, 3)}\``,
     `- MTTR hours: \`${formatNumber(payload.summary.metrics.mttrSeconds / 3600, 2)}\``,
     `- Stale hours: \`${formatNumber(payload.summary.metrics.staleHours, 2)}\``,
     `- Gate regressions: \`${payload.summary.totals.gateRegressions}\``,
@@ -358,7 +377,10 @@ function renderBreachIssueBody(payload) {
   lines.push('', '### Workflow metrics');
   for (const workflow of payload.workflowSummaries) {
     lines.push(
-      `- \`${workflow.workflow}\`: failureRate=${formatNumber(workflow.summary.metrics.failureRate, 3)}, mttrHours=${formatNumber(
+      `- \`${workflow.workflow}\`: failureRate=${formatNumber(workflow.summary.metrics.failureRate, 3)}, skipRate=${formatNumber(
+        workflow.summary.metrics.skipRate,
+        3
+      )}, mttrHours=${formatNumber(
         workflow.summary.metrics.mttrSeconds / 3600,
         2
       )}, staleHours=${formatNumber(workflow.summary.metrics.staleHours, 2)}, total=${workflow.summary.totals.totalRuns}`
@@ -426,24 +448,30 @@ export function buildSloSummary(workflowSummaries) {
     const summary = entry.summary;
     return {
       total: summary.totals.totalRuns,
+      observed: summary.totals.observedRuns,
       success: summary.totals.successRuns,
       failed: summary.totals.failedRuns,
+      skipped: summary.totals.skippedRuns,
       gateRegressions: summary.totals.gateRegressions,
       leadTimeP50Seconds: summary.metrics.leadTimeP50Seconds,
       leadTimeP95Seconds: summary.metrics.leadTimeP95Seconds,
       mttrSeconds: summary.metrics.mttrSeconds,
-      staleHours: summary.metrics.staleHours
+      staleHours: summary.metrics.staleHours,
+      skipRate: summary.metrics.skipRate
     };
   });
 
   const totals = {
     totalRuns: allRuns.reduce((sum, item) => sum + item.total, 0),
+    observedRuns: allRuns.reduce((sum, item) => sum + item.observed, 0),
     successRuns: allRuns.reduce((sum, item) => sum + item.success, 0),
     failedRuns: allRuns.reduce((sum, item) => sum + item.failed, 0),
+    skippedRuns: allRuns.reduce((sum, item) => sum + item.skipped, 0),
     gateRegressions: allRuns.reduce((sum, item) => sum + item.gateRegressions, 0)
   };
 
   const failureRate = totals.totalRuns > 0 ? totals.failedRuns / totals.totalRuns : 0;
+  const skipRate = totals.observedRuns > 0 ? totals.skippedRuns / totals.observedRuns : 0;
   const leadTimeP50Seconds = percentile(
     allRuns.map((item) => item.leadTimeP50Seconds).filter((value) => Number.isFinite(value)),
     0.5
@@ -463,6 +491,7 @@ export function buildSloSummary(workflowSummaries) {
     totals,
     metrics: {
       failureRate,
+      skipRate,
       leadTimeP50Seconds,
       leadTimeP95Seconds,
       mttrSeconds,
@@ -499,6 +528,7 @@ export async function main(argv = process.argv) {
   const summary = buildSloSummary(workflowSummaries);
   const thresholds = {
     failureRate: options.thresholdFailureRate,
+    skipRate: options.thresholdSkipRate,
     mttrHours: options.thresholdMttrHours,
     staleHours: options.thresholdStaleHours,
     gateRegressions: options.thresholdGateRegressions
@@ -524,6 +554,7 @@ export async function main(argv = process.argv) {
     `- Repository: \`${repository}\``,
     `- Workflows: ${options.workflows.map((entry) => `\`${entry}\``).join(', ')}`,
     `- Failure rate: \`${formatNumber(summary.metrics.failureRate, 3)}\``,
+    `- Skip rate: \`${formatNumber(summary.metrics.skipRate, 3)}\``,
     `- Lead time p50 (s): \`${formatNumber(summary.metrics.leadTimeP50Seconds, 2)}\``,
     `- MTTR (hours): \`${formatNumber(summary.metrics.mttrSeconds / 3600, 2)}\``,
     `- Stale hours (max): \`${formatNumber(summary.metrics.staleHours, 2)}\``,


### PR DESCRIPTION
## Summary
Implements #774 by adding a commit-integrity drift/SLO monitor lane and extending SLO telemetry to track skip-rate.

## What changed
- Added scheduled/manual workflow: `.github/workflows/commit-integrity-drift-monitor.yml`
  - emits `tests/results/_agent/commit-integrity/commit-integrity-drift-report.json`
  - routes SLO breaches to governance issues (`slo,ci,governance,supply-chain`)
- Added helper script: `priority:commit-integrity:drift`
- Extended `tools/priority/slo-metrics.mjs`:
  - skip-rate metric + `--threshold-skip-rate`
  - skip-rate breach detection (`skip-rate`)
  - payload/summary/issue body now include skip telemetry
- Added/expanded tests:
  - `tools/priority/__tests__/slo-metrics.test.mjs`
  - `tools/priority/__tests__/slo-metrics-schema.test.mjs`
- Added schema: `docs/schemas/priority-slo-metrics-v1.schema.json`
- Updated docs: `docs/COMMIT_INTEGRITY_CHECK.md`

## Validation
- `node --test tools/priority/__tests__/slo-metrics.test.mjs tools/priority/__tests__/slo-metrics-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`
