### PR TITLE
feat: deterministic code-scanning + warnings threshold policy (#811)

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,0 +1,47 @@
+name: Code Scanning
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  merge_group:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: code-scanning-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: codeql (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -14,7 +14,8 @@ param(
   [string]$ActionlintVersion = '1.7.7',
   [bool]$InstallIfMissing = $true,
   [switch]$SkipNiImageFlagScenarios,
-  [switch]$SkipIconEditorFixtureChecks
+  [switch]$SkipIconEditorFixtureChecks,
+  [switch]$SkipPSScriptAnalyzer
 )
 
 $ErrorActionPreference = 'Stop'
@@ -107,6 +108,71 @@ function Invoke-Actionlint([string]$repoRoot){
   }
 }
 
+function Get-ChangedPowerShellPaths([string]$repoRoot) {
+  $patterns = @('*.ps1', '*.psm1', '*.psd1')
+  $ranges = @('upstream/develop...HEAD', 'origin/develop...HEAD', 'HEAD~1..HEAD')
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $files = New-Object System.Collections.Generic.List[string]
+
+  foreach ($range in $ranges) {
+    $diffArgs = @('-C', $repoRoot, 'diff', '--name-only', '--diff-filter=ACMRT', $range, '--') + $patterns
+    $raw = & git @diffArgs 2>$null
+    if ($LASTEXITCODE -ne 0) {
+      continue
+    }
+    foreach ($entry in @($raw | Where-Object { $_ -and $_.Trim() })) {
+      $relative = $entry.Trim()
+      if (-not $seen.Add($relative)) {
+        continue
+      }
+      $absolute = Join-Path $repoRoot $relative
+      if (Test-Path -LiteralPath $absolute -PathType Leaf) {
+        $files.Add($absolute)
+      }
+    }
+    if ($files.Count -gt 0) {
+      break
+    }
+  }
+
+  return $files.ToArray()
+}
+
+function Invoke-PSScriptAnalyzerGate([string]$repoRoot) {
+  $skipAnalyzer = $SkipPSScriptAnalyzer -or ($env:PREPUSH_SKIP_PSSCRIPTANALYZER -match '^(1|true|yes|on)$')
+  if ($skipAnalyzer) {
+    Write-Host '[pre-push] Skipping PSScriptAnalyzer by request' -ForegroundColor Yellow
+    return
+  }
+
+  if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+    Write-Host '[pre-push] PSScriptAnalyzer not installed; skipping analyzer gate' -ForegroundColor Yellow
+    return
+  }
+
+  $paths = @(Get-ChangedPowerShellPaths -repoRoot $repoRoot)
+  if ($paths.Count -eq 0) {
+    Write-Host '[pre-push] No changed PowerShell files detected for analyzer gate' -ForegroundColor DarkGray
+    return
+  }
+
+  Import-Module PSScriptAnalyzer -ErrorAction Stop | Out-Null
+  Write-Host ("[pre-push] Running PSScriptAnalyzer on {0} changed file(s)" -f $paths.Count) -ForegroundColor Cyan
+  $issues = @()
+  foreach ($path in $paths) {
+    $issues += Invoke-ScriptAnalyzer -Path $path -Severity Error,Warning -ErrorAction Stop
+  }
+
+  if ($issues.Count -gt 0) {
+    $issues | ForEach-Object {
+      Write-Host ("[pre-push][pssa] {0}:{1} {2} ({3})" -f $_.ScriptPath, $_.Line, $_.Message, $_.RuleName) -ForegroundColor Red
+    }
+    throw ("PSScriptAnalyzer detected {0} issue(s)." -f $issues.Count)
+  }
+
+  Write-Host '[pre-push] PSScriptAnalyzer gate OK' -ForegroundColor Green
+}
+
 function Invoke-WorkspaceHealthGate([string]$repoRoot){
   $scriptPath = Join-Path $repoRoot 'tools' 'priority' 'check-workspace-health.mjs'
   if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
@@ -168,6 +234,7 @@ if ($code -ne 0) {
   exit $code
 }
 Write-Host '[pre-push] actionlint OK' -ForegroundColor Green
+Invoke-PSScriptAnalyzerGate -repoRoot $root
 
 Write-Host '[pre-push] Validating safe PR watch task contract' -ForegroundColor Cyan
 $safeWatchContractExit = Invoke-NodeTestSanitized -Args @('--test','tools/priority/__tests__/safe-watch-task-contract.test.mjs')

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -399,6 +399,9 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     developPullRule.parameters.allowed_merge_methods.sort(),
     ['rebase', 'squash']
   );
