### PR TITLE
feat(governance): add weekly scorecard and gameday lane (#815 #809)

### DIFF
--- a/.github/workflows/weekly-scorecard.yml
+++ b/.github/workflows/weekly-scorecard.yml
@@ -1,0 +1,207 @@
+name: Weekly Governance Scorecard
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Scorecard mode override (auto|weekly|gameday)'
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - weekly
+          - gameday
+      require_canary:
+        description: 'Require canary report to pass'
+        required: false
+        default: true
+        type: boolean
+      route_on_persistent_breach:
+        description: 'Upsert governance incident on persistent breach'
+        required: false
+        default: true
+        type: boolean
+      strict_canary:
+        description: 'Fail job when canary replay reports drift'
+        required: false
+        default: true
+        type: boolean
+  schedule:
+    - cron: '20 18 * * 3'
+
+concurrency:
+  group: weekly-governance-scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  weekly-scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Prepare governance token
+        shell: pwsh
+        env:
+          INPUT_TOKEN_PRIMARY: ${{ secrets.GH_TOKEN }}
+          INPUT_TOKEN_SECONDARY: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN_TERTIARY: ${{ github.token }}
+        run: |
+          pwsh -NoLogo -NoProfile -File tools/priority/Resolve-PolicyToken.ps1 `
+            -TokenFileName weekly-scorecard-gh-token.txt `
+            -RequireAdmin:$false
+
+      - name: Resolve scorecard mode
+        id: mode
+        shell: pwsh
+        run: |
+          $manualMode = '${{ inputs.mode }}'.Trim().ToLowerInvariant()
+          if ([string]::IsNullOrWhiteSpace($manualMode)) {
+            $manualMode = 'auto'
+          }
+
+          $selectedMode = $manualMode
+          if ($manualMode -eq 'auto') {
+            $now = [DateTime]::UtcNow
+            $isFirstWednesday = $now.DayOfWeek -eq [System.DayOfWeek]::Wednesday -and $now.Day -le 7
+            if ($isFirstWednesday) {
+              $selectedMode = 'gameday'
+            } else {
+              $selectedMode = 'weekly'
+            }
+          }
+
+          if (@('weekly', 'gameday') -notcontains $selectedMode) {
+            throw "Unsupported mode '$selectedMode'. Expected weekly or gameday."
+          }
+
+          $isScheduled = '${{ github.event_name }}' -eq 'schedule'
+
+          $requireCanary = '${{ inputs.require_canary }}' -eq 'true'
+          if ($isScheduled -or $selectedMode -eq 'gameday') {
+            $requireCanary = $true
+          }
+
+          $routePersistent = '${{ inputs.route_on_persistent_breach }}' -eq 'true'
+          if ($isScheduled) {
+            $routePersistent = $true
+          }
+
+          $strictCanary = '${{ inputs.strict_canary }}' -eq 'true'
+          if ($isScheduled) {
+            $strictCanary = $true
+          }
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "mode=$selectedMode"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "require_canary=$($requireCanary.ToString().ToLowerInvariant())"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "route_on_persistent_breach=$($routePersistent.ToString().ToLowerInvariant())"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "strict_canary=$($strictCanary.ToString().ToLowerInvariant())"
+
+          @(
+            '### Weekly Governance Scorecard Mode',
+            '',
+            "- event: `${{ github.event_name }}`",
+            "- selected mode: `$selectedMode`",
+            "- require canary: `$($requireCanary.ToString().ToLowerInvariant())`",
+            "- route on persistent breach: `$($routePersistent.ToString().ToLowerInvariant())`",
+            "- strict canary: `$($strictCanary.ToString().ToLowerInvariant())`"
+          ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Install dependencies
+        shell: pwsh
+        run: npm ci --ignore-scripts
+
+      - name: Run canary replay conformance
+        id: canary
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $args = @(
+            'tools/npm/run-script.mjs',
+            'priority:canary:replay',
+            '--',
+            '--report',
+            'tests/results/_agent/canary/canary-replay-conformance-report.json'
+          )
+
+          if ('${{ steps.mode.outputs.strict_canary }}' -ne 'true') {
+            $args += '--no-strict'
+          }
+
+          node @args
+
+      - name: Build remediation SLO report
+        shell: pwsh
+        run: |
+          node tools/npm/run-script.mjs priority:remediation:slo -- --output tests/results/_agent/slo/remediation-slo-report.json
+
+      - name: Build weekly scorecard
+        shell: pwsh
+        run: |
+          $args = @(
+            'tools/npm/run-script.mjs',
+            'priority:weekly:scorecard',
+            '--',
+            '--output',
+            'tests/results/_agent/slo/weekly-scorecard.json',
+            '--remediation-report',
+            'tests/results/_agent/slo/remediation-slo-report.json',
+            '--canary-report',
+            'tests/results/_agent/canary/canary-replay-conformance-report.json',
+            '--mode',
+            '${{ steps.mode.outputs.mode }}'
+          )
+
+          if ('${{ steps.mode.outputs.require_canary }}' -eq 'true') {
+            $args += '--require-canary'
+          }
+
+          if ('${{ steps.mode.outputs.route_on_persistent_breach }}' -eq 'true') {
+            $args += '--route-on-persistent-breach'
+          }
+
+          node @args
+
+      - name: Validate governance report schemas
+        shell: pwsh
+        run: |
+          node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/weekly-scorecard-v1.schema.json --data tests/results/_agent/slo/weekly-scorecard.json
+          node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/remediation-slo-report-v1.schema.json --data tests/results/_agent/slo/remediation-slo-report.json --optional
+          node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/canary-replay-conformance-report-v1.schema.json --data tests/results/_agent/canary/canary-replay-conformance-report.json --optional
+
+      - name: Enforce strict canary mode
+        if: always()
+        shell: pwsh
+        run: |
+          $strict = '${{ steps.mode.outputs.strict_canary }}' -eq 'true'
+          $outcome = '${{ steps.canary.outcome }}'
+
+          if ($strict -and $outcome -ne 'success') {
+            throw "Canary replay failed in strict mode (outcome=$outcome)."
+          }
+
+      - name: Upload SLO artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: weekly-scorecard-slo-${{ github.run_id }}
+          path: tests/results/_agent/slo/*.json
+          if-no-files-found: warn
+
+      - name: Upload canary artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: weekly-scorecard-canary-${{ github.run_id }}
+          path: tests/results/_agent/canary/*.json
+          if-no-files-found: warn

--- a/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
+++ b/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
@@ -10,8 +10,8 @@ This scaffold tracks the six planned mergeable slices so agents can resume deter
 | PR2 | #814 | `codex/pr2-814-readiness-buffer-admission` | Readiness buffer + admission scoring | committed | `tests/results/_agent/queue/queue-readiness-report.json` |
 | PR3 | #814 | `codex/pr3-814-release-burst-windows` | Burst windows and backoff | committed | `tests/results/_agent/queue/queue-supervisor-report.json` |
 | PR4 | #809 child | `codex/pr4-809-queue-aware-release-conductor` | Queue-aware release conductor (CLI stream) | committed | `tests/results/_agent/release/release-conductor-report.json` |
-| PR5 | #813 | `codex/pr5-813-remediation-slo-evaluator` | Remediation SLO evaluator + governance transitions | in-progress | `tests/results/_agent/slo/remediation-slo-report.json` |
-| PR6 | #815 | `codex/pr6-815-weekly-scorecards-gameday` | Weekly scorecards + canary game-day | pending | `tests/results/_agent/slo/weekly-scorecard.json` |
+| PR5 | #813 | `codex/pr5-813-remediation-slo-evaluator` | Remediation SLO evaluator + governance transitions | committed | `tests/results/_agent/slo/remediation-slo-report.json` |
+| PR6 | #815 | `codex/pr6-815-weekly-scorecards-gameday` | Weekly scorecards + canary game-day | committed | `tests/results/_agent/slo/weekly-scorecard.json` |
 
 ## Sequencing notes
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -319,6 +319,10 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   Use `node tools/npm/run-script.mjs priority:remediation:slo` to compute remediation SLO governance metrics
   (MTTD, route latency, MTTR by priority, reopen rate, queue/trunk/release signals) and emit
   `tests/results/_agent/slo/remediation-slo-report.json`.
+  Use `node tools/npm/run-script.mjs priority:weekly:scorecard` to build the weekly governance snapshot at
+  `tests/results/_agent/slo/weekly-scorecard.json` (optionally with `--route-on-persistent-breach`).
+  The `Weekly Governance Scorecard` workflow (`.github/workflows/weekly-scorecard.yml`) runs weekly and auto-switches
+  to `gameday` mode on the first Wednesday UTC to replay canary + scorecard governance in one lane.
 - For deterministic incident routing, run the control-plane chain in order:
   - `node tools/npm/run-script.mjs priority:event:ingest -- ...`
   - `node tools/npm/run-script.mjs priority:policy:route -- --event <event-report-or-event-json>`

--- a/docs/schemas/weekly-scorecard-v1.schema.json
+++ b/docs/schemas/weekly-scorecard-v1.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "priority/weekly-scorecard@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "repository",
+    "mode",
+    "requireCanary",
+    "inputs",
+    "components",
+    "summary",
+    "routing"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/weekly-scorecard@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["weekly", "gameday"]
+    },
+    "requireCanary": {
+      "type": "boolean"
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outputPath", "remediationReportPath", "canaryReportPath"],
+      "properties": {
+        "outputPath": { "type": "string" },
+        "remediationReportPath": { "type": "string" },
+        "canaryReportPath": { "type": "string" }
+      }
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["remediation", "canary"],
+      "properties": {
+        "remediation": { "$ref": "#/$defs/component" },
+        "canary": {
+          "allOf": [
+            { "$ref": "#/$defs/component" },
+            {
+              "type": "object",
+              "required": ["required"],
+              "properties": {
+                "required": { "type": "boolean" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "breachCount",
+        "breaches",
+        "previousStatus",
+        "firstBreach",
+        "persistentBreach"
+      ],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "warn", "fail"] },
+        "breachCount": { "type": "integer", "minimum": 0 },
+        "breaches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["key", "status"],
+            "properties": {
+              "key": { "type": "string" },
+              "status": { "type": "string", "enum": ["warn", "fail"] }
+            }
+          }
+        },
+        "previousStatus": { "type": "string", "enum": ["pass", "warn", "fail"] },
+        "firstBreach": { "type": "boolean" },
+        "persistentBreach": { "type": "boolean" }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "action", "issueNumber", "issueUrl", "error"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "action": { "type": "string" },
+        "issueNumber": { "type": ["integer", "null"] },
+        "issueUrl": { "type": ["string", "null"] },
+        "error": { "type": ["string", "null"] }
+      }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "exists", "error"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "warn", "fail", "n/a"] },
+        "exists": { "type": "boolean" },
+        "error": { "type": ["string", "null"] },
+        "required": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "priority:release:scorecard": "node tools/priority/release-scorecard.mjs",
     "priority:release:conductor": "node tools/priority/release-conductor.mjs",
     "priority:remediation:slo": "node tools/priority/remediation-slo-evaluator.mjs",
+    "priority:weekly:scorecard": "node tools/priority/weekly-scorecard.mjs",
     "priority:security:intake": "node tools/priority/security-intake.mjs",
     "priority:security:gate": "node tools/priority/security-intake.mjs --route-on-breach --fail-on-breach --fail-on-skip",
     "priority:onboard:downstream": "node tools/priority/downstream-onboarding.mjs",

--- a/tools/priority/__tests__/weekly-scorecard-schema.test.mjs
+++ b/tools/priority/__tests__/weekly-scorecard-schema.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { runWeeklyScorecard } from '../weekly-scorecard.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('weekly scorecard report validates schema', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'weekly-scorecard-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.endsWith('weekly-scorecard.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'warn'
+          }
+        },
+        error: null
+      };
+    }
+    if (normalized.includes('remediation-slo-report.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'fail'
+          }
+        },
+        error: null
+      };
+    }
+    if (normalized.includes('canary-replay-conformance-report.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          status: 'warn'
+        },
+        error: null
+      };
+    }
+    throw new Error(`Unexpected path: ${filePath}`);
+  };
+
+  const { report } = await runWeeklyScorecard({
+    repoRoot,
+    now: new Date('2026-03-07T00:00:00Z'),
+    args: {
+      outputPath: 'tests/results/_agent/slo/weekly-scorecard.json',
+      remediationReportPath: 'tests/results/_agent/slo/remediation-slo-report.json',
+      canaryReportPath: 'tests/results/_agent/canary/canary-replay-conformance-report.json',
+      mode: 'gameday',
+      requireCanary: true,
+      routeOnPersistentBreach: true,
+      issueTitlePrefix: '[Governance] Weekly scorecard breach',
+      issueLabels: ['governance', 'slo', 'canary'],
+      repo: 'owner/repo',
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo'
+    },
+    githubToken: 'test-token',
+    routeIssueFn: async () => ({
+      action: 'comment',
+      issueNumber: 42,
+      issueUrl: 'https://example.test/issues/42',
+      error: null
+    }),
+    readJsonOptionalFn,
+    writeJsonFn: async (reportPath) => reportPath
+  });
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/weekly-scorecard-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/weekly-scorecard-workflow-contract.test.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('weekly scorecard workflow schedules weekly execution', () => {
+  const workflow = readRepoFile('.github/workflows/weekly-scorecard.yml');
+  assert.match(workflow, /name:\s+Weekly Governance Scorecard/);
+  assert.match(workflow, /schedule:\s*\n\s*-\s*cron:\s*'20 18 \* \* 3'/);
+});
+
+test('weekly scorecard workflow runs canary, remediation, and weekly scorecard contracts', () => {
+  const workflow = readRepoFile('.github/workflows/weekly-scorecard.yml');
+  assert.match(workflow, /priority:canary:replay/);
+  assert.match(workflow, /priority:remediation:slo/);
+  assert.match(workflow, /priority:weekly:scorecard/);
+  assert.match(workflow, /--route-on-persistent-breach/);
+  assert.match(workflow, /tests\/results\/_agent\/slo\/weekly-scorecard\.json/);
+  assert.match(workflow, /tests\/results\/_agent\/canary\/canary-replay-conformance-report\.json/);
+});

--- a/tools/priority/__tests__/weekly-scorecard.test.mjs
+++ b/tools/priority/__tests__/weekly-scorecard.test.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs, runWeeklyScorecard } from '../weekly-scorecard.mjs';
+
+test('parseArgs applies defaults and explicit options', () => {
+  const defaults = parseArgs(['node', 'weekly-scorecard.mjs']);
+  assert.equal(defaults.mode, 'weekly');
+  assert.equal(defaults.requireCanary, false);
+  assert.equal(defaults.routeOnPersistentBreach, false);
+  assert.deepEqual(defaults.issueLabels, ['governance', 'slo', 'canary']);
+
+  const parsed = parseArgs([
+    'node',
+    'weekly-scorecard.mjs',
+    '--mode',
+    'gameday',
+    '--require-canary',
+    '--route-on-persistent-breach',
+    '--issue-title-prefix',
+    '[Gov] Breach',
+    '--issue-labels',
+    'governance,slo',
+    '--repo',
+    'owner/repo'
+  ]);
+  assert.equal(parsed.mode, 'gameday');
+  assert.equal(parsed.requireCanary, true);
+  assert.equal(parsed.routeOnPersistentBreach, true);
+  assert.equal(parsed.issueTitlePrefix, '[Gov] Breach');
+  assert.deepEqual(parsed.issueLabels, ['governance', 'slo']);
+  assert.equal(parsed.repo, 'owner/repo');
+});
+
+test('runWeeklyScorecard passes when remediation passes and canary is optional', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.endsWith('weekly-scorecard.json')) {
+      return {
+        exists: false,
+        path: filePath,
+        payload: null,
+        error: null
+      };
+    }
+    if (normalized.includes('remediation-slo-report.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'pass'
+          }
+        },
+        error: null
+      };
+    }
+    return {
+      exists: false,
+      path: filePath,
+      payload: null,
+      error: null
+    };
+  };
+
+  const { report, exitCode } = await runWeeklyScorecard({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-07T00:00:00Z'),
+    args: {
+      outputPath: 'tests/results/_agent/slo/weekly-scorecard.json',
+      remediationReportPath: 'tests/results/_agent/slo/remediation-slo-report.json',
+      canaryReportPath: 'tests/results/_agent/canary/canary-replay-conformance-report.json',
+      mode: 'weekly',
+      requireCanary: false,
+      routeOnPersistentBreach: true,
+      issueTitlePrefix: '[Governance] Weekly scorecard breach',
+      issueLabels: ['governance', 'slo', 'canary'],
+      repo: 'owner/repo',
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo'
+    },
+    readJsonOptionalFn,
+    writeJsonFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.summary.status, 'pass');
+  assert.equal(report.summary.breachCount, 0);
+  assert.equal(report.routing.action, 'none');
+});
+
+test('runWeeklyScorecard fails gameday when canary report is required but missing', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.endsWith('weekly-scorecard.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'pass'
+          }
+        },
+        error: null
+      };
+    }
+    if (normalized.includes('remediation-slo-report.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'pass'
+          }
+        },
+        error: null
+      };
+    }
+    return {
+      exists: false,
+      path: filePath,
+      payload: null,
+      error: null
+    };
+  };
+
+  const { report } = await runWeeklyScorecard({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-07T00:00:00Z'),
+    args: {
+      outputPath: 'tests/results/_agent/slo/weekly-scorecard.json',
+      remediationReportPath: 'tests/results/_agent/slo/remediation-slo-report.json',
+      canaryReportPath: 'tests/results/_agent/canary/canary-replay-conformance-report.json',
+      mode: 'gameday',
+      requireCanary: true,
+      routeOnPersistentBreach: false,
+      issueTitlePrefix: '[Governance] Weekly scorecard breach',
+      issueLabels: ['governance', 'slo', 'canary'],
+      repo: 'owner/repo',
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo'
+    },
+    readJsonOptionalFn,
+    writeJsonFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(report.summary.status, 'fail');
+  assert.ok(report.summary.breaches.some((entry) => entry.key === 'canary-missing'));
+});
+
+test('runWeeklyScorecard upserts governance issue on persistent breach', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.endsWith('weekly-scorecard.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'warn'
+          }
+        },
+        error: null
+      };
+    }
+    if (normalized.includes('remediation-slo-report.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          summary: {
+            status: 'fail'
+          }
+        },
+        error: null
+      };
+    }
+    if (normalized.includes('canary-replay-conformance-report.json')) {
+      return {
+        exists: true,
+        path: filePath,
+        payload: {
+          status: 'fail'
+        },
+        error: null
+      };
+    }
+    throw new Error(`Unexpected path: ${filePath}`);
+  };
+
+  let routeCallCount = 0;
+  const routeIssueFn = async () => {
+    routeCallCount += 1;
+    return {
+      action: 'create',
+      issueNumber: 999,
+      issueUrl: 'https://example.test/issues/999',
+      error: null
+    };
+  };
+
+  const { report } = await runWeeklyScorecard({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-07T00:00:00Z'),
+    args: {
+      outputPath: 'tests/results/_agent/slo/weekly-scorecard.json',
+      remediationReportPath: 'tests/results/_agent/slo/remediation-slo-report.json',
+      canaryReportPath: 'tests/results/_agent/canary/canary-replay-conformance-report.json',
+      mode: 'gameday',
+      requireCanary: true,
+      routeOnPersistentBreach: true,
+      issueTitlePrefix: '[Governance] Weekly scorecard breach',
+      issueLabels: ['governance', 'slo', 'canary'],
+      repo: 'owner/repo',
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo'
+    },
+    githubToken: 'token',
+    readJsonOptionalFn,
+    routeIssueFn,
+    writeJsonFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(report.summary.persistentBreach, true);
+  assert.equal(routeCallCount, 1);
+  assert.equal(report.routing.action, 'create');
+  assert.equal(report.routing.issueNumber, 999);
+});

--- a/tools/priority/weekly-scorecard.mjs
+++ b/tools/priority/weekly-scorecard.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const REPORT_SCHEMA = 'priority/weekly-scorecard@v1';
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'slo', 'weekly-scorecard.json');
+export const DEFAULT_REMEDIATION_REPORT_PATH = path.join('tests', 'results', '_agent', 'slo', 'remediation-slo-report.json');
+export const DEFAULT_CANARY_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'canary',
+  'canary-replay-conformance-report.json'
+);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/weekly-scorecard.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(`  --output <path>              Weekly scorecard output path (default: ${DEFAULT_OUTPUT_PATH}).`);
+  console.log(`  --remediation-report <path>  Remediation SLO report path (default: ${DEFAULT_REMEDIATION_REPORT_PATH}).`);
+  console.log(`  --canary-report <path>       Canary replay report path (default: ${DEFAULT_CANARY_REPORT_PATH}).`);
+  console.log('  --mode <weekly|gameday>      Scorecard mode (default: weekly).');
+  console.log('  --require-canary             Fail scorecard when canary report is missing/non-pass.');
+  console.log('  --route-on-persistent-breach Upsert governance incident issue when breach is persistent.');
+  console.log('  --issue-title-prefix <text>  Incident issue title prefix (default: [Governance] Weekly scorecard breach).');
+  console.log('  --issue-labels <a,b,c>       Incident issue labels (default: governance,slo,canary).');
+  console.log('  --repo <owner/repo>          Repository slug (default: GITHUB_REPOSITORY/upstream/origin remote).');
+  console.log('  -h, --help                   Show this help text and exit.');
+}
+
+function normalizeText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function normalizeLabels(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function parseRemoteUrl(url) {
+  if (!url) return null;
+  const ssh = String(url).match(/:(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const https = String(url).match(/github\.com\/(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const repoPath = ssh?.groups?.repoPath ?? https?.groups?.repoPath;
+  if (!repoPath) return null;
+  const [owner, repoRaw] = repoPath.split('/');
+  if (!owner || !repoRaw) return null;
+  const repo = repoRaw.endsWith('.git') ? repoRaw.slice(0, -4) : repoRaw;
+  return `${owner}/${repo}`;
+}
+
+export function resolveRepositorySlug(repoRoot, explicitRepo, environment = process.env) {
+  const explicit = normalizeText(explicitRepo);
+  if (explicit && explicit.includes('/')) return explicit;
+  const envRepo = normalizeText(environment.GITHUB_REPOSITORY);
+  if (envRepo && envRepo.includes('/')) return envRepo;
+
+  for (const remoteName of ['upstream', 'origin']) {
+    const result = spawnSync('git', ['config', '--get', `remote.${remoteName}.url`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    if (result.status !== 0) continue;
+    const parsed = parseRemoteUrl(result.stdout.trim());
+    if (parsed) return parsed;
+  }
+
+  throw new Error('Unable to resolve repository slug. Set GITHUB_REPOSITORY or pass --repo.');
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    outputPath: DEFAULT_OUTPUT_PATH,
+    remediationReportPath: DEFAULT_REMEDIATION_REPORT_PATH,
+    canaryReportPath: DEFAULT_CANARY_REPORT_PATH,
+    mode: 'weekly',
+    requireCanary: false,
+    routeOnPersistentBreach: false,
+    issueTitlePrefix: '[Governance] Weekly scorecard breach',
+    issueLabels: ['governance', 'slo', 'canary'],
+    repo: null,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--require-canary') {
+      options.requireCanary = true;
+      continue;
+    }
+    if (token === '--route-on-persistent-breach') {
+      options.routeOnPersistentBreach = true;
+      continue;
+    }
+
+    if (
+      token === '--output' ||
+      token === '--remediation-report' ||
+      token === '--canary-report' ||
+      token === '--mode' ||
+      token === '--issue-title-prefix' ||
+      token === '--issue-labels' ||
+      token === '--repo'
+    ) {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--remediation-report') options.remediationReportPath = next;
+      if (token === '--canary-report') options.canaryReportPath = next;
+      if (token === '--mode') options.mode = next.trim().toLowerCase();
+      if (token === '--issue-title-prefix') options.issueTitlePrefix = next;
+      if (token === '--issue-labels') options.issueLabels = normalizeLabels(next);
+      if (token === '--repo') options.repo = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!['weekly', 'gameday'].includes(options.mode)) {
+    throw new Error(`Invalid --mode '${options.mode}'. Expected weekly or gameday.`);
+  }
+  return options;
+}
+
+async function readJsonOptional(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!existsSync(resolved)) {
+    return {
+      exists: false,
+      path: resolved,
+      payload: null,
+      error: null
+    };
+  }
+
+  try {
+    const raw = await readFile(resolved, 'utf8');
+    return {
+      exists: true,
+      path: resolved,
+      payload: JSON.parse(raw),
+      error: null
+    };
+  } catch (error) {
+    return {
+      exists: true,
+      path: resolved,
+      payload: null,
+      error: error?.message ?? String(error)
+    };
+  }
+}
+
+function resolveStatus(payload, fallback = 'fail') {
+  const status = normalizeText(payload?.summary?.status) ?? normalizeText(payload?.status);
+  if (!status) return fallback;
+  const normalized = status.toLowerCase();
+  if (normalized === 'pass' || normalized === 'warn' || normalized === 'fail') {
+    return normalized;
+  }
+  return fallback;
+}
+
+function severityRank(status) {
+  if (status === 'fail') return 2;
+  if (status === 'warn') return 1;
+  return 0;
+}
+
+async function resolveToken() {
+  for (const candidate of [process.env.GH_TOKEN, process.env.GITHUB_TOKEN]) {
+    const token = normalizeText(candidate);
+    if (token) return token;
+  }
+
+  const files = [process.env.GH_TOKEN_FILE];
+  if (process.platform === 'win32') {
+    files.push('C:\\github_token.txt');
+  }
+
+  for (const filePath of files) {
+    if (!filePath) continue;
+    try {
+      await access(filePath);
+      const token = normalizeText(await readFile(filePath, 'utf8'));
+      if (token) return token;
+    } catch {
+      // ignore
+    }
+  }
+
+  return null;
+}
+
+async function requestGitHubJson(url, token, method = 'GET', body = null) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'priority-weekly-scorecard'
+    },
+    body: body ? JSON.stringify(body) : undefined
+  });
+
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(`GitHub API ${method} ${url} failed (${response.status}): ${text}`);
+  }
+  return payload;
+}
+
+function buildIncidentBody({ report, mode }) {
+  const lines = [
+    '## Governance Scorecard Incident',
+    '',
+    `- Mode: \`${mode}\``,
+    `- Generated at: \`${report.generatedAt}\``,
+    `- Status: \`${report.summary.status}\``,
+    `- Persistent breach: \`${report.summary.persistentBreach}\``,
+    '',
+    '### Components',
+    `- remediation: \`${report.components.remediation.status}\``,
+    `- canary: \`${report.components.canary.status}\``,
+    '',
+    '### Breaches',
+    ...report.summary.breaches.map((entry) => `- ${entry.key}: ${entry.status}`)
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+async function upsertGovernanceIssue({ repository, token, report, titlePrefix, labels, mode }) {
+  const encodedLabels = encodeURIComponent(labels.join(','));
+  const listUrl = `https://api.github.com/repos/${repository}/issues?state=open&labels=${encodedLabels}&per_page=100`;
+  const issues = await requestGitHubJson(listUrl, token, 'GET');
+  const existing = Array.isArray(issues)
+    ? issues.find((issue) => String(issue?.title ?? '').startsWith(titlePrefix))
+    : null;
+
+  const body = buildIncidentBody({ report, mode });
+  if (existing?.number) {
+    await requestGitHubJson(
+      `https://api.github.com/repos/${repository}/issues/${existing.number}/comments`,
+      token,
+      'POST',
+      { body }
+    );
+    return {
+      action: 'comment',
+      issueNumber: existing.number,
+      issueUrl: existing.html_url ?? null,
+      error: null
+    };
+  }
+
+  const created = await requestGitHubJson(
+    `https://api.github.com/repos/${repository}/issues`,
+    token,
+    'POST',
+    {
+      title: `${titlePrefix} (${report.generatedAt.slice(0, 10)})`,
+      body,
+      labels
+    }
+  );
+
+  return {
+    action: 'create',
+    issueNumber: created?.number ?? null,
+    issueUrl: created?.html_url ?? null,
+    error: null
+  };
+}
+
+async function writeJson(filePath, payload) {
+  const resolved = path.resolve(filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export async function runWeeklyScorecard(options = {}) {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const args = options.args ?? parseArgs();
+  const now = options.now ?? new Date();
+  const environment = options.environment ?? process.env;
+  const readJsonOptionalFn = options.readJsonOptionalFn ?? readJsonOptional;
+  const writeJsonFn = options.writeJsonFn ?? writeJson;
+  const routeIssueFn = options.routeIssueFn ?? upsertGovernanceIssue;
+
+  const repository = resolveRepositorySlug(repoRoot, args.repo, environment);
+  const previousEnvelope = await readJsonOptionalFn(path.resolve(repoRoot, args.outputPath));
+  const remediationEnvelope = await readJsonOptionalFn(path.resolve(repoRoot, args.remediationReportPath));
+  const canaryEnvelope = await readJsonOptionalFn(path.resolve(repoRoot, args.canaryReportPath));
+
+  const remediationStatus =
+    remediationEnvelope.exists && !remediationEnvelope.error && remediationEnvelope.payload
+      ? resolveStatus(remediationEnvelope.payload)
+      : 'fail';
+
+  let canaryStatus = 'n/a';
+  const canaryAvailable = canaryEnvelope.exists && !canaryEnvelope.error && Boolean(canaryEnvelope.payload);
+  if (canaryAvailable) {
+    canaryStatus = resolveStatus(canaryEnvelope.payload);
+  } else if (args.requireCanary) {
+    canaryStatus = 'fail';
+  }
+
+  const statuses = [remediationStatus];
+  if (canaryStatus !== 'n/a') {
+    statuses.push(canaryStatus);
+  }
+  const overallStatus = statuses.sort((left, right) => severityRank(right) - severityRank(left))[0] ?? 'pass';
+
+  const breaches = [];
+  if (remediationStatus !== 'pass') {
+    breaches.push({ key: 'remediation', status: remediationStatus });
+  }
+  if (canaryStatus === 'warn' || canaryStatus === 'fail') {
+    breaches.push({ key: 'canary', status: canaryStatus });
+  }
+  if (args.requireCanary && !canaryAvailable) {
+    breaches.push({ key: 'canary-missing', status: 'fail' });
+  }
+
+  const previousStatus = resolveStatus(previousEnvelope.payload, 'pass');
+  const firstBreach = previousStatus === 'pass' && overallStatus !== 'pass';
+  const persistentBreach = previousStatus !== 'pass' && overallStatus !== 'pass';
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: now.toISOString(),
+    repository,
+    mode: args.mode,
+    requireCanary: args.requireCanary,
+    inputs: {
+      outputPath: args.outputPath,
+      remediationReportPath: args.remediationReportPath,
+      canaryReportPath: args.canaryReportPath
+    },
+    components: {
+      remediation: {
+        status: remediationStatus,
+        exists: remediationEnvelope.exists,
+        error: remediationEnvelope.error
+      },
+      canary: {
+        status: canaryStatus,
+        exists: canaryEnvelope.exists,
+        error: canaryEnvelope.error,
+        required: args.requireCanary
+      }
+    },
+    summary: {
+      status: overallStatus,
+      breachCount: breaches.length,
+      breaches,
+      previousStatus,
+      firstBreach,
+      persistentBreach
+    },
+    routing: {
+      enabled: args.routeOnPersistentBreach,
+      action: 'none',
+      issueNumber: null,
+      issueUrl: null,
+      error: null
+    }
+  };
+
+  if (args.routeOnPersistentBreach && persistentBreach) {
+    const token = normalizeText(options.githubToken ?? (await resolveToken()));
+    if (!token) {
+      report.routing.action = 'skip-no-token';
+      report.routing.error = 'GitHub token unavailable for issue upsert.';
+    } else {
+      try {
+        const routed = await routeIssueFn({
+          repository,
+          token,
+          report,
+          titlePrefix: args.issueTitlePrefix,
+          labels: args.issueLabels,
+          mode: args.mode
+        });
+        report.routing.action = routed.action;
+        report.routing.issueNumber = routed.issueNumber ?? null;
+        report.routing.issueUrl = routed.issueUrl ?? null;
+        report.routing.error = routed.error ?? null;
+      } catch (error) {
+        report.routing.action = 'error';
+        report.routing.error = error?.message ?? String(error);
+      }
+    }
+  }
+
+  const reportPath = await writeJsonFn(args.outputPath, report);
+  return {
+    report,
+    reportPath,
+    exitCode: 0
+  };
+}
+
+export async function main(argv = process.argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printUsage();
+    return 0;
+  }
+
+  const { report, reportPath } = await runWeeklyScorecard({ args });
+  console.log(
+    `[weekly-scorecard] report: ${reportPath} status=${report.summary.status} persistent=${report.summary.persistentBreach} route=${report.routing.action}`
+  );
+  return 0;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((exitCode) => {
+      if (exitCode !== 0) {
+        process.exitCode = exitCode;
+      }
+    })
+    .catch((error) => {
+      console.error(error?.stack ?? error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- Adds weekly governance scorecard CLI + workflow lane.
- Adds gameday mode, persistent-breach routing seam, and schema/tests.

Coupling: soft
Depends-On: #834

Refs: #809 #815