### PR TITLE
feat: canary catalog contract + NI container pre-push hardening (#810)

### DIFF
--- a/docs/schemas/canary-signal-catalog-report-v1.schema.json
+++ b/docs/schemas/canary-signal-catalog-report-v1.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "priority/canary-signal-catalog-report@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAt",
+    "status",
+    "strict",
+    "catalogPath",
+    "catalog",
+    "coverage",
+    "signals",
+    "issues"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/canary-signal-catalog-report@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "warn",
+        "fail"
+      ]
+    },
+    "strict": {
+      "type": "boolean"
+    },
+    "catalogPath": {
+      "type": "string"
+    },
+    "catalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "schemaVersion",
+        "signalCount",
+        "uniqueKeyCount",
+        "digest"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "schemaVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signalCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uniqueKeyCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "digest": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bySourceType",
+        "bySeverity"
+      ],
+      "properties": {
+        "bySourceType": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "bySeverity": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "sourceType",
+          "incidentClass",
+          "branch",
+          "signaturePattern",
+          "severity",
+          "owner",
+          "labels",
+          "expectedRoute",
+          "key",
+          "keyDigest"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": "string"
+          },
+          "incidentClass": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "signaturePattern": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "owner": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expectedRoute": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "actionType",
+              "priority",
+              "labels"
+            ],
+            "properties": {
+              "actionType": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string"
+              },
+              "labels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "key": {
+            "type": "string"
+          },
+          "keyDigest": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/schemas/canary-signal-catalog-v1.schema.json
+++ b/docs/schemas/canary-signal-catalog-v1.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "canary-signal-catalog@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "signals"
+  ],
+  "properties": {
+    "schema": {
+      "const": "canary-signal-catalog@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "sourceType",
+          "incidentClass",
+          "branch",
+          "signaturePattern",
+          "severity",
+          "owner",
+          "labels",
+          "expectedRoute"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sourceType": {
+            "enum": [
+              "incident-event",
+              "workflow-run",
+              "required-check-drift",
+              "deployment-state"
+            ]
+          },
+          "incidentClass": {
+            "type": "string",
+            "minLength": 1
+          },
+          "branch": {
+            "type": "string",
+            "minLength": 1
+          },
+          "signaturePattern": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low",
+              "info"
+            ]
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expectedRoute": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "actionType",
+              "priority",
+              "labels"
+            ],
+            "properties": {
+              "actionType": {
+                "enum": [
+                  "open-issue",
+                  "update-issue",
+                  "comment",
+                  "pause-queue",
+                  "noop"
+                ]
+              },
+              "priority": {
+                "enum": [
+                  "P0",
+                  "P1",
+                  "P2"
+                ]
+              },
+              "labels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "priority:event:ingest": "node tools/priority/event-ingest.mjs",
     "priority:commit-integrity": "node tools/priority/commit-integrity.mjs",
     "priority:commit-integrity:drift": "node tools/priority/slo-metrics.mjs --workflow commit-integrity.yml --lookback-days 30 --max-runs 200 --threshold-failure-rate 0.3 --threshold-skip-rate 0.25 --threshold-mttr-hours 24 --threshold-stale-hours 168 --threshold-gate-regressions 5 --output tests/results/_agent/commit-integrity/commit-integrity-drift-report.json",
+    "priority:canary:catalog": "node tools/priority/canary-catalog.mjs",
     "priority:deployment:assert": "node tools/priority/assert-validation-deployment-determinism.mjs",
     "priority:release:scorecard": "node tools/priority/release-scorecard.mjs",
     "priority:security:intake": "node tools/priority/security-intake.mjs",

--- a/tests/Run-NIWindowsContainerCompare.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCompare.Tests.ps1
@@ -220,6 +220,23 @@ exit 0
       return @([string]$parsed)
     }
 