+  const developCodeQualityRule = rulesetDevelop.rules.find((rule) => rule.type === 'code_quality');
+  assert.ok(developCodeQualityRule, 'code_quality rule expected on develop');
+  assert.equal(developCodeQualityRule.parameters.severity, 'warnings');
 
   const mergeQueueRule = rulesetMain.rules.find((rule) => rule.type === 'merge_queue');
   assert.equal(mergeQueueRule.parameters.min_entries_to_merge_wait_minutes, 5);
@@ -443,9 +446,12 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   const developCommitIntegrityCheck = developRulesetPayload.rules
     .find((rule) => rule.type === 'required_status_checks')
     .parameters.required_status_checks.find((check) => check.context === 'commit-integrity');
+  const developPayloadCodeQualityRule = developRulesetPayload.rules.find((rule) => rule.type === 'code_quality');
   const mainCommitIntegrityCheck = mainRulesetPayload.rules
     .find((rule) => rule.type === 'required_status_checks')
     .parameters.required_status_checks.find((check) => check.context === 'commit-integrity');
+  assert.ok(developPayloadCodeQualityRule, 'develop payload should include code_quality rule');
+  assert.equal(developPayloadCodeQualityRule.parameters.severity, 'warnings');
   assert.ok(developCommitIntegrityCheck, 'develop ruleset should include commit-integrity required check');
   assert.ok(mainCommitIntegrityCheck, 'main ruleset should include commit-integrity required check');
   assert.equal(
@@ -961,6 +967,12 @@ test('priority:policy verify fails when queue-managed ruleset is missing merge_q
           required_review_thread_resolution: false,
           allowed_merge_methods: ['squash', 'rebase']
         }
+      },
+      {
+        type: 'code_quality',
+        parameters: {
+          severity: 'warnings'
+        }
       }
     ]
   };
@@ -997,6 +1009,12 @@ test('priority:policy verify fails when queue-managed ruleset is missing merge_q
           require_last_push_approval: false,
           required_review_thread_resolution: false,
           allowed_merge_methods: ['squash', 'rebase']
+        }
+      },
+      {
+        type: 'code_quality',
+        parameters: {
+          severity: 'warnings'
         }
       }
     ]
@@ -1202,6 +1220,12 @@ test('priority:policy verify uses queue-managed rulesets as required-check sourc
           required_review_thread_resolution: false,
           allowed_merge_methods: ['squash', 'rebase']
         }
+      },
+      {
+        type: 'code_quality',
+        parameters: {
+          severity: 'warnings'
+        }
       }
     ]
   };
@@ -1302,7 +1326,11 @@ test('priority:policy verify uses queue-managed rulesets as required-check sourc
     error: (msg) => errorMessages.push(msg)
   });
 
-  assert.equal(code, 0, 'verify mode should pass when queue-managed rulesets match policy');
+  assert.equal(
+    code,
+    0,
+    `verify mode should pass when queue-managed rulesets match policy: ${errorMessages.join(' | ')}`
+  );
   assert.deepEqual(errorMessages, []);
   assert.ok(
     logMessages.some((msg) => msg.includes('auth source: GITHUB_TOKEN')),
@@ -1578,3 +1606,26 @@ test('priority:policy build branch-protection payload honors explicit disabled s
   assert.equal(payload.allow_fork_syncing, false);
 });
 
+test('priority:policy optional ruleset seam treats disabled expectation as explicit absence', () => {
+  const normalized = __test.normalizeOptionalRuleExpectation({ enabled: false, severity: 'warnings' });
+  assert.deepEqual(normalized, { mode: 'absent', parameters: null });
+});
+
+test('priority:policy optional ruleset seam detects missing code_quality rule', () => {
+  const diffs = __test.compareOptionalParameterizedRule('code_quality', { severity: 'warnings' }, null);
+  assert.deepEqual(diffs, ['code_quality: rule missing']);
+});
+
+test('priority:policy optional ruleset seam detects code_quality severity drift', () => {
+  const diffs = __test.compareOptionalParameterizedRule(
+    'code_quality',
+    { severity: 'warnings' },
+    {
+      type: 'code_quality',
+      parameters: {
+        severity: 'errors'
+      }
+    }
+  );
+  assert.deepEqual(diffs, ['code_quality.severity: expected warnings, actual errors']);
+});

