### PR TITLE
Project Portfolio: resync checked-in board contract after queue-empty handoff cleanup (#919)

### DIFF
--- a/tools/priority/__tests__/project-portfolio-config.test.mjs
+++ b/tools/priority/__tests__/project-portfolio-config.test.mjs
@@ -22,7 +22,7 @@ test('project portfolio config item URLs are unique and cover the tracked portfo
   const parsedUrls = config.items.map((item) => new URL(item.url));
   const urlStrings = parsedUrls.map((item) => item.toString());
   assert.equal(new Set(urlStrings).size, urlStrings.length);
-  assert.equal(parsedUrls.length, 29);
+  assert.equal(parsedUrls.length, 31);
 
   const issueCoordinates = new Set(
     parsedUrls.map((item) => {
@@ -49,6 +49,8 @@ test('project portfolio config item URLs are unique and cover the tracked portfo
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#906'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#907'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#911'));
+  assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#913'));
+  assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/compare-vi-cli-action#915'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/comparevi-history#14'));
   assert.ok(issueCoordinates.has('LabVIEW-Community-CI-CD/comparevi-history#15'));
 });

--- a/tools/priority/project-portfolio.json
+++ b/tools/priority/project-portfolio.json
@@ -341,7 +341,27 @@
     },
     {
       "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/911",
-      "status": "In Progress",
+      "status": "Done",
+      "program": "Shared Infra",
+      "phase": "Sustain",
+      "environmentClass": "Infra",
+      "blockingSignal": "Scope",
+      "evidenceState": "Ready",
+      "portfolioTrack": "Agent UX"
+    },
+    {
+      "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/913",
+      "status": "Done",
+      "program": "Shared Infra",
+      "phase": "Sustain",
+      "environmentClass": "Infra",
+      "blockingSignal": "Scope",
+      "evidenceState": "Ready",
+      "portfolioTrack": "Agent UX"
+    },
+    {
+      "url": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/915",
+      "status": "Done",
       "program": "Shared Infra",
       "phase": "Sustain",
       "environmentClass": "Infra",


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #919
- Issue title: Project Portfolio: resync checked-in board contract after queue-empty handoff cleanup
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/919
- Standing priority at PR creation: Yes (#919)
- Base branch: `develop`
- Head branch: `issue/919-project-portfolio-resync-checked-in-board-contract-after-queue-empty-handoff-cleanup`
- Template variant: `default-agent-template`
- Auto-close intent: Closes #919

# Summary

This PR restores the checked-in project portfolio contract to the live GitHub project after the recent queue-empty
handoff cleanup. It marks `#911` as `Done`, adds the missing `#913` and `#915` board items, and realigns the local
config/test pair so `priority:project:portfolio:check` passes again in an idle repository state.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: `#919`, opened to restore repo-local portfolio parity after the queue
  became empty and the live project advanced beyond the checked-in contract.
- Files, tools, workflows, or policies touched:
  - `tools/priority/project-portfolio.json`
  - `tools/priority/__tests__/project-portfolio-config.test.mjs`
- Cross-repo or external-consumer impact: preserves the existing `comparevi-history#14` and `comparevi-history#15`
  entries; no external workflow or release contract changes.
- Required checks, merge-queue behavior, or approval flows affected: restores the `priority:project:portfolio:check`
  contract only; no branch-protection, merge-queue, or workflow-approval changes.

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs priority:project:portfolio:check`
  - `node --test tools/priority/__tests__/project-portfolio-config.test.mjs tools/priority/__tests__/project-portfolio-cli.test.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/project/portfolio-snapshot.json`
- Risk-based checks not run:
  - None

## Risks and Follow-ups

- Residual risks: the checked-in contract will drift again whenever the live board changes; this PR only restores parity
  for the current board state.
- Follow-up issues or deferred work: `#919` is intentionally not added to the checked-in portfolio config to avoid
  creating immediate self-drift for this sync-only maintenance slice.
- Deployment, approval, or rollback notes: no deployment surface; rollback is a normal revert of the portfolio config
  sync.

## Reviewer Focus

- Please verify: the live board state for `#911`, `#913`, and `#915` matches the checked-in contract updates.
- Areas where the reasoning is subtle: `#919` itself is deliberately omitted from `project-portfolio.json` even though it
  is the standing issue driving this PR.
- Manual spot checks requested: confirm `priority:project:portfolio:check` remains green and the PR body now reflects the
  actual scope.
