### PR TITLE
Update for standing priority #775

### DIFF
--- a/.github/workflows/commit-integrity.yml
+++ b/.github/workflows/commit-integrity.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      issues: write
 
     steps:
       - uses: actions/checkout@v5
@@ -43,13 +44,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           COMMIT_INTEGRITY_ENFORCE: ${{ vars.COMMIT_INTEGRITY_ENFORCE || '0' }}
+          COMMIT_INTEGRITY_BYPASS_REASON: ${{ vars.COMMIT_INTEGRITY_BYPASS_REASON || '' }}
+          COMMIT_INTEGRITY_BYPASS_OWNER: ${{ vars.COMMIT_INTEGRITY_BYPASS_OWNER || '' }}
+          COMMIT_INTEGRITY_BYPASS_EXPIRES_AT: ${{ vars.COMMIT_INTEGRITY_BYPASS_EXPIRES_AT || '' }}
+          COMMIT_INTEGRITY_BYPASS_TICKET: ${{ vars.COMMIT_INTEGRITY_BYPASS_TICKET || '' }}
+          COMMIT_INTEGRITY_BYPASS_LABELS: ${{ vars.COMMIT_INTEGRITY_BYPASS_LABELS || '' }}
           DISPATCH_PR: ${{ inputs.pull_request || '' }}
           DISPATCH_ENFORCE: ${{ inputs.enforce || false }}
         run: |
           $reportPath = 'tests/results/_agent/commit-integrity/commit-integrity-report.json'
+          $ledgerPath = 'tests/results/_agent/commit-integrity/commit-integrity-bypass-ledger.json'
           $args = @(
             'tools/priority/commit-integrity.mjs',
-            '--report', $reportPath
+            '--report', $reportPath,
+            '--ledger', $ledgerPath
           )
 
           if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
@@ -64,6 +72,22 @@ jobs:
             $args += '--observe-only'
           }
 
+          if (-not [string]::IsNullOrWhiteSpace($env:COMMIT_INTEGRITY_BYPASS_REASON)) {
+            $args += @('--bypass-reason', $env:COMMIT_INTEGRITY_BYPASS_REASON)
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:COMMIT_INTEGRITY_BYPASS_OWNER)) {
+            $args += @('--bypass-owner', $env:COMMIT_INTEGRITY_BYPASS_OWNER)
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:COMMIT_INTEGRITY_BYPASS_EXPIRES_AT)) {
+            $args += @('--bypass-expires-at', $env:COMMIT_INTEGRITY_BYPASS_EXPIRES_AT)
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:COMMIT_INTEGRITY_BYPASS_TICKET)) {
+            $args += @('--bypass-ticket', $env:COMMIT_INTEGRITY_BYPASS_TICKET)
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:COMMIT_INTEGRITY_BYPASS_LABELS)) {
+            $args += @('--bypass-labels', $env:COMMIT_INTEGRITY_BYPASS_LABELS)
+          }
+
           node @args
 
       - name: Upload commit integrity artifact
@@ -71,5 +95,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: commit-integrity-${{ github.run_id }}
-          path: tests/results/_agent/commit-integrity/commit-integrity-report.json
+          path: |
+            tests/results/_agent/commit-integrity/commit-integrity-report.json
+            tests/results/_agent/commit-integrity/commit-integrity-bypass-ledger.json
           if-no-files-found: error

--- a/docs/COMMIT_INTEGRITY_CHECK.md
+++ b/docs/COMMIT_INTEGRITY_CHECK.md
@@ -1,6 +1,6 @@
 # Commit Integrity Check
 
-Issues: `#743`, `#774`
+Issues: `#743`, `#774`, `#775`
 
 This document defines the `commit-integrity` contract used to evaluate commit trust posture for PR/queue scopes.
 
@@ -10,6 +10,7 @@ This document defines the `commit-integrity` contract used to evaluate commit tr
 - Job/check target: `commit-integrity`
 - Deterministic artifact:
   - `tests/results/_agent/commit-integrity/commit-integrity-report.json`
+  - `tests/results/_agent/commit-integrity/commit-integrity-bypass-ledger.json`
   - Uploaded on every run via `if: always()`
 - Drift monitor workflow: `.github/workflows/commit-integrity-drift-monitor.yml`
   - Deterministic artifact:
@@ -75,6 +76,12 @@ Policy file: `tools/policy/commit-integrity-policy.json`
   - `bot_identity_policy.require_allowlist_for_bot_commits`
   - `bot_identity_policy.allowed_bot_logins[]`
   - `bot_identity_policy.allowed_bot_email_patterns[]`
+- Bypass governance contract:
+  - `exception_governance.allow_bypass`
+  - `exception_governance.require_reason_owner_expiry`
+  - `exception_governance.remediation_labels[]`
+  - `exception_governance.remediation_title_prefix`
+  - `exception_governance.remediation_issue_marker`
 
 ## Drift Guard
 
@@ -94,6 +101,20 @@ Policy file: `tools/policy/commit-integrity-policy.json`
   - `0` (default): observe-only mode (`report.result` still indicates pass/fail; workflow exit remains non-blocking)
   - `1`: enforcing mode (violations fail the job)
 - `workflow_dispatch` input `enforce` can override mode for manual runs.
+- Temporary bypass metadata variables (all required when bypass is used):
+  - `COMMIT_INTEGRITY_BYPASS_REASON`
+  - `COMMIT_INTEGRITY_BYPASS_OWNER`
+  - `COMMIT_INTEGRITY_BYPASS_EXPIRES_AT` (ISO-8601 UTC recommended)
+- Optional bypass variables:
+  - `COMMIT_INTEGRITY_BYPASS_TICKET`
+  - `COMMIT_INTEGRITY_BYPASS_LABELS` (comma-separated)
+
+## Exception Governance
+
+- Bypass is only accepted when all required metadata exists.
+- Expired bypass metadata forces a failing check and routes remediation by opening/commenting an issue.
+- Remediation issue routing is deterministic (marker-based dedupe) and uses policy-defined labels/title prefix.
+- Every run writes a bypass ledger artifact, including runs where no bypass is requested.
 
 ## Local Usage
 

