### PR TITLE
Update for standing priority #811

### DIFF
--- a/.github/workflows/issue-milestone-hygiene.yml
+++ b/.github/workflows/issue-milestone-hygiene.yml
@@ -1,0 +1,154 @@
+name: Issue Milestone Hygiene
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - unlabeled
+      - milestoned
+      - demilestoned
+  schedule:
+    - cron: '25 * * * *'
+  workflow_dispatch:
+    inputs:
+      apply_default_milestone:
+        description: 'Assign default milestone to violating issues'
+        required: false
+        default: false
+        type: boolean
+      create_default_milestone:
+        description: 'Create default milestone if missing during apply mode'
+        required: false
+        default: false
+        type: boolean
+      default_milestone:
+        description: 'Default milestone title override'
+        required: false
+        type: string
+      default_milestone_due_on:
+        description: 'ISO-8601 due date when creating default milestone'
+        required: false
+        type: string
+      warn_only:
+        description: 'Warn only (do not fail)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  issue-milestone-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Evaluate milestone hygiene policy
+        shell: bash
+        env:
+          REPO_SLUG: ${{ github.repository }}
+          APPLY_INPUT: ${{ inputs.apply_default_milestone }}
+          CREATE_INPUT: ${{ inputs.create_default_milestone }}
+          DEFAULT_INPUT: ${{ inputs.default_milestone }}
+          DUE_INPUT: ${{ inputs.default_milestone_due_on }}
+          WARN_INPUT: ${{ inputs.warn_only }}
+          APPLY_VAR: ${{ vars.MILESTONE_HYGIENE_APPLY_DEFAULT || '0' }}
+          CREATE_VAR: ${{ vars.MILESTONE_HYGIENE_CREATE_DEFAULT || '0' }}
+          DEFAULT_VAR: ${{ vars.MILESTONE_HYGIENE_DEFAULT_MILESTONE || '' }}
+          DUE_VAR: ${{ vars.MILESTONE_HYGIENE_DEFAULT_MILESTONE_DUE_ON || '' }}
+          WARN_VAR: ${{ vars.MILESTONE_HYGIENE_WARN_ONLY || '0' }}
+        run: |
+          set -euo pipefail
+          args=(
+            "tools/npm/run-script.mjs"
+            "priority:milestone:hygiene"
+            "--"
+            "--repo" "$REPO_SLUG"
+            "--report" "tests/results/_agent/issue/milestone-hygiene-report.json"
+          )
+
+          warn_effective="${WARN_INPUT:-}"
+          if [[ -z "$warn_effective" || "$warn_effective" == "false" ]]; then
+            warn_effective="${WARN_VAR:-0}"
+          fi
+          warn_effective="$(echo "$warn_effective" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$warn_effective" == "1" || "$warn_effective" == "true" || "$warn_effective" == "yes" || "$warn_effective" == "on" ]]; then
+            args+=("--warn-only")
+          fi
+
+          default_effective="${DEFAULT_INPUT:-}"
+          if [[ -z "$default_effective" ]]; then
+            default_effective="${DEFAULT_VAR:-}"
+          fi
+          if [[ -n "$default_effective" ]]; then
+            args+=("--default-milestone" "$default_effective")
+          fi
+
+          due_effective="${DUE_INPUT:-}"
+          if [[ -z "$due_effective" ]]; then
+            due_effective="${DUE_VAR:-}"
+          fi
+          if [[ -n "$due_effective" ]]; then
+            args+=("--default-milestone-due-on" "$due_effective")
+          fi
+
+          apply_effective="${APPLY_INPUT:-}"
+          if [[ -z "$apply_effective" || "$apply_effective" == "false" ]]; then
+            apply_effective="${APPLY_VAR:-0}"
+          fi
+          apply_effective="$(echo "$apply_effective" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$apply_effective" == "1" || "$apply_effective" == "true" || "$apply_effective" == "yes" || "$apply_effective" == "on" ]]; then
+            args+=("--apply-default-milestone")
+          fi
+
+          create_effective="${CREATE_INPUT:-}"
+          if [[ -z "$create_effective" || "$create_effective" == "false" ]]; then
+            create_effective="${CREATE_VAR:-0}"
+          fi
+          create_effective="$(echo "$create_effective" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$create_effective" == "1" || "$create_effective" == "true" || "$create_effective" == "yes" || "$create_effective" == "on" ]]; then
+            args+=("--create-default-milestone")
+          fi
+
+          node "${args[@]}"
+
+      - name: Append summary
+        if: always()
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const reportPath = 'tests/results/_agent/issue/milestone-hygiene-report.json';
+          if (!fs.existsSync(reportPath)) {
+            console.log('milestone hygiene report missing');
+            process.exit(0);
+          }
+          const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+          const remaining = report.summary?.remainingViolationCount ?? 0;
+          const lines = [
+            '## Issue Milestone Hygiene',
+            `- remaining violations: \`${remaining}\``,
+            `- required issues evaluated: \`${report.summary?.requiredIssueCount ?? 0}\``,
+            `- auto-assigned this run: \`${report.summary?.assignedDefaultMilestoneCount ?? 0}\``,
+            `- failed assignments: \`${report.summary?.failedAssignmentsCount ?? 0}\``,
+            `- default milestone created this run: \`${report.milestones?.createdDefaultMilestone ?? false}\``
+          ];
+          if (process.env.GITHUB_STEP_SUMMARY) {
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\\n')}\\n`);
+          }
+          console.log(lines.join('\\n'));
+          NODE
+
+      - name: Upload milestone hygiene report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: issue-milestone-hygiene-report
+          path: tests/results/_agent/issue/milestone-hygiene-report.json
+          if-no-files-found: warn

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -305,6 +305,11 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   missing or duplicate standing-priority labels fail fast and emit deterministic diagnostics:
   - `tests/results/_agent/issue/no-standing-priority.json`
   - `tests/results/_agent/issue/multiple-standing-priority.json`
+- Enforce milestone hygiene for `standing-priority` / `program` / `[P0|P1]` issues with
+  `node tools/npm/run-script.mjs priority:milestone:hygiene -- --repo <owner/repo>`.
+  Use `--apply-default-milestone --default-milestone <title>` for reconciliation and add
+  `--create-default-milestone --default-milestone-due-on <iso-8601>` when the default
+  milestone does not exist yet.
 - Use strict verification (`node tools/priority/check-policy.mjs --fail-on-skip`) when you need token/permission skips to
   fail deterministically (for example in upstream policy guard workflows).
 - Policy guard workflows resolve token candidates with