+    $script:GetDecodedContainerCommand = {
+      param([Parameter(Mandatory)]$Record)
+      $args = @($Record.args | ForEach-Object { [string]$_ })
+      $encodedCommand = $null
+      for ($i = 0; $i -lt ($args.Count - 1); $i++) {
+        if ($args[$i] -eq '-EncodedCommand') {
+          $encodedCommand = $args[$i + 1]
+          break
+        }
+      }
+      if ([string]::IsNullOrWhiteSpace($encodedCommand)) {
+        return ''
+      }
+      $decodedBytes = [Convert]::FromBase64String($encodedCommand)
+      return [System.Text.Encoding]::Unicode.GetString($decodedBytes)
+    }
+
   }
 
   BeforeEach {
@@ -403,6 +420,50 @@ exit 0
     ($labviewEnvKeyOnly -or ($labviewEnvArg -eq ("COMPARE_LABVIEW_PATH={0}" -f $script:ContainerLabVIEWPath))) | Should -BeTrue
     $runArgs | Should -Not -Contain 'Files\National'
     $runArgs | Should -Not -Contain 'Instruments\LabVIEW'
+  }
+
+  It 'passes -LabVIEWPath through the in-container LabVIEWCLI invocation' {
+    $work = Join-Path $TestDrive 'compare-labviewpath-cli-arg'
+    New-Item -ItemType Directory -Path $work | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    $logPath = Join-Path $work 'docker-log.ndjson'
+    Set-Item Env:DOCKER_STUB_LOG $logPath
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '1'
+    Set-Item Env:DOCKER_STUB_RUN_STDOUT 'CreateComparisonReport completed with diff.'
+
+    $baseVi = Join-Path $work 'Base.vi'
+    $headVi = Join-Path $work 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $work 'out\compare-report.html'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath `
+      -LabVIEWPath $script:ContainerLabVIEWPath `
+      -RuntimeEngineReadyTimeoutSeconds 5 `
+      -RuntimeEngineReadyPollSeconds 1 2>&1
+    $LASTEXITCODE | Should -Be 1 -Because ($output -join "`n")
+
+    $records = & $script:ReadDockerStubLog -Path $logPath
+    $runRecord = @(
+      $records | Where-Object {
+        $recordArgs = @($_.args | ForEach-Object { [string]$_ })
+        $recordArgs -contains 'run'
+      } | Select-Object -First 1
+    )
+    $runRecord | Should -Not -BeNullOrEmpty
+
+    $decodedCommand = & $script:GetDecodedContainerCommand -Record $runRecord[0]
+    [string]::IsNullOrWhiteSpace($decodedCommand) | Should -BeFalse
+    $decodedCommand | Should -Match '\-LabVIEWPath'
+    $decodedCommand | Should -Match '\$env:COMPARE_LABVIEW_PATH'
+    $decodedCommand | Should -Match '"-Headless",\s*"true"'
   }
 
   It 'writes deterministic capture artifacts for compare execution' {

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -247,6 +247,11 @@ if (-not (Test-Path -LiteralPath $headVi -PathType Leaf)) {
 }
 
 $expectedImage = 'nationalinstruments/labview:2026q1-windows'
+$containerLabVIEWPath = if ([string]::IsNullOrWhiteSpace($env:NI_WINDOWS_LABVIEW_PATH)) {
+  'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe'
+} else {
+  $env:NI_WINDOWS_LABVIEW_PATH.Trim()
+}
 $knownFlags = @('-noattr', '-nofppos', '-nobdcosm')
 $scenarioDir = Join-Path $root 'tests' 'results' '_agent' 'pre-push-ni-image'
 New-Item -ItemType Directory -Path $scenarioDir -Force | Out-Null
@@ -256,11 +261,12 @@ $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
 Write-Host '[pre-push] Running NI image known-flag scenario (real container compare)' -ForegroundColor Cyan
 Push-Location $root
 try {
-  pwsh -NoLogo -NoProfile -File $niCompareScript `
+  & $niCompareScript `
     -BaseVi $baseVi `
     -HeadVi $headVi `
     -Image $expectedImage `
     -ReportPath $reportPath `
+    -LabVIEWPath $containerLabVIEWPath `
     -Flags $knownFlags `
     -TimeoutSeconds 240 `
     -HeartbeatSeconds 15 `

--- a/tools/Run-NIWindowsContainerCompare.ps1
+++ b/tools/Run-NIWindowsContainerCompare.ps1
@@ -331,8 +331,7 @@ $args = @(
   "-VI1", $env:COMPARE_BASE_VI,
   "-VI2", $env:COMPARE_HEAD_VI,
   "-ReportPath", $env:COMPARE_REPORT_PATH,
-  "-ReportType", $env:COMPARE_REPORT_TYPE,
-  "-Headless"
+  "-ReportType", $env:COMPARE_REPORT_TYPE
 )
 $flags = @()
 if (-not [string]::IsNullOrWhiteSpace($env:COMPARE_FLAGS_B64)) {
@@ -342,18 +341,26 @@ if (-not [string]::IsNullOrWhiteSpace($env:COMPARE_FLAGS_B64)) {
     $parsed = $rawJson | ConvertFrom-Json -ErrorAction Stop
     if ($parsed -is [System.Collections.IEnumerable] -and -not ($parsed -is [string])) {
       foreach ($flag in $parsed) {
-        if (-not [string]::IsNullOrWhiteSpace([string]$flag)) {
-          $flags += [string]$flag
-        }
+        if ([string]::IsNullOrWhiteSpace([string]$flag)) { continue }
+        $flagText = [string]$flag
+        if ([string]::Equals($flagText.Trim(), '-Headless', [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+        $flags += $flagText
       }
     } elseif (-not [string]::IsNullOrWhiteSpace([string]$parsed)) {
-      $flags += [string]$parsed
+      $flagText = [string]$parsed
+      if (-not [string]::Equals($flagText.Trim(), '-Headless', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $flags += $flagText
+      }
     }
   }
 }
 if ($flags.Count -gt 0) {
   $args += $flags
 }
+if (-not [string]::IsNullOrWhiteSpace($env:COMPARE_LABVIEW_PATH)) {
+  $args += @("-LabVIEWPath", $env:COMPARE_LABVIEW_PATH)
+}
+$args += @("-Headless", "true")
 $prelaunchEnabled = -not [string]::Equals($env:COMPARE_PRELAUNCH_ENABLED, '0', [System.StringComparison]::OrdinalIgnoreCase)
 if ($prelaunchEnabled) {
   $lvCandidates = @(
@@ -394,26 +401,11 @@ function Invoke-CliWithCapturedStreams {
     [Parameter(Mandatory)][string[]]$ArgumentList
   )
 
-  $stdoutPath = Join-Path $env:TEMP ("lvcli-stdout-{0}.log" -f ([guid]::NewGuid().ToString('N')))
-  $stderrPath = Join-Path $env:TEMP ("lvcli-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
-  try {
-    $proc = Start-Process -FilePath $FilePath `
-      -ArgumentList $ArgumentList `
-      -NoNewWindow `
-      -Wait `
-      -PassThru `
-      -RedirectStandardOutput $stdoutPath `
-      -RedirectStandardError $stderrPath
-    $stdoutText = if (Test-Path -LiteralPath $stdoutPath -PathType Leaf) { Get-Content -LiteralPath $stdoutPath -Raw } else { '' }
-    $stderrText = if (Test-Path -LiteralPath $stderrPath -PathType Leaf) { Get-Content -LiteralPath $stderrPath -Raw } else { '' }
-    $combinedText = ((@($stdoutText, $stderrText) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join [Environment]::NewLine)
-    return [pscustomobject]@{
-      ExitCode = [int]$proc.ExitCode
-      Output = $combinedText
-    }
-  } finally {
-    Remove-Item -LiteralPath $stdoutPath -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath $stderrPath -Force -ErrorAction SilentlyContinue
+  $outputLines = @(& $FilePath @ArgumentList 2>&1)
+  $outputText = @($outputLines | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+  return [pscustomobject]@{
+    ExitCode = [int]$LASTEXITCODE
+    Output = $outputText
   }
 }
 

--- a/tools/priority/__tests__/canary-catalog-schema.test.mjs
+++ b/tools/priority/__tests__/canary-catalog-schema.test.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { runCanaryCatalog } from '../canary-catalog.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function createAjv() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+test('canary signal catalog fixture validates against schema', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'canary-signal-catalog-v1.schema.json');
+  const catalogPath = path.join(repoRoot, 'tools', 'priority', 'canary-signal-catalog.json');
+
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+
+  const validate = createAjv().compile(schema);
+  const valid = validate(catalog);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+  assert.ok(Array.isArray(catalog.signals) && catalog.signals.length > 0);
+});
+
+test('canary report validates against schema and preserves label coverage', async () => {
+  const catalogSchemaPath = path.join(repoRoot, 'docs', 'schemas', 'canary-signal-catalog-v1.schema.json');
+  const reportSchemaPath = path.join(repoRoot, 'docs', 'schemas', 'canary-signal-catalog-report-v1.schema.json');
+  const catalogPath = path.join(repoRoot, 'tools', 'priority', 'canary-signal-catalog.json');
+  const reportSchema = JSON.parse(await readFile(reportSchemaPath, 'utf8'));
+  const catalogSchema = JSON.parse(await readFile(catalogSchemaPath, 'utf8'));
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canary-catalog-schema-'));
+  const reportPath = path.join(tmpDir, 'report.json');
+
+  const result = await runCanaryCatalog({
+    argv: ['node', 'canary-catalog.mjs', '--catalog', catalogPath, '--report', reportPath],
+    now: new Date('2026-03-06T22:30:00Z'),
+    repoRoot
+  });
+
+  assert.equal(result.exitCode, 0);
+
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+  const ajv = createAjv();
+  const validateCatalog = ajv.compile(catalogSchema);
+  const validateReport = ajv.compile(reportSchema);
+  const catalogSignalsFromReport = report.signals.map((signal) => ({
+    id: signal.id,
+    sourceType: signal.sourceType,
+    incidentClass: signal.incidentClass,
+    branch: signal.branch,
+    signaturePattern: signal.signaturePattern,
+    severity: signal.severity,
+    owner: signal.owner,
+    labels: signal.labels,
+    expectedRoute: signal.expectedRoute
+  }));
+
+  const validCatalog = validateCatalog(result.report ? {
+    schema: 'canary-signal-catalog@v1',
+    schemaVersion: result.report.catalog.schemaVersion ?? '1.0.0',
+    signals: catalogSignalsFromReport
+  } : null);
+  assert.equal(validCatalog, true, JSON.stringify(validateCatalog.errors, null, 2));
+
+  const validReport = validateReport(report);
+  assert.equal(validReport, true, JSON.stringify(validateReport.errors, null, 2));
+
+  assert.equal(report.status, 'pass');
+  assert.ok(report.catalog.signalCount >= 1);
+  assert.ok(Object.keys(report.coverage.bySourceType).length >= 1);
+  assert.ok(report.signals.every((signal) => Array.isArray(signal.expectedRoute.labels) && signal.expectedRoute.labels.length > 0));
+});

--- a/tools/priority/__tests__/canary-catalog.test.mjs
+++ b/tools/priority/__tests__/canary-catalog.test.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  buildSignalKey,
+  evaluateCatalog,
+  normalizeCatalog,
+  parseArgs,
+  runCanaryCatalog
+} from '../canary-catalog.mjs';
+
+function sampleCatalog(overrides = {}) {
+  return {
+    schema: 'canary-signal-catalog@v1',
+    schemaVersion: '1.0.0',
+    signals: [
+      {
+        id: 'signal-a',
+        sourceType: 'workflow-run',
+        incidentClass: 'workflow-run-failure',
+        branch: 'develop',
+        signaturePattern: 'validate:failure',
+        severity: 'high',
+        owner: 'release-platform',
+        labels: ['ci'],
+        expectedRoute: {
+          actionType: 'open-issue',
+          priority: 'P1',
+          labels: ['ci']
+        }
+      },
+      {
+        id: 'signal-b',
+        sourceType: 'deployment-state',
+        incidentClass: 'deployment-state-anomaly',
+        branch: 'develop',
+        signaturePattern: 'validation:fail:no-active',
+        severity: 'high',
+        owner: 'release-platform',
+        labels: ['ci', 'governance'],
+        expectedRoute: {
+          actionType: 'open-issue',
+          priority: 'P1',
+          labels: ['ci', 'governance']
+        }
+      }
+    ],
+    ...overrides
+  };
+}
+
+test('parseArgs supports strict toggles and paths', () => {
+  const parsed = parseArgs([
+    'node',
+    'canary-catalog.mjs',
+    '--catalog',
+    'catalog.json',
+    '--report',
+    'report.json',
+    '--no-strict'
+  ]);
+  assert.equal(parsed.catalogPath, 'catalog.json');
+  assert.equal(parsed.reportPath, 'report.json');
+  assert.equal(parsed.strict, false);
+});
+
+test('buildSignalKey is deterministic and normalized', () => {
+  const key = buildSignalKey({
+    sourceType: 'Workflow-Run',
+    incidentClass: 'Workflow-Run-Failure',
+    branch: 'Develop',
+    signaturePattern: 'Validate:Failure'
+  });
+  assert.equal(key, 'workflow-run|workflow-run-failure|develop|validate:failure');
+});
+
+test('normalizeCatalog validates schema and sorts signals by id', () => {
+  const normalized = normalizeCatalog(
+    sampleCatalog({
+      signals: [
+        sampleCatalog().signals[1],
+        sampleCatalog().signals[0]
+      ]
+    })
+  );
+  assert.deepEqual(
+    normalized.signals.map((signal) => signal.id),
+    ['signal-a', 'signal-b']
+  );
+});
+
+test('evaluateCatalog flags duplicate keys and missing owner', () => {
+  const normalized = normalizeCatalog(
+    sampleCatalog({
+      signals: [
+        {
+          ...sampleCatalog().signals[0],
+          id: 'dup-a',
+          owner: ''
+        },
+        {
+          ...sampleCatalog().signals[0],
+          id: 'dup-b'
+        }
+      ]
+    })
+  );
+  const evaluation = evaluateCatalog(normalized);
+  assert.ok(evaluation.issues.some((item) => item.startsWith('duplicate-key:')));
+  assert.ok(evaluation.issues.some((item) => item === 'signal:dup-a:owner-missing'));
+});
+
+test('runCanaryCatalog writes pass report for valid catalog', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canary-catalog-'));
+  const catalogPath = path.join(tmpDir, 'catalog.json');
+  const reportPath = path.join(tmpDir, 'report.json');
+  fs.writeFileSync(catalogPath, `${JSON.stringify(sampleCatalog(), null, 2)}\n`, 'utf8');
+
+  const result = await runCanaryCatalog({
+    argv: [
+      'node',
+      'canary-catalog.mjs',
+      '--catalog',
+      catalogPath,
+      '--report',
+      reportPath
+    ],
+    now: new Date('2026-03-06T22:00:00Z'),
+    repoRoot: tmpDir
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.status, 'pass');
+  assert.equal(result.report.catalog.signalCount, 2);
+  assert.equal(result.report.issues.length, 0);
+
+  const persisted = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  assert.equal(persisted.schema, 'priority/canary-signal-catalog-report@v1');
+});
+
+test('runCanaryCatalog fails in strict mode when duplicate keys exist', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canary-catalog-fail-'));
+  const catalogPath = path.join(tmpDir, 'catalog.json');
+  const reportPath = path.join(tmpDir, 'report.json');
+  fs.writeFileSync(
+    catalogPath,
+    `${JSON.stringify(
+      sampleCatalog({
+        signals: [
+          {
+            ...sampleCatalog().signals[0],
+            id: 'dup-a'
+          },
+          {
+            ...sampleCatalog().signals[0],
+            id: 'dup-b'
+          }
+        ]
+      }),
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const result = await runCanaryCatalog({
+    argv: [
+      'node',
+      'canary-catalog.mjs',
+      '--catalog',
+      catalogPath,
+      '--report',
+      reportPath
+    ],
+    now: new Date('2026-03-06T22:01:00Z'),
+    repoRoot: tmpDir
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.report.status, 'fail');
+  assert.ok(result.report.issues.some((item) => item.startsWith('duplicate-key:')));
+});

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -24,6 +24,14 @@ test('PrePush-Checks invokes workspace health gate in optional lease mode', () =
   assert.match(content, /pre-push-workspace-health\.json/);
 });
 
+test('PrePush NI image known-flag scenario uses direct script invocation and explicit LabVIEWPath', () => {
+  const content = readRepoFile('tools/PrePush-Checks.ps1');
+  assert.match(content, /& \$niCompareScript/);
+  assert.match(content, /-LabVIEWPath \$containerLabVIEWPath/);
+  assert.match(content, /\$knownFlags = @\('-noattr', '-nofppos', '-nobdcosm'\)/);
+  assert.doesNotMatch(content, /pwsh\s+-NoLogo\s+-NoProfile\s+-File\s+\$niCompareScript/);
+});
+
 test('policy workflows enforce workspace health gate and publish health artifacts', () => {
   const guardWorkflow = readRepoFile('.github/workflows/policy-guard-upstream.yml');
   assert.match(guardWorkflow, /Workspace health gate/);
@@ -35,4 +43,3 @@ test('policy workflows enforce workspace health gate and publish health artifact
   assert.match(syncWorkflow, /check-workspace-health\.mjs --repo-root \. --lease-mode ignore --report tests\/results\/_agent\/health\/policy-sync-workspace-health\.json/);
   assert.match(syncWorkflow, /tests\/results\/_agent\/health\/policy-sync-workspace-health\.json/);
 });
-

--- a/tools/priority/canary-catalog.mjs
+++ b/tools/priority/canary-catalog.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { getRepoRoot } from './lib/branch-utils.mjs';
+
+export const CATALOG_SCHEMA = 'canary-signal-catalog@v1';
+export const REPORT_SCHEMA = 'priority/canary-signal-catalog-report@v1';
+export const DEFAULT_CATALOG_PATH = path.join('tools', 'priority', 'canary-signal-catalog.json');
+export const DEFAULT_REPORT_PATH = path.join('tests', 'results', '_agent', 'canary', 'canary-signal-catalog-report.json');
+
+const VALID_SOURCE_TYPES = new Set(['incident-event', 'workflow-run', 'required-check-drift', 'deployment-state']);
+const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+const VALID_ACTION_TYPES = new Set(['open-issue', 'update-issue', 'comment', 'pause-queue', 'noop']);
+const VALID_PRIORITIES = new Set(['P0', 'P1', 'P2']);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/canary-catalog.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(`  --catalog <path>      Catalog path (default: ${DEFAULT_CATALOG_PATH}).`);
+  console.log(`  --report <path>       Report path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log('  --strict              Fail when validation issues are detected (default: true).');
+  console.log('  --no-strict           Emit report but do not fail on validation issues.');
+  console.log('  -h, --help            Show help and exit.');
+}
+
+function normalizeText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function normalizeLower(value) {
+  const text = normalizeText(value);
+  return text ? text.toLowerCase() : null;
+}
+
+function normalizeLabels(values) {
+  const labels = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const normalized = normalizeLower(value);
+    if (!normalized) continue;
+    labels.push(normalized);
+  }
+  return [...new Set(labels)].sort((left, right) => left.localeCompare(right));
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    catalogPath: DEFAULT_CATALOG_PATH,
+    reportPath: DEFAULT_REPORT_PATH,
+    strict: true,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--strict') {
+      options.strict = true;
+      continue;
+    }
+    if (token === '--no-strict') {
+      options.strict = false;
+      continue;
+    }
+    if (token === '--catalog' || token === '--report') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--catalog') options.catalogPath = next;
+      if (token === '--report') options.reportPath = next;
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+function readJsonFile(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+  return readFile(resolved, 'utf8').then((content) => {
+    try {
+      return JSON.parse(content);
+    } catch (error) {
+      throw new Error(`Invalid JSON in ${resolved}: ${error.message}`);
+    }
+  });
+}
+
+export function buildSignalKey({ sourceType, incidentClass, branch, signaturePattern }) {
+  return [
+    normalizeLower(sourceType) ?? 'unknown',
+    normalizeLower(incidentClass) ?? 'unknown',
+    normalizeLower(branch) ?? '*',
+    normalizeLower(signaturePattern) ?? 'unknown'
+  ].join('|');
+}
+
+function digestText(value) {
+  const hash = createHash('sha256');
+  hash.update(String(value));
+  return hash.digest('hex');
+}
+
+function normalizeExpectedRoute(route = {}) {
+  const actionType = normalizeLower(route.actionType) ?? 'comment';
+  if (!VALID_ACTION_TYPES.has(actionType)) {
+    throw new Error(`Invalid expectedRoute.actionType '${route.actionType}'.`);
+  }
+  const priority = normalizeText(route.priority)?.toUpperCase() ?? 'P2';
+  if (!VALID_PRIORITIES.has(priority)) {
+    throw new Error(`Invalid expectedRoute.priority '${route.priority}'.`);
+  }
+  return {
+    actionType,
+    priority,
+    labels: normalizeLabels(route.labels)
+  };
+}
+
+function normalizeSignal(rawSignal, index) {
+  const id = normalizeText(rawSignal?.id);
+  if (!id) {
+    throw new Error(`Signal at index ${index} is missing id.`);
+  }
+  const sourceType = normalizeLower(rawSignal.sourceType);
+  if (!VALID_SOURCE_TYPES.has(sourceType)) {
+    throw new Error(`Signal '${id}' has invalid sourceType '${rawSignal.sourceType}'.`);
+  }
+  const incidentClass = normalizeLower(rawSignal.incidentClass);
+  if (!incidentClass) {
+    throw new Error(`Signal '${id}' is missing incidentClass.`);
+  }
+  const severity = normalizeLower(rawSignal.severity);
+  if (!VALID_SEVERITIES.has(severity)) {
+    throw new Error(`Signal '${id}' has invalid severity '${rawSignal.severity}'.`);
+  }
+  const signaturePattern = normalizeLower(rawSignal.signaturePattern);
+  if (!signaturePattern) {
+    throw new Error(`Signal '${id}' is missing signaturePattern.`);
+  }
+
+  const branch = normalizeLower(rawSignal.branch) ?? '*';
+  const key = buildSignalKey({
+    sourceType,
+    incidentClass,
+    branch,
+    signaturePattern
+  });
+
+  return {
+    id,
+    sourceType,
+    incidentClass,
+    branch,
+    signaturePattern,
+    severity,
+    owner: normalizeText(rawSignal.owner),
+    labels: normalizeLabels(rawSignal.labels),
+    expectedRoute: normalizeExpectedRoute(rawSignal.expectedRoute ?? {}),
+    key,
+    keyDigest: digestText(key)
+  };
+}
+
+export function normalizeCatalog(catalog = {}) {
+  if (catalog?.schema !== CATALOG_SCHEMA) {
+    throw new Error(`Invalid catalog schema '${catalog?.schema}'. Expected '${CATALOG_SCHEMA}'.`);
+  }
+  const signals = (Array.isArray(catalog.signals) ? catalog.signals : [])
+    .map((signal, index) => normalizeSignal(signal, index))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    schema: CATALOG_SCHEMA,
+    schemaVersion: normalizeText(catalog.schemaVersion) ?? '1.0.0',
+    description: normalizeText(catalog.description),
+    signals
+  };
+}
+
+export function evaluateCatalog(catalog) {
+  const keyToIds = new Map();
+  const issues = [];
+  const bySourceType = {};
+  const bySeverity = {};
+
+  for (const signal of catalog.signals) {
+    const existing = keyToIds.get(signal.key) ?? [];
+    existing.push(signal.id);
+    keyToIds.set(signal.key, existing);
+
+    bySourceType[signal.sourceType] = (bySourceType[signal.sourceType] ?? 0) + 1;
+    bySeverity[signal.severity] = (bySeverity[signal.severity] ?? 0) + 1;
+
+    if (!signal.owner) {
+      issues.push(`signal:${signal.id}:owner-missing`);
+    }
+    if (signal.expectedRoute.labels.length === 0) {
+      issues.push(`signal:${signal.id}:expected-route-labels-empty`);
+    }
+  }
+
+  for (const [key, ids] of keyToIds.entries()) {
+    if (ids.length > 1) {
+      issues.push(`duplicate-key:${key}:${ids.sort((left, right) => left.localeCompare(right)).join(',')}`);
+    }
+  }
+
+  return {
+    issues: issues.sort((left, right) => left.localeCompare(right)),
+    bySourceType,
+    bySeverity,
+    uniqueKeyCount: keyToIds.size
+  };
+}
+
+async function writeReport(reportPath, report) {
+  const resolvedPath = path.resolve(reportPath);
+  await mkdir(path.dirname(resolvedPath), { recursive: true });
+  await writeFile(resolvedPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+export async function runCanaryCatalog({
+  argv = process.argv,
+  now = new Date(),
+  repoRoot = getRepoRoot(),
+  readJsonFileFn = readJsonFile,
+  writeReportFn = writeReport
+} = {}) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return { exitCode: 0, report: null, reportPath: null };
+  }
+
+  const resolvedCatalogPath = path.resolve(repoRoot, options.catalogPath);
+  let exitCode = 0;
+  let report = null;
+
+  try {
+    const catalogPayload = await readJsonFileFn(resolvedCatalogPath);
+    const catalog = normalizeCatalog(catalogPayload);
+    const evaluation = evaluateCatalog(catalog);
+    const pass = evaluation.issues.length === 0;
+    if (!pass && options.strict) {
+      exitCode = 1;
+    }
+    report = {
+      schema: REPORT_SCHEMA,
+      schemaVersion: '1.0.0',
+      generatedAt: now.toISOString(),
+      status: pass ? 'pass' : options.strict ? 'fail' : 'warn',
+      strict: options.strict,
+      catalogPath: resolvedCatalogPath,
+      catalog: {
+        schema: catalog.schema,
+        schemaVersion: catalog.schemaVersion,
+        signalCount: catalog.signals.length,
+        uniqueKeyCount: evaluation.uniqueKeyCount,
+        digest: digestText(JSON.stringify(catalog.signals))
+      },
+      coverage: {
+        bySourceType: evaluation.bySourceType,
+        bySeverity: evaluation.bySeverity
+      },
+      signals: catalog.signals,
+      issues: evaluation.issues
+    };
+  } catch (error) {
+    exitCode = 1;
+    report = {
+      schema: REPORT_SCHEMA,
+      schemaVersion: '1.0.0',
+      generatedAt: now.toISOString(),
+      status: 'fail',
+      strict: options.strict,
+      catalogPath: resolvedCatalogPath,
+      catalog: {
+        schema: CATALOG_SCHEMA,
+        schemaVersion: null,
+        signalCount: 0,
+        uniqueKeyCount: 0,
+        digest: null
+      },
+      coverage: {
+        bySourceType: {},
+        bySeverity: {}
+      },
+      signals: [],
+      issues: [error.message || String(error)]
+    };
+  }
+
+  const resolvedReportPath = await writeReportFn(options.reportPath, report);
+  console.log(`[canary-catalog] report: ${resolvedReportPath}`);
+  console.log(`[canary-catalog] status=${report.status} signals=${report.catalog.signalCount} issues=${report.issues.length}`);
+  return { exitCode, report, reportPath: resolvedReportPath };
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isDirectRun) {
+  runCanaryCatalog().then(({ exitCode }) => {
+    process.exit(exitCode);
+  }).catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}

--- a/tools/priority/canary-signal-catalog.json
+++ b/tools/priority/canary-signal-catalog.json
@@ -1,0 +1,112 @@
+{
+  "schema": "canary-signal-catalog@v1",
+  "schemaVersion": "1.0.0",
+  "description": "Canonical failure-signal canary catalog for deterministic routing coverage.",
+  "signals": [
+    {
+      "id": "ni-known-flag-nofppos",
+      "sourceType": "incident-event",
+      "incidentClass": "ni-known-flag-parameter-mismatch",
+      "branch": "develop",
+      "signaturePattern": "run-niwindowscontainercompare:nofppos",
+      "severity": "high",
+      "owner": "release-platform",
+      "labels": [
+        "ci",
+        "governance"
+      ],
+      "expectedRoute": {
+        "actionType": "open-issue",
+        "priority": "P1",
+        "labels": [
+          "ci",
+          "governance"
+        ]
+      }
+    },
+    {
+      "id": "workflow-validate-failure",
+      "sourceType": "workflow-run",
+      "incidentClass": "workflow-run-failure",
+      "branch": "develop",
+      "signaturePattern": "validate:failure",
+      "severity": "high",
+      "owner": "release-platform",
+      "labels": [
+        "ci"
+      ],
+      "expectedRoute": {
+        "actionType": "open-issue",
+        "priority": "P1",
+        "labels": [
+          "ci"
+        ]
+      }
+    },
+    {
+      "id": "workflow-commit-integrity-failure",
+      "sourceType": "workflow-run",
+      "incidentClass": "workflow-run-failure",
+      "branch": "develop",
+      "signaturePattern": "commit-integrity:failure",
+      "severity": "high",
+      "owner": "release-platform",
+      "labels": [
+        "ci",
+        "governance"
+      ],
+      "expectedRoute": {
+        "actionType": "open-issue",
+        "priority": "P1",
+        "labels": [
+          "ci",
+          "governance"
+        ]
+      }
+    },
+    {
+      "id": "required-check-drift-develop",
+      "sourceType": "required-check-drift",
+      "incidentClass": "required-check-drift",
+      "branch": "develop",
+      "signaturePattern": "fail:*",
+      "severity": "critical",
+      "owner": "release-platform",
+      "labels": [
+        "ci",
+        "governance",
+        "program"
+      ],
+      "expectedRoute": {
+        "actionType": "open-issue",
+        "priority": "P0",
+        "labels": [
+          "ci",
+          "governance",
+          "program"
+        ]
+      }
+    },
+    {
+      "id": "deployment-determinism-validation-no-active",
+      "sourceType": "deployment-state",
+      "incidentClass": "deployment-state-anomaly",
+      "branch": "develop",
+      "signaturePattern": "validation:fail:no-active-deployment-found",
+      "severity": "high",
+      "owner": "release-platform",
+      "labels": [
+        "ci",
+        "governance"
+      ],
+      "expectedRoute": {
+        "actionType": "open-issue",
+        "priority": "P1",
+        "labels": [
+          "ci",
+          "governance"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- adds a deterministic canary signal catalog contract (`canary-signal-catalog@v1`) plus a validator/report CLI for standing-priority routing coverage
- introduces schema + unit coverage for catalog normalization, duplicate-key detection, and report artifact validation
- hardens NI Windows container compare invocation so pre-push no longer misparses known flags and always passes a valid `-LabVIEWPath`

## Changes
- added:
  - `tools/priority/canary-signal-catalog.json`
  - `tools/priority/canary-catalog.mjs`
  - `docs/schemas/canary-signal-catalog-v1.schema.json`
  - `docs/schemas/canary-signal-catalog-report-v1.schema.json`
  - `tools/priority/__tests__/canary-catalog.test.mjs`
  - `tools/priority/__tests__/canary-catalog-schema.test.mjs`
- updated `package.json` with `priority:canary:catalog`
- updated `tools/PrePush-Checks.ps1`:
  - invoke NI compare script directly (no nested `pwsh -File` arg reparse)
  - pass explicit `-LabVIEWPath` for the NI container scenario
- updated `tools/Run-NIWindowsContainerCompare.ps1`:
  - fix repo-root defaulting bug in catalog runner integration path
  - normalize CLI argument assembly to include `-Headless true` and pass `-LabVIEWPath` safely
  - replace `Start-Process -ArgumentList` capture path with native argument splatting to preserve paths with spaces (`C:\Program Files\...`)
- updated tests/contracts:
  - `tests/Run-NIWindowsContainerCompare.Tests.ps1` decodes encoded container command and asserts `-LabVIEWPath` + `-Headless true`
  - `tools/priority/__tests__/workspace-health-contract.test.mjs` asserts direct NI script invocation + explicit labview path in pre-push lane

## Validation
- `node --test tools/priority/__tests__/canary-catalog.test.mjs tools/priority/__tests__/canary-catalog-schema.test.mjs tools/priority/__tests__/workspace-health-contract.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `Import-Module ./tools/modules/Pester/5.7.1/Pester.psd1 -Force; Invoke-Pester -Path tests/Run-NIWindowsContainerCompare.Tests.ps1`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` (passes with NI image known-flag scenario)

Closes #810
