### PR TITLE
fix(bundle): include VI history renderer in CompareVI.Tools (#849)

### DIFF
--- a/tests/CompareVITools.Artifact.Tests.ps1
+++ b/tests/CompareVITools.Artifact.Tests.ps1
@@ -101,6 +101,7 @@ Describe 'CompareVI.Tools artifact publishing' {
       'tools/Compare-VIHistory.ps1',
       'tools/Compare-RefsToTemp.ps1',
       'tools/Invoke-LVCompare.ps1',
+      'tools/Render-VIHistoryReport.ps1',
       'tools/Stage-CompareInputs.ps1',
       'tools/VendorTools.psm1',
       'tools/VICategoryBuckets.psm1',

--- a/tools/Publish-CompareVIToolsArtifact.ps1
+++ b/tools/Publish-CompareVIToolsArtifact.ps1
@@ -121,6 +121,7 @@ $requiredRelativePaths = @(
   'tools/Compare-VIHistory.ps1',
   'tools/Compare-RefsToTemp.ps1',
   'tools/Invoke-LVCompare.ps1',
+  'tools/Render-VIHistoryReport.ps1',
   'tools/VendorTools.psm1',
   'tools/VICategoryBuckets.psm1',
   'tools/Stage-CompareInputs.ps1',


### PR DESCRIPTION
## Summary

Include the VI history renderer script in the CompareVI.Tools release bundle.

## Changes

- add `tools/Render-VIHistoryReport.ps1` to the bundle file closure
- extend the CompareVI.Tools artifact test to require the renderer script in extracted bundles
- publish corrected backend bundle release tag `v0.6.3-tools.2` from commit `05d41953c83185e65f5477766ccc5bdcbae96489`

## Validation

- `Invoke-Pester -Path tests/CompareVITools.Artifact.Tests.ps1 -CI` using cached Pester 5.7.1
- local bundle-backed VI history run against `svelderrainruiz/labview-icon-editor` confirmed the full history report renders without the previous missing-renderer warning

Refs #849.