--- a/docs/schemas/commit-integrity-bypass-ledger-v1.schema.json
+++ b/docs/schemas/commit-integrity-bypass-ledger-v1.schema.json
@@ -1,0 +1,272 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "commit-integrity/bypass-ledger@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAt",
+    "repository",
+    "scope",
+    "policy",
+    "enforcement",
+    "bypass",
+    "remediation",
+    "evaluation",
+    "reportPath"
+  ],
+  "properties": {
+    "schema": {
+      "const": "commit-integrity/bypass-ledger@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "pullRequest",
+        "baseSha",
+        "headSha"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "pullRequest": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "baseSha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headSha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "schema",
+        "exceptionGovernance"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "exceptionGovernance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "allowBypass",
+            "requireReasonOwnerExpiry",
+            "remediationLabels",
+            "remediationTitlePrefix",
+            "remediationIssueMarker"
+          ],
+          "properties": {
+            "allowBypass": {
+              "type": "boolean"
+            },
+            "requireReasonOwnerExpiry": {
+              "type": "boolean"
+            },
+            "remediationLabels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "remediationTitlePrefix": {
+              "type": "string"
+            },
+            "remediationIssueMarker": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "enforcement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observeOnly",
+        "blocking"
+      ],
+      "properties": {
+        "observeOnly": {
+          "type": "boolean"
+        },
+        "blocking": {
+          "type": "boolean"
+        }
+      }
+    },
+    "bypass": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested",
+        "status",
+        "active",
+        "bypassEnabled",
+        "reason",
+        "owner",
+        "expiresAt",
+        "ticket",
+        "labels",
+        "metadataErrors"
+      ],
+      "properties": {
+        "requested": {
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "none",
+            "active",
+            "expired",
+            "invalid"
+          ]
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "bypassEnabled": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expiresAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ticket": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "metadataErrors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "remediation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "enum": [
+            "none",
+            "create",
+            "comment",
+            "error"
+          ]
+        },
+        "issueNumber": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "issueUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result",
+        "violationCount",
+        "issueCount"
+      ],
+      "properties": {
+        "result": {
+          "enum": [
+            "pass",
+            "fail"
+          ]
+        },
+        "violationCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "issueCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "reportPath": {
+      "type": "string"
+    }
+  }
+}

--- a/docs/schemas/commit-integrity-report-v1.schema.json
+++ b/docs/schemas/commit-integrity-report-v1.schema.json
@@ -16,6 +16,7 @@
     "commits",
     "violations",
     "issues",
+    "bypass",
     "result",
     "errors",
     "exitCode"
@@ -80,7 +81,8 @@
         "checks",
         "sourceResolution",
         "botIdentityPolicy",
-        "trailerContract"
+        "trailerContract",
+        "exceptionGovernance"
       ],
       "properties": {
         "schema": {
@@ -208,6 +210,37 @@
               }
             }
           }
+        },
+        "exceptionGovernance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "allowBypass",
+            "requireReasonOwnerExpiry",
+            "remediationLabels",
+            "remediationTitlePrefix",
+            "remediationIssueMarker"
+          ],
+          "properties": {
+            "allowBypass": {
+              "type": "boolean"
+            },
+            "requireReasonOwnerExpiry": {
+              "type": "boolean"
+            },
+            "remediationLabels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "remediationTitlePrefix": {
+              "type": "string"
+            },
+            "remediationIssueMarker": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -216,13 +249,25 @@
       "additionalProperties": false,
       "required": [
         "observeOnly",
-        "blocking"
+        "blocking",
+        "bypassRequested",
+        "bypassApplied",
+        "governanceFailure"
       ],
       "properties": {
         "observeOnly": {
           "type": "boolean"
         },
         "blocking": {
+          "type": "boolean"
+        },
+        "bypassRequested": {
+          "type": "boolean"
+        },
+        "bypassApplied": {
+          "type": "boolean"
+        },
+        "governanceFailure": {
           "type": "boolean"
         }
       }
@@ -437,6 +482,113 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "bypass": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested",
+        "status",
+        "active",
+        "reason",
+        "owner",
+        "expiresAt",
+        "ticket",
+        "labels",
+        "metadataErrors",
+        "remediation"
+      ],
+      "properties": {
+        "requested": {
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "none",
+            "active",
+            "expired",
+            "invalid"
+          ]
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expiresAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ticket": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "metadataErrors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "remediation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "action"
+          ],
+          "properties": {
+            "action": {
+              "enum": [
+                "none",
+                "create",
+                "comment",
+                "error"
+              ]
+            },
+            "issueNumber": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            },
+            "issueUrl": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "message": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
     "result": {

--- a/tools/policy/commit-integrity-policy.json
+++ b/tools/policy/commit-integrity-policy.json
@@ -26,6 +26,17 @@
   "verification": {
     "fail_on_unverified": true
   },
+  "exception_governance": {
+    "allow_bypass": true,
+    "require_reason_owner_expiry": true,
+    "remediation_labels": [
+      "ci",
+      "governance",
+      "supply-chain"
+    ],
+    "remediation_title_prefix": "[Commit Integrity] Expired bypass remediation",
+    "remediation_issue_marker": "<!-- commit-integrity-bypass-remediation@v1 -->"
+  },
   "checks": {
     "require_author_attribution": true,
     "require_committer_attribution": true,

--- a/tools/priority/__tests__/commit-integrity-ledger-schema.test.mjs
+++ b/tools/priority/__tests__/commit-integrity-ledger-schema.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { __test } from '../commit-integrity.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('commit integrity bypass ledger schema validates generated payload', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'commit-integrity-bypass-ledger-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const ledger = __test.buildBypassLedger({
+    repository: 'example/repo',
+    scope: {
+      mode: 'pull_request',
+      pullRequest: 775,
+      baseSha: null,
+      headSha: null
+    },
+    policy: {
+      path: path.join(repoRoot, 'tools', 'policy', 'commit-integrity-policy.json'),
+      schema: 'commit-integrity-policy/v1',
+      failOnUnverified: true,
+      exceptionGovernance: {
+        allowBypass: true,
+        requireReasonOwnerExpiry: true,
+        remediationLabels: ['ci', 'governance', 'supply-chain'],
+        remediationTitlePrefix: '[Commit Integrity] Expired bypass remediation',
+        remediationIssueMarker: '<!-- commit-integrity-bypass-remediation@v1 -->'
+      }
+    },
+    observeOnly: false,
+    bypass: {
+      requested: true,
+      status: 'active',
+      active: true,
+      bypassEnabled: true,
+      reason: 'temporary incident mitigation',
+      owner: '@octocat',
+      expiresAt: '2026-03-31T00:00:00.000Z',
+      ticket: '#775',
+      labels: ['ci', 'governance', 'supply-chain'],
+      metadataErrors: []
+    },
+    remediation: {
+      action: 'none'
+    },
+    evaluation: {
+      result: 'fail',
+      violations: [{ category: 'unverified-commit' }],
+      issues: []
+    },
+    reportPath: 'tests/results/_agent/commit-integrity/commit-integrity-report.json',
+    generatedAt: '2026-03-06T00:00:00.000Z'
+  });
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(ledger);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/commit-integrity-schema.test.mjs
+++ b/tools/priority/__tests__/commit-integrity-schema.test.mjs
@@ -96,11 +96,37 @@ test('commit integrity report schema validates generated report payload', async 
           { key: 'Issue', valuePattern: '^#\\d+$' },
           { key: 'Refs', valuePattern: '^#\\d+$' }
         ]
+      },
+      exceptionGovernance: {
+        allowBypass: true,
+        requireReasonOwnerExpiry: true,
+        remediationLabels: ['ci', 'governance', 'supply-chain'],
+        remediationTitlePrefix: '[Commit Integrity] Expired bypass remediation',
+        remediationIssueMarker: '<!-- commit-integrity-bypass-remediation@v1 -->'
       }
     },
     observeOnly: false,
     commits,
     evaluation,