--- a/docs/schemas/issue-milestone-hygiene-report-v1.schema.json
+++ b/docs/schemas/issue-milestone-hygiene-report-v1.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comparevi.dev/schemas/issue-milestone-hygiene-report-v1.schema.json",
+  "title": "Issue Milestone Hygiene Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAt",
+    "repository",
+    "state",
+    "flags",
+    "policy",
+    "milestones",
+    "summary",
+    "violations",
+    "reconciliations"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/issue-milestone-hygiene-report@v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$"
+    },
+    "state": {
+      "enum": ["open", "all"]
+    },
+    "flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "applyDefaultMilestone",
+        "warnOnly",
+        "requireOpenMilestone",
+        "createDefaultMilestone"
+      ],
+      "properties": {
+        "applyDefaultMilestone": { "type": "boolean" },
+        "warnOnly": { "type": "boolean" },
+        "requireOpenMilestone": { "type": "boolean" },
+        "createDefaultMilestone": { "type": "boolean" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "requiredLabels",
+        "titlePriorityPattern",
+        "defaultMilestone",
+        "defaultMilestoneDueOn"
+      ],
+      "properties": {
+        "path": { "type": "string" },
+        "requiredLabels": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "titlePriorityPattern": { "type": "string" },
+        "defaultMilestone": { "type": ["string", "null"] },
+        "defaultMilestoneDueOn": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    },
+    "milestones": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalCount",
+        "openCount",
+        "closedCount",
+        "defaultMilestone",
+        "createdDefaultMilestone"
+      ],
+      "properties": {
+        "totalCount": { "type": "integer", "minimum": 0 },
+        "openCount": { "type": "integer", "minimum": 0 },
+        "closedCount": { "type": "integer", "minimum": 0 },
+        "createdDefaultMilestone": { "type": "boolean" },
+        "defaultMilestone": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "required": ["number", "title", "state", "dueOn"],
+          "properties": {
+            "number": { "type": "integer", "minimum": 1 },
+            "title": { "type": "string" },
+            "state": { "type": ["string", "null"] },
+            "dueOn": { "type": ["string", "null"], "format": "date-time" }
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issueCount",
+        "requiredIssueCount",
+        "triggerCounts",
+        "initialViolationCount",
+        "remainingViolationCount",
+        "remainingReasonCounts",
+        "assignedDefaultMilestoneCount",
+        "failedAssignmentsCount"
+      ],
+      "properties": {
+        "issueCount": { "type": "integer", "minimum": 0 },
+        "requiredIssueCount": { "type": "integer", "minimum": 0 },
+        "triggerCounts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "initialViolationCount": { "type": "integer", "minimum": 0 },
+        "remainingViolationCount": { "type": "integer", "minimum": 0 },
+        "remainingReasonCounts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "assignedDefaultMilestoneCount": { "type": "integer", "minimum": 0 },
+        "failedAssignmentsCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/issueEvaluation"
+      }
+    },
+    "reconciliations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "number",
+          "status",
+          "reason",
+          "previousMilestone",
+          "milestone",
+          "milestoneNumber",
+          "triggers"
+        ],
+        "properties": {
+          "number": { "type": "integer", "minimum": 1 },
+          "status": { "enum": ["assigned", "failed"] },
+          "reason": { "type": ["string", "null"] },
+          "previousMilestone": { "type": ["string", "null"] },
+          "milestone": { "type": "string" },
+          "milestoneNumber": { "type": "integer", "minimum": 1 },
+          "triggers": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "error": { "type": "string" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "issueEvaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "title",
+        "url",
+        "labels",
+        "milestone",
+        "milestoneNumber",
+        "milestoneState",
+        "triggers",
+        "requiresMilestone",
+        "isViolation",
+        "reason"
+      ],
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "title": { "type": "string" },
+        "url": { "type": ["string", "null"] },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "milestone": { "type": ["string", "null"] },
+        "milestoneNumber": { "type": ["integer", "null"], "minimum": 1 },
+        "milestoneState": { "type": ["string", "null"] },
+        "triggers": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "requiresMilestone": { "type": "boolean" },
+        "isViolation": { "type": "boolean" },
+        "reason": {
+          "type": ["string", "null"],
+          "enum": ["missing-milestone", "closed-milestone", null]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "priority:policy:sync": "pwsh -NoLogo -NoProfile -File tools/priority/Sync-BranchProtectionPolicy.ps1",
     "priority:pr": "node tools/priority/create-pr.mjs",
     "priority:release": "pwsh -NoLogo -NoProfile -File tools/priority/Simulate-Release.ps1",
+    "priority:milestone:hygiene": "node tools/priority/check-issue-milestones.mjs",
     "priority:schema": "node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/standing-priority-issue-v1.schema.json --data tests/results/_agent/issue/[0-9]*.json --optional",
     "priority:show": "node -e \"console.log(require('fs').readFileSync('tests/results/_agent/issue/router.json','utf8'))\"",
     "priority:safe-git:trend": "node tools/priority/summarize-safe-git-telemetry.mjs",

--- a/tools/policy/issue-milestone-hygiene.json
+++ b/tools/policy/issue-milestone-hygiene.json
@@ -1,0 +1,15 @@
+{
+  "schema": "issue-milestone-hygiene-policy@v1",
+  "required": {
+    "labels": [
+      "standing-priority",
+      "program"
+    ],
+    "titlePriorityPattern": "\\[(P0|P1)\\]",
+    "requireOpenMilestone": true
+  },
+  "defaultMilestone": null,
+  "defaultMilestoneDueOn": null,
+  "warnOnly": false,
+  "createDefaultMilestone": false
+}

--- a/tools/priority/__tests__/issue-milestone-hygiene-schema.test.mjs
+++ b/tools/priority/__tests__/issue-milestone-hygiene-schema.test.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { runMilestoneHygiene } from '../check-issue-milestones.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function makeRunGhJson({ issues, milestones, createdMilestone }) {
+  return (args) => {
+    if (args[0] === 'issue' && args[1] === 'list') {
+      return issues;
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/milestones')) {
+      if (args.includes('--method') && args.includes('POST')) {
+        return [createdMilestone];
+      }
+      return milestones;
+    }
+    throw new Error(`Unexpected gh json invocation: ${args.join(' ')}`);
+  };
+}
+
+test('issue milestone hygiene schema validates generated report and asserts labels/flags coverage', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'issue-milestone-hygiene-report-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'milestone-hygiene-schema-'));
+  const outputPath = path.join(tmpDir, 'report.json');
+
+  const result = await runMilestoneHygiene({
+    argv: [
+      '--repo',
+      'example/repo',
+      '--apply-default-milestone',
+      '--default-milestone',
+      'Program Q2',
+      '--default-milestone-due-on',
+      '2026-06-30T00:00:00Z',
+      '--create-default-milestone',
+      '--report',
+      outputPath
+    ],
+    now: new Date('2026-03-06T12:00:00Z'),
+    loadPolicyFn: async () => ({
+      path: path.join(repoRoot, 'tools', 'policy', 'issue-milestone-hygiene.json'),
+      required: {
+        labels: ['standing-priority', 'program'],
+        titlePriorityPattern: String.raw`\[(P0|P1)\]`,
+        requireOpenMilestone: true
+      },
+      defaultMilestone: null,
+      defaultMilestoneDueOn: null,
+      warnOnly: false,
+      createDefaultMilestone: false
+    }),
+    runGhJsonFn: makeRunGhJson({
+      issues: [
+        {
+          number: 701,
+          title: '[P1] milestone lane',
+          milestone: null,
+          labels: [{ name: 'program' }],
+          url: 'https://example.test/issues/701'
+        }
+      ],
+      milestones: [],
+      createdMilestone: {
+        number: 21,
+        title: 'Program Q2',
+        state: 'open',
+        due_on: '2026-06-30T00:00:00Z'
+      }
+    }),
+    runGhFn: () => ({ status: 0, stdout: '', stderr: '' })
+  });
+
+  assert.equal(result.exitCode, 0);
+
+  const report = JSON.parse(await readFile(outputPath, 'utf8'));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+
+  assert.equal(report.flags.createDefaultMilestone, true);
+  assert.equal(report.flags.applyDefaultMilestone, true);
+  assert.equal(report.policy.requiredLabels.includes('program'), true);
+  assert.equal(report.reconciliations[0].triggers.includes('label:program'), true);
+  assert.equal(report.summary.triggerCounts['label:program'], 1);
+});

