### PR TITLE
feat(governance): add decision ledger contracts (#803)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -330,8 +330,13 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   - `node tools/npm/run-script.mjs priority:event:ingest -- ...`
   - `node tools/npm/run-script.mjs priority:policy:route -- --event <event-report-or-event-json>`
   - `node tools/npm/run-script.mjs priority:issue:route -- --decision tests/results/_agent/ops/policy-decision-report.json`
+  - `node tools/npm/run-script.mjs priority:decision:ledger -- append --decision tests/results/_agent/ops/policy-decision-report.json`
+  - `node tools/npm/run-script.mjs priority:decision:ledger -- replay --sequence <n>`
   The router dedupes by incident fingerprint marker and emits
   `tests/results/_agent/ops/issue-routing-report.json` (`priority/issue-routing-report@v1`).
+  The decision ledger is append-only (`ops-decision-ledger@v1`) at
+  `tests/results/_agent/ops/ops-decision-ledger.json` with replay output under
+  `tests/results/_agent/ops/ops-decision-replay.json`.
   For canary replay conformance (single/repeated/reordered fixtures with deterministic dedupe assertions), run
   `node tools/npm/run-script.mjs priority:canary:replay`; this emits
   `tests/results/_agent/canary/canary-replay-conformance-report.json`

--- a/docs/schemas/ops-decision-ledger-v1.schema.json
+++ b/docs/schemas/ops-decision-ledger-v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ops-decision-ledger@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "generatedAt", "entryCount", "entries"],
+  "properties": {
+    "schema": {
+      "const": "ops-decision-ledger@v1"
+    },
+    "generatedAt": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "entryCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sequence", "appendedAt", "source", "decisionDigest", "decision", "fingerprint"],
+        "properties": {
+          "sequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "appendedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "source": {
+            "type": "string"
+          },
+          "decisionDigest": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "fingerprint": {
+            "type": ["string", "null"]
+          },
+          "decision": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "priority:queue:readiness": "node tools/priority/queue-readiness.mjs",
     "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
     "priority:event:ingest": "node tools/priority/event-ingest.mjs",
+    "priority:decision:ledger": "node tools/priority/decision-ledger.mjs",
     "priority:commit-integrity": "node tools/priority/commit-integrity.mjs",
     "priority:commit-integrity:drift": "node tools/priority/slo-metrics.mjs --workflow commit-integrity.yml --lookback-days 30 --max-runs 200 --threshold-failure-rate 0.3 --threshold-skip-rate 0.25 --threshold-mttr-hours 24 --threshold-stale-hours 168 --threshold-gate-regressions 5 --output tests/results/_agent/commit-integrity/commit-integrity-drift-report.json",
     "priority:canary:catalog": "node tools/priority/canary-catalog.mjs",

--- a/tools/priority/__tests__/decision-ledger-schema.test.mjs
+++ b/tools/priority/__tests__/decision-ledger-schema.test.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { appendDecisionLedgerEntry } from '../decision-ledger.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('ops decision ledger payload validates schema', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'ops-decision-ledger-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const decision = {
+    schema: 'priority/policy-decision-report@v1',
+    generatedAt: '2026-03-07T04:00:00Z',
+    event: { fingerprint: 'fp-100' },
+    decision: { type: 'open-issue', labels: ['governance'] }
+  };
+
+  const appended = await appendDecisionLedgerEntry({
+    decisionPath: 'ignored',
+    ledgerPath: 'ignored',
+    source: 'policy-engine',
+    now: new Date('2026-03-07T04:10:00Z'),
+    readDecisionFn: async () => decision,
+    readLedgerFn: async () => ({
+      schema: 'ops-decision-ledger@v1',
+      generatedAt: null,
+      entryCount: 0,
+      entries: []
+    }),
+    writeJsonFn: async (ledgerPath, payload) => ({ ledgerPath, payload })
+  });
+
+  const ledger = appended.ledger;
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(ledger);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/decision-ledger.test.mjs
+++ b/tools/priority/__tests__/decision-ledger.test.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { appendDecisionLedgerEntry, redactSensitiveFields, replayDecisionLedger, runDecisionLedger } from '../decision-ledger.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf8');
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('redactSensitiveFields redacts token-adjacent keys and values', () => {
+  const payload = {
+    token: 'ghp_abcdefghijklmnopqrstuvwxyz123456',
+    auth: {
+      authorization: 'Bearer secret-value',
+      safe: 'ok'
+    },
+    notes: 'contains github_pat_abc12345678901234567890',
+    nested: [
+      {
+        api_key: 'value'
+      }
+    ]
+  };
+
+  const redacted = redactSensitiveFields(payload);
+  assert.equal(redacted.token, '[REDACTED]');
+  assert.equal(redacted.auth.authorization, '[REDACTED]');
+  assert.equal(redacted.auth.safe, 'ok');
+  assert.equal(redacted.notes, '[REDACTED]');
+  assert.equal(redacted.nested[0].api_key, '[REDACTED]');
+});
+
+test('appendDecisionLedgerEntry appends deterministically without mutating prior records', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ops-ledger-'));
+  const ledgerPath = path.join(tmpDir, 'ledger.json');
+  const decision1Path = path.join(tmpDir, 'decision-1.json');
+  const decision2Path = path.join(tmpDir, 'decision-2.json');
+
+  writeJson(decision1Path, {
+    schema: 'priority/policy-decision-report@v1',
+    event: { fingerprint: 'fp-1' },
+    decision: { type: 'open-issue' },
+    authToken: 'gho_secret_value_12345678901234567890'
+  });
+  writeJson(decision2Path, {
+    schema: 'priority/policy-decision-report@v1',
+    event: { fingerprint: 'fp-2' },
+    decision: { type: 'comment-issue' }
+  });
+
+  const first = await appendDecisionLedgerEntry({
+    decisionPath: decision1Path,
+    ledgerPath,
+    source: 'policy-engine',
+    now: new Date('2026-03-07T04:00:00Z')
+  });
+  assert.equal(first.ledger.entryCount, 1);
+  assert.equal(first.entry.sequence, 1);
+  assert.equal(first.entry.fingerprint, 'fp-1');
+  assert.equal(first.entry.decision.authToken, '[REDACTED]');
+
+  const firstDigest = first.entry.decisionDigest;
+  const second = await appendDecisionLedgerEntry({
+    decisionPath: decision2Path,
+    ledgerPath,
+    source: 'policy-engine',
+    now: new Date('2026-03-07T04:01:00Z')
+  });
+
+  assert.equal(second.ledger.entryCount, 2);
+  assert.equal(second.ledger.entries[0].sequence, 1);
+  assert.equal(second.ledger.entries[0].decisionDigest, firstDigest);
+  assert.equal(second.ledger.entries[1].sequence, 2);
+  assert.equal(second.ledger.entries[1].fingerprint, 'fp-2');
+
+  const persisted = readJson(ledgerPath);
+  assert.equal(persisted.entryCount, 2);
+});
+
+test('replayDecisionLedger filters by sequence and fingerprint deterministically', () => {
+  const ledger = {
+    schema: 'ops-decision-ledger@v1',
+    generatedAt: '2026-03-07T04:00:00Z',
+    entryCount: 2,
+    entries: [
+      { sequence: 1, appendedAt: '2026-03-07T04:00:00Z', source: 'a', decisionDigest: 'a'.repeat(64), fingerprint: 'fp-1', decision: { id: 1 } },
+      { sequence: 2, appendedAt: '2026-03-07T04:01:00Z', source: 'b', decisionDigest: 'b'.repeat(64), fingerprint: 'fp-2', decision: { id: 2 } }
+    ]
+  };
+
+  const bySequence = replayDecisionLedger(ledger, { sequence: 2, now: '2026-03-07T04:02:00Z' });
+  assert.equal(bySequence.count, 1);
+  assert.equal(bySequence.decisions[0].sequence, 2);
+
+  const byFingerprint = replayDecisionLedger(ledger, { fingerprint: 'fp-1', now: '2026-03-07T04:02:00Z' });
+  assert.equal(byFingerprint.count, 1);
+  assert.equal(byFingerprint.decisions[0].fingerprint, 'fp-1');
+});
+
+test('runDecisionLedger supports append and replay commands', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ops-ledger-cli-'));
+  const ledgerPath = path.join(tmpDir, 'ledger.json');
+  const replayPath = path.join(tmpDir, 'replay.json');
+  const decisionPath = path.join(tmpDir, 'decision.json');
+
+  writeJson(decisionPath, {
+    schema: 'priority/policy-decision-report@v1',
+    event: { fingerprint: 'fp-cli' },
+    decision: { type: 'open-issue' }
+  });
+
+  const appendResult = await runDecisionLedger({
+    argv: ['node', 'decision-ledger.mjs', 'append', '--decision', decisionPath, '--ledger', ledgerPath, '--source', 'policy-engine']
+  });
+  assert.equal(appendResult.exitCode, 0);
+  assert.equal(appendResult.mode, 'append');
+
+  const replayResult = await runDecisionLedger({
+    argv: ['node', 'decision-ledger.mjs', 'replay', '--ledger', ledgerPath, '--output', replayPath, '--sequence', '1']
+  });
+  assert.equal(replayResult.exitCode, 0);
+  assert.equal(replayResult.mode, 'replay');
+
+  const replay = readJson(replayPath);
+  assert.equal(replay.schema, 'ops-decision-replay@v1');
+  assert.equal(replay.count, 1);
+});

