### PR TITLE
fix: avoid false fail after standing auto-select (#797)

### DIFF
--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -13,6 +13,7 @@ import {
   buildMultipleStandingPriorityReport,
   buildNoStandingPriorityState,
   shouldRethrowStandingPriorityError,
+  shouldContinueAfterAutoSelectLaneEmpty,
   determinePrioritySyncExitCode,
   isStandingPriorityCacheCandidate,
   resolveStandingPriorityLabels,
@@ -199,6 +200,21 @@ test('shouldRethrowStandingPriorityError skips rethrow after successful auto-sel
   assert.equal(
     shouldRethrowStandingPriorityError(new Error('network failure'), { number: 797 }),
     true
+  );
+});
+
+test('shouldContinueAfterAutoSelectLaneEmpty allows transient empty lane after auto-select', () => {
+  assert.equal(
+    shouldContinueAfterAutoSelectLaneEmpty({ source: 'auto-select', number: 797 }, []),
+    true
+  );
+  assert.equal(
+    shouldContinueAfterAutoSelectLaneEmpty({ source: 'gh', number: 797 }, []),
+    false
+  );
+  assert.equal(
+    shouldContinueAfterAutoSelectLaneEmpty({ source: 'auto-select', number: 797 }, [797]),
+    false
   );
 });
 

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -1930,7 +1930,14 @@ export async function main(options = {}) {
     }
     const issueNumbers = Array.isArray(laneState.numbers) ? laneState.numbers : [];
     if (issueNumbers.length === 0) {
-      throw createNoStandingPriorityError(undefined, laneLabels);
+      const laneErr = createNoStandingPriorityError(undefined, laneLabels);
+      if (shouldContinueAfterAutoSelectLaneEmpty(standingPriority, issueNumbers)) {
+        console.warn(
+          `[priority] ${laneErr.message} Auto-select selected #${number}; continuing with resolved standing issue.`
+        );
+      } else {
+        throw laneErr;
+      }
     }
     if (issueNumbers.length > 1) {
       const message = `Multiple open issues found with labels ${formatStandingPriorityLabels(
@@ -1948,7 +1955,7 @@ export async function main(options = {}) {
       );
       throw createMultipleStandingPriorityError(message, laneLabels, issueNumbers);
     }
-    if (issueNumbers[0] !== number) {
+    if (issueNumbers.length > 0 && issueNumbers[0] !== number) {
       throw new Error(
         `Standing-priority lane mismatch: resolved issue #${number} but unique open standing issue is #${issueNumbers[0]}.`
       );
@@ -2077,6 +2084,14 @@ export function shouldRethrowStandingPriorityError(err, standingPriority) {
     return false;
   }
   return true;
+}
+
+export function shouldContinueAfterAutoSelectLaneEmpty(standingPriority, issueNumbers = []) {
+  return Boolean(
+    standingPriority?.source === 'auto-select' &&
+      Array.isArray(issueNumbers) &&
+      issueNumbers.length === 0
+  );
 }
 
 export function determinePrioritySyncExitCode(err, { failOnMissing = false, failOnMultiple = false } = {}) {


### PR DESCRIPTION
## Summary
- avoid rethrowing `NO_STANDING_PRIORITY` when `--auto-select-next` has already resolved a valid standing issue
- keep strict lane uniqueness/missing failures for non-auto-select paths
- add a regression unit seam for transient empty-lane state after auto-select

## Metadata
- Coupling: independent
- Depends-On:

## Validation
- node --test tools/priority/__tests__/standing-priority-resolution.test.mjs
- node --test tools/priority/__tests__/*.mjs
- node tools/npm/run-script.mjs priority:sync:lane
- ./bin/actionlint.exe -color

Refs #797
