### PR TITLE
test(queue): harden supervisor pause/order contracts (#804)

### DIFF
--- a/docs/schemas/queue-supervisor-report-v1.schema.json
+++ b/docs/schemas/queue-supervisor-report-v1.schema.json
@@ -1,0 +1,328 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.comparevi.dev/queue-supervisor-report-v1.schema.json",
+  "title": "Queue Supervisor Report v1",
+  "description": "Deterministic queue supervisor report contract.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "generatedAt",
+    "repository",
+    "mode",
+    "queueManagedBranches",
+    "summary",
+    "paused",
+    "pausedReasons",
+    "actions",
+    "candidates",
+    "orderedEligible",
+    "readiness",
+    "retryHistory"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/queue-supervisor-report@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/\\s]+/[^/\\s]+$"
+    },
+    "mode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "apply",
+        "dryRun"
+      ],
+      "properties": {
+        "apply": {
+          "type": "boolean"
+        },
+        "dryRun": {
+          "type": "boolean"
+        }
+      }
+    },
+    "queueManagedBranches": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "openCount",
+        "candidateCount",
+        "eligibleCount",
+        "plannedCount",
+        "enqueuedCount",
+        "quarantinedCount"
+      ],
+      "properties": {
+        "openCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candidateCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eligibleCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "plannedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "enqueuedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "quarantinedCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "paused": {
+      "type": "boolean"
+    },
+    "pausedReasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/action"
+      }
+    },
+    "candidates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/candidate"
+      }
+    },
+    "orderedEligible": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "reportPath",
+        "summary",
+        "readySet"
+      ],
+      "properties": {
+        "reportPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "readySet": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "number",
+              "score",
+              "dependencyRank"
+            ],
+            "properties": {
+              "number": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "score": {
+                "type": "number"
+              },
+              "dependencyRank": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        }
+      }
+    },
+    "retryHistory": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "failures"
+        ],
+        "properties": {
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "action": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "number",
+        "status",
+        "attempts",
+        "quarantined",
+        "retriedUpdateBranch"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "enqueued",
+            "failed"
+          ]
+        },
+        "attempts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "type",
+              "status"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "status": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "stderr": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "quarantined": {
+          "type": "boolean"
+        },
+        "retriedUpdateBranch": {
+          "type": "boolean"
+        }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "number",
+        "baseRefName",
+        "priority",
+        "coupling",
+        "dependsOn",
+        "eligible",
+        "reasons",
+        "checks"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "baseRefName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "coupling": {
+          "type": "string",
+          "enum": [
+            "independent",
+            "soft",
+            "hard"
+          ]
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "eligible": {
+          "type": "boolean"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "checks": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "ok",
+            "missing",
+            "failing"
+          ],
+          "properties": {
+            "ok": {
+              "type": "boolean"
+            },
+            "missing": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "failing": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/priority/__tests__/queue-supervisor-schema.test.mjs
+++ b/tools/priority/__tests__/queue-supervisor-schema.test.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { runQueueSupervisor } from '../queue-supervisor.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function successCheck(name) {
+  return {
+    __typename: 'CheckRun',
+    name,
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS'
+  };
+}
+
+test('queue supervisor report validates schema', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'queue-supervisor-report-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'pr' && args[1] === 'list') {
+      return [
+        {
+          number: 501,
+          title: '[P0] queue-ready',
+          body: 'Coupling: independent',
+          baseRefName: 'develop',
+          headRepositoryOwner: { login: 'owner' },
+          isDraft: false,
+          mergeStateStatus: 'CLEAN',
+          mergeable: 'MERGEABLE',
+          updatedAt: '2026-03-06T11:00:00Z',
+          url: 'https://example.test/pr/501',
+          labels: [],
+          statusCheckRollup: [successCheck('lint')],
+          autoMergeRequest: null
+        }
+      ];
+    }
+    if (args[0] === 'api' && String(args[1]).includes('validate.yml')) {
+      return {
+        workflow_runs: [
+          { conclusion: 'success', status: 'completed', created_at: '2026-03-06T10:40:00Z', updated_at: '2026-03-06T10:41:00Z' }
+        ]
+      };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('policy-guard-upstream.yml')) {
+      return {
+        workflow_runs: [
+          { conclusion: 'success', status: 'completed', created_at: '2026-03-06T10:30:00Z', updated_at: '2026-03-06T10:31:00Z' }
+        ]
+      };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('fixture-drift.yml')) return { workflow_runs: [] };
+    if (args[0] === 'api' && String(args[1]).includes('commit-integrity.yml')) return { workflow_runs: [] };
+    throw new Error(`Unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const runCommandFn = (command, args) => {
+    if (command === 'node' && args[0] === 'tools/priority/merge-sync-pr.mjs') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'edit') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const readJsonFileFn = async (filePath) => {
+    if (String(filePath).endsWith('branch-required-checks.json')) {
+      return { branches: { develop: ['lint'] } };
+    }
+    if (String(filePath).endsWith('policy.json')) {
+      return {
+        rulesets: {
+          develop: {
+            includes: ['refs/heads/develop'],
+            merge_queue: { merge_method: 'SQUASH' }
+          }
+        }
+      };
+    }
+    throw new Error(`Unexpected read path: ${filePath}`);
+  };
+
+  const { report } = await runQueueSupervisor({
+    repoRoot,
+    args: {
+      apply: true,
+      dryRun: false,
+      reportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      maxInflight: 5,
+      minInflight: 1,
+      adaptiveCap: false,
+      maxQueuedRuns: 6,
+      maxInProgressRuns: 8,
+      stallThresholdMinutes: 45,
+      repo: 'owner/repo',
+      baseBranches: ['develop', 'main'],
+      healthBranch: 'develop',
+      help: false
+    },
+    now: new Date('2026-03-06T12:00:00Z'),
+    runGhJsonFn,
+    runCommandFn,
+    readJsonFileFn,
+    readOptionalJsonFn: async () => ({}),
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/queue-supervisor.test.mjs
+++ b/tools/priority/__tests__/queue-supervisor.test.mjs
@@ -576,3 +576,255 @@ test('runQueueSupervisor apply mode quarantines on second failure within 24h', a
   assert.ok(writeCalls.some((call) => String(call.reportPath).includes('throughput-controller-state.json')));
   assert.ok(writeCalls.some((call) => String(call.reportPath).includes('queue-readiness-report.json')));
 });
+
+test('runQueueSupervisor does not enqueue when pause control is active', async () => {
+  const priorPause = process.env.QUEUE_AUTOPILOT_PAUSED;
+  process.env.QUEUE_AUTOPILOT_PAUSED = '1';
+  const commandCalls = [];
+
+  try {
+    const runGhJsonFn = (args) => {
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return [
+          {
+            number: 301,
+            title: '[P0] eligible change',
+            body: 'Coupling: independent',
+            baseRefName: 'develop',
+            headRepositoryOwner: { login: 'owner' },
+            isDraft: false,
+            mergeStateStatus: 'CLEAN',
+            mergeable: 'MERGEABLE',
+            updatedAt: '2026-03-05T21:00:00Z',
+            url: 'https://example.test/pr/301',
+            labels: [],
+            statusCheckRollup: [successCheck('lint')],
+            autoMergeRequest: null
+          }
+        ];
+      }
+      if (args[0] === 'api' && String(args[1]).includes('validate.yml')) {
+        return {
+          workflow_runs: [
+            { conclusion: 'success', status: 'completed', created_at: '2026-03-05T20:50:00Z', updated_at: '2026-03-05T20:52:00Z' }
+          ]
+        };
+      }
+      if (args[0] === 'api' && String(args[1]).includes('policy-guard-upstream.yml')) {
+        return {
+          workflow_runs: [
+            { conclusion: 'success', status: 'completed', created_at: '2026-03-05T20:40:00Z', updated_at: '2026-03-05T20:41:00Z' }
+          ]
+        };
+      }
+      if (args[0] === 'api' && String(args[1]).includes('fixture-drift.yml')) return { workflow_runs: [] };
+      if (args[0] === 'api' && String(args[1]).includes('commit-integrity.yml')) return { workflow_runs: [] };
+      throw new Error(`Unexpected gh args: ${args.join(' ')}`);
+    };
+
+    const runCommandFn = (command, args) => {
+      commandCalls.push({ command, args });
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    const readJsonFileFn = async (filePath) => {
+      if (String(filePath).endsWith('branch-required-checks.json')) {
+        return { branches: { develop: ['lint'] } };
+      }
+      if (String(filePath).endsWith('policy.json')) {
+        return {
+          rulesets: {
+            develop: {
+              includes: ['refs/heads/develop'],
+              merge_queue: { merge_method: 'SQUASH' }
+            }
+          }
+        };
+      }
+      throw new Error(`Unexpected read path: ${filePath}`);
+    };
+
+    const { report } = await runQueueSupervisor({
+      repoRoot: process.cwd(),
+      args: {
+        apply: true,
+        dryRun: false,
+        reportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+        maxInflight: 4,
+        minInflight: 1,
+        adaptiveCap: false,
+        maxQueuedRuns: 6,
+        maxInProgressRuns: 8,
+        stallThresholdMinutes: 45,
+        repo: 'owner/repo',
+        baseBranches: ['develop', 'main'],
+        healthBranch: 'develop',
+        help: false
+      },
+      now: new Date('2026-03-05T21:30:00.000Z'),
+      runGhJsonFn,
+      runCommandFn,
+      readJsonFileFn,
+      readOptionalJsonFn: async () => ({}),
+      writeReportFn: async (reportPath) => reportPath
+    });
+
+    assert.equal(report.paused, true);
+    assert.ok(report.pausedReasons.includes('paused-by-variable'));
+    assert.equal(report.summary.eligibleCount, 1);
+    assert.equal(report.summary.enqueuedCount, 0);
+    assert.equal(report.actions.length, 0);
+    assert.equal(
+      commandCalls.some((call) => call.command === 'node' && call.args.includes('tools/priority/merge-sync-pr.mjs')),
+      false
+    );
+  } finally {
+    if (priorPause === undefined) {
+      delete process.env.QUEUE_AUTOPILOT_PAUSED;
+    } else {
+      process.env.QUEUE_AUTOPILOT_PAUSED = priorPause;
+    }
+  }
+});
+
+test('runQueueSupervisor enqueues eligible PRs in dependency-safe deterministic order', async () => {
+  const commandCalls = [];
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'pr' && args[1] === 'list') {
+      return [
+        {
+          number: 401,
+          title: '[P1] foundational change',
+          body: 'Coupling: independent',
+          baseRefName: 'develop',
+          headRepositoryOwner: { login: 'owner' },
+          isDraft: false,
+          mergeStateStatus: 'CLEAN',
+          mergeable: 'MERGEABLE',
+          updatedAt: '2026-03-05T20:05:00Z',
+          url: 'https://example.test/pr/401',
+          labels: [],
+          statusCheckRollup: [successCheck('lint')],
+          autoMergeRequest: null
+        },
+        {
+          number: 402,
+          title: '[P0] follow-up dependent change',
+          body: 'Coupling: hard\nDepends-On: #401',
+          baseRefName: 'develop',
+          headRepositoryOwner: { login: 'owner' },
+          isDraft: false,
+          mergeStateStatus: 'CLEAN',
+          mergeable: 'MERGEABLE',
+          updatedAt: '2026-03-05T20:10:00Z',
+          url: 'https://example.test/pr/402',
+          labels: [],
+          statusCheckRollup: [successCheck('lint')],
+          autoMergeRequest: null
+        },
+        {
+          number: 403,
+          title: '[P0] independent urgent change',
+          body: 'Coupling: independent',
+          baseRefName: 'develop',
+          headRepositoryOwner: { login: 'owner' },
+          isDraft: false,
+          mergeStateStatus: 'CLEAN',
+          mergeable: 'MERGEABLE',
+          updatedAt: '2026-03-05T20:00:00Z',
+          url: 'https://example.test/pr/403',
+          labels: [],
+          statusCheckRollup: [successCheck('lint')],
+          autoMergeRequest: null
+        }
+      ];
+    }
+    if (args[0] === 'api' && String(args[1]).includes('validate.yml')) {
+      return {
+        workflow_runs: [
+          { conclusion: 'success', status: 'completed', created_at: '2026-03-05T20:50:00Z', updated_at: '2026-03-05T20:52:00Z' }
+        ]
+      };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('policy-guard-upstream.yml')) {
+      return {
+        workflow_runs: [
+          { conclusion: 'success', status: 'completed', created_at: '2026-03-05T20:40:00Z', updated_at: '2026-03-05T20:41:00Z' }
+        ]
+      };
+    }
+    if (args[0] === 'api' && String(args[1]).includes('fixture-drift.yml')) return { workflow_runs: [] };
+    if (args[0] === 'api' && String(args[1]).includes('commit-integrity.yml')) return { workflow_runs: [] };
+    throw new Error(`Unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'node' && args[0] === 'tools/priority/merge-sync-pr.mjs') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (command === 'gh' && args[0] === 'pr' && args[1] === 'edit') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const readJsonFileFn = async (filePath) => {
+    if (String(filePath).endsWith('branch-required-checks.json')) {
+      return { branches: { develop: ['lint'] } };
+    }
+    if (String(filePath).endsWith('policy.json')) {
+      return {
+        rulesets: {
+          develop: {
+            includes: ['refs/heads/develop'],
+            merge_queue: { merge_method: 'SQUASH' }
+          }
+        }
+      };
+    }
+    throw new Error(`Unexpected read path: ${filePath}`);
+  };
+
+  const { report } = await runQueueSupervisor({
+    repoRoot: process.cwd(),
+    args: {
+      apply: true,
+      dryRun: false,
+      reportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      maxInflight: 5,
+      minInflight: 1,
+      adaptiveCap: false,
+      maxQueuedRuns: 6,
+      maxInProgressRuns: 8,
+      stallThresholdMinutes: 45,
+      repo: 'owner/repo',
+      baseBranches: ['develop', 'main'],
+      healthBranch: 'develop',
+      help: false
+    },
+    now: new Date('2026-03-05T21:30:00.000Z'),
+    runGhJsonFn,
+    runCommandFn,
+    readJsonFileFn,
+    readOptionalJsonFn: async () => ({}),
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  const actionNumbers = report.actions.map((action) => action.number);
+  assert.deepEqual(actionNumbers, [403, 401, 402]);
+  assert.equal(actionNumbers.indexOf(401) < actionNumbers.indexOf(402), true);
+  assert.equal(report.summary.enqueuedCount, 3);
+  assert.equal(report.summary.quarantinedCount, 0);
+  assert.equal(report.readiness.readySet[0].number, 403);
+  assert.equal(report.readiness.readySet[1].number, 401);
+  assert.equal(report.readiness.readySet[2].number, 402);
+  for (const action of report.actions) {
+    assert.equal(action.status, 'enqueued');
+    assert.ok(action.attempts.some((attempt) => attempt.type === 'merge-sync' && attempt.status === 0));
+  }
+  const mergeSyncInvocations = commandCalls.filter(
+    (call) => call.command === 'node' && call.args[0] === 'tools/priority/merge-sync-pr.mjs'
+  );
+  assert.equal(mergeSyncInvocations.length, 3);
+});


### PR DESCRIPTION
## Summary
- add `queue-supervisor` schema contract at `docs/schemas/queue-supervisor-report-v1.schema.json`
- add schema validation test `tools/priority/__tests__/queue-supervisor-schema.test.mjs`
- expand `queue-supervisor` unit coverage for pause control and dependency-safe enqueue ordering

## Testing
- `node --test tools/priority/__tests__/queue-supervisor.test.mjs tools/priority/__tests__/queue-supervisor-schema.test.mjs`
- `node --test tools/priority/__tests__/*.mjs`
- `./bin/actionlint.exe -color`

Coupling: independent
Depends-On:

Refs #804