--- a/tools/priority/__tests__/issue-milestone-hygiene-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/issue-milestone-hygiene-workflow-contract.test.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('issue milestone hygiene workflow has deterministic trigger and artifact contract', () => {
+  const workflow = readRepoFile('.github/workflows/issue-milestone-hygiene.yml');
+
+  assert.match(workflow, /name:\s+Issue Milestone Hygiene/);
+  assert.match(workflow, /issues:\s*\n\s*types:/);
+  assert.match(workflow, /-\s*milestoned/);
+  assert.match(workflow, /-\s*demilestoned/);
+  assert.match(workflow, /schedule:\s*\n\s*-\s*cron:\s*'25 \* \* \* \*'/);
+  assert.match(workflow, /workflow_dispatch:/);
+
+  assert.match(workflow, /apply_default_milestone:/);
+  assert.match(workflow, /create_default_milestone:/);
+  assert.match(workflow, /default_milestone:/);
+  assert.match(workflow, /default_milestone_due_on:/);
+  assert.match(workflow, /warn_only:/);
+
+  assert.match(workflow, /issues:\s*write/);
+  assert.match(workflow, /priority:milestone:hygiene/);
+  assert.match(workflow, /--create-default-milestone/);
+  assert.match(workflow, /--default-milestone-due-on/);
+  assert.match(workflow, /tests\/results\/_agent\/issue\/milestone-hygiene-report\.json/);
+  assert.match(workflow, /uses:\s+actions\/upload-artifact@v5/);
+});

