### PR TITLE
feat(queue): add burst window controls (#814 #809)

### DIFF
--- a/.github/workflows/queue-supervisor.yml
+++ b/.github/workflows/queue-supervisor.yml
@@ -21,6 +21,14 @@ on:
         description: 'Optional adaptive inflight floor override'
         required: false
         type: string
+      burst_mode:
+        description: 'Burst mode override (auto|on|off)'
+        required: false
+        type: string
+      burst_refill_cycles:
+        description: 'Burst refill cycles override'
+        required: false
+        type: string
   schedule:
     - cron: '*/5 * * * *'
   workflow_run:
@@ -68,6 +76,8 @@ jobs:
           QUEUE_AUTOPILOT_MAX_INFLIGHT: ${{ vars.QUEUE_AUTOPILOT_MAX_INFLIGHT || '' }}
           QUEUE_AUTOPILOT_MIN_INFLIGHT: ${{ vars.QUEUE_AUTOPILOT_MIN_INFLIGHT || '' }}
           QUEUE_AUTOPILOT_ADAPTIVE_CAP: ${{ vars.QUEUE_AUTOPILOT_ADAPTIVE_CAP || '1' }}
+          QUEUE_BURST_MODE: ${{ vars.QUEUE_BURST_MODE || 'auto' }}
+          QUEUE_BURST_REFILL_CYCLES: ${{ vars.QUEUE_BURST_REFILL_CYCLES || '3' }}
         run: |
           npm ci --ignore-scripts
           $reportPath = 'tests/results/_agent/queue/queue-supervisor-report.json'
@@ -101,6 +111,16 @@ jobs:
           $minInflightInput = '${{ inputs.min_inflight }}'
           if (-not [string]::IsNullOrWhiteSpace($minInflightInput)) {
             $args += @('--min-inflight', $minInflightInput.Trim())
+          }
+
+          $burstModeInput = '${{ inputs.burst_mode }}'
+          if (-not [string]::IsNullOrWhiteSpace($burstModeInput)) {
+            $args += @('--burst-mode', $burstModeInput.Trim().ToLowerInvariant())
+          }
+
+          $burstRefillCyclesInput = '${{ inputs.burst_refill_cycles }}'
+          if (-not [string]::IsNullOrWhiteSpace($burstRefillCyclesInput)) {
+            $args += @('--burst-refill-cycles', $burstRefillCyclesInput.Trim())
           }
 
           if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ inputs.adaptive_cap }}' -ne 'true') {

--- a/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
+++ b/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
@@ -7,8 +7,8 @@ This scaffold tracks the six planned mergeable slices so agents can resume deter
 | PR | Issue | Branch | Scope | Status | Required artifacts |
 | --- | --- | --- | --- | --- | --- |
 | PR1 | #813 | `codex/pr1-813-adaptive-throughput-controller` | Adaptive throughput controller (2/3/5 + hysteresis) | committed | `tests/results/_agent/queue/throughput-controller-state.json` |
-| PR2 | #814 | `codex/pr2-814-readiness-buffer-admission` | Readiness buffer + admission scoring | in-progress | `tests/results/_agent/queue/queue-readiness-report.json` |
-| PR3 | #814 | `codex/pr3-814-release-burst-windows` | Burst windows and backoff | pending | `tests/results/_agent/queue/queue-supervisor-report.json` |
+| PR2 | #814 | `codex/pr2-814-readiness-buffer-admission` | Readiness buffer + admission scoring | committed | `tests/results/_agent/queue/queue-readiness-report.json` |
+| PR3 | #814 | `codex/pr3-814-release-burst-windows` | Burst windows and backoff | in-progress | `tests/results/_agent/queue/queue-supervisor-report.json` |
 | PR4 | #809 child | `codex/pr4-809-queue-aware-release-conductor` | Queue-aware release conductor (CLI stream) | pending | `tests/results/_agent/release/release-conductor-report.json` |
 | PR5 | #813 | `codex/pr5-813-remediation-slo-evaluator` | Remediation SLO evaluator + governance transitions | pending | `tests/results/_agent/slo/remediation-slo-report.json` |
 | PR6 | #815 | `codex/pr6-815-weekly-scorecards-gameday` | Weekly scorecards + canary game-day | pending | `tests/results/_agent/slo/weekly-scorecard.json` |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -309,6 +309,10 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   - `QUEUE_AUTOPILOT_MAX_INFLIGHT` / `--max-inflight` sets the queue target cap.
   - `QUEUE_AUTOPILOT_ADAPTIVE_CAP` (default `1`) and `QUEUE_AUTOPILOT_MIN_INFLIGHT` / `--min-inflight` enable
     adaptive throttling when runtime pressure or trunk-health degradation is detected.
