### PR TITLE
#859 Tighten docker-only LabVIEW path contracts

### DIFF
--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -277,7 +277,6 @@ jobs:
       CLEAN_LV_INCLUDE_COMPARE: ${{ vars.CLEAN_LV_INCLUDE_COMPARE || vars.CLEAN_LVCOMPARE || 'true' }}
       LVCI_SINGLE_COMPARE: '1'
       WATCH_CONSOLE: '1'
-      LABVIEW_EXE: 'C:\\Program Files\\National Instruments\\LabVIEW 2025\\LabVIEW.exe'
       LV_NOTICE_DIR: 'results/fixture-drift/_lv'
       LV_NO_ACTIVATE: ${{ vars.LV_NO_ACTIVATE || '1' }}
       LV_CURSOR_RESTORE: ${{ vars.LV_CURSOR_RESTORE || '1' }}

--- a/tests/Test-DockerDesktopFastLoop.Tests.ps1
+++ b/tests/Test-DockerDesktopFastLoop.Tests.ps1
@@ -228,6 +228,14 @@ param(
 )
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+if (-not [string]::IsNullOrWhiteSpace($env:FASTLOOP_LINUX_TRACE_PATH)) {
+  $traceDir = Split-Path -Parent $env:FASTLOOP_LINUX_TRACE_PATH
+  if ($traceDir -and -not (Test-Path -LiteralPath $traceDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $traceDir -Force | Out-Null
+  }
+  $traceLine = "probe={0};labviewPath={1};baseVi={2};headVi={3};reportPath={4}" -f $Probe.IsPresent, $LabVIEWPath, $BaseVi, $HeadVi, $ReportPath
+  Add-Content -LiteralPath $env:FASTLOOP_LINUX_TRACE_PATH -Value $traceLine -Encoding utf8
+}
 if ($Probe) {
   if ($PassThru) {
     [pscustomobject]@{
@@ -696,6 +704,105 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
     } finally {
       Remove-Item Env:FASTLOOP_WINDOWS_TRACE_PATH -ErrorAction SilentlyContinue
       Remove-Item Env:LABVIEW_PATH -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'does not forward shared compare path envs when docker-specific windows path is absent' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-shared-windows-labview-ignored'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $tracePath = Join-Path $resultsRoot 'windows-trace.log'
+      $sharedPath = 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe'
+      $loopPath = 'C:\Program Files\National Instruments\LabVIEW 2025\LabVIEW.exe'
+      $env:FASTLOOP_WINDOWS_TRACE_PATH = $tracePath
+      $env:COMPARE_LABVIEW_PATH = $sharedPath
+      $env:LOOP_LABVIEW_PATH = $loopPath
+
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -SkipWindowsProbe `
+        -SkipLinuxProbe `
+        -HistoryScenarioSet history-core 2>&1
+      $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+      Test-Path -LiteralPath $tracePath -PathType Leaf | Should -BeTrue
+      $traceLines = @(Get-Content -LiteralPath $tracePath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+      $traceLines.Count | Should -BeGreaterThan 0
+      $traceLines[-1] | Should -Match 'probe=False;labviewPath=(;|$)'
+    } finally {
+      Remove-Item Env:FASTLOOP_WINDOWS_TRACE_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:COMPARE_LABVIEW_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:LOOP_LABVIEW_PATH -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'prefers NI_LINUX_LABVIEW_PATH over shared compare path envs for linux probe' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-linux-labview-path-forwarding'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $tracePath = Join-Path $resultsRoot 'linux-trace.log'
+      $expectedPath = '/usr/local/natinst/LabVIEW-2026-64/labview'
+      $sharedPath = '/usr/local/natinst/LabVIEW-2025-64/labview'
+      $env:FASTLOOP_LINUX_TRACE_PATH = $tracePath
+      $env:NI_LINUX_LABVIEW_PATH = $expectedPath
+      $env:COMPARE_LABVIEW_PATH = $sharedPath
+
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -LaneScope linux `
+        -HistoryScenarioSet none 2>&1
+      $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+      Test-Path -LiteralPath $tracePath -PathType Leaf | Should -BeTrue
+      $traceLines = @(Get-Content -LiteralPath $tracePath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+      $traceLines.Count | Should -BeGreaterThan 0
+      $traceLines[-1] | Should -Match 'probe=True;labviewPath='
+      ($traceLines[-1] -match ("labviewPath={0}(;|$)" -f [regex]::Escape($expectedPath))) | Should -BeTrue
+      ($traceLines[-1] -match ("labviewPath={0}(;|$)" -f [regex]::Escape($sharedPath))) | Should -BeFalse
+    } finally {
+      Remove-Item Env:FASTLOOP_LINUX_TRACE_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:NI_LINUX_LABVIEW_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:COMPARE_LABVIEW_PATH -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'does not forward shared compare path envs when docker-specific linux path is absent' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-shared-linux-labview-ignored'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $tracePath = Join-Path $resultsRoot 'linux-trace.log'
+      $sharedPath = '/usr/local/natinst/LabVIEW-2026-64/labview'
+      $loopPath = '/usr/local/natinst/LabVIEW-2025-64/labview'
+      $env:FASTLOOP_LINUX_TRACE_PATH = $tracePath
+      $env:COMPARE_LABVIEW_PATH = $sharedPath
+      $env:LOOP_LABVIEW_PATH = $loopPath
+
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -LaneScope linux `
+        -HistoryScenarioSet none 2>&1
+      $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+      Test-Path -LiteralPath $tracePath -PathType Leaf | Should -BeTrue
+      $traceLines = @(Get-Content -LiteralPath $tracePath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+      $traceLines.Count | Should -BeGreaterThan 0
+      $traceLines[-1] | Should -Match 'probe=True;labviewPath=(;|$)'
+    } finally {
+      Remove-Item Env:FASTLOOP_LINUX_TRACE_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:COMPARE_LABVIEW_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:LOOP_LABVIEW_PATH -ErrorAction SilentlyContinue
       Pop-Location | Out-Null
     }
   }

--- a/tools/Test-DockerDesktopFastLoop.ps1
+++ b/tools/Test-DockerDesktopFastLoop.ps1
@@ -16,7 +16,6 @@ param(
   [string]$LinuxImage = 'nationalinstruments/labview:2026q1-linux',
   [string]$WindowsLabVIEWPath = '',
   [string]$LinuxLabVIEWPath = '',
-  [string]$LabVIEWPath = '',
   [string]$ResultsRoot = 'tests/results/local-parity',
   [string]$StatusPath = '',
   [string]$ReadinessJsonPath = '',
@@ -44,9 +43,7 @@ $classifierScriptPath = Join-Path (Split-Path -Parent $PSCommandPath) 'Compare-E
 function Resolve-DockerLaneLabVIEWPath {
   param(
     [string]$ExplicitPath,
-    [string]$LegacySharedPath,
-    [string[]]$PreferredEnvNames = @(),
-    [string[]]$SharedEnvNames = @()
+    [string[]]$PreferredEnvNames = @()
   )
 
   if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
@@ -54,20 +51,6 @@ function Resolve-DockerLaneLabVIEWPath {
   }
 
   foreach ($envName in @($PreferredEnvNames)) {
-    if ([string]::IsNullOrWhiteSpace($envName)) {
-      continue
-    }
-    $candidate = [Environment]::GetEnvironmentVariable($envName, 'Process')
-    if (-not [string]::IsNullOrWhiteSpace($candidate)) {
-      return $candidate.Trim()
-    }
-  }
-
-  if (-not [string]::IsNullOrWhiteSpace($LegacySharedPath)) {
-    return $LegacySharedPath.Trim()
-  }
-
-  foreach ($envName in @($SharedEnvNames)) {
     if ([string]::IsNullOrWhiteSpace($envName)) {
       continue
     }
@@ -1099,14 +1082,10 @@ $effectiveManageDockerEngine = if ($singleLaneMode) { $false } else { [bool]$Man
 $runtimeAutoRepairEnabled = -not $singleLaneMode
 $effectiveWindowsLabVIEWPath = Resolve-DockerLaneLabVIEWPath `
   -ExplicitPath $WindowsLabVIEWPath `
-  -LegacySharedPath $LabVIEWPath `
-  -PreferredEnvNames @('NI_WINDOWS_LABVIEW_PATH', 'COMPARE_WINDOWS_LABVIEW_PATH') `
-  -SharedEnvNames @('COMPARE_LABVIEW_PATH', 'LOOP_LABVIEW_PATH')
+  -PreferredEnvNames @('NI_WINDOWS_LABVIEW_PATH', 'COMPARE_WINDOWS_LABVIEW_PATH')
 $effectiveLinuxLabVIEWPath = Resolve-DockerLaneLabVIEWPath `
   -ExplicitPath $LinuxLabVIEWPath `
-  -LegacySharedPath $LabVIEWPath `
-  -PreferredEnvNames @('NI_LINUX_LABVIEW_PATH', 'COMPARE_LINUX_LABVIEW_PATH') `
-  -SharedEnvNames @('COMPARE_LABVIEW_PATH', 'LOOP_LABVIEW_PATH')
+  -PreferredEnvNames @('NI_LINUX_LABVIEW_PATH', 'COMPARE_LINUX_LABVIEW_PATH')
 $effectiveSkipWindowsProbe = [bool]$SkipWindowsProbe
 $effectiveSkipLinuxProbe = [bool]$SkipLinuxProbe
 switch ($laneScopeNormalized) {

--- a/tools/priority/__tests__/docker-labview-path-contract.test.mjs
+++ b/tools/priority/__tests__/docker-labview-path-contract.test.mjs
@@ -35,6 +35,16 @@ test('fixture-drift hosted Linux lane passes an explicit linux container LabVIEW
   assert.match(workflow, /-LabVIEWPath \$env:NI_LINUX_LABVIEW_PATH/);
 });
 
+test('fixture-drift windows docker lane uses an explicit in-container LabVIEW path without host executable env fallback', () => {
+  const workflow = readRepoFile('.github/workflows/fixture-drift.yml');
+
+  assert.match(workflow, /NI_WINDOWS_IMAGE:\s*nationalinstruments\/labview:2026q1-windows/);
+  assert.match(workflow, /NI_WINDOWS_LABVIEW_PATH:\s*C:\\Program Files\\National Instruments\\LabVIEW 2026\\LabVIEW\.exe/);
+  assert.match(workflow, /-Image \$env:NI_WINDOWS_IMAGE/);
+  assert.match(workflow, /-LabVIEWPath \$env:NI_WINDOWS_LABVIEW_PATH/);
+  assert.doesNotMatch(workflow, /LABVIEW_EXE:/);
+});
+
 test('runbook validation canary uses an explicit Windows container LabVIEW path', () => {
   const workflow = readRepoFile('.github/workflows/runbook-validation.yml');
 
@@ -42,4 +52,14 @@ test('runbook validation canary uses an explicit Windows container LabVIEW path'
   assert.match(workflow, /NI_WINDOWS_LABVIEW_PATH:\s*C:\\Program Files\\National Instruments\\LabVIEW 2026\\LabVIEW\.exe/);
   assert.match(workflow, /-WindowsImage \$env:NI_WINDOWS_IMAGE/);
   assert.match(workflow, /-WindowsLabVIEWPath \$env:NI_WINDOWS_LABVIEW_PATH/);
+});
+
+test('docker desktop fast-loop only accepts lane-specific LabVIEW path contracts', () => {
+  const script = readRepoFile('tools/Test-DockerDesktopFastLoop.ps1');
+
+  assert.doesNotMatch(script, /\[string\]\$LabVIEWPath\s*=/);
+  assert.match(script, /PreferredEnvNames @\('NI_WINDOWS_LABVIEW_PATH', 'COMPARE_WINDOWS_LABVIEW_PATH'\)/);
+  assert.match(script, /PreferredEnvNames @\('NI_LINUX_LABVIEW_PATH', 'COMPARE_LINUX_LABVIEW_PATH'\)/);
+  assert.doesNotMatch(script, /COMPARE_LABVIEW_PATH/);
+  assert.doesNotMatch(script, /LOOP_LABVIEW_PATH/);
 });


### PR DESCRIPTION
## Summary
- remove the fast-loop helper's shared LabVIEW path fallback so Docker validation only accepts lane-specific Windows and Linux path contracts
- remove the stale host `LABVIEW_EXE` fallback from the Docker fixture-drift Windows lane
- add regression coverage for Windows and Linux lane path forwarding plus the workflow/script contract checks

## Validation
- `pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/Test-DockerDesktopFastLoop.Tests.ps1 -ResultsPath tests/results-859-fastloop -IntegrationMode exclude`
- `node --test tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipNiImageFlagScenarios -SkipPSScriptAnalyzer`
- `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope both -ManageDockerEngine:$true -HistoryScenarioSet history-core -WindowsLabVIEWPath 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe' -LinuxLabVIEWPath '/usr/local/natinst/LabVIEW-2026-64/labview' -StepTimeoutSeconds 600`
- `pwsh -NoLogo -NoProfile -File tools/Run-NILinuxContainerCompare.ps1 -BaseVi fixtures/vi-stage/control-rename/Base.vi -HeadVi fixtures/vi-stage/control-rename/Head.vi -Image nationalinstruments/labview:2026q1-linux -LabVIEWPath /usr/local/natinst/LabVIEW-2026-64/labview -ReportPath tests/results-859-linux-compare/linux-compare-report.html -TimeoutSeconds 300 -AutoRepairRuntime:$true -RuntimeEngineReadyTimeoutSeconds 120 -RuntimeEngineReadyPollSeconds 3`