+    bypass: {
+      requested: false,
+      status: 'none',
+      active: false,
+      reason: null,
+      owner: null,
+      expiresAt: null,
+      ticket: null,
+      labels: ['ci', 'governance', 'supply-chain'],
+      metadataErrors: []
+    },
+    remediation: { action: 'none' },
+    governance: {
+      issues: [...evaluation.issues],
+      governanceFailure: false,
+      bypassApplied: false,
+      finalResult: evaluation.result,
+      exitCode: 1
+    },
     generatedAt: '2026-03-06T00:00:00.000Z'
   });
 

--- a/tools/priority/__tests__/commit-integrity.test.mjs
+++ b/tools/priority/__tests__/commit-integrity.test.mjs
@@ -57,6 +57,33 @@ test('parseArgs supports observe-only and pull-request selection', () => {
   assert.equal(options.observeOnly, true);
 });
 
+test('parseArgs captures bypass metadata options', () => {
+  const options = parseArgs([
+    'node',
+    'tools/priority/commit-integrity.mjs',
+    '--pr',
+    '42',
+    '--ledger',
+    'tests/results/ledger.json',
+    '--bypass-reason',
+    'temporary-incident-mitigation',
+    '--bypass-owner',
+    '@octocat',
+    '--bypass-expires-at',
+    '2026-03-31T00:00:00Z',
+    '--bypass-ticket',
+    '#775',
+    '--bypass-labels',
+    'ci,governance'
+  ]);
+  assert.equal(options.ledgerPath, 'tests/results/ledger.json');
+  assert.equal(options.bypassReason, 'temporary-incident-mitigation');
+  assert.equal(options.bypassOwner, '@octocat');
+  assert.equal(options.bypassExpiresAt, '2026-03-31T00:00:00Z');
+  assert.equal(options.bypassTicket, '#775');
+  assert.deepEqual(options.bypassLabels, ['ci', 'governance']);
+});
+
 test('normalizeCommitRecords applies deterministic sha ordering', () => {
   const commits = normalizeCommitRecords(
     [
@@ -359,4 +386,186 @@ test('evaluateCommitIntegrity fails on non-allowlisted bot identities', () => {
 
   assert.equal(evaluation.result, 'fail');
   assert.ok(evaluation.violations.some((violation) => violation.category === 'unauthorized-bot-identity'));
+});
+
+test('resolveBypassRequest requires explicit metadata when bypass is requested', () => {
+  const bypass = __test.resolveBypassRequest(
+    {
+      bypassReason: 'temporary bypass',
+      bypassOwner: null,
+      bypassExpiresAt: null,
+      bypassTicket: null,
+      bypassLabels: []
+    },
+    {},
+    {
+      exceptionGovernance: {
+        allowBypass: true,
+        remediationLabels: ['ci', 'governance', 'supply-chain']
+      }
+    },
+    new Date('2026-03-06T00:00:00Z')
+  );
+
+  assert.equal(bypass.requested, true);
+  assert.equal(bypass.status, 'invalid');
+  assert.ok(bypass.metadataErrors.includes('missing-bypass-owner'));
+  assert.ok(bypass.metadataErrors.includes('missing-bypass-expiry'));
+});
+
+test('resolveBypassRequest classifies active versus expired metadata deterministically', () => {
+  const expired = __test.resolveBypassRequest(
+    {
+      bypassReason: 'incident',
+      bypassOwner: '@octocat',
+      bypassExpiresAt: '2026-03-01T00:00:00Z',
+      bypassTicket: '#775',
+      bypassLabels: []
+    },
+    {},
+    {
+      exceptionGovernance: {
+        allowBypass: true,
+        remediationLabels: ['ci', 'governance', 'supply-chain']
+      }
+    },
+    new Date('2026-03-06T00:00:00Z')
+  );
+  assert.equal(expired.status, 'expired');
+  assert.equal(expired.active, false);
+
+  const active = __test.resolveBypassRequest(
+    {
+      bypassReason: 'incident',
+      bypassOwner: '@octocat',
+      bypassExpiresAt: '2026-03-20T00:00:00Z',
+      bypassTicket: '#775',
+      bypassLabels: []
+    },
+    {},
+    {
+      exceptionGovernance: {
+        allowBypass: true,
+        remediationLabels: ['ci', 'governance', 'supply-chain']
+      }
+    },
+    new Date('2026-03-06T00:00:00Z')
+  );
+  assert.equal(active.status, 'active');
+  assert.equal(active.active, true);
+});
+
+test('buildBypassLedger records bypass usage and remediation state', () => {
+  const ledger = __test.buildBypassLedger({
+    repository: 'example/repo',
+    scope: {
+      mode: 'pull_request',
+      pullRequest: 775,
+      baseSha: null,
+      headSha: null
+    },
+    policy: {
+      path: 'tools/policy/commit-integrity-policy.json',
+      schema: 'commit-integrity-policy/v1',
+      failOnUnverified: true,
+      exceptionGovernance: {
+        allowBypass: true,
+        requireReasonOwnerExpiry: true,
+        remediationLabels: ['ci', 'governance', 'supply-chain'],
+        remediationTitlePrefix: '[Commit Integrity] Expired bypass remediation',
+        remediationIssueMarker: '<!-- commit-integrity-bypass-remediation@v1 -->'
+      }
+    },
+    observeOnly: false,
+    bypass: {
+      requested: true,
+      status: 'expired',
+      active: false,
+      bypassEnabled: true,
+      reason: 'incident',
+      owner: '@octocat',
+      expiresAt: '2026-03-01T00:00:00.000Z',
+      ticket: '#775',
+      labels: ['ci', 'governance', 'supply-chain'],
+      metadataErrors: []
+    },
+    remediation: {
+      action: 'create',
+      issueNumber: 800
+    },
+    evaluation: {
+      result: 'fail',
+      violations: [{ category: 'unverified-commit' }],
+      issues: ['bypass-expired']
+    },
+    reportPath: 'tests/results/_agent/commit-integrity/commit-integrity-report.json',
+    generatedAt: '2026-03-06T00:00:00.000Z'
+  });
+
+  assert.equal(ledger.schema, 'commit-integrity/bypass-ledger@v1');
+  assert.equal(ledger.bypass.status, 'expired');
+  assert.equal(ledger.remediation.action, 'create');
+  assert.equal(ledger.evaluation.violationCount, 1);
+});
+
+test('routeExpiredBypassRemediationIssue opens remediation issue for expired bypass metadata', async () => {
+  const calls = [];
+  const createResponse = (payload, status = 200, statusText = 'OK') => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: async () => (payload === null ? '' : JSON.stringify(payload))
+  });
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    calls.push({ url, method, body: options.body ?? null });
+    if (method === 'GET' && String(url).includes('/issues?')) {
+      return createResponse([]);
+    }
+    if (method === 'POST' && String(url).endsWith('/issues')) {
+      return createResponse({
+        number: 901,
+        html_url: 'https://github.com/example/repo/issues/901'
+      });
+    }
+    throw new Error(`Unexpected request: ${method} ${url}`);
+  };
+
+  const route = await __test.routeExpiredBypassRemediationIssue({
+    repository: 'example/repo',
+    token: 'test-token',
+    policy: {
+      exceptionGovernance: {
+        remediationTitlePrefix: '[Commit Integrity] Expired bypass remediation',
+        remediationIssueMarker: '<!-- commit-integrity-bypass-remediation@v1 -->',
+        remediationLabels: ['ci', 'governance', 'supply-chain']
+      }
+    },
+    scope: {
+      mode: 'pull_request',
+      pullRequest: 775,
+      baseSha: null,
+      headSha: null
+    },
+    bypass: {
+      owner: '@octocat',
+      reason: 'incident',
+      expiresAt: '2026-03-01T00:00:00.000Z',
+      ticket: '#775',
+      labels: ['ci', 'governance', 'supply-chain']
+    },
+    evaluation: {
+      violations: [{ category: 'unverified-commit' }],
+      issues: ['bypass-expired']
+    },
+    generatedAt: '2026-03-06T00:00:00.000Z',
+    fetchFn: fetchMock
+  });
+
+  assert.equal(route.action, 'create');
+  assert.equal(route.issueNumber, 901);
+  assert.equal(
+    calls.filter((entry) => entry.method === 'POST' && String(entry.url).endsWith('/issues')).length,
+    1
+  );
 });

--- a/tools/priority/commit-integrity.mjs
+++ b/tools/priority/commit-integrity.mjs
@@ -13,7 +13,17 @@ const DEFAULT_REPORT_PATH = path.join(
   'commit-integrity',
   'commit-integrity-report.json'
 );
+const DEFAULT_BYPASS_LEDGER_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'commit-integrity',
+  'commit-integrity-bypass-ledger.json'
+);
 const DEFAULT_POLICY_PATH = path.join('tools', 'policy', 'commit-integrity-policy.json');
