### PR TITLE
Fix stable CompareVI.Tools outputs

### DIFF
--- a/tests/CompareVITools.Artifact.Tests.ps1
+++ b/tests/CompareVITools.Artifact.Tests.ps1
@@ -143,6 +143,39 @@ Describe 'CompareVI.Tools artifact publishing' {
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Compare-ExitCodeClassifier.ps1'
   }
 
+  It 'emits an empty prerelease GitHub output for stable CompareVI.Tools bundles' {
+    $outDir = Join-Path $TestDrive 'artifacts-github-output'
+    $metadataPath = Join-Path $TestDrive 'comparevi-tools-artifact-github-output.json'
+    $githubOutputPath = Join-Path $TestDrive 'github-output.txt'
+
+    $originalGitHubOutput = $env:GITHUB_OUTPUT
+    try {
+      $env:GITHUB_OUTPUT = $githubOutputPath
+
+      & $publishScript `
+        -OutputRoot $outDir `
+        -MetadataReportPath $metadataPath `
+        -Repository 'owner/repo' `
+        -SourceRef 'refs/tags/v9.9.9' `
+        -SourceSha '0123456789abcdef0123456789abcdef01234567' `
+        -ReleaseTag 'v9.9.9' `
+        -EmitGitHubOutputs
+    } finally {
+      if ($null -ne $originalGitHubOutput) {
+        $env:GITHUB_OUTPUT = $originalGitHubOutput
+      } else {
+        Remove-Item Env:GITHUB_OUTPUT -ErrorAction SilentlyContinue
+      }
+    }
+
+    Test-Path -LiteralPath $githubOutputPath | Should -BeTrue
+    $outputLines = Get-Content -LiteralPath $githubOutputPath
+    $outputLines | Should -Contain "comparevi_tools_module_version=$moduleVersion"
+    $outputLines | Should -Contain "comparevi_tools_release_version=$moduleReleaseVersion"
+    $outputLines | Should -Contain 'comparevi_tools_module_prerelease='
+    ($outputLines | Where-Object { $_ -like 'comparevi_tools_module_prerelease=*' }).Count | Should -Be 1
+  }
+
   It 'exports the bundle root through COMPAREVI_SCRIPTS_ROOT when invoking the module wrapper' {
     $bundleRoot = Join-Path $TestDrive 'bundle'
     $moduleRoot = Join-Path $bundleRoot 'tools' 'CompareVI.Tools'

--- a/tools/Publish-CompareVIToolsArtifact.ps1
+++ b/tools/Publish-CompareVIToolsArtifact.ps1
@@ -100,7 +100,7 @@ function Resolve-SourceRef {
 function Write-GitHubOutputValue {
   param(
     [Parameter(Mandatory = $true)][string]$Key,
-    [Parameter(Mandatory = $true)][string]$Value
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value
   )
 
   if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {


### PR DESCRIPTION
## Summary
This follow-up closes the stable-release gap in `Publish-CompareVIToolsArtifact.ps1`. `Release on tag` was failing after the bundle was already written because the script tried to emit `comparevi_tools_module_prerelease` through `GITHUB_OUTPUT` even when the stable `CompareVI.Tools` manifest had no prerelease segment.

## Change Surface
- allow the GitHub output helper in `tools/Publish-CompareVIToolsArtifact.ps1` to emit an intentional empty string for stable releases
- add a regression in `tests/CompareVITools.Artifact.Tests.ps1` that exercises `-EmitGitHubOutputs` and asserts the raw `comparevi_tools_module_prerelease=` line
- keep the output key present so future workflows can distinguish stable versus prerelease bundles without rediscovering this PowerShell binding edge case

## Validation
- `Import-Module Pester -RequiredVersion 5.7.1 -Force; Invoke-Pester -Path 'tests/CompareVITools.Artifact.Tests.ps1','tests/CompareVI.BundleCertification.Tests.ps1' -CI`
- `node tools/npm/run-script.mjs priority:test`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`

Closes #936
Refs #930