--- a/tools/priority/__tests__/code-scanning-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/code-scanning-workflow-contract.test.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('code scanning workflow is deterministic across pull_request, merge_group, and push', () => {
+  const workflow = readRepoFile('.github/workflows/code-scanning.yml');
+  assert.match(workflow, /name:\s+Code Scanning/);
+  assert.match(workflow, /pull_request:\s*\n\s*branches:\s*\n\s*-\s*develop\s*\n\s*-\s*main/);
+  assert.match(workflow, /merge_group:\s*\n\s*branches:\s*\n\s*-\s*develop\s*\n\s*-\s*main/);
+  assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*-\s*develop\s*\n\s*-\s*main/);
+  assert.match(workflow, /security-events:\s+write/);
+  assert.match(workflow, /concurrency:\s*\n\s*group:\s+code-scanning-\$\{\{\s*github\.event_name\s*\}\}-\$\{\{\s*github\.event\.pull_request\.number \|\| github\.ref\s*\}\}/);
+  assert.match(workflow, /cancel-in-progress:\s+true/);
+});
+
+test('code scanning workflow uses CodeQL security-and-quality queries for JavaScript/TypeScript', () => {
+  const workflow = readRepoFile('.github/workflows/code-scanning.yml');
+  assert.match(workflow, /github\/codeql-action\/init@v3/);
+  assert.match(workflow, /languages:\s+javascript-typescript/);
+  assert.match(workflow, /queries:\s+security-and-quality/);
+  assert.match(workflow, /github\/codeql-action\/analyze@v3/);
+  assert.match(workflow, /category:\s+\/language:javascript-typescript/);
+});

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -32,6 +32,14 @@ test('PrePush NI image known-flag scenario uses direct script invocation and exp
   assert.doesNotMatch(content, /pwsh\s+-NoLogo\s+-NoProfile\s+-File\s+\$niCompareScript/);
 });
 
