### PR TITLE
Compare-vi-cli-action: evaluate deferred wiki sync automation after curated portal rollout (#904)

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -79,6 +79,7 @@
         "docs/knowledgebase/LVCompare-Git-CLI-Guide_Windows-LabVIEW-2025Q3.md",
         "docs/knowledgebase/CrossRepo-VIHistory.md",
         "docs/knowledgebase/GitHub-Intake-Layer.md",
+        "docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md",
         "docs/knowledgebase/GitHub-Wiki-Portal.md",
         "docs/knowledgebase/Offline-RealHistory-Corpus.md",
         "docs/knowledgebase/DOCKER_TOOLS_PARITY.md",

--- a/docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md
+++ b/docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md
@@ -1,0 +1,69 @@
+# GitHub Wiki Portal Automation Evaluation
+
+This document records the deferred automation evaluation for the compare-vi wiki portal tracked under `#904`.
+
+## Decision
+
+Keep manual curation for now.
+
+- Do not add wiki sync or export automation as part of the initial portal rollout.
+- If automation becomes justified later, start with the smallest read-only or narrowly bounded helper.
+- Do not treat the wiki as a second source of truth.
+
+## Context
+
+- The authoritative docs live in this repository under `docs/`.
+- The published wiki pages live in the separate GitHub wiki backing repo,
+  `LabVIEW-Community-CI-CD/compare-vi-cli-action.wiki.git`.
+- The wiki exists to help humans and future agents find the right checked-in doc quickly.
+- The March 8, 2026 portal rollout established the wiki information architecture and repo touchpoints, but it did not
+  produce repeated maintenance evidence yet.
+
+The separate wiki repo matters. Any write automation that updates published pages increases cross-repo coupling,
+credential scope, rollback surface, and drift risk.
+
+## Evaluation criteria
+
+Any future automation proposal should be judged against these criteria:
+
+1. Preserve `docs/` as the source of truth.
+2. Minimize cross-repo write coupling with the wiki backing repo.
+3. Keep manual editorial control over curated summaries.
+4. Reduce repeated toil instead of moving one-off setup work into code.
+5. Be easy to validate and easy to roll back.
+
+## Option matrix
+
+| Option | Value | Risks | Recommendation |
+| --- | --- | --- | --- |
+| Keep manual curation | Zero new tooling; preserves editorial control | Ongoing manual updates | Keep as the default now |
+| Read-only route/link report | Detects stale authoritative-doc links and missing portal routes without changing content | May need explicit wiki snapshot input because published pages live in a separate repo | First candidate if drift evidence appears |
+| Navigation manifest export | Reduces repeated edits to `Home` and `_Sidebar` structure | Couples a checked-in manifest to wiki repo writes; may flatten intentional page curation | Consider only after repeated navigation churn |
+| Page skeleton generator | Speeds creation of stable page sections like `Start here` and `Authoritative repo docs` | Limited value once the initial portal pages already exist | Only if future page creation becomes frequent |
+| Summary snippet export | Reuses checked-in summaries | Higher drift and formatting risk across repos; encourages duplication | Not recommended as an early step |
+| Full sync or parity enforcement | Strongest consistency signal | Recreates the wiki as a mirrored docs system and raises rollback complexity | Reject |
+
+## Concrete triggers
+
+Automation should only be reconsidered if there is measured evidence such as:
+
+- three or more stale-link fixes across wiki pages within a short maintenance window
+- two or more standing-priority cycles that require the same `Home` or `_Sidebar` edits
+- repeated missed wiki follow-up after checked-in docs change
+- operator or agent confusion that persists even after the current portal contract is in place
+
+## Recommended progression
+
+If the triggers are met, use this order:
+
+1. Add a read-only helper that reports broken authoritative-doc links or missing required portal sections.
+2. If navigation churn remains high, evaluate a checked-in manifest that can export `Home` and `_Sidebar` skeletons.
+3. Reevaluate before introducing any cross-repo write automation.
+
+Do not start with snippet export or full wiki sync.
+
+## Current conclusion
+
+As of March 8, 2026, the repository does not have enough repeated maintenance evidence to justify wiki automation.
+Manual curation remains the correct operating mode, and `#904` should stay focused on decision quality rather than
+premature implementation.

--- a/docs/knowledgebase/GitHub-Wiki-Portal.md
+++ b/docs/knowledgebase/GitHub-Wiki-Portal.md
@@ -53,6 +53,13 @@ These repo surfaces should point readers at the wiki when discoverability matter
 - Do not make the wiki the primary authoring location.
 - Do not add sync automation or parity enforcement in the initial rollout.
 
+## Deferred automation
+
+Automation evaluation is tracked in
+[`docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md`](./GitHub-Wiki-Portal-Automation-Evaluation.md).
+The current recommendation is to keep manual curation and only consider narrow helpers such as read-only route/link
+reporting or navigation export if repeated maintenance toil justifies them.
+
 ## Maintenance note
 
 When a wiki page needs a detail-heavy update, prefer improving the checked-in repo doc first, then refresh the wiki

--- a/tools/priority/__tests__/github-intake-contract.test.mjs
+++ b/tools/priority/__tests__/github-intake-contract.test.mjs
@@ -61,6 +61,7 @@ test('github intake docs and manifest reference the new helper layer', () => {
   const readme = readText('README.md');
   const manifest = JSON.parse(readText('docs/documentation-manifest.json'));
   const intakeGuide = readText('docs/knowledgebase/GitHub-Intake-Layer.md');
+  const automationGuide = readText('docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md');
   const wikiGuide = readText('docs/knowledgebase/GitHub-Wiki-Portal.md');
   const orchestrator = readText('tools/Branch-Orchestrator.ps1');
   const intakeModule = readText('tools/GitHubIntake.psm1');
@@ -75,7 +76,10 @@ test('github intake docs and manifest reference the new helper layer', () => {
   assert.match(intakeGuide, /New-PullRequestBody\.ps1/);
   assert.match(intakeGuide, /GitHub-Wiki-Portal\.md/);
   assert.match(intakeGuide, /gh pr create --title "<title>" --body-file pr-body\.md/);
+  assert.match(automationGuide, /Keep manual curation for now/);
+  assert.match(automationGuide, /compare-vi-cli-action\.wiki\.git/);
   assert.match(wikiGuide, /Authoritative repo docs/);
+  assert.match(wikiGuide, /GitHub-Wiki-Portal-Automation-Evaluation\.md/);
   assert.match(wikiGuide, /README\.md/);
   assert.match(orchestrator, /Import-Module \(Join-Path \$PSScriptRoot 'GitHubIntake\.psm1'\)/);
   assert.match(orchestrator, /'pr'\s+'create'\s+'--title'/);
@@ -96,5 +100,6 @@ test('github intake docs and manifest reference the new helper layer', () => {
   const docsEntry = manifest.entries.find((entry) => entry.name === 'Docs Tree');
   assert.ok(docsEntry);
   assert.ok(docsEntry.files.includes('docs/knowledgebase/GitHub-Intake-Layer.md'));
+  assert.ok(docsEntry.files.includes('docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md'));
   assert.ok(docsEntry.files.includes('docs/knowledgebase/GitHub-Wiki-Portal.md'));
 });

--- a/tools/priority/__tests__/project-portfolio-config.test.mjs
+++ b/tools/priority/__tests__/project-portfolio-config.test.mjs
@@ -22,7 +22,7 @@ test('project portfolio config item URLs are unique and cover the tracked portfo
   const parsedUrls = config.items.map((item) => new URL(item.url));
   const urlStrings = parsedUrls.map((item) => item.toString());
   assert.equal(new Set(urlStrings).size, urlStrings.length);
-  assert.equal(parsedUrls.length, 26);
+  assert.equal(parsedUrls.length, 28);
 
   const issueCoordinates = new Set(
     parsedUrls.map((item) => {
@@ -46,6 +46,8 @@ test('project portfolio config item URLs are unique and cover the tracked portfo
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#897'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#903'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#904'));
+  assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#906'));
+  assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#907'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/comparevi-history#14'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/comparevi-history#15'));
 });

--- a/tools/priority/project-portfolio.json
+++ b/tools/priority/project-portfolio.json
@@ -301,7 +301,7 @@
     },
     {
       "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/903",
-      "status": "In Progress",
+      "status": "Done",
       "program": "Shared Infra",
       "phase": "Policy",
       "environmentClass": "Infra",
@@ -311,12 +311,32 @@
     },
     {
       "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/904",
-      "status": "Todo",
+      "status": "In Progress",
       "program": "Shared Infra",
       "phase": "Policy",
       "environmentClass": "Infra",
       "blockingSignal": "Scope",
       "evidenceState": "None",
+      "portfolioTrack": "Agent UX"
+    },
+    {
+      "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/906",
+      "status": "Todo",
+      "program": "Shared Infra",
+      "phase": "Sustain",
+      "environmentClass": "Infra",
+      "blockingSignal": "CI",
+      "evidenceState": "Ready",
+      "portfolioTrack": "Agent UX"
+    },
+    {
+      "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/907",
+      "status": "Todo",
+      "program": "Shared Infra",
+      "phase": "Sustain",
+      "environmentClass": "Infra",
+      "blockingSignal": "CI",
+      "evidenceState": "Ready",
       "portfolioTrack": "Agent UX"
     },
     {


### PR DESCRIPTION
Closes #904

## Summary

This PR turns the deferred wiki-automation question into an explicit checked-in decision instead of leaving it as implicit tribal knowledge. It documents that `docs/` remains authoritative, the published wiki lives in the separate `compare-vi-cli-action.wiki.git` repo, and manual curation remains the correct operating mode until there is measured maintenance evidence that justifies a smaller helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#904`
- Files, tools, workflows, or policies touched: wiki portal knowledgebase docs, docs manifest, intake/portfolio contract tests, and the checked-in project portfolio snapshot
- Cross-repo or external-consumer impact: documents the separate wiki backing repo boundary and rejects phase-1 cross-repo write automation
- Required checks, merge-queue behavior, or approval flows affected: no workflow behavior changes; this is a docs-and-contract update

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/github-intake-contract.test.mjs tools/priority/__tests__/project-portfolio-config.test.mjs tools/priority/__tests__/project-portfolio-cli.test.mjs`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs priority:project:portfolio:check`
  - `node tools/npm/run-script.mjs lint:md:changed`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- Key artifacts, logs, or workflow runs:
  - `docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md`
  - `tools/priority/project-portfolio.json`
- Risk-based checks not run:
  - None beyond the branch's normal CI matrix

## Risks and Follow-ups

- Residual risks: the checked-in portfolio snapshot will drift again as live project items move; that remains expected and should be folded into the next related branch
- Follow-up issues or deferred work:
  - `#906` release-conductor failure follow-up
  - `#907` issue-milestone-hygiene failure follow-up
- Deployment, approval, or rollback notes: merge should close `#904`; no release or runtime rollback action is needed

## Reviewer Focus

- Please verify: the decision boundary is clear that the wiki is a portal layer and not a second source of truth
- Areas where the reasoning is subtle: the separate wiki repo is the main reason to defer cross-repo write automation until repeated toil is measured
- Manual spot checks requested: sanity-check the new automation-evaluation doc and the linked project-portfolio sync against the live board