--- a/tools/priority/__tests__/issue-milestone-hygiene.test.mjs
+++ b/tools/priority/__tests__/issue-milestone-hygiene.test.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import {
+  DEFAULT_POLICY_PATH,
+  parseArgs,
+  normalizePolicy,
+  evaluateIssue,
+  runMilestoneHygiene
+} from '../check-issue-milestones.mjs';
+
+function makeRunGhJson({ issues = [], milestones = [], createdMilestone = null, calls = [] } = {}) {
+  return (args) => {
+    calls.push(args);
+    if (args[0] === 'issue' && args[1] === 'list') {
+      return issues;
+    }
+    if (args[0] === 'api' && String(args[1]).includes('/milestones')) {
+      if (args.includes('--method') && args.includes('POST')) {
+        return createdMilestone ? [createdMilestone] : [];
+      }
+      return milestones;
+    }
+    throw new Error(`Unexpected gh json invocation: ${args.join(' ')}`);
+  };
+}
+
+test('parseArgs uses repo from env and applies defaults', () => {
+  const parsed = parseArgs([], { GITHUB_REPOSITORY: 'example/repo' });
+  assert.equal(parsed.repo, 'example/repo');
+  assert.equal(parsed.policyPath, DEFAULT_POLICY_PATH);
+  assert.equal(parsed.state, 'open');
+  assert.equal(parsed.limit, 200);
+  assert.equal(parsed.applyDefaultMilestone, false);
+  assert.equal(parsed.createDefaultMilestone, false);
+  assert.equal(parsed.requireOpenMilestone, null);
+  assert.equal(parsed.warnOnly, null);
+});
+
+test('normalizePolicy applies defaults and validates required settings', () => {
+  const policy = normalizePolicy({});
+  assert.deepEqual(policy.required.labels, ['standing-priority', 'program']);
+  assert.equal(policy.required.titlePriorityPattern, String.raw`\[(P0|P1)\]`);
+  assert.equal(policy.required.requireOpenMilestone, true);
+  assert.equal(policy.defaultMilestone, null);
+  assert.equal(policy.defaultMilestoneDueOn, null);
+  assert.equal(policy.warnOnly, false);
+  assert.equal(policy.createDefaultMilestone, false);
+});
+
+test('evaluateIssue marks missing and closed milestone violations', () => {
+  const context = {
+    requiredLabels: ['standing-priority', 'program'],
+    titlePriorityPattern: String.raw`\[(P0|P1)\]`,
+    requireOpenMilestone: true,
+    milestonesByNumber: new Map([[7, { number: 7, title: 'Q1', state: 'closed' }]])
+  };
+
+  const missing = evaluateIssue(
+    {
+      number: 11,
+      title: '[P1] missing',
+      milestone: null,
+      labels: [{ name: 'ci' }],
+      url: 'https://example.test/issues/11'
+    },
+    context
+  );
+  assert.equal(missing.requiresMilestone, true);
+  assert.equal(missing.isViolation, true);
+  assert.equal(missing.reason, 'missing-milestone');
+
+  const closed = evaluateIssue(
+    {
+      number: 12,
+      title: '[P0] closed lane',
+      milestone: { number: 7, title: 'Q1' },
+      labels: [{ name: 'ci' }],
+      url: 'https://example.test/issues/12'
+    },
+    context
+  );
+  assert.equal(closed.requiresMilestone, true);
+  assert.equal(closed.isViolation, true);
+  assert.equal(closed.reason, 'closed-milestone');
+});
+
+test('runMilestoneHygiene fails when required issues have no milestone and emits report flags', async () => {
+  const writes = [];
+  const ghCalls = [];
+  const result = await runMilestoneHygiene({
+    argv: ['--repo', 'example/repo'],
+    loadPolicyFn: async () => ({
+      path: path.join(process.cwd(), 'tools', 'policy', 'issue-milestone-hygiene.json'),
+      required: {
+        labels: ['standing-priority', 'program'],
+        titlePriorityPattern: String.raw`\[(P0|P1)\]`,
+        requireOpenMilestone: true
+      },
+      defaultMilestone: null,
+      defaultMilestoneDueOn: null,
+      warnOnly: false,
+      createDefaultMilestone: false
+    }),
+    runGhJsonFn: makeRunGhJson({
+      issues: [
+        {
+          number: 101,
+          title: '[P1] missing milestone',
+          milestone: null,
+          labels: [{ name: 'ci' }],
+          url: 'https://example.test/issues/101'
+        }
+      ],
+      milestones: [{ number: 2, title: 'Program', state: 'open', dueOn: null }],
+      calls: ghCalls
+    }),
+    writeJsonReportFn: async (reportPath, payload) => {
+      writes.push({ reportPath, payload });
+      return reportPath;
+    }
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.report.flags.requireOpenMilestone, true);
+  assert.equal(result.report.summary.remainingViolationCount, 1);
+  assert.equal(result.report.summary.triggerCounts['title-priority'], 1);
+  assert.equal(writes.length, 1);
+  assert.equal(ghCalls.length >= 2, true);
+});
+
+test('runMilestoneHygiene assigns default milestone in apply mode', async () => {
+  const edits = [];
+  const result = await runMilestoneHygiene({
+    argv: [
+      '--repo',
+      'example/repo',
+      '--apply-default-milestone',
+      '--default-milestone',
+      'Backlog / Unscheduled'
+    ],
+    loadPolicyFn: async () => ({
+      path: path.join(process.cwd(), 'tools', 'policy', 'issue-milestone-hygiene.json'),
+      required: {
+        labels: ['standing-priority', 'program'],
+        titlePriorityPattern: String.raw`\[(P0|P1)\]`,
+        requireOpenMilestone: true
+      },
+      defaultMilestone: null,
+      defaultMilestoneDueOn: null,
+      warnOnly: false,
+      createDefaultMilestone: false
+    }),
+    runGhJsonFn: makeRunGhJson({
+      issues: [
+        {
+          number: 111,
+          title: '[P0] needs assignment',
+          milestone: null,
+          labels: [{ name: 'ci' }],
+          url: 'https://example.test/issues/111'
+        }
+      ],
+      milestones: [{ number: 12, title: 'Backlog / Unscheduled', state: 'open', dueOn: null }]
+    }),
+    runGhFn: (args) => {
+      edits.push(args);
+      return { status: 0, stdout: '', stderr: '' };
+    },
+    writeJsonReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.summary.initialViolationCount, 1);
+  assert.equal(result.report.summary.remainingViolationCount, 0);
+  assert.equal(result.report.summary.assignedDefaultMilestoneCount, 1);
+  assert.equal(result.report.milestones.createdDefaultMilestone, false);
+  assert.equal(edits.length, 1);
+  assert.deepEqual(edits[0], [
+    'issue',
+    'edit',
+    '111',
+    '--repo',
+    'example/repo',
+    '--milestone',
+    'Backlog / Unscheduled'
+  ]);
+});
+
+test('runMilestoneHygiene creates missing default milestone when requested', async () => {
+  const ghCalls = [];
+  const edits = [];
+  const result = await runMilestoneHygiene({
+    argv: [
+      '--repo',
+      'example/repo',
+      '--apply-default-milestone',
+      '--default-milestone',
+      'Program Q2',
+      '--default-milestone-due-on',
+      '2026-06-30T00:00:00Z',
+      '--create-default-milestone'
+    ],
+    loadPolicyFn: async () => ({
+      path: path.join(process.cwd(), 'tools', 'policy', 'issue-milestone-hygiene.json'),
+      required: {
+        labels: ['standing-priority', 'program'],
+        titlePriorityPattern: String.raw`\[(P0|P1)\]`,
+        requireOpenMilestone: true
+      },
+      defaultMilestone: null,
+      defaultMilestoneDueOn: null,
+      warnOnly: false,
+      createDefaultMilestone: false
+    }),
+    runGhJsonFn: makeRunGhJson({
+      issues: [
+        {
+          number: 201,
+          title: '[P1] needs milestone',
+          milestone: null,
+          labels: [{ name: 'program' }],
+          url: 'https://example.test/issues/201'
+        }
+      ],
+      milestones: [],
+      createdMilestone: {
+        number: 33,
+        title: 'Program Q2',
+        state: 'open',
+        due_on: '2026-06-30T00:00:00Z'
+      },
+      calls: ghCalls
+    }),
+    runGhFn: (args) => {
+      edits.push(args);
+      return { status: 0, stdout: '', stderr: '' };
+    },
+    writeJsonReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.milestones.createdDefaultMilestone, true);
+  assert.equal(result.report.policy.defaultMilestoneDueOn, '2026-06-30T00:00:00Z');
+  assert.equal(result.report.summary.assignedDefaultMilestoneCount, 1);
+  assert.equal(ghCalls.some((args) => args.includes('--method') && args.includes('POST')), true);
+  assert.equal(edits.length, 1);
+});
+
+test('runMilestoneHygiene rejects closed default milestone in strict mode', async () => {
+  await assert.rejects(
+    runMilestoneHygiene({
+      argv: [
+        '--repo',
+        'example/repo',
+        '--apply-default-milestone',
+        '--default-milestone',
+        'Program Closed'
+      ],
+      loadPolicyFn: async () => ({
+        path: path.join(process.cwd(), 'tools', 'policy', 'issue-milestone-hygiene.json'),
+        required: {
+          labels: ['standing-priority', 'program'],
+          titlePriorityPattern: String.raw`\[(P0|P1)\]`,
+          requireOpenMilestone: true
+        },
+        defaultMilestone: null,
+        defaultMilestoneDueOn: null,
+        warnOnly: false,
+        createDefaultMilestone: false
+      }),
+      runGhJsonFn: makeRunGhJson({
+        issues: [],
+        milestones: [{ number: 44, title: 'Program Closed', state: 'closed', dueOn: null }]
+      })
+    }),
+    /closed/
+  );
+});

--- a/tools/priority/check-issue-milestones.mjs
+++ b/tools/priority/check-issue-milestones.mjs
@@ -1,0 +1,647 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_POLICY_PATH = path.join('tools', 'policy', 'issue-milestone-hygiene.json');
+export const DEFAULT_REPORT_PATH = path.join('tests', 'results', '_agent', 'issue', 'milestone-hygiene-report.json');
+export const DEFAULT_REQUIRED_LABELS = ['standing-priority', 'program'];
+export const DEFAULT_TITLE_PRIORITY_PATTERN = String.raw`\[(P0|P1)\]`;
+export const DEFAULT_REQUIRE_OPEN_MILESTONE = true;
+export const REPORT_SCHEMA = 'priority/issue-milestone-hygiene-report@v1';
+
+function normalizeText(value) {
+  if (value == null) return null;
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeLabel(name) {
+  const normalized = normalizeText(name);
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+function parseList(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((entry) => normalizeLabel(entry))
+    .filter(Boolean);
+}
+
+function resolveRepository(argvRepo, env = process.env) {
+  const fromCli = normalizeText(argvRepo);
+  if (fromCli) return fromCli;
+  const fromEnv = normalizeText(env.GITHUB_REPOSITORY);
+  if (fromEnv) return fromEnv;
+  throw new Error('Repository slug is required. Pass --repo <owner/repo> or set GITHUB_REPOSITORY.');
+}
+
+function parseBooleanLike(value) {
+  if (typeof value === 'boolean') return value;
+  const normalized = normalizeText(value);
+  if (!normalized) return false;
+  const lowered = normalized.toLowerCase();
+  return lowered === '1' || lowered === 'true' || lowered === 'yes' || lowered === 'on';
+}
+
+function normalizeMilestoneState(value) {
+  const normalized = normalizeText(value);
+  if (!normalized) return null;
+  const lowered = normalized.toLowerCase();
+  if (lowered === 'open' || lowered === 'closed') return lowered;
+  return lowered;
+}
+
+function isValidDateTime(value) {
+  const normalized = normalizeText(value);
+  if (!normalized) return true;
+  return !Number.isNaN(Date.parse(normalized));
+}
+
+export function parseArgs(argv = process.argv.slice(2), env = process.env) {
+  const args = Array.from(argv ?? []);
+  const options = {
+    repo: null,
+    state: 'open',
+    limit: 200,
+    policyPath: DEFAULT_POLICY_PATH,
+    requiredLabels: null,
+    titlePriorityPattern: null,
+    requireOpenMilestone: null,
+    reportPath: DEFAULT_REPORT_PATH,
+    defaultMilestone: null,
+    defaultMilestoneDueOn: null,
+    applyDefaultMilestone: false,
+    createDefaultMilestone: false,
+    warnOnly: null,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--apply-default-milestone') {
+      options.applyDefaultMilestone = true;
+      continue;
+    }
+    if (token === '--create-default-milestone') {
+      options.createDefaultMilestone = true;
+      continue;
+    }
+    if (token === '--allow-closed-milestone') {
+      options.requireOpenMilestone = false;
+      continue;
+    }
+    if (token === '--warn-only') {
+      options.warnOnly = true;
+      continue;
+    }
+
+    if (
+      token === '--repo' ||
+      token === '--state' ||
+      token === '--limit' ||
+      token === '--policy' ||
+      token === '--required-labels' ||
+      token === '--title-priority-pattern' ||
+      token === '--default-milestone' ||
+      token === '--default-milestone-due-on' ||
+      token === '--report'
+    ) {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--repo') options.repo = normalizeText(next);
+      if (token === '--state') options.state = String(next).trim().toLowerCase();
+      if (token === '--limit') {
+        const parsed = Number(next);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new Error(`Invalid --limit value: ${next}`);
+        }
+        options.limit = parsed;
+      }
+      if (token === '--policy') options.policyPath = next;
+      if (token === '--required-labels') options.requiredLabels = parseList(next);
+      if (token === '--title-priority-pattern') options.titlePriorityPattern = String(next);
+      if (token === '--default-milestone') options.defaultMilestone = normalizeText(next);
+      if (token === '--default-milestone-due-on') options.defaultMilestoneDueOn = normalizeText(next);
+      if (token === '--report') options.reportPath = next;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (options.help) {
+    return options;
+  }
+
+  options.repo = resolveRepository(options.repo, env);
+  if (options.state !== 'open' && options.state !== 'all') {
+    throw new Error(`Invalid --state '${options.state}'. Supported values: open|all`);
+  }
+  if (!isValidDateTime(options.defaultMilestoneDueOn)) {
+    throw new Error(`Invalid --default-milestone-due-on value '${options.defaultMilestoneDueOn}'. Use ISO-8601 date/time.`);
+  }
+  return options;
+}
+
+export function normalizePolicy(rawPolicy) {
+  const raw = rawPolicy && typeof rawPolicy === 'object' ? rawPolicy : {};
+  const required = raw.required && typeof raw.required === 'object' ? raw.required : {};
+
+  const labels = Array.isArray(required.labels)
+    ? required.labels.map((entry) => normalizeLabel(entry)).filter(Boolean)
+    : [...DEFAULT_REQUIRED_LABELS];
+  const requiredLabels = labels.length > 0 ? [...new Set(labels)] : [...DEFAULT_REQUIRED_LABELS];
+
+  const titlePriorityPattern = normalizeText(required.titlePriorityPattern) ?? DEFAULT_TITLE_PRIORITY_PATTERN;
+  try {
+    // Validate regex once at policy parse time.
+    // eslint-disable-next-line no-new
+    new RegExp(titlePriorityPattern, 'i');
+  } catch (error) {
+    throw new Error(`Invalid policy required.titlePriorityPattern: ${error.message}`);
+  }
+
+  const requireOpenMilestone = required.requireOpenMilestone == null
+    ? DEFAULT_REQUIRE_OPEN_MILESTONE
+    : parseBooleanLike(required.requireOpenMilestone);
+
+  const defaultMilestoneDueOn = normalizeText(raw.defaultMilestoneDueOn);
+  if (!isValidDateTime(defaultMilestoneDueOn)) {
+    throw new Error(`Invalid policy defaultMilestoneDueOn '${defaultMilestoneDueOn}'. Use ISO-8601 date/time.`);
+  }
+
+  return {
+    schema: normalizeText(raw.schema) ?? 'issue-milestone-hygiene-policy@v1',
+    required: {
+      labels: requiredLabels,
+      titlePriorityPattern,
+      requireOpenMilestone
+    },
+    defaultMilestone: normalizeText(raw.defaultMilestone),
+    defaultMilestoneDueOn,
+    warnOnly: parseBooleanLike(raw.warnOnly),
+    createDefaultMilestone: parseBooleanLike(raw.createDefaultMilestone)
+  };
+}
+
+export async function loadPolicy(policyPath, { readFileFn = readFile } = {}) {
+  const resolved = path.resolve(policyPath);
+  const raw = await readFileFn(resolved, 'utf8');
+  return {
+    path: resolved,
+    ...normalizePolicy(JSON.parse(raw))
+  };
+}
+
+function runGh(args, { cwd = process.cwd(), spawnSyncFn = spawnSync } = {}) {
+  const result = spawnSyncFn('gh', args, { cwd, encoding: 'utf8', shell: false });
+  if (result?.error?.code === 'ENOENT') {
+    throw new Error('GitHub CLI (gh) is required but was not found in PATH.');
+  }
+  return result;
+}
+
+function runGhJson(args, context = {}) {
+  const result = runGh(args, context);
+  if (result.status !== 0) {
+    const details = normalizeText(result.stderr) ?? normalizeText(result.stdout) ?? 'unknown error';
+    throw new Error(`gh ${args.join(' ')} failed: ${details}`);
+  }
+  const raw = normalizeText(result.stdout);
+  if (!raw) return [];
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function issueLabelNames(issue) {
+  if (!Array.isArray(issue?.labels)) return [];
+  return issue.labels
+    .map((entry) => (typeof entry === 'string' ? entry : entry?.name))
+    .map((entry) => normalizeLabel(entry))
+    .filter(Boolean);
+}
+
+function milestoneCatalogFromApi(items = []) {
+  return items
+    .map((milestone) => ({
+      number: Number.isInteger(milestone?.number) ? milestone.number : null,
+      title: normalizeText(milestone?.title),
+      state: normalizeMilestoneState(milestone?.state),
+      dueOn: normalizeText(milestone?.due_on ?? milestone?.dueOn)
+    }))
+    .filter((milestone) => milestone.number != null && milestone.title);
+}
+
+function buildMilestoneMaps(milestones = []) {
+  const byNumber = new Map();
+  const byTitle = new Map();
+  for (const milestone of milestones) {
+    byNumber.set(milestone.number, milestone);
+    byTitle.set(milestone.title.toLowerCase(), milestone);
+  }
+  return { byNumber, byTitle };
+}
+
+function listMilestonesForState(repo, state, runGhJsonFn) {
+  return runGhJsonFn(
+    ['api', `repos/${repo}/milestones`, '--method', 'GET', '-f', `state=${state}`, '-f', 'per_page=100'],
+    { cwd: process.cwd() }
+  );
+}
+
+function listMilestones(repo, runGhJsonFn) {
+  const openRows = listMilestonesForState(repo, 'open', runGhJsonFn);
+  const closedRows = listMilestonesForState(repo, 'closed', runGhJsonFn);
+  const combined = [...openRows, ...closedRows];
+  const seen = new Set();
+  const unique = [];
+  for (const row of combined) {
+    const number = Number.isInteger(row?.number) ? row.number : null;
+    if (number == null || seen.has(number)) continue;
+    seen.add(number);
+    unique.push(row);
+  }
+  return unique;
+}
+
+function summarizeMilestones(milestones = []) {
+  let openCount = 0;
+  let closedCount = 0;
+  for (const milestone of milestones) {
+    if (milestone.state === 'open') openCount += 1;
+    if (milestone.state === 'closed') closedCount += 1;
+  }
+  return {
+    totalCount: milestones.length,
+    openCount,
+    closedCount
+  };
+}
+
+function buildTriggerCounts(entries) {
+  const counts = {};
+  for (const entry of entries) {
+    for (const trigger of entry.triggers) {
+      counts[trigger] = (counts[trigger] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+async function writeJsonReport(reportPath, payload) {
+  const resolved = path.resolve(reportPath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export function evaluateIssue(issue, {
+  requiredLabels,
+  titlePriorityPattern,
+  requireOpenMilestone,
+  milestonesByNumber = new Map()
+}) {
+  const labels = issueLabelNames(issue);
+  const title = normalizeText(issue?.title) ?? '';
+  const milestoneTitle = normalizeText(issue?.milestone?.title);
+  const milestoneNumber = Number.isInteger(issue?.milestone?.number) ? issue.milestone.number : null;
+  const mappedMilestone = milestoneNumber != null ? milestonesByNumber.get(milestoneNumber) : null;
+  const milestoneState = normalizeMilestoneState(mappedMilestone?.state ?? issue?.milestone?.state);
+  const triggers = [];
+
+  for (const label of requiredLabels) {
+    if (labels.includes(label)) {
+      triggers.push(`label:${label}`);
+    }
+  }
+
+  const priorityRegex = new RegExp(titlePriorityPattern, 'i');
+  if (priorityRegex.test(title)) {
+    triggers.push('title-priority');
+  }
+
+  const requiresMilestone = triggers.length > 0;
+  const hasMilestone = Boolean(milestoneTitle);
+  let reason = null;
+  if (requiresMilestone && !hasMilestone) {
+    reason = 'missing-milestone';
+  } else if (requiresMilestone && requireOpenMilestone && milestoneState === 'closed') {
+    reason = 'closed-milestone';
+  }
+  const isViolation = reason !== null;
+
+  return {
+    number: Number(issue?.number),
+    title,
+    url: normalizeText(issue?.url),
+    labels,
+    milestone: milestoneTitle,
+    milestoneNumber,
+    milestoneState,
+    triggers,
+    requiresMilestone,
+    isViolation,
+    reason
+  };
+}
+
+async function resolveDefaultMilestone({
+  repo,
+  defaultMilestoneTitle,
+  defaultMilestoneDueOn,
+  requireOpenMilestone,
+  createDefaultMilestone,
+  milestones,
+  runGhJsonFn
+}) {
+  const wanted = normalizeText(defaultMilestoneTitle);
+  if (!wanted) {
+    throw new Error('Default milestone is required when --apply-default-milestone is set.');
+  }
+
+  const { byTitle } = buildMilestoneMaps(milestones);
+  const existing = byTitle.get(wanted.toLowerCase()) ?? null;
+  if (existing) {
+    if (requireOpenMilestone && existing.state === 'closed') {
+      throw new Error(`Default milestone '${wanted}' is closed; reopen it or use --allow-closed-milestone.`);
+    }
+    return { milestone: existing, created: false };
+  }
+
+  if (!createDefaultMilestone) {
+    throw new Error(`Default milestone '${wanted}' was not found. Set --create-default-milestone to create it.`);
+  }
+
+  const createArgs = ['api', `repos/${repo}/milestones`, '--method', 'POST', '-f', `title=${wanted}`];
+  if (defaultMilestoneDueOn) {
+    createArgs.push('-f', `due_on=${defaultMilestoneDueOn}`);
+  }
+
+  const createdRows = runGhJsonFn(createArgs, { cwd: process.cwd() });
+  const created = milestoneCatalogFromApi(createdRows)[0] ?? null;
+  if (!created) {
+    throw new Error(`Failed to create default milestone '${wanted}'.`);
+  }
+  if (requireOpenMilestone && created.state === 'closed') {
+    throw new Error(`Created default milestone '${wanted}' is closed; cannot use for reconciliation.`);
+  }
+
+  return { milestone: created, created: true };
+}
+
+export async function runMilestoneHygiene({
+  argv = process.argv.slice(2),
+  env = process.env,
+  now = new Date(),
+  runGhJsonFn = runGhJson,
+  runGhFn = runGh,
+  loadPolicyFn = loadPolicy,
+  writeJsonReportFn = writeJsonReport
+} = {}) {
+  const options = parseArgs(argv, env);
+  if (options.help) {
+    return { exitCode: 0, report: null, reportPath: null, help: true };
+  }
+
+  const policy = await loadPolicyFn(options.policyPath);
+  const requiredLabels = options.requiredLabels ?? policy.required.labels;
+  const titlePriorityPattern = options.titlePriorityPattern ?? policy.required.titlePriorityPattern;
+  const requireOpenMilestone = options.requireOpenMilestone == null
+    ? policy.required.requireOpenMilestone
+    : Boolean(options.requireOpenMilestone);
+  const warnOnly = options.warnOnly === null ? policy.warnOnly : Boolean(options.warnOnly);
+  const defaultMilestoneTitle = options.defaultMilestone ?? policy.defaultMilestone;
+  const defaultMilestoneDueOn = options.defaultMilestoneDueOn ?? policy.defaultMilestoneDueOn;
+  const createDefaultMilestone = options.createDefaultMilestone || policy.createDefaultMilestone;
+
+  if (!isValidDateTime(defaultMilestoneDueOn)) {
+    throw new Error(`Invalid default milestone due date '${defaultMilestoneDueOn}'. Use ISO-8601 date/time.`);
+  }
+  if (options.applyDefaultMilestone && !defaultMilestoneTitle) {
+    throw new Error('Default milestone is required when --apply-default-milestone is set.');
+  }
+
+  const issues = runGhJsonFn(
+    [
+      'issue',
+      'list',
+      '--repo',
+      options.repo,
+      '--state',
+      options.state,
+      '--limit',
+      String(options.limit),
+      '--json',
+      'number,title,milestone,labels,url'
+    ],
+    { cwd: process.cwd() }
+  );
+
+  const milestoneRows = listMilestones(options.repo, runGhJsonFn);
+  const milestones = milestoneCatalogFromApi(milestoneRows);
+  const milestoneMaps = buildMilestoneMaps(milestones);
+
+  let defaultMilestone = null;
+  let createdDefaultMilestone = null;
+  if (options.applyDefaultMilestone) {
+    const resolved = await resolveDefaultMilestone({
+      repo: options.repo,
+      defaultMilestoneTitle,
+      defaultMilestoneDueOn,
+      requireOpenMilestone,
+      createDefaultMilestone,
+      milestones,
+      runGhJsonFn
+    });
+    defaultMilestone = resolved.milestone;
+    if (resolved.created) {
+      createdDefaultMilestone = resolved.milestone;
+      milestones.push(resolved.milestone);
+      milestoneMaps.byNumber.set(resolved.milestone.number, resolved.milestone);
+      milestoneMaps.byTitle.set(resolved.milestone.title.toLowerCase(), resolved.milestone);
+    }
+  }
+
+  const evaluations = issues.map((issue) => evaluateIssue(issue, {
+    requiredLabels,
+    titlePriorityPattern,
+    requireOpenMilestone,
+    milestonesByNumber: milestoneMaps.byNumber
+  }));
+  const requiredIssues = evaluations.filter((entry) => entry.requiresMilestone);
+  const violations = evaluations.filter((entry) => entry.isViolation);
+  const triggerCounts = buildTriggerCounts(requiredIssues);
+
+  const reconciliations = [];
+  const remainingViolations = [];
+  for (const violation of violations) {
+    if (!options.applyDefaultMilestone) {
+      remainingViolations.push(violation);
+      continue;
+    }
+
+    const editResult = runGhFn(
+      [
+        'issue',
+        'edit',
+        String(violation.number),
+        '--repo',
+        options.repo,
+        '--milestone',
+        defaultMilestone.title
+      ],
+      { cwd: process.cwd() }
+    );
+
+    if (editResult.status === 0) {
+      reconciliations.push({
+        number: violation.number,
+        status: 'assigned',
+        reason: violation.reason,
+        previousMilestone: violation.milestone,
+        milestone: defaultMilestone.title,
+        milestoneNumber: defaultMilestone.number,
+        triggers: violation.triggers
+      });
+      continue;
+    }
+
+    const errorMessage = normalizeText(editResult.stderr) ?? normalizeText(editResult.stdout) ?? 'unknown error';
+    reconciliations.push({
+      number: violation.number,
+      status: 'failed',
+      reason: violation.reason,
+      previousMilestone: violation.milestone,
+      milestone: defaultMilestone.title,
+      milestoneNumber: defaultMilestone.number,
+      triggers: violation.triggers,
+      error: errorMessage
+    });
+    remainingViolations.push(violation);
+  }
+
+  const reasonCounts = remainingViolations.reduce((acc, entry) => {
+    const key = entry.reason ?? 'unknown';
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    schemaVersion: '1.0.0',
+    generatedAt: now.toISOString(),
+    repository: options.repo,
+    state: options.state,
+    flags: {
+      applyDefaultMilestone: options.applyDefaultMilestone,
+      warnOnly,
+      requireOpenMilestone,
+      createDefaultMilestone
+    },
+    policy: {
+      path: policy.path,
+      requiredLabels,
+      titlePriorityPattern,
+      defaultMilestone: defaultMilestoneTitle,
+      defaultMilestoneDueOn
+    },
+    milestones: {
+      ...summarizeMilestones(milestones),
+      defaultMilestone: defaultMilestone
+        ? {
+            number: defaultMilestone.number,
+            title: defaultMilestone.title,
+            state: defaultMilestone.state,
+            dueOn: defaultMilestone.dueOn ?? defaultMilestoneDueOn ?? null
+          }
+        : null,
+      createdDefaultMilestone: createdDefaultMilestone != null
+    },
+    summary: {
+      issueCount: evaluations.length,
+      requiredIssueCount: requiredIssues.length,
+      triggerCounts,
+      initialViolationCount: violations.length,
+      remainingViolationCount: remainingViolations.length,
+      remainingReasonCounts: reasonCounts,
+      assignedDefaultMilestoneCount: reconciliations.filter((entry) => entry.status === 'assigned').length,
+      failedAssignmentsCount: reconciliations.filter((entry) => entry.status === 'failed').length
+    },
+    violations: remainingViolations,
+    reconciliations
+  };
+
+  const reportPath = await writeJsonReportFn(options.reportPath, report);
+  const status = remainingViolations.length === 0 ? 'pass' : (warnOnly ? 'warn' : 'fail');
+  console.log(`[milestone-hygiene] report: ${reportPath}`);
+  console.log(
+    `[milestone-hygiene] status=${status} issues=${report.summary.issueCount} required=${report.summary.requiredIssueCount} remaining=${report.summary.remainingViolationCount}`
+  );
+  for (const entry of remainingViolations) {
+    const triggers = entry.triggers.join(',') || 'unknown';
+    console.log(`[milestone-hygiene] issue=#${entry.number} reason=${entry.reason} triggers=${triggers}`);
+  }
+  if (createdDefaultMilestone) {
+    console.log(
+      `[milestone-hygiene] created default milestone title=${createdDefaultMilestone.title} number=${createdDefaultMilestone.number}`
+    );
+  }
+  for (const entry of reconciliations) {
+    if (entry.status === 'assigned') {
+      console.log(`[milestone-hygiene] assigned default milestone issue=#${entry.number} milestone=${entry.milestone}`);
+    } else {
+      console.log(`[milestone-hygiene] failed to assign milestone issue=#${entry.number}: ${entry.error}`);
+    }
+  }
+
+  const exitCode = remainingViolations.length === 0 || warnOnly ? 0 : 1;
+  return { exitCode, report, reportPath, help: false };
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node tools/priority/check-issue-milestones.mjs [options]
+
+Options:
+  --repo <owner/repo>              Repository slug (defaults to GITHUB_REPOSITORY)
+  --state <open|all>               Issue state filter (default: open)
+  --limit <n>                      Max issues to evaluate (default: 200)
+  --policy <path>                  Policy file (default: ${DEFAULT_POLICY_PATH})
+  --required-labels <a,b,c>        Override policy labels requiring milestones
+  --title-priority-pattern <regex> Override policy title regex requiring milestones
+  --allow-closed-milestone         Permit closed milestones for required issues
+  --default-milestone <title>      Default milestone title for reconciliation mode
+  --default-milestone-due-on <iso> Due date used when creating a missing default milestone
+  --apply-default-milestone        Assign default milestone to violating issues
+  --create-default-milestone       Create missing default milestone in apply mode
+  --report <path>                  Report path (default: ${DEFAULT_REPORT_PATH})
+  --warn-only                      Emit warnings but do not fail
+  -h, --help                       Show this help`);
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  runMilestoneHygiene()
+    .then(({ exitCode, help }) => {
+      if (help) {
+        printHelp();
+      }
+      process.exit(exitCode);
+    })
+    .catch((error) => {
+      console.error(`[milestone-hygiene] ${error.message || error}`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add a milestone hygiene control lane (`priority:milestone:hygiene`) that enforces milestone requirements for `standing-priority`, `program`, and `[P0|P1]` issues
- add controlled reconciliation with optional default-milestone creation (`--create-default-milestone` + `--default-milestone-due-on`)
- add deterministic report schema + unit/contract/schema tests and a scheduled/issues workflow that uploads artifacts every run
- document operator usage in `docs/DEVELOPER_GUIDE.md`
- reconcile upstream open issues to `LabVIEW CI Platform v1 (2026Q2)` and verify remaining violations = 0

## Testing
- `node --test tools/priority/__tests__/issue-milestone-hygiene.test.mjs`
- `node --test tools/priority/__tests__/issue-milestone-hygiene-schema.test.mjs`
- `node --test tools/priority/__tests__/issue-milestone-hygiene-workflow-contract.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint -color`
- `node tools/npm/run-script.mjs priority:milestone:hygiene -- --repo LabVIEW-Community-CI-CD/compare-vi-cli-action --apply-default-milestone --default-milestone "LabVIEW CI Platform v1 (2026Q2)" --report tests/results/_agent/issue/milestone-hygiene-upstream-apply.json`
- `node tools/npm/run-script.mjs priority:milestone:hygiene -- --repo LabVIEW-Community-CI-CD/compare-vi-cli-action --limit 300 --report tests/results/_agent/issue/milestone-hygiene-upstream-verify.json --warn-only`

Closes #811