+const DEFAULT_BYPASS_LABELS = Object.freeze(['ci', 'governance', 'supply-chain']);
+const DEFAULT_BYPASS_REMEDIATION_TITLE_PREFIX = '[Commit Integrity] Expired bypass remediation';
+const DEFAULT_BYPASS_REMEDIATION_MARKER = '<!-- commit-integrity-bypass-remediation@v1 -->';
 const DEFAULT_POLICY_CHECKS = Object.freeze({
   requireBotAllowlist: false,
   allowedBotLogins: Object.freeze([]),
@@ -83,6 +93,12 @@ function printUsage() {
   console.log('  --head-sha <sha>       Head SHA for compare mode.');
   console.log(`  --policy <path>        Policy path (default: ${DEFAULT_POLICY_PATH}).`);
   console.log(`  --report <path>        Report path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log(`  --ledger <path>        Bypass ledger path (default: ${DEFAULT_BYPASS_LEDGER_PATH}).`);
+  console.log('  --bypass-reason <text> Temporary bypass reason metadata.');
+  console.log('  --bypass-owner <text>  Temporary bypass owner metadata.');
+  console.log('  --bypass-expires-at <iso-date-time>  Temporary bypass expiry metadata.');
+  console.log('  --bypass-ticket <text> Optional ticket/issue identifier for bypass context.');
+  console.log('  --bypass-labels <a,b,c> Labels used for expired bypass remediation issue routing.');
   console.log('  --observe-only         Do not fail the process when violations are present.');
   console.log('  -h, --help             Show usage.');
 }
@@ -108,6 +124,17 @@ function normalizeOptionalString(value) {
   }
   const normalized = String(value).trim();
   return normalized || null;
+}
+
+function parseCsvList(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return [];
+  }
+  return normalized
+    .split(',')
+    .map((entry) => normalizeOptionalString(entry))
+    .filter(Boolean);
 }
 
 function firstLine(value) {
@@ -300,6 +327,12 @@ export function parseArgs(argv = process.argv) {
     headSha: null,
     policyPath: DEFAULT_POLICY_PATH,
     reportPath: DEFAULT_REPORT_PATH,
+    ledgerPath: DEFAULT_BYPASS_LEDGER_PATH,
+    bypassReason: null,
+    bypassOwner: null,
+    bypassExpiresAt: null,
+    bypassTicket: null,
+    bypassLabels: [],
     observeOnly: false
   };
 
@@ -313,7 +346,20 @@ export function parseArgs(argv = process.argv) {
       options.observeOnly = true;
       continue;
     }
-    if (arg === '--repo' || arg === '--pr' || arg === '--base-sha' || arg === '--head-sha' || arg === '--policy' || arg === '--report') {
+    if (
+      arg === '--repo' ||
+      arg === '--pr' ||
+      arg === '--base-sha' ||
+      arg === '--head-sha' ||
+      arg === '--policy' ||
+      arg === '--report' ||
+      arg === '--ledger' ||
+      arg === '--bypass-reason' ||
+      arg === '--bypass-owner' ||
+      arg === '--bypass-expires-at' ||
+      arg === '--bypass-ticket' ||
+      arg === '--bypass-labels'
+    ) {
       const next = args[index + 1];
       if (!next || next.startsWith('-')) {
         throw new Error(`Missing value for ${arg}.`);
@@ -331,6 +377,18 @@ export function parseArgs(argv = process.argv) {
         options.policyPath = next;
       } else if (arg === '--report') {
         options.reportPath = next;
+      } else if (arg === '--ledger') {
+        options.ledgerPath = next;
+      } else if (arg === '--bypass-reason') {
+        options.bypassReason = normalizeOptionalString(next);
+      } else if (arg === '--bypass-owner') {
+        options.bypassOwner = normalizeOptionalString(next);
+      } else if (arg === '--bypass-expires-at') {
+        options.bypassExpiresAt = normalizeOptionalString(next);
+      } else if (arg === '--bypass-ticket') {
+        options.bypassTicket = normalizeOptionalString(next);
+      } else if (arg === '--bypass-labels') {
+        options.bypassLabels = parseCsvList(next);
       }
       continue;
     }
@@ -342,6 +400,142 @@ export function parseArgs(argv = process.argv) {
   }
 
   return options;
+}
+
+function normalizeBypassLabels(values, fallback = DEFAULT_BYPASS_LABELS) {
+  const normalized = Array.from(
+    new Set(
+      (Array.isArray(values) ? values : [])
+        .map((entry) => normalizeOptionalString(entry)?.toLowerCase())
+        .filter(Boolean)
+    )
+  );
+  if (normalized.length > 0) {
+    return normalized;
+  }
+  return [...fallback];
+}
+
+function parseBypassExpiry(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return {
+      iso: null,
+      ms: null,
+      error: 'missing-expiry'
+    };
+  }
+  const ms = Date.parse(normalized);
+  if (!Number.isFinite(ms)) {
+    return {
+      iso: normalized,
+      ms: null,
+      error: 'invalid-expiry'
+    };
+  }
+  return {
+    iso: new Date(ms).toISOString(),
+    ms,
+    error: null
+  };
+}
+
+function resolveBypassRequest(options, env, policy, now = new Date()) {
+  const governance = policy?.exceptionGovernance ?? {};
+  const bypassEnabled = governance.allowBypass === true;
+  const reason = normalizeOptionalString(options.bypassReason) ?? normalizeOptionalString(env.COMMIT_INTEGRITY_BYPASS_REASON);
+  const owner = normalizeOptionalString(options.bypassOwner) ?? normalizeOptionalString(env.COMMIT_INTEGRITY_BYPASS_OWNER);
+  const expiresAtRaw =
+    normalizeOptionalString(options.bypassExpiresAt) ?? normalizeOptionalString(env.COMMIT_INTEGRITY_BYPASS_EXPIRES_AT);
+  const ticket = normalizeOptionalString(options.bypassTicket) ?? normalizeOptionalString(env.COMMIT_INTEGRITY_BYPASS_TICKET);
+  const labelCandidates =
+    options.bypassLabels.length > 0
+      ? options.bypassLabels
+      : parseCsvList(env.COMMIT_INTEGRITY_BYPASS_LABELS ?? governance.remediationLabels?.join(',') ?? '');
+  const labels = normalizeBypassLabels(labelCandidates, governance.remediationLabels ?? DEFAULT_BYPASS_LABELS);
+
+  const requested =
+    reason !== null ||
+    owner !== null ||
+    expiresAtRaw !== null ||
+    ticket !== null ||
+    (options.bypassLabels?.length ?? 0) > 0 ||
+    normalizeOptionalString(env.COMMIT_INTEGRITY_BYPASS_LABELS) !== null;
+
+  if (!requested) {
+    return {
+      requested: false,
+      status: 'none',
+      active: false,
+      bypassEnabled,
+      reason: null,
+      owner: null,
+      expiresAt: null,
+      ticket: null,
+      labels,
+      metadataErrors: []
+    };
+  }
+
+  if (!bypassEnabled) {
+    return {
+      requested: true,
+      status: 'invalid',
+      active: false,
+      bypassEnabled,
+      reason,
+      owner,
+      expiresAt: expiresAtRaw,
+      ticket,
+      labels,
+      metadataErrors: ['bypass-disabled-by-policy']
+    };
+  }
+
+  const requireMetadata = governance.requireReasonOwnerExpiry !== false;
+  const metadataErrors = [];
+  if (requireMetadata && !reason) {
+    metadataErrors.push('missing-bypass-reason');
+  }
+  if (requireMetadata && !owner) {
+    metadataErrors.push('missing-bypass-owner');
+  }
+  const expiry = parseBypassExpiry(expiresAtRaw);
+  if (requireMetadata && expiry.error === 'missing-expiry') {
+    metadataErrors.push('missing-bypass-expiry');
+  } else if (expiry.error === 'invalid-expiry') {
+    metadataErrors.push('invalid-bypass-expiry');
+  }
+  if (metadataErrors.length > 0) {
+    return {
+      requested: true,
+      status: 'invalid',
+      active: false,
+      bypassEnabled,
+      reason,
+      owner,
+      expiresAt: expiry.iso ?? expiresAtRaw,
+      ticket,
+      labels,
+      metadataErrors
+    };
+  }
+
+  const nowMs = now.getTime();
+  const expired = Number.isFinite(expiry.ms) ? expiry.ms <= nowMs : true;
+  return {
+    requested: true,
+    status: expired ? 'expired' : 'active',
+    active: !expired,
+    bypassEnabled,
+    reason,
+    owner,
+    expiresAt: expiry.iso,
+    expiresAtMs: expiry.ms,
+    ticket,
+    labels,
+    metadataErrors: []
+  };
 }
 
 export function classifySourceKind(commit, sourceResolution) {
@@ -815,19 +1009,24 @@ function createHeaders(token) {
   };
 }
 
-async function requestJson(url, token, { fetchFn = globalThis.fetch } = {}) {
+async function requestJson(url, token, { fetchFn = globalThis.fetch, method = 'GET', body = null } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new Error('Global fetch is unavailable.');
   }
   const response = await fetchFn(url, {
-    method: 'GET',
-    headers: createHeaders(token)
+    method,
+    headers: createHeaders(token),
+    body: body ? JSON.stringify(body) : undefined
   });
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText} -> ${text}`);
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText} (${method} ${url}) -> ${text}`);
   }
-  return response.json();
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  return JSON.parse(text);
 }
 
 async function listPullRequestCommits(repo, pullRequest, token, { fetchFn = globalThis.fetch } = {}) {
@@ -862,6 +1061,7 @@ async function loadPolicy(policyPath) {
   const checkSettings = parsed?.checks ?? {};
   const botIdentityPolicy = parsed?.bot_identity_policy ?? {};
   const trailerContract = parsed?.trailer_contract ?? {};
+  const exceptionGovernance = parsed?.exception_governance ?? {};
   const requiredAnyTrailers = Array.isArray(trailerContract.required_any)
     ? trailerContract.required_any.map((entry) => ({
       key: entry?.key,
@@ -894,6 +1094,17 @@ async function loadPolicy(policyPath) {
       botEmailRegexes: compileRegexList(sourceResolution.bot_email_patterns, {
         label: 'source_resolution.bot_email_patterns'
       })
+    },
+    exceptionGovernance: {
+      allowBypass: exceptionGovernance.allow_bypass === true,
+      requireReasonOwnerExpiry: exceptionGovernance.require_reason_owner_expiry !== false,
+      remediationLabels: normalizeBypassLabels(exceptionGovernance.remediation_labels, DEFAULT_BYPASS_LABELS),
+      remediationTitlePrefix:
+        normalizeOptionalString(exceptionGovernance.remediation_title_prefix) ??
+        DEFAULT_BYPASS_REMEDIATION_TITLE_PREFIX,
+      remediationIssueMarker:
+        normalizeOptionalString(exceptionGovernance.remediation_issue_marker) ??
+        DEFAULT_BYPASS_REMEDIATION_MARKER
     }
   };
   return policy;
@@ -906,6 +1117,171 @@ async function writeReport(reportPath, report) {
   return resolvedPath;
 }
 
+function renderBypassRemediationBody({
+  marker,
+  repository,
+  generatedAt,
+  scope,
+  bypass,
+  evaluation
+}) {
+  const lines = [
+    marker,
+    '',
+    '## Commit Integrity Bypass Expired',
+    '',
+    `- Repository: \`${repository}\``,
+    `- Generated at: \`${generatedAt}\``,
+    `- Owner: \`${bypass.owner ?? 'unknown'}\``,
+    `- Reason: ${bypass.reason ?? 'n/a'}`,
+    `- Expires at: \`${bypass.expiresAt ?? 'unknown'}\``,
+    `- Ticket: ${bypass.ticket ? `\`${bypass.ticket}\`` : 'n/a'}`,
+    `- Scope: \`${scope.mode}\`${scope.pullRequest ? ` (PR #${scope.pullRequest})` : ''}`,
+    `- Violations: \`${evaluation?.violations?.length ?? 0}\``,
+    `- Issues: \`${evaluation?.issues?.length ?? 0}\``,
+    '',
+    '## Remediation',
+    '',
+    '1. Remove or renew bypass metadata with a new expiry after approval.',
+    '2. Fix underlying commit-integrity violations.',
+    '3. Re-run commit-integrity workflow and confirm green status.'
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+async function routeExpiredBypassRemediationIssue({
+  repository,
+  token,
+  policy,
+  scope,
+  bypass,
+  evaluation,
+  generatedAt,
+  fetchFn = globalThis.fetch
+}) {
+  const titlePrefix = policy.exceptionGovernance.remediationTitlePrefix;
+  const marker = policy.exceptionGovernance.remediationIssueMarker;
+  const labels = normalizeBypassLabels(
+    bypass.labels,
+    policy.exceptionGovernance.remediationLabels
+  );
+  const body = renderBypassRemediationBody({
+    marker,
+    repository,
+    generatedAt,
+    scope,
+    bypass,
+    evaluation
+  });
+
+  try {
+    const listUrl = `https://api.github.com/repos/${repository}/issues?state=open&per_page=100&labels=${encodeURIComponent(labels.join(','))}`;
+    const openIssues = await requestJson(listUrl, token, { fetchFn });
+    const existing = (Array.isArray(openIssues) ? openIssues : []).find(
+      (issue) => !issue.pull_request && normalizeOptionalString(issue.body)?.includes(marker)
+    );
+
+    if (existing?.number) {
+      await requestJson(
+        `https://api.github.com/repos/${repository}/issues/${existing.number}/comments`,
+        token,
+        { fetchFn, method: 'POST', body: { body } }
+      );
+      return {
+        action: 'comment',
+        issueNumber: existing.number,
+        issueUrl: normalizeOptionalString(existing.html_url),
+        labels
+      };
+    }
+
+    const created = await requestJson(
+      `https://api.github.com/repos/${repository}/issues`,
+      token,
+      {
+        fetchFn,
+        method: 'POST',
+        body: {
+          title: `${titlePrefix} (${generatedAt.slice(0, 10)})`,
+          body,
+          labels
+        }
+      }
+    );
+    return {
+      action: 'create',
+      issueNumber: Number.isInteger(created?.number) ? created.number : null,
+      issueUrl: normalizeOptionalString(created?.html_url),
+      labels
+    };
+  } catch (error) {
+    return {
+      action: 'error',
+      message: error?.message ?? String(error),
+      labels
+    };
+  }
+}
+
+function buildBypassLedger({
+  repository,
+  scope,
+  policy,
+  observeOnly,
+  bypass,
+  remediation,
+  evaluation,
+  reportPath,
+  generatedAt = new Date().toISOString()
+}) {
+  return {
+    schema: 'commit-integrity/bypass-ledger@v1',
+    schemaVersion: '1.0.0',
+    generatedAt,
+    repository,
+    scope: {
+      mode: scope.mode,
+      pullRequest: scope.pullRequest ?? null,
+      baseSha: scope.baseSha ?? null,
+      headSha: scope.headSha ?? null
+    },
+    policy: {
+      path: policy.path,
+      schema: policy.schema,
+      exceptionGovernance: {
+        allowBypass: policy.exceptionGovernance.allowBypass,
+        requireReasonOwnerExpiry: policy.exceptionGovernance.requireReasonOwnerExpiry,
+        remediationLabels: policy.exceptionGovernance.remediationLabels,
+        remediationTitlePrefix: policy.exceptionGovernance.remediationTitlePrefix,
+        remediationIssueMarker: policy.exceptionGovernance.remediationIssueMarker
+      }
+    },
+    enforcement: {
+      observeOnly,
+      blocking: !observeOnly && policy.failOnUnverified
+    },
+    bypass: {
+      requested: bypass.requested,
+      status: bypass.status,
+      active: bypass.active === true,
+      bypassEnabled: bypass.bypassEnabled === true,
+      reason: bypass.reason ?? null,
+      owner: bypass.owner ?? null,
+      expiresAt: bypass.expiresAt ?? null,
+      ticket: bypass.ticket ?? null,
+      labels: bypass.labels ?? [],
+      metadataErrors: Array.isArray(bypass.metadataErrors) ? bypass.metadataErrors : []
+    },
+    remediation: remediation ?? { action: 'none' },
+    evaluation: {
+      result: evaluation.result,
+      violationCount: evaluation.violations.length,
+      issueCount: evaluation.issues.length
+    },
+    reportPath
+  };
+}
+
 function buildReport({
   repository,
   scope,
@@ -913,11 +1289,13 @@ function buildReport({
   observeOnly,
   commits,
   evaluation,
+  bypass,
+  remediation,
+  governance,
   errors = [],
   generatedAt = new Date().toISOString()
 }) {
   const blocking = !observeOnly && policy.failOnUnverified;
-  const shouldFailProcess = blocking && evaluation.result === 'fail';
   return {
     schema: 'commit-integrity/report@v1',
     schemaVersion: '1.0.0',
@@ -958,20 +1336,42 @@ function buildReport({
           key: rule.key,
           valuePattern: rule.valuePattern
         }))
+      },
+      exceptionGovernance: {
+        allowBypass: policy.exceptionGovernance.allowBypass,
+        requireReasonOwnerExpiry: policy.exceptionGovernance.requireReasonOwnerExpiry,
+        remediationLabels: policy.exceptionGovernance.remediationLabels,
+        remediationTitlePrefix: policy.exceptionGovernance.remediationTitlePrefix,
+        remediationIssueMarker: policy.exceptionGovernance.remediationIssueMarker
       }
     },
     enforcement: {
       observeOnly,
-      blocking
+      blocking,
+      bypassRequested: bypass?.requested === true,
+      bypassApplied: governance?.bypassApplied === true,
+      governanceFailure: governance?.governanceFailure === true
     },
     checks: evaluation.checks,
     summary: evaluation.summary,
     commits,
     violations: evaluation.violations,
-    issues: evaluation.issues,
-    result: evaluation.result,
+    issues: governance?.issues ?? evaluation.issues,
+    bypass: {
+      requested: bypass?.requested === true,
+      status: bypass?.status ?? 'none',
+      active: bypass?.active === true,
+      reason: bypass?.reason ?? null,
+      owner: bypass?.owner ?? null,
+      expiresAt: bypass?.expiresAt ?? null,
+      ticket: bypass?.ticket ?? null,
+      labels: bypass?.labels ?? [],
+      metadataErrors: bypass?.metadataErrors ?? [],
+      remediation: remediation ?? { action: 'none' }
+    },
+    result: governance?.finalResult ?? evaluation.result,
     errors: Array.isArray(errors) ? errors : [],
-    exitCode: shouldFailProcess ? 1 : 0
+    exitCode: governance?.exitCode ?? (blocking && evaluation.result === 'fail' ? 1 : 0)
   };
 }
 
@@ -986,9 +1386,12 @@ export async function runCommitIntegrity({
   warn = console.warn
 } = {}) {
   let options = {
-    reportPath: DEFAULT_REPORT_PATH
+    reportPath: DEFAULT_REPORT_PATH,
+    ledgerPath: DEFAULT_BYPASS_LEDGER_PATH,
+    observeOnly: false
   };
   let report = null;
+  let ledger = null;
 
   try {
     options = parseArgs(argv);
@@ -1006,6 +1409,52 @@ export async function runCommitIntegrity({
     const evaluation = evaluateCommitIntegrity(commits, {
       checks: policy.checks
     });
+    const generatedAt = new Date().toISOString();
+    const bypass = resolveBypassRequest(options, env, policy, new Date(generatedAt));
+    const blocking = !options.observeOnly && policy.failOnUnverified;
+    const governanceIssues = [...evaluation.issues];
+    let governanceFailure = false;
+    let bypassApplied = false;
+    let remediation = { action: 'none' };
+
+    if (bypass.requested) {
+      if (bypass.status === 'invalid') {
+        governanceIssues.push('bypass-metadata-invalid');
+        for (const metadataError of bypass.metadataErrors) {
+          governanceIssues.push(`bypass:${metadataError}`);
+        }
+        governanceFailure = true;
+      } else if (bypass.status === 'expired') {
+        governanceIssues.push('bypass-expired');
+        governanceFailure = true;
+        remediation = await routeExpiredBypassRemediationIssue({
+          repository,
+          token,
+          policy,
+          scope,
+          bypass,
+          evaluation,
+          generatedAt,
+          fetchFn
+        });
+        if (remediation.action === 'error') {
+          governanceIssues.push('bypass-remediation-route-failed');
+        }
+      } else if (bypass.status === 'active' && blocking && evaluation.result === 'fail') {
+        bypassApplied = true;
+        governanceIssues.push('bypass-applied');
+      }
+    }
+
+    const finalResult = evaluation.result === 'fail' || governanceFailure ? 'fail' : 'pass';
+    const exitCode = governanceFailure ? 1 : (blocking && evaluation.result === 'fail' && !bypassApplied ? 1 : 0);
+    const governance = {
+      issues: Array.from(new Set(governanceIssues)),
+      governanceFailure,
+      bypassApplied,
+      finalResult,
+      exitCode
+    };
 
     report = buildReport({
       repository,
@@ -1013,11 +1462,29 @@ export async function runCommitIntegrity({
       policy,
       observeOnly: options.observeOnly,
       commits,
-      evaluation
+      evaluation,
+      bypass,
+      remediation,
+      governance,
+      generatedAt
+    });
+
+    ledger = buildBypassLedger({
+      repository,
+      scope,
+      policy,
+      observeOnly: options.observeOnly,
+      bypass,
+      remediation,
+      evaluation,
+      reportPath: options.reportPath,
+      generatedAt
     });
 
     const resolvedReportPath = await writeReport(options.reportPath, report);
+    const resolvedLedgerPath = await writeReport(options.ledgerPath, ledger);
     log(`[commit-integrity] report: ${resolvedReportPath}`);
+    log(`[commit-integrity] bypass-ledger: ${resolvedLedgerPath}`);
     if (report.result === 'fail' && report.exitCode === 1) {
       throw new Error(
         `Commit integrity validation failed: ${report.violations.length} violation(s), ${report.issues.length} issue(s).`
@@ -1072,11 +1539,21 @@ export async function runCommitIntegrity({
         },
         trailerContract: {
           requiredAny: []
+        },
+        exceptionGovernance: {
+          allowBypass: false,
+          requireReasonOwnerExpiry: true,
+          remediationLabels: [...DEFAULT_BYPASS_LABELS],
+          remediationTitlePrefix: DEFAULT_BYPASS_REMEDIATION_TITLE_PREFIX,
+          remediationIssueMarker: DEFAULT_BYPASS_REMEDIATION_MARKER
         }
       },
         enforcement: {
           observeOnly: Boolean(options.observeOnly),
-          blocking: true
+          blocking: true,
+          bypassRequested: false,
+          bypassApplied: false,
+          governanceFailure: true
         },
         checks: [],
         summary: {
@@ -1089,15 +1566,65 @@ export async function runCommitIntegrity({
         commits: [],
         violations: [],
         issues: ['runtime-error'],
+        bypass: {
+          requested: false,
+          status: 'none',
+          active: false,
+          reason: null,
+          owner: null,
+          expiresAt: null,
+          ticket: null,
+          labels: [...DEFAULT_BYPASS_LABELS],
+          metadataErrors: [],
+          remediation: { action: 'none' }
+        },
         result: 'fail',
         errors: [],
         exitCode: 1
+      };
+    }
+    if (!ledger) {
+      ledger = {
+        schema: 'commit-integrity/bypass-ledger@v1',
+        schemaVersion: '1.0.0',
+        generatedAt: report.generatedAt,
+        repository: report.repository,
+        scope: report.scope,
+        policy: {
+          path: report.policy.path,
+          schema: report.policy.schema,
+          exceptionGovernance: report.policy.exceptionGovernance
+        },
+        enforcement: {
+          observeOnly: report.enforcement.observeOnly,
+          blocking: report.enforcement.blocking
+        },
+        bypass: {
+          requested: false,
+          status: 'none',
+          active: false,
+          bypassEnabled: false,
+          reason: null,
+          owner: null,
+          expiresAt: null,
+          ticket: null,
+          labels: [...DEFAULT_BYPASS_LABELS],
+          metadataErrors: []
+        },
+        remediation: { action: 'none' },
+        evaluation: {
+          result: 'fail',
+          violationCount: 0,
+          issueCount: 1
+        },
+        reportPath: options.reportPath ?? DEFAULT_REPORT_PATH
       };
     }
     report.errors = [...(Array.isArray(report.errors) ? report.errors : []), error.message ?? String(error)];
     report.result = 'fail';
     report.exitCode = 1;
     await writeReport(options.reportPath ?? DEFAULT_REPORT_PATH, report);
+    await writeReport(options.ledgerPath ?? DEFAULT_BYPASS_LEDGER_PATH, ledger);
     throw error;
   }
 }
@@ -1108,7 +1635,10 @@ export const __test = Object.freeze({
   normalizeCommitRecord,
   normalizeCommitRecords,
   evaluateCommitIntegrity,
-  buildReport
+  buildReport,
+  resolveBypassRequest,
+  buildBypassLedger,
+  routeExpiredBypassRemediationIssue
 });
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- enforce commit-integrity bypass governance metadata requirements (`reason`, `owner`, `expires-at`)
- fail commit-integrity deterministically when bypass metadata is invalid or expired, and route remediation issue evidence
- add a dedicated bypass ledger artifact/schema and expand unit/schema coverage for the new contracts

## Testing
- `node --check tools/priority/commit-integrity.mjs`
- `node --test tools/priority/__tests__/commit-integrity.test.mjs tools/priority/__tests__/commit-integrity-schema.test.mjs tools/priority/__tests__/commit-integrity-ledger-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`

Refs #775
