### PR TITLE
feat(release): add queue-aware release conductor (#809)

### DIFF
--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -1,0 +1,134 @@
+name: Release Conductor
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply mode (requires RELEASE_CONDUCTOR_ENABLED=1)'
+        required: false
+        default: false
+        type: boolean
+      channel:
+        description: 'Release channel'
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+      version:
+        description: 'Release version proposal (for example 0.8.0 or 0.8.0-rc.1)'
+        required: false
+        type: string
+      dwell_minutes:
+        description: 'Green dwell minutes (default 60)'
+        required: false
+        type: string
+      quarantine_stale_hours:
+        description: 'Quarantine stale threshold hours (default 24)'
+        required: false
+        type: string
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_run:
+    workflows:
+      - Queue Supervisor
+    types:
+      - completed
+    branches:
+      - develop
+
+concurrency:
+  group: release-conductor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-conductor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Prepare release conductor token
+        shell: pwsh
+        env:
+          INPUT_TOKEN_PRIMARY: ${{ secrets.GH_TOKEN }}
+          INPUT_TOKEN_SECONDARY: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN_TERTIARY: ${{ github.token }}
+        run: |
+          pwsh -NoLogo -NoProfile -File tools/priority/Resolve-PolicyToken.ps1 -TokenFileName release-conductor-gh-token.txt
+
+      - name: Run release conductor
+        shell: pwsh
+        env:
+          RELEASE_CONDUCTOR_ENABLED: ${{ vars.RELEASE_CONDUCTOR_ENABLED || '0' }}
+        run: |
+          npm ci --ignore-scripts
+          node tools/npm/run-script.mjs priority:policy:snapshot -- --output tests/results/_agent/policy/policy-state-snapshot.json
+
+          $reportPath = 'tests/results/_agent/release/release-conductor-report.json'
+          $args = @(
+            'tools/npm/run-script.mjs',
+            'priority:release:conductor',
+            '--',
+            '--report',
+            $reportPath,
+            '--queue-report',
+            'tests/results/_agent/queue/queue-supervisor-report.json',
+            '--policy-snapshot',
+            'tests/results/_agent/policy/policy-state-snapshot.json'
+          )
+
+          $eventName = '${{ github.event_name }}'
+          $apply = $false
+          if ($eventName -eq 'workflow_dispatch') {
+            $apply = ('${{ inputs.apply }}' -eq 'true')
+          } elseif ($eventName -eq 'workflow_run') {
+            $apply = $true
+          }
+
+          if ($apply) {
+            $args += '--apply'
+          } else {
+            $args += '--dry-run'
+          }
+
+          $channelInput = '${{ inputs.channel }}'
+          if (-not [string]::IsNullOrWhiteSpace($channelInput)) {
+            $args += @('--channel', $channelInput.Trim().ToLowerInvariant())
+          }
+
+          $versionInput = '${{ inputs.version }}'
+          if (-not [string]::IsNullOrWhiteSpace($versionInput)) {
+            $args += @('--version', $versionInput.Trim())
+          }
+
+          $dwellInput = '${{ inputs.dwell_minutes }}'
+          if (-not [string]::IsNullOrWhiteSpace($dwellInput)) {
+            $args += @('--dwell-minutes', $dwellInput.Trim())
+          }
+
+          $quarantineInput = '${{ inputs.quarantine_stale_hours }}'
+          if (-not [string]::IsNullOrWhiteSpace($quarantineInput)) {
+            $args += @('--quarantine-stale-hours', $quarantineInput.Trim())
+          }
+
+          node @args
+
+      - name: Upload release conductor artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: release-conductor-${{ github.run_id }}
+          path: |
+            tests/results/_agent/release/release-conductor-report.json
+            tests/results/_agent/policy/policy-state-snapshot.json
+          if-no-files-found: error

--- a/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
+++ b/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
@@ -8,8 +8,8 @@ This scaffold tracks the six planned mergeable slices so agents can resume deter
 | --- | --- | --- | --- | --- | --- |
 | PR1 | #813 | `codex/pr1-813-adaptive-throughput-controller` | Adaptive throughput controller (2/3/5 + hysteresis) | committed | `tests/results/_agent/queue/throughput-controller-state.json` |
 | PR2 | #814 | `codex/pr2-814-readiness-buffer-admission` | Readiness buffer + admission scoring | committed | `tests/results/_agent/queue/queue-readiness-report.json` |
-| PR3 | #814 | `codex/pr3-814-release-burst-windows` | Burst windows and backoff | in-progress | `tests/results/_agent/queue/queue-supervisor-report.json` |
-| PR4 | #809 child | `codex/pr4-809-queue-aware-release-conductor` | Queue-aware release conductor (CLI stream) | pending | `tests/results/_agent/release/release-conductor-report.json` |
+| PR3 | #814 | `codex/pr3-814-release-burst-windows` | Burst windows and backoff | committed | `tests/results/_agent/queue/queue-supervisor-report.json` |
+| PR4 | #809 child | `codex/pr4-809-queue-aware-release-conductor` | Queue-aware release conductor (CLI stream) | in-progress | `tests/results/_agent/release/release-conductor-report.json` |
 | PR5 | #813 | `codex/pr5-813-remediation-slo-evaluator` | Remediation SLO evaluator + governance transitions | pending | `tests/results/_agent/slo/remediation-slo-report.json` |
 | PR6 | #815 | `codex/pr6-815-weekly-scorecards-gameday` | Weekly scorecards + canary game-day | pending | `tests/results/_agent/slo/weekly-scorecard.json` |
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -313,6 +313,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
     `QUEUE_BURST_REFILL_CYCLES` / `--burst-refill-cycles` control release burst behavior.
     Auto mode activates on release windows, open `release/*` PRs, or `release-burst` labels, and backs off for
     30 minutes whenever the throughput controller enters `stabilize`.
+  For queue-aware release proposals, run `node tools/npm/run-script.mjs priority:release:conductor -- --dry-run`.
+  Apply mode requires `RELEASE_CONDUCTOR_ENABLED=1`; if signing material is unavailable, the conductor remains
+  proposal-only and emits evidence without mutating tags.
 - For deterministic incident routing, run the control-plane chain in order:
   - `node tools/npm/run-script.mjs priority:event:ingest -- ...`
   - `node tools/npm/run-script.mjs priority:policy:route -- --event <event-report-or-event-json>`

--- a/docs/schemas/release-conductor-report-v1.schema.json
+++ b/docs/schemas/release-conductor-report-v1.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "release/release-conductor-report@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "repository",
+    "mode",
+    "release",
+    "inputs",
+    "gates",
+    "workflowFetchErrors",
+    "decision"
+  ],
+  "properties": {
+    "schema": {
+      "const": "release/release-conductor-report@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "mode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["apply", "dryRun", "releaseConductorEnabled"],
+      "properties": {
+        "apply": { "type": "boolean" },
+        "dryRun": { "type": "boolean" },
+        "releaseConductorEnabled": { "type": "boolean" }
+      }
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stream",
+        "channel",
+        "version",
+        "targetTag",
+        "proposalOnly",
+        "tagCreated",
+        "tagError",
+        "signingMaterial"
+      ],
+      "properties": {
+        "stream": { "type": "string" },
+        "channel": { "type": "string", "enum": ["stable", "rc"] },
+        "version": { "type": ["string", "null"] },
+        "targetTag": { "type": ["string", "null"] },
+        "proposalOnly": { "type": "boolean" },
+        "tagCreated": { "type": "boolean" },
+        "tagError": { "type": ["string", "null"] },
+        "signingMaterial": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available", "signingKey", "source"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "signingKey": { "type": ["string", "null"] },
+            "source": { "type": "string" }
+          }
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reportPath",
+        "queueReportPath",
+        "policySnapshotPath",
+        "dwellMinutes",
+        "quarantineStaleHours"
+      ],
+      "properties": {
+        "reportPath": { "type": "string" },
+        "queueReportPath": { "type": "string" },
+        "policySnapshotPath": { "type": "string" },
+        "dwellMinutes": { "type": "integer", "minimum": 0 },
+        "quarantineStaleHours": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["greenDwell", "queueHealth", "policySnapshot", "quarantine"],
+      "properties": {
+        "greenDwell": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "dwellMinutes", "evaluatedAt", "reasons", "workflows"],
+          "properties": {
+            "status": { "type": "string", "enum": ["pass", "fail"] },
+            "dwellMinutes": { "type": "integer", "minimum": 0 },
+            "evaluatedAt": { "type": "string", "format": "date-time" },
+            "reasons": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "workflows": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "file",
+                  "runCount",
+                  "inWindowCount",
+                  "successInWindow",
+                  "failureInWindow",
+                  "latestSuccessAt"
+                ],
+                "properties": {
+                  "name": { "type": "string" },
+                  "file": { "type": "string" },
+                  "runCount": { "type": "integer", "minimum": 0 },
+                  "inWindowCount": { "type": "integer", "minimum": 0 },
+                  "successInWindow": { "type": "boolean" },
+                  "failureInWindow": { "type": "boolean" },
+                  "latestSuccessAt": { "type": ["string", "null"] }
+                }
+              }
+            }
+          }
+        },
+        "queueHealth": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reasons", "paused", "controllerMode"],
+          "properties": {
+            "status": { "type": "string", "enum": ["pass", "fail"] },
+            "reasons": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "paused": { "type": ["boolean", "null"] },
+            "controllerMode": { "type": ["string", "null"] }
+          }
+        },
+        "policySnapshot": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reasons", "schema", "generatedAt"],
+          "properties": {
+            "status": { "type": "string", "enum": ["pass", "fail"] },
+            "reasons": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "schema": { "type": ["string", "null"] },
+            "generatedAt": { "type": ["string", "null"] }
+          }
+        },
+        "quarantine": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reasons",
+            "staleHours",
+            "staleCount",
+            "activeCount",
+            "staleEntries"
+          ],
+          "properties": {
+            "status": { "type": "string", "enum": ["pass", "fail"] },
+            "reasons": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "staleHours": { "type": "integer", "minimum": 0 },
+            "staleCount": { "type": ["integer", "null"], "minimum": 0 },
+            "activeCount": { "type": ["integer", "null"], "minimum": 0 },
+            "staleEntries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["number", "latestFailureAt", "failureCount"],
+                "properties": {
+                  "number": { "type": "integer", "minimum": 1 },
+                  "latestFailureAt": { "type": ["string", "null"] },
+                  "failureCount": { "type": "integer", "minimum": 0 }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "workflowFetchErrors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["workflow", "file", "message"],
+        "properties": {
+          "workflow": { "type": "string" },
+          "file": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "blockerCount", "blockers"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "fail"] },
+        "blockerCount": { "type": "integer", "minimum": 0 },
+        "blockers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["code", "message"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "priority:contracts:bootstrap": "node tools/priority/bootstrap-contracts.mjs",
     "priority:deployment:assert": "node tools/priority/assert-validation-deployment-determinism.mjs",
     "priority:release:scorecard": "node tools/priority/release-scorecard.mjs",
+    "priority:release:conductor": "node tools/priority/release-conductor.mjs",
     "priority:security:intake": "node tools/priority/security-intake.mjs",
     "priority:security:gate": "node tools/priority/security-intake.mjs --route-on-breach --fail-on-breach --fail-on-skip",
     "priority:onboard:downstream": "node tools/priority/downstream-onboarding.mjs",

--- a/tools/priority/__tests__/release-conductor-schema.test.mjs
+++ b/tools/priority/__tests__/release-conductor-schema.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { runReleaseConductor } from '../release-conductor.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('release conductor report validates schema', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'release-conductor-report-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] !== 'api') {
+      throw new Error(`unexpected gh args: ${args.join(' ')}`);
+    }
+    return {
+      workflow_runs: [
+        {
+          id: 1,
+          status: 'completed',
+          conclusion: 'success',
+          updated_at: '2026-03-06T11:50:00Z'
+        }
+      ]
+    };
+  };
+
+  const { report } = await runReleaseConductor({
+    repoRoot,
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: false,
+      dryRun: true,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'stable',
+      version: '0.8.0',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '0'
+    },
+    runGhJsonFn,
+    runCommandFn: () => ({ status: 0, stdout: '', stderr: '' }),
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  evaluateGreenDwell,
+  evaluatePolicySnapshotGate,
+  evaluateQuarantineGate,
+  evaluateQueueHealthGate,
+  parseArgs,
+  runReleaseConductor
+} from '../release-conductor.mjs';
+
+function makeWorkflowRunsResponse(workflowFile) {
+  if (workflowFile.includes('validate.yml')) {
+    return {
+      workflow_runs: [
+        {
+          id: 1,
+          status: 'completed',
+          conclusion: 'success',
+          updated_at: '2026-03-06T11:45:00Z'
+        }
+      ]
+    };
+  }
+  return {
+    workflow_runs: [
+      {
+        id: 2,
+        status: 'completed',
+        conclusion: 'success',
+        updated_at: '2026-03-06T11:40:00Z'
+      }
+    ]
+  };
+}
+
+test('parseArgs applies defaults and supports burst-style apply flags', () => {
+  const defaults = parseArgs(['node', 'release-conductor.mjs']);
+  assert.equal(defaults.apply, false);
+  assert.equal(defaults.dryRun, true);
+  assert.equal(defaults.channel, 'stable');
+  assert.equal(defaults.dwellMinutes, 60);
+
+  const parsed = parseArgs([
+    'node',
+    'release-conductor.mjs',
+    '--apply',
+    '--repo',
+    'owner/repo',
+    '--channel',
+    'rc',
+    '--version',
+    '0.8.0-rc.1',
+    '--dwell-minutes',
+    '30',
+    '--quarantine-stale-hours',
+    '12'
+  ]);
+  assert.equal(parsed.apply, true);
+  assert.equal(parsed.dryRun, false);
+  assert.equal(parsed.repo, 'owner/repo');
+  assert.equal(parsed.channel, 'rc');
+  assert.equal(parsed.version, '0.8.0-rc.1');
+  assert.equal(parsed.dwellMinutes, 30);
+  assert.equal(parsed.quarantineStaleHours, 12);
+});
+
+test('gate evaluators classify pass/fail deterministically', () => {
+  const now = new Date('2026-03-06T12:00:00.000Z');
+  const green = evaluateGreenDwell({
+    now,
+    dwellMinutes: 60,
+    workflowRunsByName: {
+      Validate: [{ status: 'completed', conclusion: 'success', updated_at: '2026-03-06T11:30:00Z' }],
+      'Policy Guard (Upstream)': [{ status: 'completed', conclusion: 'success', updated_at: '2026-03-06T11:35:00Z' }]
+    }
+  });
+  assert.equal(green.status, 'pass');
+
+  const queueFail = evaluateQueueHealthGate({
+    exists: true,
+    error: null,
+    payload: {
+      paused: true,
+      throughputController: { mode: 'stabilize' }
+    }
+  });
+  assert.equal(queueFail.status, 'fail');
+  assert.ok(queueFail.reasons.includes('queue-paused'));
+
+  const policyPass = evaluatePolicySnapshotGate({
+    exists: true,
+    error: null,
+    payload: {
+      schema: 'priority/policy-live-state@v1',
+      generatedAt: '2026-03-06T11:00:00Z',
+      state: {}
+    }
+  });
+  assert.equal(policyPass.status, 'pass');
+
+  const quarantineFail = evaluateQuarantineGate({
+    now,
+    staleHours: 24,
+    queueReportEnvelope: {
+      exists: true,
+      error: null,
+      payload: {
+        retryHistory: {
+          '88': {
+            failures: ['2026-03-04T10:00:00Z', '2026-03-04T11:00:00Z']
+          }
+        }
+      }
+    }
+  });
+  assert.equal(quarantineFail.status, 'fail');
+  assert.equal(quarantineFail.staleCount, 1);
+});
+
+test('runReleaseConductor blocks apply when release conductor flag is disabled', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      return { status: 0, stdout: 'ABC123', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'stable',
+      version: '0.8.0',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '0'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(report.decision.status, 'fail');
+  assert.ok(report.decision.blockers.some((entry) => entry.code === 'apply-disabled'));
+  assert.equal(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'), false);
+});
+
+test('runReleaseConductor creates signed tag when apply is enabled and signing key is available', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      return { status: 0, stdout: 'ABC123', stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'tag') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'stable',
+      version: '0.8.0',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.proposalOnly, false);
+  assert.equal(report.release.tagCreated, true);
+  assert.ok(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'));
+});
+
+test('runReleaseConductor stays proposal-only when signing material is unavailable', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      return { status: 1, stdout: '', stderr: 'missing signing key' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'stable',
+      version: '0.8.0',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.proposalOnly, true);
+  assert.equal(report.release.tagCreated, false);
+  assert.equal(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'), false);
+});

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -1,0 +1,635 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const REPORT_SCHEMA = 'release/release-conductor-report@v1';
+export const DEFAULT_REPORT_PATH = path.join('tests', 'results', '_agent', 'release', 'release-conductor-report.json');
+export const DEFAULT_QUEUE_REPORT_PATH = path.join('tests', 'results', '_agent', 'queue', 'queue-supervisor-report.json');
+export const DEFAULT_POLICY_SNAPSHOT_PATH = path.join('tests', 'results', '_agent', 'policy', 'policy-state-snapshot.json');
+export const DEFAULT_DWELL_MINUTES = 60;
+export const DEFAULT_QUARANTINE_STALE_HOURS = 24;
+
+const REQUIRED_DWELL_WORKFLOWS = Object.freeze([
+  { name: 'Validate', file: 'validate.yml' },
+  { name: 'Policy Guard (Upstream)', file: 'policy-guard-upstream.yml' }
+]);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/release-conductor.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --apply                     Apply release mutation (default is --dry-run).');
+  console.log(`  --report <path>             Write report JSON (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log(`  --queue-report <path>       Queue supervisor report path (default: ${DEFAULT_QUEUE_REPORT_PATH}).`);
+  console.log(`  --policy-snapshot <path>    Policy snapshot path (default: ${DEFAULT_POLICY_SNAPSHOT_PATH}).`);
+  console.log('  --repo <owner/repo>         Target repository (default: GITHUB_REPOSITORY/upstream/origin remote).');
+  console.log('  --stream <name>             Release stream name (default: comparevi-cli).');
+  console.log('  --channel <stable|rc>       Release channel (default: stable).');
+  console.log('  --version <semver>          Proposed version used for release tag proposal (optional).');
+  console.log(`  --dwell-minutes <n>         Required green dwell window in minutes (default: ${DEFAULT_DWELL_MINUTES}).`);
+  console.log(`  --quarantine-stale-hours <n> Fail when queue quarantine is stale beyond N hours (default: ${DEFAULT_QUARANTINE_STALE_HOURS}).`);
+  console.log('  --dry-run                   Force dry-run mode.');
+  console.log('  -h, --help                  Show this help text and exit.');
+}
+
+function parseIntStrict(value, { label }) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${label} value '${value}'.`);
+  }
+  return parsed;
+}
+
+function asOptional(value) {
+  if (value == null) return null;
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+export function parseRemoteUrl(url) {
+  if (!url) return null;
+  const ssh = String(url).match(/:(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const https = String(url).match(/github\.com\/(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const repoPath = ssh?.groups?.repoPath ?? https?.groups?.repoPath;
+  if (!repoPath) return null;
+  const [owner, repoRaw] = repoPath.split('/');
+  if (!owner || !repoRaw) return null;
+  const repo = repoRaw.endsWith('.git') ? repoRaw.slice(0, -4) : repoRaw;
+  return `${owner}/${repo}`;
+}
+
+export function resolveRepositorySlug(repoRoot, explicitRepo, environment = process.env) {
+  const explicit = asOptional(explicitRepo);
+  if (explicit && explicit.includes('/')) {
+    return explicit;
+  }
+  const envRepo = asOptional(environment.GITHUB_REPOSITORY);
+  if (envRepo && envRepo.includes('/')) {
+    return envRepo;
+  }
+
+  for (const remoteName of ['upstream', 'origin']) {
+    const result = spawnSync('git', ['config', '--get', `remote.${remoteName}.url`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    if (result.status !== 0) {
+      continue;
+    }
+    const parsed = parseRemoteUrl(result.stdout.trim());
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  throw new Error('Unable to resolve repository slug. Set GITHUB_REPOSITORY or pass --repo.');
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    apply: false,
+    dryRun: true,
+    reportPath: DEFAULT_REPORT_PATH,
+    queueReportPath: DEFAULT_QUEUE_REPORT_PATH,
+    policySnapshotPath: DEFAULT_POLICY_SNAPSHOT_PATH,
+    repo: null,
+    stream: 'comparevi-cli',
+    channel: 'stable',
+    version: null,
+    dwellMinutes: DEFAULT_DWELL_MINUTES,
+    quarantineStaleHours: DEFAULT_QUARANTINE_STALE_HOURS,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--apply') {
+      options.apply = true;
+      options.dryRun = false;
+      continue;
+    }
+    if (token === '--dry-run') {
+      options.apply = false;
+      options.dryRun = true;
+      continue;
+    }
+
+    if (
+      token === '--report' ||
+      token === '--queue-report' ||
+      token === '--policy-snapshot' ||
+      token === '--repo' ||
+      token === '--stream' ||
+      token === '--channel' ||
+      token === '--version' ||
+      token === '--dwell-minutes' ||
+      token === '--quarantine-stale-hours'
+    ) {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--report') options.reportPath = next;
+      if (token === '--queue-report') options.queueReportPath = next;
+      if (token === '--policy-snapshot') options.policySnapshotPath = next;
+      if (token === '--repo') options.repo = next;
+      if (token === '--stream') options.stream = next;
+      if (token === '--channel') options.channel = next.trim().toLowerCase();
+      if (token === '--version') options.version = next;
+      if (token === '--dwell-minutes') options.dwellMinutes = parseIntStrict(next, { label: '--dwell-minutes' });
+      if (token === '--quarantine-stale-hours') {
+        options.quarantineStaleHours = parseIntStrict(next, { label: '--quarantine-stale-hours' });
+      }
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!['stable', 'rc'].includes(options.channel)) {
+    throw new Error(`Invalid --channel '${options.channel}'. Expected stable or rc.`);
+  }
+
+  return options;
+}
+
+function runCommand(command, args, { cwd, allowFailure = false } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.status !== 0 && !allowFailure) {
+    const stderr = result.stderr?.trim();
+    throw new Error(`${command} ${args.join(' ')} failed (${result.status})${stderr ? `: ${stderr}` : ''}`);
+  }
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? ''
+  };
+}
+
+function runGhJson(args, { cwd } = {}) {
+  const result = runCommand('gh', args, { cwd, allowFailure: true });
+  if (result.status !== 0) {
+    const message = result.stderr?.trim() || result.stdout?.trim() || `gh ${args.join(' ')} failed (${result.status})`;
+    throw new Error(message);
+  }
+  const raw = (result.stdout ?? '').trim();
+  return raw ? JSON.parse(raw) : null;
+}
+
+async function readJsonOptional(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!existsSync(resolved)) {
+    return {
+      exists: false,
+      path: resolved,
+      payload: null,
+      error: null
+    };
+  }
+
+  try {
+    const raw = await readFile(resolved, 'utf8');
+    return {
+      exists: true,
+      path: resolved,
+      payload: JSON.parse(raw),
+      error: null
+    };
+  } catch (error) {
+    return {
+      exists: true,
+      path: resolved,
+      payload: null,
+      error: error?.message ?? String(error)
+    };
+  }
+}
+
+function normalizeUpdatedAt(entry) {
+  const updatedAt = new Date(entry?.updated_at ?? entry?.updatedAt ?? 0);
+  return Number.isNaN(updatedAt.valueOf()) ? null : updatedAt;
+}
+
+function normalizeConclusion(entry) {
+  return String(entry?.conclusion ?? '').trim().toLowerCase();
+}
+
+export function evaluateGreenDwell({
+  workflowRunsByName = {},
+  now = new Date(),
+  dwellMinutes = DEFAULT_DWELL_MINUTES
+} = {}) {
+  const dwellStartMs = now.valueOf() - dwellMinutes * 60 * 1000;
+  const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure']);
+  const details = [];
+  const reasons = [];
+
+  for (const spec of REQUIRED_DWELL_WORKFLOWS) {
+    const runs = Array.isArray(workflowRunsByName[spec.name]) ? workflowRunsByName[spec.name] : [];
+    const inWindow = runs.filter((entry) => {
+      const updatedAt = normalizeUpdatedAt(entry);
+      return updatedAt && updatedAt.valueOf() >= dwellStartMs;
+    });
+    const successInWindow = inWindow.some((entry) => normalizeConclusion(entry) === 'success');
+    const failureInWindow = inWindow.some((entry) => failureConclusions.has(normalizeConclusion(entry)));
+    const latestSuccess = runs
+      .filter((entry) => normalizeConclusion(entry) === 'success')
+      .map((entry) => normalizeUpdatedAt(entry)?.toISOString() ?? null)
+      .find(Boolean);
+
+    const status = successInWindow && !failureInWindow ? 'pass' : 'fail';
+    if (!successInWindow) {
+      reasons.push(`no-success-${spec.file}`);
+    }
+    if (failureInWindow) {
+      reasons.push(`failure-in-window-${spec.file}`);
+    }
+
+    details.push({
+      name: spec.name,
+      file: spec.file,
+      runCount: runs.length,
+      inWindowCount: inWindow.length,
+      successInWindow,
+      failureInWindow,
+      latestSuccessAt: latestSuccess
+    });
+  }
+
+  return {
+    status: reasons.length === 0 ? 'pass' : 'fail',
+    dwellMinutes,
+    evaluatedAt: now.toISOString(),
+    reasons: [...new Set(reasons)],
+    workflows: details
+  };
+}
+
+export function evaluateQueueHealthGate(queueReportEnvelope) {
+  if (!queueReportEnvelope.exists || queueReportEnvelope.error || !queueReportEnvelope.payload) {
+    return {
+      status: 'fail',
+      reasons: ['queue-report-unavailable'],
+      paused: null,
+      controllerMode: null
+    };
+  }
+
+  const queueReport = queueReportEnvelope.payload;
+  const paused = Boolean(queueReport?.paused);
+  const controllerMode =
+    queueReport?.throughputController?.mode ??
+    queueReport?.adaptiveInflight?.mode ??
+    null;
+
+  const reasons = [];
+  if (paused) reasons.push('queue-paused');
+  if (controllerMode === 'stabilize') reasons.push('queue-stabilize-mode');
+
+  return {
+    status: reasons.length === 0 ? 'pass' : 'fail',
+    reasons,
+    paused,
+    controllerMode
+  };
+}
+
+export function evaluatePolicySnapshotGate(policySnapshotEnvelope) {
+  if (!policySnapshotEnvelope.exists || policySnapshotEnvelope.error || !policySnapshotEnvelope.payload) {
+    return {
+      status: 'fail',
+      reasons: ['policy-snapshot-unavailable'],
+      schema: null,
+      generatedAt: null
+    };
+  }
+
+  const payload = policySnapshotEnvelope.payload;
+  const reasons = [];
+  if (payload?.schema !== 'priority/policy-live-state@v1') {
+    reasons.push('policy-snapshot-schema-mismatch');
+  }
+  const generatedAt = payload?.generatedAt;
+  if (!generatedAt || Number.isNaN(Date.parse(generatedAt))) {
+    reasons.push('policy-snapshot-generated-at-invalid');
+  }
+  if (!payload?.state || typeof payload.state !== 'object') {
+    reasons.push('policy-snapshot-state-missing');
+  }
+
+  return {
+    status: reasons.length === 0 ? 'pass' : 'fail',
+    reasons,
+    schema: payload?.schema ?? null,
+    generatedAt: generatedAt ?? null
+  };
+}
+
+export function evaluateQuarantineGate({
+  queueReportEnvelope,
+  now = new Date(),
+  staleHours = DEFAULT_QUARANTINE_STALE_HOURS
+} = {}) {
+  if (!queueReportEnvelope.exists || queueReportEnvelope.error || !queueReportEnvelope.payload) {
+    return {
+      status: 'fail',
+      reasons: ['queue-report-unavailable'],
+      staleCount: null,
+      activeCount: null,
+      staleEntries: []
+    };
+  }
+
+  const retryHistory =
+    queueReportEnvelope.payload?.retryHistory && typeof queueReportEnvelope.payload.retryHistory === 'object'
+      ? queueReportEnvelope.payload.retryHistory
+      : {};
+
+  const staleCutoffMs = now.valueOf() - staleHours * 60 * 60 * 1000;
+  const staleEntries = [];
+  let activeCount = 0;
+
+  for (const [number, entry] of Object.entries(retryHistory)) {
+    const failures = Array.isArray(entry?.failures) ? entry.failures : [];
+    if (failures.length < 2) {
+      continue;
+    }
+    activeCount += 1;
+    const latestFailure = failures
+      .map((value) => Date.parse(value))
+      .filter((value) => Number.isFinite(value))
+      .sort((a, b) => b - a)[0];
+
+    if (!Number.isFinite(latestFailure) || latestFailure <= staleCutoffMs) {
+      staleEntries.push({
+        number: Number(number),
+        latestFailureAt: Number.isFinite(latestFailure) ? new Date(latestFailure).toISOString() : null,
+        failureCount: failures.length
+      });
+    }
+  }
+
+  const reasons = staleEntries.length > 0 ? ['stale-quarantine-present'] : [];
+  return {
+    status: reasons.length === 0 ? 'pass' : 'fail',
+    reasons,
+    staleHours,
+    staleCount: staleEntries.length,
+    activeCount,
+    staleEntries: staleEntries.sort((left, right) => left.number - right.number)
+  };
+}
+
+function fetchWorkflowRunsByName({ runGhJsonFn, repository, branch, sampleSize, cwd }) {
+  const workflowRunsByName = {};
+  const fetchErrors = [];
+
+  for (const workflow of REQUIRED_DWELL_WORKFLOWS) {
+    const endpoint = `repos/${repository}/actions/workflows/${workflow.file}/runs?branch=${encodeURIComponent(branch)}&per_page=${sampleSize}`;
+    try {
+      const response = runGhJsonFn(['api', endpoint], { cwd }) ?? {};
+      workflowRunsByName[workflow.name] = Array.isArray(response.workflow_runs) ? response.workflow_runs : [];
+    } catch (error) {
+      workflowRunsByName[workflow.name] = [];
+      fetchErrors.push({
+        workflow: workflow.name,
+        file: workflow.file,
+        message: error?.message ?? String(error)
+      });
+    }
+  }
+
+  return {
+    workflowRunsByName,
+    fetchErrors
+  };
+}
+
+function detectSigningMaterial({ runCommandFn, repoRoot }) {
+  const keyResult = runCommandFn('git', ['config', '--get', 'user.signingkey'], {
+    cwd: repoRoot,
+    allowFailure: true
+  });
+  const signingKey = asOptional(keyResult.stdout);
+
+  return {
+    available: Boolean(signingKey),
+    signingKey,
+    source: signingKey ? 'git-config' : 'missing'
+  };
+}
+
+function resolveTargetTag(version) {
+  const normalized = asOptional(version);
+  if (!normalized) return null;
+  return normalized.startsWith('v') ? normalized : `v${normalized}`;
+}
+
+async function writeReport(filePath, payload) {
+  const resolved = path.resolve(filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export async function runReleaseConductor(options = {}) {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const now = options.now ?? new Date();
+  const args = options.args ?? parseArgs();
+  const runGhJsonFn = options.runGhJsonFn ?? runGhJson;
+  const runCommandFn = options.runCommandFn ?? runCommand;
+  const readJsonOptionalFn = options.readJsonOptionalFn ?? readJsonOptional;
+  const writeReportFn = options.writeReportFn ?? writeReport;
+  const environment = options.environment ?? process.env;
+
+  const repository = resolveRepositorySlug(repoRoot, args.repo, environment);
+  const queueReportEnvelope = await readJsonOptionalFn(path.resolve(repoRoot, args.queueReportPath));
+  const policySnapshotEnvelope = await readJsonOptionalFn(path.resolve(repoRoot, args.policySnapshotPath));
+  const { workflowRunsByName, fetchErrors } = fetchWorkflowRunsByName({
+    runGhJsonFn,
+    repository,
+    branch: 'develop',
+    sampleSize: 20,
+    cwd: repoRoot
+  });
+
+  const greenDwellGate = evaluateGreenDwell({
+    workflowRunsByName,
+    now,
+    dwellMinutes: args.dwellMinutes
+  });
+  const queueHealthGate = evaluateQueueHealthGate(queueReportEnvelope);
+  const policySnapshotGate = evaluatePolicySnapshotGate(policySnapshotEnvelope);
+  const quarantineGate = evaluateQuarantineGate({
+    queueReportEnvelope,
+    now,
+    staleHours: args.quarantineStaleHours
+  });
+
+  const blockers = [];
+  if (fetchErrors.length > 0) {
+    blockers.push({
+      code: 'workflow-fetch-failed',
+      message: 'Unable to fetch required workflow run history for dwell gate.'
+    });
+  }
+  if (greenDwellGate.status !== 'pass') {
+    blockers.push({
+      code: 'green-dwell-failed',
+      message: `Required workflows were not continuously green for ${args.dwellMinutes} minutes.`
+    });
+  }
+  if (queueHealthGate.status !== 'pass') {
+    blockers.push({
+      code: 'queue-health-failed',
+      message: 'Queue supervisor reported paused/stabilize state.'
+    });
+  }
+  if (policySnapshotGate.status !== 'pass') {
+    blockers.push({
+      code: 'policy-snapshot-failed',
+      message: 'Policy snapshot artifact is missing or invalid.'
+    });
+  }
+  if (quarantineGate.status !== 'pass') {
+    blockers.push({
+      code: 'stale-quarantine-failed',
+      message: 'Queue quarantine has stale entries that require manual remediation.'
+    });
+  }
+
+  const applyRequested = Boolean(args.apply && !args.dryRun);
+  const conductorEnabled = String(environment.RELEASE_CONDUCTOR_ENABLED ?? '').trim() === '1';
+  if (applyRequested && !conductorEnabled) {
+    blockers.push({
+      code: 'apply-disabled',
+      message: 'Apply mode requested but RELEASE_CONDUCTOR_ENABLED is not set to 1.'
+    });
+  }
+
+  const signingMaterial = detectSigningMaterial({ runCommandFn, repoRoot });
+  const targetTag = resolveTargetTag(args.version);
+  let tagCreated = false;
+  let tagError = null;
+  let proposalOnly = true;
+
+  if (blockers.length === 0 && applyRequested && conductorEnabled) {
+    if (!targetTag) {
+      blockers.push({
+        code: 'missing-version-for-tag',
+        message: 'Apply mode requires --version to propose/create a release tag.'
+      });
+    } else if (signingMaterial.available) {
+      const tagResult = runCommandFn('git', ['tag', '-s', targetTag, '-m', `Release ${targetTag}`], {
+        cwd: repoRoot,
+        allowFailure: true
+      });
+      if (tagResult.status === 0) {
+        tagCreated = true;
+        proposalOnly = false;
+      } else {
+        tagError = asOptional(tagResult.stderr) ?? asOptional(tagResult.stdout) ?? 'tag creation failed';
+        blockers.push({
+          code: 'tag-create-failed',
+          message: `Signed tag creation failed for ${targetTag}: ${tagError}`
+        });
+      }
+    }
+  }
+
+  const status = blockers.length === 0 ? 'pass' : 'fail';
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: now.toISOString(),
+    repository,
+    mode: {
+      apply: applyRequested,
+      dryRun: !applyRequested,
+      releaseConductorEnabled: conductorEnabled
+    },
+    release: {
+      stream: args.stream,
+      channel: args.channel,
+      version: asOptional(args.version),
+      targetTag,
+      proposalOnly,
+      tagCreated,
+      tagError,
+      signingMaterial
+    },
+    inputs: {
+      reportPath: args.reportPath,
+      queueReportPath: args.queueReportPath,
+      policySnapshotPath: args.policySnapshotPath,
+      dwellMinutes: args.dwellMinutes,
+      quarantineStaleHours: args.quarantineStaleHours
+    },
+    gates: {
+      greenDwell: greenDwellGate,
+      queueHealth: queueHealthGate,
+      policySnapshot: policySnapshotGate,
+      quarantine: quarantineGate
+    },
+    workflowFetchErrors: fetchErrors,
+    decision: {
+      status,
+      blockerCount: blockers.length,
+      blockers
+    }
+  };
+
+  const reportPath = await writeReportFn(args.reportPath, report);
+  return {
+    report,
+    reportPath,
+    exitCode: status === 'pass' ? 0 : 1
+  };
+}
+
+export async function main(argv = process.argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printUsage();
+    return 0;
+  }
+
+  const { report, reportPath, exitCode } = await runReleaseConductor({ args });
+  console.log(
+    `[release-conductor] report: ${reportPath} status=${report.decision.status} blockers=${report.decision.blockerCount}`
+  );
+  if (report.release.targetTag) {
+    console.log(`[release-conductor] targetTag=${report.release.targetTag} proposalOnly=${report.release.proposalOnly}`);
+  }
+  return exitCode;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((exitCode) => {
+      if (exitCode !== 0) {
+        process.exitCode = exitCode;
+      }
+    })
+    .catch((error) => {
+      console.error(error?.stack ?? error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- Adds queue-aware release conductor CLI + workflow.
- Applies proposal-only fallback when signing material is unavailable.

Coupling: hard
Depends-On: #832

Refs: #809