### PR TITLE
feat: emit deployment canary incident artifact in Validate (#811)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -401,12 +401,33 @@ jobs:
           --run-id "${{ github.run_id }}" \
           --sha "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}" \
           --report tests/results/_agent/deployments/validation-deployment-determinism.json
+    - name: Normalize deployment determinism canary event
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+        report_path="tests/results/_agent/deployments/validation-deployment-determinism.json"
+        if [ ! -f "$report_path" ]; then
+          echo "::warning::Deployment determinism report missing at $report_path; skipping canary normalization."
+          exit 0
+        fi
+        node tools/npm/run-script.mjs priority:event:ingest -- \
+          --source-type deployment-state \
+          --input "$report_path" \
+          --report tests/results/_agent/canary/validation-deployment-incident-event.json
     - name: Upload deployment determinism report
       if: always()
       uses: actions/upload-artifact@v5
       with:
         name: validate-deployment-determinism
         path: tests/results/_agent/deployments/validation-deployment-determinism.json
+    - name: Upload deployment determinism canary event report
+      if: always()
+      uses: actions/upload-artifact@v5
+      with:
+        name: validate-deployment-determinism-event
+        path: tests/results/_agent/canary/validation-deployment-incident-event.json
+        if-no-files-found: warn
   fixtures:
     runs-on: [self-hosted, Windows, X64]
     env:

--- a/tools/priority/__tests__/validate-deployment-canary-contract.test.mjs
+++ b/tools/priority/__tests__/validate-deployment-canary-contract.test.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('Validate deployment-determinism lane emits normalized deployment-state incident event artifact', () => {
+  const workflow = readRepoFile('.github/workflows/validate.yml');
+  assert.match(workflow, /name:\s+Normalize deployment determinism canary event/);
+  assert.ok(workflow.includes('priority:event:ingest -- \\'));
+  assert.match(workflow, /--source-type deployment-state/);
+  assert.match(workflow, /--input \"\$report_path\"/);
+  assert.match(workflow, /tests\/results\/_agent\/canary\/validation-deployment-incident-event\.json/);
+});
+
+test('Validate deployment-determinism lane uploads canary event artifact', () => {
+  const workflow = readRepoFile('.github/workflows/validate.yml');
+  assert.match(workflow, /name:\s+Upload deployment determinism canary event report/);
+  assert.match(workflow, /name:\s+validate-deployment-determinism-event/);
+  assert.match(workflow, /if-no-files-found:\s+warn/);
+});


### PR DESCRIPTION
## Summary
- normalize `deployment-determinism` output into an `incident-event@v1` artifact in Validate
- add deterministic upload artifact for deployment canary event evidence
- add workflow contract test to prevent regressions in deployment canary emission wiring

## Validation
- `node --test tools/priority/__tests__/validate-deployment-canary-contract.test.mjs tools/priority/__tests__/event-ingest.test.mjs tools/priority/__tests__/event-ingest-schema.test.mjs`
- `./bin/actionlint -color`

Refs #811
