### PR TITLE
fix: harden defork standing-priority portability seams (#805)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -311,6 +311,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   missing or duplicate standing-priority labels fail fast and emit deterministic diagnostics:
   - `tests/results/_agent/issue/no-standing-priority.json`
   - `tests/results/_agent/issue/multiple-standing-priority.json`
+  By default, sync does not create `.agent_priority_cache.json` on fresh clones; pass
+  `--materialize-cache` (or set `AGENT_PRIORITY_MATERIALIZE_CACHE=1`) when you explicitly want cache materialization.
 - Enforce milestone hygiene for `standing-priority` / `program` / `[P0|P1]` issues with
   `node tools/npm/run-script.mjs priority:milestone:hygiene -- --repo <owner/repo>`.
   Use `--apply-default-milestone --default-milestone <title>` for reconciliation and add

--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -23,6 +23,7 @@ import {
   resolveStandingPriorityForRepo,
   fetchIssue,
   computeNextPriorityCacheState,
+  shouldPersistCacheUpdate,
   gitRoot
 } from '../sync-standing-priority.mjs';
 
@@ -233,6 +234,9 @@ test('parseCliArgs enables strict standing-priority flags and help', () => {
   assert.equal(parsedAuto.autoSelectNext, true);
   assert.equal(parsedAuto.failOnMissing, false);
 
+  const parsedMaterialize = parseCliArgs(['node', 'sync-standing-priority.mjs', '--materialize-cache']);
+  assert.equal(parsedMaterialize.materializeCache, true);
+
   const help = parseCliArgs(['node', 'sync-standing-priority.mjs', '--help']);
   assert.equal(help.help, true);
 });
@@ -267,6 +271,41 @@ test('selectAutoStandingPriorityCandidate favors non-epic P0 oldest item', () =>
 
   assert.equal(selected?.number, 902);
   assert.equal(selected?.priority, 0);
+});
+
+test('selectAutoStandingPriorityCandidate deprioritizes program labels when actionable issues exist', () => {
+  const selected = selectAutoStandingPriorityCandidate([
+    {
+      number: 799,
+      title: '[P0] Program umbrella',
+      labels: ['program', 'governance'],
+      createdAt: '2026-03-06T08:00:00Z'
+    },
+    {
+      number: 805,
+      title: '[P0] Defork-safe portability hardening',
+      labels: ['governance'],
+      createdAt: '2026-03-06T08:05:00Z'
+    }
+  ]);
+
+  assert.equal(selected?.number, 805);
+});
+
+test('shouldPersistCacheUpdate skips cache materialization by default on fresh clones', () => {
+  const nextCache = {
+    number: 805,
+    state: 'OPEN',
+    labels: ['standing-priority']
+  };
+  assert.equal(
+    shouldPersistCacheUpdate({}, nextCache, { hasCacheFile: false, materializeCache: false }),
+    false
+  );
+  assert.equal(
+    shouldPersistCacheUpdate({}, nextCache, { hasCacheFile: false, materializeCache: true }),
+    true
+  );
 });
 
 test('autoSelectStandingPriorityIssue selects and labels next issue via injected transports', async () => {

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -26,6 +26,7 @@ const CLI_USAGE_LINES = [
   '  --fail-on-missing   Exit non-zero when no standing-priority issue is found.',
   '  --fail-on-multiple  Exit non-zero when multiple open standing-priority issues are found.',
   '  --auto-select-next  When no standing issue exists, auto-label the next open issue as standing-priority.',
+  '  --materialize-cache Persist .agent_priority_cache.json even when absent.',
   '  -h, --help          Show this help text and exit.'
 ];
 
@@ -35,6 +36,7 @@ export function parseCliArgs(argv = process.argv) {
     failOnMissing: false,
     failOnMultiple: false,
     autoSelectNext: false,
+    materializeCache: false,
     help: false
   };
 
@@ -49,6 +51,10 @@ export function parseCliArgs(argv = process.argv) {
     }
     if (arg === '--auto-select-next') {
       options.autoSelectNext = true;
+      continue;
+    }
+    if (arg === '--materialize-cache') {
+      options.materializeCache = true;
       continue;
     }
     if (arg === '--help' || arg === '-h') {
@@ -153,7 +159,8 @@ export function selectAutoStandingPriorityCandidate(entries = []) {
   }
 
   const nonEpic = normalized.filter((entry) => !entry.epic);
-  const pool = nonEpic.length > 0 ? nonEpic : normalized;
+  const nonProgram = nonEpic.filter((entry) => !entry.labels.includes('program'));
+  const pool = nonProgram.length > 0 ? nonProgram : nonEpic.length > 0 ? nonEpic : normalized;
 
   pool.sort((left, right) => {
     if (left.priority !== right.priority) {
@@ -1829,6 +1836,9 @@ export function computeNextPriorityCacheState({
 export async function main(options = {}) {
   const failOnMissing = Boolean(options.failOnMissing);
   const failOnMultiple = Boolean(options.failOnMultiple);
+  const materializeCache =
+    Boolean(options.materializeCache) ||
+    normalizeBooleanValue((options.env || process.env).AGENT_PRIORITY_MATERIALIZE_CACHE);
   const autoSelectNext =
     Boolean(options.autoSelectNext) ||
     normalizeBooleanValue((options.env || process.env).AGENT_PRIORITY_AUTO_SELECT_NEXT);
@@ -1836,6 +1846,7 @@ export async function main(options = {}) {
   const slug = resolveRepositorySlug(repoRoot);
   const standingPriorityLabels = resolveStandingPriorityLabels(repoRoot, slug);
   const cachePath = path.join(repoRoot, '.agent_priority_cache.json');
+  const hasCacheFile = fs.existsSync(cachePath);
   const cache = readJson(cachePath) || {};
   const resultsDir = path.join(repoRoot, 'tests', 'results', '_agent', 'issue');
   fs.mkdirSync(resultsDir, { recursive: true });
@@ -1877,7 +1888,12 @@ export async function main(options = {}) {
         );
         writeJson(path.join(resultsDir, 'router.json'), clearedRouter);
 
-        if (shouldWriteCache(cache, clearedCache)) {
+        if (
+          shouldPersistCacheUpdate(cache, clearedCache, {
+            hasCacheFile,
+            materializeCache
+          })
+        ) {
           writeJson(cachePath, clearedCache);
         }
 
@@ -2016,7 +2032,12 @@ export async function main(options = {}) {
     fetchSource,
     fetchError
   });
-  if (shouldWriteCache(cache, newCache)) {
+  if (
+    shouldPersistCacheUpdate(cache, newCache, {
+      hasCacheFile,
+      materializeCache
+    })
+  ) {
     writeJson(cachePath, newCache);
   }
 
@@ -2059,6 +2080,17 @@ export function shouldWriteCache(previousCache, nextCache) {
   }
 
   return !isDeepStrictEqual(previousCache, normalizedNext);
+}
+
+export function shouldPersistCacheUpdate(
+  previousCache,
+  nextCache,
+  { hasCacheFile = false, materializeCache = false } = {}
+) {
+  if (!hasCacheFile && !materializeCache) {
+    return false;
+  }
+  return shouldWriteCache(previousCache, nextCache);
 }
 
 export async function closeProxyAgents() {


### PR DESCRIPTION
## Summary
- harden standing-priority auto-select so umbrella `program` issues are de-prioritized when actionable candidates exist
- add cache persistence seam so `priority:sync` does not materialize `.agent_priority_cache.json` on fresh clones unless explicitly requested (`--materialize-cache` / `AGENT_PRIORITY_MATERIALIZE_CACHE=1`)
- add regression tests for both seams and update operator docs

## Metadata
- Coupling: independent
- Depends-On:

## Validation
- node --test tools/priority/__tests__/standing-priority-resolution.test.mjs tools/priority/__tests__/cache-update.test.mjs
- node --test tools/priority/__tests__/*.mjs
- ./bin/actionlint.exe -color

Refs #805