--- a/tools/priority/decision-ledger.mjs
+++ b/tools/priority/decision-ledger.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const LEDGER_SCHEMA = 'ops-decision-ledger@v1';
+export const REPLAY_SCHEMA = 'ops-decision-replay@v1';
+export const DEFAULT_LEDGER_PATH = path.join('tests', 'results', '_agent', 'ops', 'ops-decision-ledger.json');
+export const DEFAULT_REPLAY_PATH = path.join('tests', 'results', '_agent', 'ops', 'ops-decision-replay.json');
+
+const SENSITIVE_KEY_PATTERN = /(token|secret|authorization|password|apikey|api_key|privatekey|private_key)/i;
+const SENSITIVE_VALUE_PATTERN = /(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|bearer\s+[a-z0-9\-_\.]+)/i;
+
+function printUsage() {
+  console.log('Usage: node tools/priority/decision-ledger.mjs <append|replay> [options]');
+  console.log('');
+  console.log('Commands:');
+  console.log('  append   Append a redacted decision report entry to the ledger.');
+  console.log('  replay   Reconstruct decision artifacts from ledger entries.');
+  console.log('');
+  console.log('Options (append):');
+  console.log(`  --decision <path>   Decision report input (required).`);
+  console.log(`  --ledger <path>     Ledger path (default: ${DEFAULT_LEDGER_PATH}).`);
+  console.log('  --source <text>     Source label for the ledger entry (default: manual).');
+  console.log('');
+  console.log('Options (replay):');
+  console.log(`  --ledger <path>      Ledger path (default: ${DEFAULT_LEDGER_PATH}).`);
+  console.log(`  --output <path>      Replay output path (default: ${DEFAULT_REPLAY_PATH}).`);
+  console.log('  --sequence <n>       Replay a specific sequence (default: all entries).');
+  console.log('  --fingerprint <id>   Replay entries by event fingerprint.');
+  console.log('');
+  console.log('General:');
+  console.log('  -h, --help           Show help and exit.');
+}
+
+function normalizeText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function parsePositiveInteger(value, { label }) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid value for ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function stableSortValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableSortValue(entry));
+  }
+  if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+    const sorted = {};
+    for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
+      sorted[key] = stableSortValue(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function computeDigest(value) {
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify(stableSortValue(value)));
+  return hash.digest('hex');
+}
+
+function redactString(value) {
+  if (!SENSITIVE_VALUE_PATTERN.test(value)) {
+    return value;
+  }
+  return '[REDACTED]';
+}
+
+export function redactSensitiveFields(value, contextKey = null) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveFields(entry, contextKey));
+  }
+
+  if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+    const output = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        output[key] = '[REDACTED]';
+        continue;
+      }
+      output[key] = redactSensitiveFields(child, key);
+    }
+    return output;
+  }
+
+  if (typeof value === 'string') {
+    if (contextKey && SENSITIVE_KEY_PATTERN.test(contextKey)) {
+      return '[REDACTED]';
+    }
+    return redactString(value);
+  }
+
+  return value;
+}
+
+function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    command: null,
+    decisionPath: null,
+    ledgerPath: DEFAULT_LEDGER_PATH,
+    outputPath: DEFAULT_REPLAY_PATH,
+    source: 'manual',
+    sequence: null,
+    fingerprint: null,
+    help: false
+  };
+
+  if (args.length === 0) {
+    throw new Error('Command is required (append|replay).');
+  }
+
+  const command = args[0].trim().toLowerCase();
+  if (!['append', 'replay'].includes(command)) {
+    if (command === '--help' || command === '-h') {
+      options.help = true;
+      return options;
+    }
+    throw new Error(`Unknown command: ${args[0]}`);
+  }
+  options.command = command;
+
+  for (let index = 1; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (
+      token === '--decision' ||
+      token === '--ledger' ||
+      token === '--output' ||
+      token === '--source' ||
+      token === '--sequence' ||
+      token === '--fingerprint'
+    ) {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--decision') options.decisionPath = next;
+      if (token === '--ledger') options.ledgerPath = next;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--source') options.source = next;
+      if (token === '--sequence') options.sequence = parsePositiveInteger(next, { label: '--sequence' });
+      if (token === '--fingerprint') options.fingerprint = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (options.command === 'append' && !normalizeText(options.decisionPath)) {
+    throw new Error('--decision is required for append.');
+  }
+
+  return options;
+}
+
+async function readJsonFile(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+  const raw = await readFile(resolved, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function readLedger(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!existsSync(resolved)) {
+    return {
+      schema: LEDGER_SCHEMA,
+      generatedAt: null,
+      entryCount: 0,
+      entries: []
+    };
+  }
+
+  const payload = JSON.parse(await readFile(resolved, 'utf8'));
+  if (payload?.schema !== LEDGER_SCHEMA || !Array.isArray(payload?.entries)) {
+    throw new Error(`Invalid ledger format at ${resolved}`);
+  }
+  return payload;
+}
+
+async function writeJsonFile(filePath, payload) {
+  const resolved = path.resolve(filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export async function appendDecisionLedgerEntry({
+  decisionPath,
+  ledgerPath = DEFAULT_LEDGER_PATH,
+  source = 'manual',
+  now = new Date(),
+  readDecisionFn = readJsonFile,
+  readLedgerFn = readLedger,
+  writeJsonFn = writeJsonFile
+} = {}) {
+  const decision = await readDecisionFn(decisionPath);
+  const redactedDecision = redactSensitiveFields(decision);
+  const ledger = await readLedgerFn(ledgerPath);
+  const previousEntries = Array.isArray(ledger.entries) ? [...ledger.entries] : [];
+  const nextSequence = previousEntries.length + 1;
+
+  const entry = {
+    sequence: nextSequence,
+    appendedAt: now.toISOString(),
+    source: normalizeText(source) ?? 'manual',
+    decisionDigest: computeDigest(redactedDecision),
+    decision: redactedDecision,
+    fingerprint: normalizeText(redactedDecision?.event?.fingerprint) ?? null
+  };
+
+  const nextLedger = {
+    schema: LEDGER_SCHEMA,
+    generatedAt: now.toISOString(),
+    entryCount: previousEntries.length + 1,
+    entries: [...previousEntries, entry]
+  };
+
+  const resolvedLedgerPath = await writeJsonFn(ledgerPath, nextLedger);
+  return {
+    ledger: nextLedger,
+    ledgerPath: resolvedLedgerPath,
+    entry
+  };
+}
+
+export function replayDecisionLedger(ledger, options = {}) {
+  const sequence = options.sequence ?? null;
+  const fingerprint = normalizeText(options.fingerprint);
+  const entries = Array.isArray(ledger?.entries) ? ledger.entries : [];
+
+  const selected = entries.filter((entry) => {
+    if (sequence != null && entry.sequence !== sequence) {
+      return false;
+    }
+    if (fingerprint && entry.fingerprint !== fingerprint) {
+      return false;
+    }
+    return true;
+  });
+
+  return {
+    schema: REPLAY_SCHEMA,
+    generatedAt: new Date(options.now ?? Date.now()).toISOString(),
+    sourceSchema: ledger?.schema ?? null,
+    selection: {
+      sequence: sequence ?? null,
+      fingerprint: fingerprint ?? null
+    },
+    count: selected.length,
+    decisions: selected.map((entry) => ({
+      sequence: entry.sequence,
+      fingerprint: entry.fingerprint,
+      decisionDigest: entry.decisionDigest,
+      decision: entry.decision
+    }))
+  };
+}
+
+export async function runDecisionLedger(options = {}) {
+  const args = options.args ?? parseArgs(options.argv ?? process.argv);
+  if (args.help) {
+    printUsage();
+    return { exitCode: 0, mode: null, outputPath: null, payload: null };
+  }
+
+  if (args.command === 'append') {
+    const appended = await appendDecisionLedgerEntry({
+      decisionPath: args.decisionPath,
+      ledgerPath: args.ledgerPath,
+      source: args.source,
+      now: options.now ?? new Date(),
+      readDecisionFn: options.readDecisionFn ?? readJsonFile,
+      readLedgerFn: options.readLedgerFn ?? readLedger,
+      writeJsonFn: options.writeJsonFn ?? writeJsonFile
+    });
+
+    return {
+      exitCode: 0,
+      mode: 'append',
+      outputPath: appended.ledgerPath,
+      payload: appended.ledger
+    };
+  }
+
+  const ledger = await (options.readLedgerFn ?? readLedger)(args.ledgerPath);
+  const replay = replayDecisionLedger(ledger, {
+    now: options.now ?? new Date(),
+    sequence: args.sequence,
+    fingerprint: args.fingerprint
+  });
+  const outputPath = await (options.writeJsonFn ?? writeJsonFile)(args.outputPath, replay);
+
+  return {
+    exitCode: 0,
+    mode: 'replay',
+    outputPath,
+    payload: replay
+  };
+}
+
+export async function main(argv = process.argv) {
+  const result = await runDecisionLedger({ argv });
+  if (result.mode === 'append') {
+    console.log(`[ops-decision-ledger] appended: ${result.outputPath}`);
+  } else if (result.mode === 'replay') {
+    console.log(`[ops-decision-ledger] replay: ${result.outputPath}`);
+  }
+  return result.exitCode;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((code) => {
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    })
+    .catch((error) => {
+      console.error(error?.stack ?? error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- add `ops-decision-ledger@v1` append/replay module under `tools/priority/decision-ledger.mjs`
- add ledger/report schema and deterministic redaction/digest seams
- add unit+schema tests and wire `priority:decision:ledger` in package scripts/docs

## Testing
- `node --test tools/priority/__tests__/decision-ledger.test.mjs tools/priority/__tests__/decision-ledger-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint.exe -color`

Coupling: independent
Depends-On:

Refs #803