+  - `QUEUE_BURST_MODE` / `--burst-mode` (`auto|on|off`) and
+    `QUEUE_BURST_REFILL_CYCLES` / `--burst-refill-cycles` control release burst behavior.
+    Auto mode activates on release windows, open `release/*` PRs, or `release-burst` labels, and backs off for
+    30 minutes whenever the throughput controller enters `stabilize`.
 - For deterministic incident routing, run the control-plane chain in order:
   - `node tools/npm/run-script.mjs priority:event:ingest -- ...`
   - `node tools/npm/run-script.mjs priority:policy:route -- --event <event-report-or-event-json>`

--- a/tools/priority/__tests__/queue-supervisor.test.mjs
+++ b/tools/priority/__tests__/queue-supervisor.test.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import {
   classifyOpenPullRequests,
   evaluateAdaptiveInflight,
+  evaluateBurstWindow,
   evaluateHealthGate,
   evaluateRuntimeFleetHealth,
   evaluateRequiredChecks,
@@ -28,7 +29,9 @@ test('parseArgs defaults to dry-run and supports apply mode', () => {
     'QUEUE_AUTOPILOT_ADAPTIVE_CAP',
     'QUEUE_AUTOPILOT_MAX_QUEUED_RUNS',
     'QUEUE_AUTOPILOT_MAX_IN_PROGRESS_RUNS',
-    'QUEUE_AUTOPILOT_STALL_THRESHOLD_MINUTES'
+    'QUEUE_AUTOPILOT_STALL_THRESHOLD_MINUTES',
+    'QUEUE_BURST_MODE',
+    'QUEUE_BURST_REFILL_CYCLES'
   ];
   const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
   for (const key of keys) delete process.env[key];
@@ -42,6 +45,8 @@ test('parseArgs defaults to dry-run and supports apply mode', () => {
     assert.equal(defaults.maxQueuedRuns, 6);
     assert.equal(defaults.maxInProgressRuns, 8);
     assert.equal(defaults.stallThresholdMinutes, 45);
+    assert.equal(defaults.burstMode, 'auto');
+    assert.equal(defaults.burstRefillCycles, 3);
     assert.match(defaults.readinessReportPath, /queue-readiness-report\.json$/);
 
     const apply = parseArgs([
@@ -58,7 +63,11 @@ test('parseArgs defaults to dry-run and supports apply mode', () => {
       '--max-in-progress-runs',
       '9',
       '--stall-threshold-minutes',
-      '50'
+      '50',
+      '--burst-mode',
+      'on',
+      '--burst-refill-cycles',
+      '4'
     ]);
     assert.equal(apply.apply, true);
     assert.equal(apply.dryRun, false);
@@ -68,6 +77,8 @@ test('parseArgs defaults to dry-run and supports apply mode', () => {
     assert.equal(apply.maxQueuedRuns, 7);
     assert.equal(apply.maxInProgressRuns, 9);
     assert.equal(apply.stallThresholdMinutes, 50);
+    assert.equal(apply.burstMode, 'on');
+    assert.equal(apply.burstRefillCycles, 4);
   } finally {
     for (const key of keys) {
       if (previous[key] === undefined) {
@@ -90,16 +101,22 @@ test('parseArgs reads adaptive inflight controls from environment', () => {
   const previous = {
     max: process.env.QUEUE_AUTOPILOT_MAX_INFLIGHT,
     min: process.env.QUEUE_AUTOPILOT_MIN_INFLIGHT,
-    adaptive: process.env.QUEUE_AUTOPILOT_ADAPTIVE_CAP
+    adaptive: process.env.QUEUE_AUTOPILOT_ADAPTIVE_CAP,
+    burstMode: process.env.QUEUE_BURST_MODE,
+    burstRefillCycles: process.env.QUEUE_BURST_REFILL_CYCLES
   };
   process.env.QUEUE_AUTOPILOT_MAX_INFLIGHT = '4';
   process.env.QUEUE_AUTOPILOT_MIN_INFLIGHT = '1';
   process.env.QUEUE_AUTOPILOT_ADAPTIVE_CAP = '0';
+  process.env.QUEUE_BURST_MODE = 'on';
+  process.env.QUEUE_BURST_REFILL_CYCLES = '6';
   try {
     const parsed = parseArgs(['node', 'queue-supervisor.mjs']);
     assert.equal(parsed.maxInflight, 4);
     assert.equal(parsed.minInflight, 1);
     assert.equal(parsed.adaptiveCap, false);
+    assert.equal(parsed.burstMode, 'on');
+    assert.equal(parsed.burstRefillCycles, 6);
   } finally {
     if (previous.max === undefined) delete process.env.QUEUE_AUTOPILOT_MAX_INFLIGHT;
     else process.env.QUEUE_AUTOPILOT_MAX_INFLIGHT = previous.max;
@@ -107,6 +124,10 @@ test('parseArgs reads adaptive inflight controls from environment', () => {
     else process.env.QUEUE_AUTOPILOT_MIN_INFLIGHT = previous.min;
     if (previous.adaptive === undefined) delete process.env.QUEUE_AUTOPILOT_ADAPTIVE_CAP;
     else process.env.QUEUE_AUTOPILOT_ADAPTIVE_CAP = previous.adaptive;
+    if (previous.burstMode === undefined) delete process.env.QUEUE_BURST_MODE;
+    else process.env.QUEUE_BURST_MODE = previous.burstMode;
+    if (previous.burstRefillCycles === undefined) delete process.env.QUEUE_BURST_REFILL_CYCLES;
+    else process.env.QUEUE_BURST_REFILL_CYCLES = previous.burstRefillCycles;
   }
 });
 
@@ -171,6 +192,52 @@ test('evaluateAdaptiveInflight applies hysteresis before upgrading from stabiliz
   });
   assert.equal(secondRecovery.tier, 'guarded');
   assert.equal(secondRecovery.hysteresis.transition, 'upgrade-applied');
+});
+
+test('evaluateBurstWindow activates on release triggers and carries refill cycles', () => {
+  const initial = evaluateBurstWindow({
+    burstMode: 'auto',
+    burstRefillCycles: 2,
+    now: new Date('2026-03-04T18:10:00.000Z'),
+    pullRequests: []
+  });
+  assert.equal(initial.active, true);
+  assert.equal(initial.refillCyclesRemaining, 2);
+  assert.ok(initial.reasons.includes('release-window'));
+
+  const refill = evaluateBurstWindow({
+    burstMode: 'auto',
+    burstRefillCycles: 2,
+    now: new Date('2026-03-04T19:10:00.000Z'),
+    pullRequests: [],
+    previousBurst: {
+      refillCyclesRemaining: initial.refillCyclesRemaining
+    }
+  });
+  assert.equal(refill.active, true);
+  assert.equal(refill.refillCyclesRemaining, 1);
+  assert.ok(refill.reasons.includes('refill-cycles'));
+});
+
+test('evaluateBurstWindow applies stabilize backoff and disables burst temporarily', () => {
+  const burst = evaluateBurstWindow({
+    burstMode: 'on',
+    burstRefillCycles: 3,
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    controllerMode: 'stabilize',
+    pullRequests: [
+      {
+        number: 700,
+        baseRefName: 'develop',
+        headRefName: 'release/2026.03'
+      }
+    ]
+  });
+
+  assert.equal(burst.active, false);
+  assert.equal(burst.backoffActive, true);
+  assert.ok(typeof burst.backoffUntil === 'string' && burst.backoffUntil.endsWith('Z'));
+  assert.ok(burst.reasons.includes('stabilize-backoff'));
 });
 
 test('evaluateRequiredChecks detects missing and failing contexts', () => {

--- a/tools/priority/queue-supervisor.mjs
+++ b/tools/priority/queue-supervisor.mjs
@@ -28,6 +28,12 @@ const DEFAULT_HEALTH_MAX_RED_MINUTES = 30;
 const DEFAULT_MAX_QUEUED_RUNS = 6;
 const DEFAULT_MAX_IN_PROGRESS_RUNS = 8;
 const DEFAULT_STALL_THRESHOLD_MINUTES = 45;
+const DEFAULT_BURST_MODE = 'auto';
+const DEFAULT_BURST_REFILL_CYCLES = 3;
+const BURST_BACKOFF_MINUTES = 30;
+const RELEASE_WINDOW_DAY_UTC = 3;
+const RELEASE_WINDOW_MAX_DAY_OF_MONTH = 7;
+const RELEASE_WINDOW_HOUR_UTC = 18;
 const RETRY_WINDOW_HOURS = 24;
 const CONTROLLER_REQUIRED_UPGRADE_STREAK = 2;
 const CONTROLLER_THRESHOLDS = Object.freeze({
@@ -43,6 +49,7 @@ const CONTROLLER_THRESHOLDS = Object.freeze({
 const EXCLUDED_LABELS = new Set(['queue-blocked', 'do-not-queue']);
 const DEFAULT_BASE_BRANCHES = ['develop', 'main'];
 const COUPLING_VALUES = new Set(['independent', 'soft', 'hard']);
+const BURST_MODES = new Set(['auto', 'on', 'off']);
 const COUPLING_PRIORITY = Object.freeze({
   independent: 0,
   soft: 1,
@@ -66,6 +73,8 @@ function printUsage() {
   console.log(`  --max-queued-runs <n>  Pause when queued workflow runs exceed this threshold (default: ${DEFAULT_MAX_QUEUED_RUNS}).`);
   console.log(`  --max-in-progress-runs <n> Pause when in-progress workflow runs exceed this threshold (default: ${DEFAULT_MAX_IN_PROGRESS_RUNS}).`);
   console.log(`  --stall-threshold-minutes <n> Pause when active runs exceed age threshold (default: ${DEFAULT_STALL_THRESHOLD_MINUTES}).`);
+  console.log(`  --burst-mode <auto|on|off> Burst controller mode (default: ${DEFAULT_BURST_MODE}, env QUEUE_BURST_MODE).`);
+  console.log(`  --burst-refill-cycles <n> Keep burst active for N follow-up cycles after trigger (default: ${DEFAULT_BURST_REFILL_CYCLES}, env QUEUE_BURST_REFILL_CYCLES).`);
   console.log('  --repo <owner/repo>    Target repository (default: GITHUB_REPOSITORY/upstream remote).');
   console.log(`  --base-branches <csv>  Queue-managed branch allowlist (default: ${DEFAULT_BASE_BRANCHES.join(',')}).`);
   console.log('  --health-branch <name> Branch to evaluate trunk health (default: develop).');
@@ -95,6 +104,16 @@ function parseCsv(value) {
     .filter(Boolean);
 }
 
+function parseBurstMode(value, { label }) {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase();
+  if (!BURST_MODES.has(normalized)) {
+    throw new Error(`Invalid ${label} value '${value}'. Expected one of: auto,on,off.`);
+  }
+  return normalized;
+}
+
 export function parseArgs(argv = process.argv) {
   const args = argv.slice(2);
   const options = {
@@ -112,6 +131,8 @@ export function parseArgs(argv = process.argv) {
     maxQueuedRuns: null,
     maxInProgressRuns: null,
     stallThresholdMinutes: null,
+    burstMode: null,
+    burstRefillCycles: null,
     help: false
   };
 
@@ -142,7 +163,9 @@ export function parseArgs(argv = process.argv) {
       arg === '--health-branch' ||
       arg === '--max-queued-runs' ||
       arg === '--max-in-progress-runs' ||
-      arg === '--stall-threshold-minutes'
+      arg === '--stall-threshold-minutes' ||
+      arg === '--burst-mode' ||
+      arg === '--burst-refill-cycles'
     ) {
       const next = args[index + 1];
       if (!next || next.startsWith('-')) {
@@ -178,6 +201,10 @@ export function parseArgs(argv = process.argv) {
         options.maxInProgressRuns = parseIntStrict(next, { label: '--max-in-progress-runs' });
       } else if (arg === '--stall-threshold-minutes') {
         options.stallThresholdMinutes = parseIntStrict(next, { label: '--stall-threshold-minutes' });
+      } else if (arg === '--burst-mode') {
+        options.burstMode = parseBurstMode(next, { label: '--burst-mode' });
+      } else if (arg === '--burst-refill-cycles') {
+        options.burstRefillCycles = parseIntStrict(next, { label: '--burst-refill-cycles' });
       }
       continue;
     }
@@ -242,6 +269,22 @@ export function parseArgs(argv = process.argv) {
   }
   if (options.stallThresholdMinutes == null) {
     options.stallThresholdMinutes = DEFAULT_STALL_THRESHOLD_MINUTES;
+  }
+
+  const envBurstMode = process.env.QUEUE_BURST_MODE;
+  if (options.burstMode == null && envBurstMode && String(envBurstMode).trim()) {
+    options.burstMode = parseBurstMode(envBurstMode, { label: 'QUEUE_BURST_MODE' });
+  }
+  if (options.burstMode == null) {
+    options.burstMode = DEFAULT_BURST_MODE;
+  }
+
+  const envBurstRefillCycles = process.env.QUEUE_BURST_REFILL_CYCLES;
+  if (options.burstRefillCycles == null && envBurstRefillCycles && String(envBurstRefillCycles).trim()) {
+    options.burstRefillCycles = parseIntStrict(envBurstRefillCycles, { label: 'QUEUE_BURST_REFILL_CYCLES' });
+  }
+  if (options.burstRefillCycles == null) {
+    options.burstRefillCycles = DEFAULT_BURST_REFILL_CYCLES;
   }
 
   return options;
@@ -1058,6 +1101,111 @@ export function evaluateAdaptiveInflight({
   };
 }
 
+function hasReleaseBranchPullRequest(pullRequests = []) {
+  return (pullRequests ?? []).some((pr) => {
+    const headRefName = String(pr?.headRefName ?? '')
+      .trim()
+      .toLowerCase();
+    const baseRefName = normalizeBaseBranch(pr?.baseRefName);
+    return headRefName.startsWith('release/') || baseRefName.startsWith('release/');
+  });
+}
+
+function hasReleaseBurstLabel(pullRequests = []) {
+  return (pullRequests ?? []).some((pr) =>
+    (pr?.labels ?? []).some((label) => normalizeLabelName(label) === 'release-burst')
+  );
+}
+
+function isReleaseWindow(now = new Date()) {
+  const utcDay = now.getUTCDay();
+  const utcDate = now.getUTCDate();
+  const utcHour = now.getUTCHours();
+  return utcDay === RELEASE_WINDOW_DAY_UTC && utcDate <= RELEASE_WINDOW_MAX_DAY_OF_MONTH && utcHour === RELEASE_WINDOW_HOUR_UTC;
+}
+
+export function evaluateBurstWindow({
+  burstMode = DEFAULT_BURST_MODE,
+  burstRefillCycles = DEFAULT_BURST_REFILL_CYCLES,
+  pullRequests = [],
+  previousBurst = null,
+  controllerMode = null,
+  now = new Date()
+} = {}) {
+  const mode = parseBurstMode(burstMode, { label: 'burstMode' });
+  const configuredRefillCycles = parseIntStrict(burstRefillCycles, { label: 'burstRefillCycles' });
+  const nowMs = now.valueOf();
+  const previousBackoffUntil = normalizeIso(previousBurst?.backoffUntil);
+  let backoffUntil = previousBackoffUntil;
+  let backoffActive = false;
+  if (previousBackoffUntil) {
+    const backoffUntilMs = Date.parse(previousBackoffUntil);
+    backoffActive = Number.isFinite(backoffUntilMs) && backoffUntilMs > nowMs;
+  }
+
+  const stabilized = normalizeControllerMode(controllerMode) === 'stabilize';
+  if (stabilized) {
+    backoffUntil = new Date(nowMs + BURST_BACKOFF_MINUTES * 60 * 1000).toISOString();
+    backoffActive = true;
+  }
+
+  const triggerSignals = Object.freeze({
+    releaseWindow: isReleaseWindow(now),
+    releaseBranchPullRequest: hasReleaseBranchPullRequest(pullRequests),
+    releaseBurstLabel: hasReleaseBurstLabel(pullRequests)
+  });
+  const triggerReasons = [];
+  if (triggerSignals.releaseWindow) triggerReasons.push('release-window');
+  if (triggerSignals.releaseBranchPullRequest) triggerReasons.push('open-release-branch-pr');
+  if (triggerSignals.releaseBurstLabel) triggerReasons.push('release-burst-label');
+  const triggerActive = triggerReasons.length > 0;
+
+  let refillCyclesRemaining = 0;
+  const previousRefillCycles = Math.max(0, Number(previousBurst?.refillCyclesRemaining) || 0);
+  if (mode === 'auto') {
+    if (triggerActive) {
+      refillCyclesRemaining = configuredRefillCycles;
+    } else if (previousRefillCycles > 0) {
+      refillCyclesRemaining = previousRefillCycles - 1;
+    }
+  } else if (mode === 'on') {
+    refillCyclesRemaining = configuredRefillCycles;
+  }
+
+  const reasons = [];
+  let active = false;
+  if (mode === 'off') {
+    reasons.push('burst-mode-off');
+  } else if (backoffActive) {
+    reasons.push('stabilize-backoff');
+  } else if (mode === 'on') {
+    active = true;
+    reasons.push('burst-mode-on');
+  } else if (triggerActive) {
+    active = true;
+    reasons.push(...triggerReasons);
+  } else if (refillCyclesRemaining > 0) {
+    active = true;
+    reasons.push('refill-cycles');
+  } else {
+    reasons.push('no-burst-trigger');
+  }
+
+  return {
+    mode,
+    active,
+    configuredRefillCycles,
+    refillCyclesRemaining,
+    backoffMinutes: BURST_BACKOFF_MINUTES,
+    backoffUntil,
+    backoffActive,
+    triggerSignals,
+    triggerReasons,
+    reasons: [...new Set(reasons)],
+    stabilized
+  };
+}
+
 function parseQueueManagedBranches(policy, fallbackBranches) {
   const queueManaged = new Set();
   const rulesets = policy?.rulesets ?? {};
@@ -1233,7 +1381,16 @@ export async function runQueueSupervisor(options = {}) {
     retryPressure,
     previousControllerState
   });
-  const effectiveMaxInflight = adaptiveInflight.effectiveMaxInflight;
+  const burst = evaluateBurstWindow({
+    burstMode: args.burstMode,
+    burstRefillCycles: args.burstRefillCycles,
+    pullRequests: allOpenPrs,
+    previousBurst: previousReport?.burst,
+    controllerMode: adaptiveInflight.mode,
+    now
+  });
+  const burstCapApplied = burst.active && args.maxInflight > adaptiveInflight.effectiveMaxInflight;
+  const effectiveMaxInflight = burstCapApplied ? args.maxInflight : adaptiveInflight.effectiveMaxInflight;
   const inflight = countInflight(classified.candidates.filter((candidate) => queueManagedBranches.has(candidate.baseRefName)));
   const capacity = Math.max(0, effectiveMaxInflight - inflight);
 
@@ -1243,9 +1400,12 @@ export async function runQueueSupervisor(options = {}) {
     repository,
     mode: adaptiveInflight.mode,
     desiredMode: adaptiveInflight.desiredMode,
-    targetCap: adaptiveInflight.effectiveMaxInflight,
+    targetCap: effectiveMaxInflight,
     capByMode: adaptiveInflight.capByMode,
     adaptiveEnabled: adaptiveInflight.enabled,
+    burstMode: burst.mode,
+    burstActive: burst.active,
+    burstCapApplied,
     reasons: adaptiveInflight.reasons,
     metrics: adaptiveInflight.metrics,
     thresholds: adaptiveInflight.thresholds,
@@ -1285,6 +1445,8 @@ export async function runQueueSupervisor(options = {}) {
       queueAutopilotMaxQueuedRuns: process.env.QUEUE_AUTOPILOT_MAX_QUEUED_RUNS ?? null,
       queueAutopilotMaxInProgressRuns: process.env.QUEUE_AUTOPILOT_MAX_IN_PROGRESS_RUNS ?? null,
       queueAutopilotStallThresholdMinutes: process.env.QUEUE_AUTOPILOT_STALL_THRESHOLD_MINUTES ?? null,
+      queueBurstMode: process.env.QUEUE_BURST_MODE ?? null,
+      queueBurstRefillCycles: process.env.QUEUE_BURST_REFILL_CYCLES ?? null,
       expectedHeadOwner
     },
     queueManagedBranches: [...queueManagedBranches].sort(),
@@ -1292,6 +1454,8 @@ export async function runQueueSupervisor(options = {}) {
     minInflight: args.minInflight,
     effectiveMaxInflight,
     adaptiveInflight,
+    burst,
+    burstCapApplied,
     inflight,
     capacity,
     health,
@@ -1500,6 +1664,7 @@ export const __test = Object.freeze({
   classifyOpenPullRequests,
   evaluateHealthGate,
   evaluateRuntimeFleetHealth,
+  evaluateBurstWindow,
   computeRetryPressure,
   pruneRetryHistory,
   runQueueSupervisor


### PR DESCRIPTION
## Summary
- Adds burst mode controls and refill cycles to queue supervisor.
- Adds stabilize backoff and workflow input wiring.

Coupling: soft
Depends-On: #831

Refs: #809 #814