### PR TITLE
fix(priority): clear false-fail on successful standing auto-select (#797)

### DIFF
--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -12,6 +12,7 @@ import {
   buildNoStandingPriorityReport,
   buildMultipleStandingPriorityReport,
   buildNoStandingPriorityState,
+  shouldRethrowStandingPriorityError,
   determinePrioritySyncExitCode,
   isStandingPriorityCacheCandidate,
   resolveStandingPriorityLabels,
@@ -179,6 +180,26 @@ test('determinePrioritySyncExitCode maps no-standing to success and real errors 
   assert.equal(determinePrioritySyncExitCode({ code: 'MULTIPLE_STANDING_PRIORITY' }), 0);
   assert.equal(determinePrioritySyncExitCode({ code: 'MULTIPLE_STANDING_PRIORITY' }, { failOnMultiple: true }), 1);
   assert.equal(determinePrioritySyncExitCode(new Error('boom')), 1);
+});
+
+test('shouldRethrowStandingPriorityError skips rethrow after successful auto-select resolution', () => {
+  assert.equal(
+    shouldRethrowStandingPriorityError(
+      { code: 'NO_STANDING_PRIORITY', message: 'no standing issue' },
+      { number: 797, repoSlug: 'LabVIEW-Community-CI-CD/compare-vi-cli-action', source: 'auto-select' }
+    ),
+    false
+  );
+
+  assert.equal(
+    shouldRethrowStandingPriorityError({ code: 'NO_STANDING_PRIORITY', message: 'no standing issue' }, null),
+    true
+  );
+
+  assert.equal(
+    shouldRethrowStandingPriorityError(new Error('network failure'), { number: 797 }),
+    true
+  );
 });
 
 test('parseCliArgs enables strict standing-priority flags and help', () => {

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -1905,7 +1905,9 @@ export async function main(options = {}) {
         return result;
       }
     }
-    throw err;
+    if (shouldRethrowStandingPriorityError(err, standingPriority)) {
+      throw err;
+    }
   }
   const number = standingPriority.number;
   const issueRepoSlug = standingPriority.repoSlug || slug || null;
@@ -2067,6 +2069,14 @@ export async function closeProxyAgents() {
   if (closeOps.length > 0) {
     await Promise.allSettled(closeOps);
   }
+}
+
+export function shouldRethrowStandingPriorityError(err, standingPriority) {
+  if (!err) return false;
+  if (err?.code === 'NO_STANDING_PRIORITY' && standingPriority) {
+    return false;
+  }
+  return true;
 }
 
 export function determinePrioritySyncExitCode(err, { failOnMissing = false, failOnMultiple = false } = {}) {


### PR DESCRIPTION
## Summary
- fix `sync-standing-priority` control flow so `NO_STANDING_PRIORITY` is not rethrown after successful `--auto-select-next` resolution
- preserve strict fail behavior when no standing issue is actually resolved
- add regression test for the exact rethrow decision seam

## Metadata
- Coupling: independent
- Depends-On: 

## Validation
- node --check tools/priority/sync-standing-priority.mjs
- node --test tools/priority/__tests__/standing-priority-resolution.test.mjs
- node --test tools/priority/__tests__/*.mjs
- ./bin/actionlint -color
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios

Closes #797