+test('PrePush includes local PSScriptAnalyzer gate for changed PowerShell files', () => {
+  const content = readRepoFile('tools/PrePush-Checks.ps1');
+  assert.match(content, /function Invoke-PSScriptAnalyzerGate/);
+  assert.match(content, /Get-ChangedPowerShellPaths/);
+  assert.match(content, /Invoke-ScriptAnalyzer -Path \$path -Severity Error,Warning/);
+  assert.match(content, /Invoke-PSScriptAnalyzerGate -repoRoot \$root/);
+});
+
 test('policy workflows enforce workspace health gate and publish health artifacts', () => {
   const guardWorkflow = readRepoFile('.github/workflows/policy-guard-upstream.yml');
   assert.match(guardWorkflow, /Workspace health gate/);

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -516,6 +516,61 @@ function comparePullRequestRule(expected, actualRule) {
   return diffs;
 }
 
+function normalizeOptionalRuleExpectation(expected) {
+  if (expected === undefined) {
+    return { mode: 'ignore', parameters: null };
+  }
+  if (expected === null || expected === false) {
+    return { mode: 'absent', parameters: null };
+  }
+  if (expected === true) {
+    return { mode: 'present', parameters: {} };
+  }
+  if (typeof expected !== 'object' || Array.isArray(expected)) {
+    return { mode: 'present', parameters: {} };
+  }
+
+  const enabled = hasOwnProperty(expected, 'enabled') ? Boolean(expected.enabled) : true;
+  if (!enabled) {
+    return { mode: 'absent', parameters: null };
+  }
+
+  const rawParams =
+    expected.parameters && typeof expected.parameters === 'object' && !Array.isArray(expected.parameters)
+      ? expected.parameters
+      : expected;
+  const params = { ...rawParams };
+  delete params.enabled;
+  delete params.parameters;
+  return { mode: 'present', parameters: params };
+}
+
+function compareOptionalParameterizedRule(type, expected, actualRule) {
+  const normalized = normalizeOptionalRuleExpectation(expected);
+  if (normalized.mode === 'ignore') {
+    return [];
+  }
+  if (normalized.mode === 'absent') {
+    return actualRule ? [`${type}: unexpected rule present`] : [];
+  }
+  if (!actualRule) {
+    return [`${type}: rule missing`];
+  }
+
+  const expectedParameters = normalized.parameters ?? {};
+  const actualParameters = actualRule.parameters ?? {};
+  const diffs = [];
+  for (const [key, value] of Object.entries(expectedParameters)) {
+    const actualValue = actualParameters[key];
+    const expectedJson = JSON.stringify(value);
+    const actualJson = JSON.stringify(actualValue);
+    if (expectedJson !== actualJson) {
+      diffs.push(`${type}.${key}: expected ${stringifyForDiff(value)}, actual ${stringifyForDiff(actualValue)}`);
+    }
+  }
+  return diffs;
+}
+
 function compareRulesetIncludes(expected = [], actual = []) {
   const { missing, extra } = compareSets(expected, actual);
   const diffs = [];
@@ -566,6 +621,12 @@ function compareRuleset(id, expected, actual) {
 
   const prRule = findRule(rules, 'pull_request');
   diffs.push(...comparePullRequestRule(expected.pull_request, prRule));
+
+  const codeQualityRule = findRule(rules, 'code_quality');
+  diffs.push(...compareOptionalParameterizedRule('code_quality', expected.code_quality, codeQualityRule));
+
+  const codeScanningRule = findRule(rules, 'code_scanning');
+  diffs.push(...compareOptionalParameterizedRule('code_scanning', expected.code_scanning, codeScanningRule));
 
   return diffs;
 }
@@ -729,6 +790,30 @@ function updatePullRequestRule(rules, expected, actualRule) {
   rule.parameters = parameters;
 }
 
+function updateOptionalParameterizedRule(rules, type, expected, actualRule) {
+  const normalized = normalizeOptionalRuleExpectation(expected);
+  if (normalized.mode === 'ignore') {
+    return;
+  }
+  const idx = rules.findIndex((rule) => rule?.type === type);
+  if (normalized.mode === 'absent') {
+    if (idx !== -1) {
+      rules.splice(idx, 1);
+    }
+    return;
+  }
+
+  const rule = idx === -1 ? ensureRule(rules, type) : ensureRule(rules, type);
+  const expectedParameters = normalized.parameters ?? {};
+  const hasExpectedParameters = Object.keys(expectedParameters).length > 0;
+  rule.parameters = hasExpectedParameters
+    ? {
+        ...(actualRule?.parameters ?? rule.parameters ?? {}),
+        ...structuredClone(expectedParameters)
+      }
+    : (actualRule?.parameters ?? rule.parameters ?? {});
+}
+
 function buildUpdatedRuleset(expectations, actual) {
   if (!actual) {
     throw new Error('Cannot apply ruleset changes: ruleset not found.');
@@ -771,6 +856,12 @@ function buildUpdatedRuleset(expectations, actual) {
 
   const existingPullRequestRule = updated.rules.find((rule) => rule?.type === 'pull_request');
   updatePullRequestRule(updated.rules, expectations.pull_request, existingPullRequestRule);
+
+  const existingCodeQualityRule = updated.rules.find((rule) => rule?.type === 'code_quality');
+  updateOptionalParameterizedRule(updated.rules, 'code_quality', expectations.code_quality, existingCodeQualityRule);
+
+  const existingCodeScanningRule = updated.rules.find((rule) => rule?.type === 'code_scanning');
+  updateOptionalParameterizedRule(updated.rules, 'code_scanning', expectations.code_scanning, existingCodeScanningRule);
 
   return {
     name: updated.name,
@@ -1179,7 +1270,9 @@ export const __test = Object.freeze({
   compareBranchBooleanSetting,
   compareBranchNullableSetting,
   buildBranchProtectionPayload,
-  resolveEnabledFlag
+  resolveEnabledFlag,
+  compareOptionalParameterizedRule,
+  normalizeOptionalRuleExpectation
 });
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));

--- a/tools/priority/policy.json
+++ b/tools/priority/policy.json
@@ -113,6 +113,9 @@
           "squash",
           "rebase"
         ]
+      },
+      "code_quality": {
+        "severity": "warnings"
       }
     },
     "8614140": {


### PR DESCRIPTION
## Summary
- add deterministic `Code Scanning` workflow for `pull_request`, `merge_group`, and `push` on `develop`/`main`
- run CodeQL with `security-and-quality` queries so code-quality results are emitted consistently
- extend policy seams to validate/apply optional ruleset rules (`code_quality`, `code_scanning`)
- enforce `develop` ruleset `code_quality.severity=warnings` in policy manifest and tests
- add a local pre-push PSScriptAnalyzer gate for changed PowerShell files (graceful skip when module is absent)

## Validation
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios`
- `node tools/npm/run-script.mjs priority:policy:apply`
- `node tools/npm/run-script.mjs priority:policy:sync`

Closes #811
