### PR TITLE
feat(priority): add deterministic issue routing policy engine (#801)

### DIFF
--- a/docs/schemas/issue-routing-policy-v1.schema.json
+++ b/docs/schemas/issue-routing-policy-v1.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "issue-routing-policy@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "defaultAction",
+    "rules"
+  ],
+  "properties": {
+    "schema": {
+      "const": "issue-routing-policy@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "queueManagedBranches": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultAction": {
+      "$ref": "#/$defs/action"
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "order",
+          "enabled",
+          "match",
+          "action"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "order": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "match": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "sourceTypes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "incidentClasses": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "severities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "branches": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "requiresQueueManagedBranch": {
+                "type": "boolean"
+              },
+              "requiresExactCheckNames": {
+                "type": "boolean"
+              }
+            }
+          },
+          "action": {
+            "$ref": "#/$defs/action"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "priority",
+        "labels",
+        "owner",
+        "titlePrefix",
+        "reason"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "open-issue",
+            "update-issue",
+            "comment",
+            "pause-queue",
+            "noop"
+          ]
+        },
+        "priority": {
+          "enum": [
+            "P0",
+            "P1",
+            "P2"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "titlePrefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/policy-decision-report-v1.schema.json
+++ b/docs/schemas/policy-decision-report-v1.schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "priority/policy-decision-report@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAt",
+    "status",
+    "dryRun",
+    "inputs",
+    "policy",
+    "event",
+    "branchContext",
+    "checkNameGate",
+    "evaluation",
+    "decision",
+    "errors"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/policy-decision-report@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "dryRun": {
+      "type": "boolean"
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventPath",
+        "policyPath",
+        "branchPolicyPath"
+      ],
+      "properties": {
+        "eventPath": {
+          "type": "string"
+        },
+        "policyPath": {
+          "type": "string"
+        },
+        "branchPolicyPath": {
+          "type": "string"
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "schemaVersion",
+        "digest",
+        "ruleCount"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "schemaVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "digest": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ruleCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "event": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "fingerprint",
+        "sourceType",
+        "incidentClass",
+        "severity",
+        "branch",
+        "sha",
+        "signature",
+        "suggestedLabels"
+      ],
+      "properties": {
+        "fingerprint": {
+          "type": "string"
+        },
+        "sourceType": {
+          "type": "string"
+        },
+        "incidentClass": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signature": {
+          "type": "string"
+        },
+        "suggestedLabels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "branchContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "queueManagedBranches",
+        "branch",
+        "queueManagedBranch"
+      ],
+      "properties": {
+        "queueManagedBranches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "queueManagedBranch": {
+          "type": "boolean"
+        }
+      }
+    },
+    "checkNameGate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "exactMatch",
+        "expected",
+        "observed",
+        "missing",
+        "extra"
+      ],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "exactMatch": {
+          "type": "boolean"
+        },
+        "expected": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "observed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "missing": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selectedRuleId",
+        "ruleEvaluations"
+      ],
+      "properties": {
+        "selectedRuleId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ruleEvaluations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "order",
+              "matched",
+              "reasons"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "order": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "matched": {
+                "type": "boolean"
+              },
+              "reasons": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "priority",
+        "labels",
+        "owner",
+        "titlePrefix",
+        "reason"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "titlePrefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "priority:onboard:success": "node tools/priority/downstream-onboarding-success.mjs",
     "priority:develop:sync": "pwsh -NoLogo -NoProfile -File tools/priority/Sync-OriginUpstreamDevelop.ps1",
     "priority:policy": "node tools/priority/check-policy.mjs",
+    "priority:policy:route": "node tools/priority/policy-engine.mjs",
     "priority:policy:snapshot": "node tools/priority/policy-snapshot.mjs",
     "priority:certification:matrix": "node tools/priority/certification-matrix.mjs",
     "priority:trust:gate": "node tools/priority/supply-chain-trust-gate.mjs",

--- a/tools/priority/__tests__/policy-engine-schema.test.mjs
+++ b/tools/priority/__tests__/policy-engine-schema.test.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { runPolicyEngine } from '../policy-engine.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('policy engine schemas validate policy contract and report artifact', async () => {
+  const policySchema = JSON.parse(
+    await readFile(path.join(repoRoot, 'docs', 'schemas', 'issue-routing-policy-v1.schema.json'), 'utf8')
+  );
+  const reportSchema = JSON.parse(
+    await readFile(path.join(repoRoot, 'docs', 'schemas', 'policy-decision-report-v1.schema.json'), 'utf8')
+  );
+  const policy = JSON.parse(await readFile(path.join(repoRoot, 'tools', 'priority', 'issue-routing-policy.json'), 'utf8'));
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+
+  const validatePolicy = ajv.compile(policySchema);
+  const policyValid = validatePolicy(policy);
+  assert.equal(policyValid, true, JSON.stringify(validatePolicy.errors, null, 2));
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-engine-schema-'));
+  const eventPath = path.join(tmpDir, 'event.json');
+  const reportPath = path.join(tmpDir, 'report.json');
+
+  fs.writeFileSync(
+    eventPath,
+    `${JSON.stringify(
+      {
+        schema: 'incident-event@v1',
+        sourceType: 'workflow-run',
+        incidentClass: 'workflow-run-failure',
+        severity: 'high',
+        branch: 'develop',
+        sha: 'abc123',
+        signature: 'validate:failure',
+        fingerprint: 'event-123',
+        suggestedLabels: ['ci'],
+        metadata: {}
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const result = await runPolicyEngine({
+    argv: [
+      'node',
+      'policy-engine.mjs',
+      '--event',
+      eventPath,
+      '--policy',
+      path.join(repoRoot, 'tools', 'priority', 'issue-routing-policy.json'),
+      '--branch-policy',
+      path.join(repoRoot, 'tools', 'priority', 'policy.json'),
+      '--report',
+      reportPath
+    ],
+    now: new Date('2026-03-06T21:23:00Z'),
+    repoRoot
+  });
+
+  assert.equal(result.exitCode, 0);
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+
+  const validateReport = ajv.compile(reportSchema);
+  const reportValid = validateReport(report);
+  assert.equal(reportValid, true, JSON.stringify(validateReport.errors, null, 2));
+  assert.equal(report.decision.priority, 'P1');
+  assert.deepEqual(report.decision.labels, ['ci']);
+});

--- a/tools/priority/__tests__/policy-engine.test.mjs
+++ b/tools/priority/__tests__/policy-engine.test.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  evaluateExactCheckNameGate,
+  evaluateRoutingPolicy,
+  normalizePolicy,
+  parseArgs,
+  runPolicyEngine
+} from '../policy-engine.mjs';
+
+function samplePolicy(overrides = {}) {
+  return {
+    schema: 'issue-routing-policy@v1',
+    schemaVersion: '1.0.0',
+    queueManagedBranches: ['develop', 'main'],
+    defaultAction: {
+      type: 'comment',
+      priority: 'P2',
+      labels: ['ci'],
+      owner: null,
+      titlePrefix: '[Ops]',
+      reason: 'default'
+    },
+    rules: [
+      {
+        id: 'b-rule',
+        order: 20,
+        enabled: true,
+        match: {
+          sourceTypes: ['workflow-run'],
+          incidentClasses: ['workflow-run-failure']
+        },
+        action: {
+          type: 'open-issue',
+          priority: 'P1',
+          labels: ['ci'],
+          owner: 'platform',
+          titlePrefix: '[Workflow]',
+          reason: 'workflow-failure'
+        }
+      },
+      {
+        id: 'a-rule',
+        order: 10,
+        enabled: true,
+        match: {
+          sourceTypes: ['required-check-drift'],
+          incidentClasses: ['required-check-drift'],
+          requiresQueueManagedBranch: true,
+          requiresExactCheckNames: true
+        },
+        action: {
+          type: 'open-issue',
+          priority: 'P0',
+          labels: ['governance'],
+          owner: 'platform',
+          titlePrefix: '[Policy]',
+          reason: 'drift'
+        }
+      }
+    ],
+    ...overrides
+  };
+}
+
+test('parseArgs enforces required event path and supports overrides', () => {
+  const parsed = parseArgs([
+    'node',
+    'policy-engine.mjs',
+    '--event',
+    'event.json',
+    '--policy',
+    'policy.json',
+    '--branch-policy',
+    'branch-policy.json',
+    '--report',
+    'report.json',
+    '--branch',
+    'develop',
+    '--dry-run'
+  ]);
+
+  assert.equal(parsed.eventPath, 'event.json');
+  assert.equal(parsed.policyPath, 'policy.json');
+  assert.equal(parsed.branchPolicyPath, 'branch-policy.json');
+  assert.equal(parsed.reportPath, 'report.json');
+  assert.equal(parsed.branchOverride, 'develop');
+  assert.equal(parsed.dryRun, true);
+});
+
+test('normalizePolicy sorts rules deterministically by order then id', () => {
+  const policy = normalizePolicy(samplePolicy());
+  assert.deepEqual(
+    policy.rules.map((rule) => rule.id),
+    ['a-rule', 'b-rule']
+  );
+});
+
+test('evaluateExactCheckNameGate requires exact check-name matches', () => {
+  const pass = evaluateExactCheckNameGate({
+    expectedChecks: ['lint', 'fixtures'],
+    observedChecks: ['fixtures', 'lint']
+  });
+  assert.equal(pass.required, true);
+  assert.equal(pass.exactMatch, true);
+
+  const fail = evaluateExactCheckNameGate({
+    expectedChecks: ['lint', 'fixtures'],
+    observedChecks: ['lint', 'session-index']
+  });
+  assert.equal(fail.exactMatch, false);
+  assert.deepEqual(fail.missing, ['fixtures']);
+  assert.deepEqual(fail.extra, ['session-index']);
+});
+
+test('evaluateRoutingPolicy applies queue-managed and exact-check gates', () => {
+  const policy = normalizePolicy(samplePolicy());
+  const queueManaged = new Set(['develop', 'main']);
+  const event = {
+    sourceType: 'required-check-drift',
+    incidentClass: 'required-check-drift',
+    severity: 'high',
+    repository: 'example/repo',
+    branch: 'develop',
+    sha: 'abc',
+    signature: 'fail:2',
+    fingerprint: 'fp',
+    suggestedLabels: ['ci'],
+    metadata: {
+      expectedChecks: ['lint', 'fixtures'],
+      observedChecks: ['lint', 'fixtures']
+    }
+  };
+  const decision = evaluateRoutingPolicy({
+    policy,
+    event,
+    queueManagedBranches: queueManaged,
+    now: new Date('2026-03-06T21:20:00Z')
+  });
+  assert.equal(decision.selectedRuleId, 'a-rule');
+  assert.equal(decision.selectedAction.priority, 'P0');
+  assert.deepEqual(decision.selectedAction.labels, ['ci', 'governance']);
+
+  const notExact = evaluateRoutingPolicy({
+    policy,
+    event: {
+      ...event,
+      metadata: {
+        expectedChecks: ['lint', 'fixtures'],
+        observedChecks: ['lint', 'session-index']
+      }
+    },
+    queueManagedBranches: queueManaged,
+    now: new Date('2026-03-06T21:20:00Z')
+  });
+  assert.equal(notExact.selectedRuleId, null);
+  assert.equal(notExact.selectedAction.priority, 'P2');
+});
+
+test('runPolicyEngine writes deterministic decision report', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-engine-'));
+  const policyPath = path.join(tmpDir, 'policy.json');
+  const branchPolicyPath = path.join(tmpDir, 'branch-policy.json');
+  const eventPath = path.join(tmpDir, 'event.json');
+  const reportPath = path.join(tmpDir, 'report.json');
+
+  fs.writeFileSync(policyPath, `${JSON.stringify(samplePolicy(), null, 2)}\n`, 'utf8');
+  fs.writeFileSync(
+    branchPolicyPath,
+    `${JSON.stringify(
+      {
+        rulesets: {
+          '1': {
+            includes: ['refs/heads/develop'],
+            merge_queue: { merge_method: 'SQUASH' }
+          }
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+  fs.writeFileSync(
+    eventPath,
+    `${JSON.stringify(
+      {
+        schema: 'incident-event@v1',
+        sourceType: 'required-check-drift',
+        incidentClass: 'required-check-drift',
+        severity: 'high',
+        branch: 'develop',
+        sha: 'abc123',
+        signature: 'fail:2',
+        fingerprint: 'deadbeef',
+        suggestedLabels: ['ci'],
+        metadata: {
+          expectedChecks: ['lint', 'fixtures'],
+          observedChecks: ['fixtures', 'lint']
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const result = await runPolicyEngine({
+    argv: [
+      'node',
+      'policy-engine.mjs',
+      '--event',
+      eventPath,
+      '--policy',
+      policyPath,
+      '--branch-policy',
+      branchPolicyPath,
+      '--report',
+      reportPath
+    ],
+    now: new Date('2026-03-06T21:21:00Z'),
+    repoRoot: tmpDir
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.status, 'pass');
+  assert.equal(result.report.evaluation.selectedRuleId, 'a-rule');
+  assert.equal(result.report.decision.priority, 'P0');
+  assert.deepEqual(result.report.decision.labels, ['ci', 'governance']);
+
+  const persisted = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  assert.equal(persisted.schema, 'priority/policy-decision-report@v1');
+  assert.equal(persisted.checkNameGate.exactMatch, true);
+});

--- a/tools/priority/issue-routing-policy.json
+++ b/tools/priority/issue-routing-policy.json
@@ -1,0 +1,102 @@
+{
+  "schema": "issue-routing-policy@v1",
+  "schemaVersion": "1.0.0",
+  "description": "Deterministic routing policy for normalized incident-event@v1 payloads.",
+  "queueManagedBranches": [
+    "develop",
+    "main"
+  ],
+  "defaultAction": {
+    "type": "comment",
+    "priority": "P2",
+    "labels": [
+      "ci"
+    ],
+    "owner": null,
+    "titlePrefix": "[Ops Signal]",
+    "reason": "default-fallback"
+  },
+  "rules": [
+    {
+      "id": "required-check-drift-queue",
+      "order": 10,
+      "enabled": true,
+      "match": {
+        "sourceTypes": [
+          "required-check-drift"
+        ],
+        "incidentClasses": [
+          "required-check-drift"
+        ],
+        "requiresQueueManagedBranch": true,
+        "requiresExactCheckNames": true
+      },
+      "action": {
+        "type": "open-issue",
+        "priority": "P0",
+        "labels": [
+          "ci",
+          "governance",
+          "program"
+        ],
+        "owner": "release-platform",
+        "titlePrefix": "[Policy Drift]",
+        "reason": "required-check-drift"
+      }
+    },
+    {
+      "id": "deployment-anomaly",
+      "order": 20,
+      "enabled": true,
+      "match": {
+        "sourceTypes": [
+          "deployment-state"
+        ],
+        "incidentClasses": [
+          "deployment-state-anomaly"
+        ]
+      },
+      "action": {
+        "type": "open-issue",
+        "priority": "P1",
+        "labels": [
+          "ci",
+          "governance"
+        ],
+        "owner": "release-platform",
+        "titlePrefix": "[Deployment Determinism]",
+        "reason": "deployment-anomaly"
+      }
+    },
+    {
+      "id": "workflow-failure",
+      "order": 30,
+      "enabled": true,
+      "match": {
+        "sourceTypes": [
+          "workflow-run"
+        ],
+        "incidentClasses": [
+          "workflow-run-failure",
+          "workflow-run-anomaly",
+          "workflow-run-cancelled"
+        ],
+        "severities": [
+          "critical",
+          "high",
+          "medium"
+        ]
+      },
+      "action": {
+        "type": "open-issue",
+        "priority": "P1",
+        "labels": [
+          "ci"
+        ],
+        "owner": "release-platform",
+        "titlePrefix": "[Workflow Incident]",
+        "reason": "workflow-failure"
+      }
+    }
+  ]
+}

--- a/tools/priority/policy-engine.mjs
+++ b/tools/priority/policy-engine.mjs
@@ -1,0 +1,534 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { getRepoRoot } from './lib/branch-utils.mjs';
+
+export const ISSUE_ROUTING_POLICY_SCHEMA = 'issue-routing-policy@v1';
+export const POLICY_DECISION_REPORT_SCHEMA = 'priority/policy-decision-report@v1';
+export const DEFAULT_POLICY_PATH = path.join('tools', 'priority', 'issue-routing-policy.json');
+export const DEFAULT_BRANCH_POLICY_PATH = path.join('tools', 'priority', 'policy.json');
+export const DEFAULT_REPORT_PATH = path.join('tests', 'results', '_agent', 'ops', 'policy-decision-report.json');
+
+const VALID_ACTION_TYPES = new Set(['open-issue', 'update-issue', 'comment', 'pause-queue', 'noop']);
+const VALID_PRIORITIES = new Set(['P0', 'P1', 'P2']);
+const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/policy-engine.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --event <path>               Incident event JSON path (required).');
+  console.log(`  --policy <path>              Routing policy path (default: ${DEFAULT_POLICY_PATH}).`);
+  console.log(`  --branch-policy <path>       Branch/ruleset policy path (default: ${DEFAULT_BRANCH_POLICY_PATH}).`);
+  console.log(`  --report <path>              Decision report output path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log('  --branch <name>              Optional branch override for event evaluation.');
+  console.log('  --dry-run                    Evaluate policy only; no side effects (default).');
+  console.log('  -h, --help                   Show help and exit.');
+}
+
+function normalizeText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function normalizeLower(value) {
+  const text = normalizeText(value);
+  return text ? text.toLowerCase() : null;
+}
+
+function normalizeSeverity(value) {
+  const severity = normalizeLower(value) ?? 'medium';
+  return VALID_SEVERITIES.has(severity) ? severity : 'medium';
+}
+
+function normalizePriority(value) {
+  const priority = normalizeText(value)?.toUpperCase() ?? 'P2';
+  return VALID_PRIORITIES.has(priority) ? priority : 'P2';
+}
+
+function normalizeLabels(values) {
+  const labels = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const normalized = normalizeLower(value);
+    if (!normalized) continue;
+    labels.push(normalized);
+  }
+  return [...new Set(labels)].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeStringArray(values) {
+  const normalized = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const item = normalizeLower(value);
+    if (!item) continue;
+    normalized.push(item);
+  }
+  return [...new Set(normalized)].sort((left, right) => left.localeCompare(right));
+}
+
+function stableSortValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableSortValue(item));
+  }
+  if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+    const sorted = {};
+    for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
+      sorted[key] = stableSortValue(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function digestValue(value) {
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify(stableSortValue(value)));
+  return hash.digest('hex');
+}
+
+function parseBoolean(value) {
+  return value === true;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    eventPath: null,
+    policyPath: DEFAULT_POLICY_PATH,
+    branchPolicyPath: DEFAULT_BRANCH_POLICY_PATH,
+    reportPath: DEFAULT_REPORT_PATH,
+    branchOverride: null,
+    dryRun: false,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === '--event' || token === '--policy' || token === '--branch-policy' || token === '--report' || token === '--branch') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--event') options.eventPath = next;
+      if (token === '--policy') options.policyPath = next;
+      if (token === '--branch-policy') options.branchPolicyPath = next;
+      if (token === '--report') options.reportPath = next;
+      if (token === '--branch') options.branchOverride = normalizeLower(next);
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (options.help) {
+    return options;
+  }
+  if (!options.eventPath) {
+    throw new Error('Missing required --event <path> option.');
+  }
+  return options;
+}
+
+async function readJsonFile(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+  const content = await readFile(resolved, 'utf8');
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${resolved}: ${error.message}`);
+  }
+}
+
+function normalizeAction(action = {}) {
+  const type = normalizeLower(action.type) ?? 'comment';
+  if (!VALID_ACTION_TYPES.has(type)) {
+    throw new Error(`Invalid action type '${action.type}'.`);
+  }
+  return {
+    type,
+    priority: normalizePriority(action.priority),
+    labels: normalizeLabels(action.labels),
+    owner: normalizeText(action.owner),
+    titlePrefix: normalizeText(action.titlePrefix),
+    reason: normalizeText(action.reason)
+  };
+}
+
+function normalizeRule(rule = {}, index = 0) {
+  const id = normalizeText(rule.id);
+  if (!id) {
+    throw new Error(`Rule at index ${index} is missing id.`);
+  }
+  const rawOrder = Number(rule.order);
+  const order = Number.isInteger(rawOrder) && rawOrder >= 0 ? rawOrder : 1000;
+  const enabled = rule.enabled !== false;
+  const match = rule.match ?? {};
+  return {
+    id,
+    order,
+    enabled,
+    match: {
+      sourceTypes: normalizeStringArray(match.sourceTypes),
+      incidentClasses: normalizeStringArray(match.incidentClasses),
+      severities: normalizeStringArray(match.severities),
+      branches: normalizeStringArray(match.branches),
+      requiresQueueManagedBranch: parseBoolean(match.requiresQueueManagedBranch),
+      requiresExactCheckNames: parseBoolean(match.requiresExactCheckNames)
+    },
+    action: normalizeAction(rule.action ?? {})
+  };
+}
+
+export function normalizePolicy(policy = {}, { policyPath = DEFAULT_POLICY_PATH } = {}) {
+  if (policy?.schema !== ISSUE_ROUTING_POLICY_SCHEMA) {
+    throw new Error(`Invalid policy schema '${policy?.schema}'. Expected '${ISSUE_ROUTING_POLICY_SCHEMA}'.`);
+  }
+  const rulesRaw = Array.isArray(policy.rules) ? policy.rules : [];
+  const rules = rulesRaw
+    .map((rule, index) => normalizeRule(rule, index))
+    .sort((left, right) => {
+      if (left.order !== right.order) return left.order - right.order;
+      return left.id.localeCompare(right.id);
+    });
+  return {
+    schema: ISSUE_ROUTING_POLICY_SCHEMA,
+    schemaVersion: normalizeText(policy.schemaVersion) ?? '1.0.0',
+    description: normalizeText(policy.description),
+    queueManagedBranches: normalizeStringArray(policy.queueManagedBranches),
+    defaultAction: normalizeAction(policy.defaultAction ?? {}),
+    rules,
+    policyPath: normalizeText(policyPath) ?? DEFAULT_POLICY_PATH
+  };
+}
+
+function extractQueueManagedBranchesFromBranchPolicy(branchPolicy = {}) {
+  const branches = new Set();
+  const rulesets = branchPolicy?.rulesets;
+  if (!rulesets || typeof rulesets !== 'object') {
+    return branches;
+  }
+  for (const ruleset of Object.values(rulesets)) {
+    if (!ruleset?.merge_queue) {
+      continue;
+    }
+    const includes = Array.isArray(ruleset.includes) ? ruleset.includes : [];
+    for (const include of includes) {
+      const match = String(include).match(/^refs\/heads\/(?<branch>.+)$/i);
+      if (!match?.groups?.branch) continue;
+      if (match.groups.branch.includes('*')) continue;
+      branches.add(match.groups.branch.toLowerCase());
+    }
+  }
+  return branches;
+}
+
+function toEventPayload(payload = {}) {
+  if (payload?.schema === 'priority/event-ingest-report@v1' && payload?.event) {
+    return payload.event;
+  }
+  return payload;
+}
+
+function normalizeIncidentEvent(payload = {}, branchOverride = null) {
+  const event = toEventPayload(payload);
+  const sourceType = normalizeLower(event.sourceType) ?? 'incident-event';
+  const incidentClass = normalizeLower(event.incidentClass ?? event.class ?? event.type) ?? 'incident-unknown';
+  const severity = normalizeSeverity(event.severity);
+  const branch = branchOverride ?? normalizeLower(event.branch);
+  const sha = normalizeLower(event.sha);
+  const signature = normalizeText(event.signature) ?? incidentClass;
+  const labels = normalizeLabels(event.suggestedLabels ?? event.labels);
+  const metadata = event.metadata && typeof event.metadata === 'object' ? stableSortValue(event.metadata) : {};
+  return {
+    schema: normalizeText(event.schema),
+    sourceType,
+    incidentClass,
+    severity,
+    repository: normalizeText(event.repository),
+    branch,
+    sha,
+    signature,
+    fingerprint: normalizeText(event.fingerprint) ?? digestValue({ sourceType, incidentClass, branch, sha, signature }),
+    summary: normalizeText(event.summary),
+    suggestedLabels: labels,
+    metadata
+  };
+}
+
+export function evaluateExactCheckNameGate(metadata = {}) {
+  const expected = normalizeStringArray(metadata.expectedChecks);
+  const observed = normalizeStringArray(metadata.observedChecks);
+  if (expected.length === 0 && observed.length === 0) {
+    return {
+      required: false,
+      exactMatch: true,
+      expected,
+      observed,
+      missing: [],
+      extra: []
+    };
+  }
+
+  const expectedSet = new Set(expected);
+  const observedSet = new Set(observed);
+  const missing = expected.filter((check) => !observedSet.has(check));
+  const extra = observed.filter((check) => !expectedSet.has(check));
+  return {
+    required: true,
+    exactMatch: missing.length === 0 && extra.length === 0,
+    expected,
+    observed,
+    missing,
+    extra
+  };
+}
+
+function evaluateRuleMatch(rule, context) {
+  const reasons = [];
+  if (!rule.enabled) reasons.push('rule-disabled');
+  if (rule.match.sourceTypes.length > 0 && !rule.match.sourceTypes.includes(context.event.sourceType)) {
+    reasons.push('source-type-mismatch');
+  }
+  if (rule.match.incidentClasses.length > 0 && !rule.match.incidentClasses.includes(context.event.incidentClass)) {
+    reasons.push('incident-class-mismatch');
+  }
+  if (rule.match.severities.length > 0 && !rule.match.severities.includes(context.event.severity)) {
+    reasons.push('severity-mismatch');
+  }
+  if (rule.match.branches.length > 0 && !rule.match.branches.includes(context.event.branch ?? '')) {
+    reasons.push('branch-mismatch');
+  }
+  if (rule.match.requiresQueueManagedBranch && !context.queueManagedBranch) {
+    reasons.push('queue-managed-branch-required');
+  }
+  if (rule.match.requiresExactCheckNames && !context.checkNameGate.exactMatch) {
+    reasons.push('exact-check-name-mismatch');
+  }
+  return {
+    matched: reasons.length === 0,
+    reasons
+  };
+}
+
+export function evaluateRoutingPolicy({
+  policy,
+  event,
+  queueManagedBranches = new Set(),
+  now = new Date()
+}) {
+  const queueManagedBranch = Boolean(event.branch && queueManagedBranches.has(event.branch));
+  const checkNameGate = evaluateExactCheckNameGate(event.metadata ?? {});
+  const context = { event, queueManagedBranch, checkNameGate };
+  const ruleEvaluations = [];
+  let selectedRule = null;
+  let selectedAction = null;
+
+  for (const rule of policy.rules) {
+    const evaluation = evaluateRuleMatch(rule, context);
+    ruleEvaluations.push({
+      id: rule.id,
+      order: rule.order,
+      matched: evaluation.matched,
+      reasons: evaluation.reasons
+    });
+    if (evaluation.matched && !selectedRule) {
+      selectedRule = rule;
+      selectedAction = rule.action;
+    }
+  }
+
+  if (!selectedAction) {
+    selectedAction = policy.defaultAction;
+  }
+
+  const labels = normalizeLabels([...(selectedAction.labels ?? []), ...(event.suggestedLabels ?? [])]);
+  return {
+    generatedAt: now.toISOString(),
+    queueManagedBranch,
+    checkNameGate,
+    selectedRuleId: selectedRule?.id ?? null,
+    selectedAction: {
+      type: selectedAction.type,
+      priority: selectedAction.priority,
+      labels,
+      owner: selectedAction.owner,
+      titlePrefix: selectedAction.titlePrefix,
+      reason: selectedAction.reason ?? (selectedRule ? `matched:${selectedRule.id}` : 'default-fallback')
+    },
+    ruleEvaluations
+  };
+}
+
+async function writeReport(reportPath, payload) {
+  const resolved = path.resolve(reportPath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export async function runPolicyEngine({
+  argv = process.argv,
+  now = new Date(),
+  repoRoot = getRepoRoot(process.cwd()),
+  readJsonFileFn = readJsonFile,
+  writeReportFn = writeReport
+} = {}) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return { exitCode: 0, report: null, reportPath: null };
+  }
+
+  const resolvedPolicyPath = path.resolve(repoRoot, options.policyPath);
+  const resolvedBranchPolicyPath = path.resolve(repoRoot, options.branchPolicyPath);
+  const resolvedEventPath = path.resolve(repoRoot, options.eventPath);
+  let report = null;
+  let exitCode = 0;
+
+  try {
+    const [policyPayload, eventPayload, branchPolicy] = await Promise.all([
+      readJsonFileFn(resolvedPolicyPath),
+      readJsonFileFn(resolvedEventPath),
+      readJsonFileFn(resolvedBranchPolicyPath)
+    ]);
+    const policy = normalizePolicy(policyPayload, { policyPath: path.relative(repoRoot, resolvedPolicyPath) });
+    const event = normalizeIncidentEvent(eventPayload, options.branchOverride);
+    const queueManagedBranches = new Set(
+      policy.queueManagedBranches.length > 0
+        ? policy.queueManagedBranches
+        : Array.from(extractQueueManagedBranchesFromBranchPolicy(branchPolicy)).sort()
+    );
+    const evaluation = evaluateRoutingPolicy({
+      policy,
+      event,
+      queueManagedBranches,
+      now
+    });
+
+    report = {
+      schema: POLICY_DECISION_REPORT_SCHEMA,
+      schemaVersion: '1.0.0',
+      generatedAt: now.toISOString(),
+      status: 'pass',
+      dryRun: true,
+      inputs: {
+        eventPath: resolvedEventPath,
+        policyPath: resolvedPolicyPath,
+        branchPolicyPath: resolvedBranchPolicyPath
+      },
+      policy: {
+        schema: policy.schema,
+        schemaVersion: policy.schemaVersion,
+        digest: digestValue(policy),
+        ruleCount: policy.rules.length
+      },
+      event: {
+        fingerprint: event.fingerprint,
+        sourceType: event.sourceType,
+        incidentClass: event.incidentClass,
+        severity: event.severity,
+        branch: event.branch,
+        sha: event.sha,
+        signature: event.signature,
+        suggestedLabels: event.suggestedLabels
+      },
+      branchContext: {
+        queueManagedBranches: Array.from(queueManagedBranches).sort(),
+        branch: event.branch,
+        queueManagedBranch: evaluation.queueManagedBranch
+      },
+      checkNameGate: evaluation.checkNameGate,
+      evaluation: {
+        selectedRuleId: evaluation.selectedRuleId,
+        ruleEvaluations: evaluation.ruleEvaluations
+      },
+      decision: evaluation.selectedAction,
+      errors: []
+    };
+  } catch (error) {
+    exitCode = 1;
+    report = {
+      schema: POLICY_DECISION_REPORT_SCHEMA,
+      schemaVersion: '1.0.0',
+      generatedAt: now.toISOString(),
+      status: 'fail',
+      dryRun: true,
+      inputs: {
+        eventPath: resolvedEventPath,
+        policyPath: resolvedPolicyPath,
+        branchPolicyPath: resolvedBranchPolicyPath
+      },
+      policy: {
+        schema: ISSUE_ROUTING_POLICY_SCHEMA,
+        schemaVersion: null,
+        digest: null,
+        ruleCount: 0
+      },
+      event: null,
+      branchContext: {
+        queueManagedBranches: [],
+        branch: options.branchOverride,
+        queueManagedBranch: false
+      },
+      checkNameGate: {
+        required: false,
+        exactMatch: true,
+        expected: [],
+        observed: [],
+        missing: [],
+        extra: []
+      },
+      evaluation: {
+        selectedRuleId: null,
+        ruleEvaluations: []
+      },
+      decision: {
+        type: 'noop',
+        priority: 'P2',
+        labels: [],
+        owner: null,
+        titlePrefix: null,
+        reason: null
+      },
+      errors: [error.message || String(error)]
+    };
+  }
+
+  const resolvedReportPath = await writeReportFn(options.reportPath, report);
+  console.log(`[policy-engine] report: ${resolvedReportPath}`);
+  if (exitCode !== 0) {
+    console.error(`[policy-engine] ${report.errors.join('; ')}`);
+  } else {
+    console.log(
+      `[policy-engine] selectedRule=${report.evaluation.selectedRuleId ?? 'default'} action=${report.decision.type} priority=${report.decision.priority}`
+    );
+  }
+  return { exitCode, report, reportPath: resolvedReportPath };
+}
+
+const isDirectExecution = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isDirectExecution) {
+  runPolicyEngine().then(({ exitCode }) => {
+    process.exit(exitCode);
+  }).catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add deterministic policy evaluator `tools/priority/policy-engine.mjs` for `incident-event@v1` routing decisions
- introduce policy contract file `tools/priority/issue-routing-policy.json` (`issue-routing-policy@v1`)
- enforce deterministic rule ordering and branch-aware queue-managed gating
- enforce exact check-name gate evaluation for required-check drift routing
- emit `priority/policy-decision-report@v1` artifacts under `tests/results/_agent/ops/`
- add schemas for policy contract + decision report
- add unit/schema tests and package script wiring (`priority:policy:route`)

## Linked Issues
- #801
- parent epic: #799

## Metadata
- Coupling: independent

## Validation
- `node --test tools/priority/__tests__/policy-engine.test.mjs`
- `node --test tools/priority/__tests__/policy-engine-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` *(fails in existing NI known-flag scenario path: `Run-NIWindowsContainerCompare.ps1` rejects `-nofppos`; unrelated to this change set)*