### PR TITLE
Fix Publish-Cli shared-feed version seam

### DIFF
--- a/tests/Publish-Cli.Tests.ps1
+++ b/tests/Publish-Cli.Tests.ps1
@@ -1,0 +1,113 @@
+Describe 'Publish-Cli shared package feed resolution' {
+  BeforeAll {
+    $candidateRoots = @()
+    foreach ($candidate in @($PSScriptRoot, $PSCommandPath, (Get-Location).Path)) {
+      if ([string]::IsNullOrWhiteSpace($candidate)) {
+        continue
+      }
+
+      $resolved = $candidate
+      if (Test-Path -LiteralPath $candidate) {
+        $item = Get-Item -LiteralPath $candidate
+        $resolved = if ($item.PSIsContainer) { $item.FullName } else { Split-Path -Parent $item.FullName }
+      }
+      $candidateRoots += $resolved
+    }
+
+    $repoRoot = $null
+    foreach ($root in $candidateRoots | Select-Object -Unique) {
+      $cursor = $root
+      while (-not [string]::IsNullOrWhiteSpace($cursor)) {
+        $marker = Join-Path $cursor 'tools' 'Publish-Cli.ps1'
+        if (Test-Path -LiteralPath $marker -PathType Leaf) {
+          $repoRoot = $cursor
+          break
+        }
+
+        $parent = Split-Path -Parent $cursor
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $cursor) {
+          break
+        }
+
+        $cursor = $parent
+      }
+
+      if ($repoRoot) {
+        break
+      }
+    }
+
+    if (-not $repoRoot) {
+      throw 'Unable to resolve repository root for Publish-Cli tests.'
+    }
+
+    $script:RepoRoot = $repoRoot
+    $script:PublishCliScript = Join-Path $repoRoot 'tools' 'Publish-Cli.ps1'
+    $script:CliProjectPath = Join-Path $repoRoot 'src' 'CompareVi.Tools.Cli' 'CompareVi.Tools.Cli.csproj'
+    $script:SharedProjectPath = Join-Path $repoRoot 'src' 'CompareVi.Shared' 'CompareVi.Shared.csproj'
+
+    [xml]$propsXml = Get-Content -Raw (Join-Path $repoRoot 'Directory.Build.props')
+    $script:ExpectedSharedPackageVersion = ([string]($propsXml.Project.PropertyGroup.Version | Select-Object -First 1)).Trim()
+  }
+
+  It 'resolves the package-first shared feed version from Directory.Build.props text' {
+    $outputRoot = Join-Path $TestDrive 'publish-output'
+    $sharedFeed = Join-Path $TestDrive 'shared-feed'
+    $sharedSourceReportPath = Join-Path $TestDrive 'shared-source-resolution.json'
+
+    & $script:PublishCliScript `
+      -ProjectPath $script:CliProjectPath `
+      -SharedProjectPath $script:SharedProjectPath `
+      -OutputRoot $outputRoot `
+      -CompareViSharedPackageFeed $sharedFeed `
+      -SharedSourceReportPath $sharedSourceReportPath `
+      -CompareViSharedSource package-first `
+      -PrepareSharedPackageFeed `
+      -FailOnSharedFallback `
+      -FrameworkDependent:$false `
+      -SelfContained:$false `
+      -Rids @('win-x64')
+
+    Test-Path -LiteralPath $sharedSourceReportPath | Should -BeTrue
+    $report = Get-Content -LiteralPath $sharedSourceReportPath -Raw | ConvertFrom-Json
+    $report.requestedSource | Should -Be 'package-first'
+    $report.resolvedSource | Should -Be 'package'
+    $report.packageAvailable | Should -Be 'true'
+    $report.packageVersion | Should -Be $script:ExpectedSharedPackageVersion
+    $report.packageVersion | Should -Not -Be 'System.Xml.XmlElement'
+
+    $nupkgPath = Join-Path $sharedFeed ("CompareVi.Shared.{0}.nupkg" -f $script:ExpectedSharedPackageVersion)
+    Test-Path -LiteralPath $nupkgPath | Should -BeTrue
+  }
+
+  It 'honors an explicit shared package version when preparing the package feed' {
+    $explicitVersion = '9.9.9-test.1'
+    $outputRoot = Join-Path $TestDrive 'publish-output-explicit'
+    $sharedFeed = Join-Path $TestDrive 'shared-feed-explicit'
+    $sharedSourceReportPath = Join-Path $TestDrive 'shared-source-resolution-explicit.json'
+
+    & $script:PublishCliScript `
+      -ProjectPath $script:CliProjectPath `
+      -SharedProjectPath $script:SharedProjectPath `
+      -OutputRoot $outputRoot `
+      -CompareViSharedPackageFeed $sharedFeed `
+      -SharedSourceReportPath $sharedSourceReportPath `
+      -CompareViSharedSource package-first `
+      -CompareViSharedPackageVersion $explicitVersion `
+      -PrepareSharedPackageFeed `
+      -FailOnSharedFallback `
+      -FrameworkDependent:$false `
+      -SelfContained:$false `
+      -Rids @('win-x64')
+
+    Test-Path -LiteralPath $sharedSourceReportPath | Should -BeTrue
+    $report = Get-Content -LiteralPath $sharedSourceReportPath -Raw | ConvertFrom-Json
+    $report.requestedSource | Should -Be 'package-first'
+    $report.resolvedSource | Should -Be 'package'
+    $report.packageAvailable | Should -Be 'true'
+    $report.packageVersion | Should -Be $explicitVersion
+
+    $nupkgPath = Join-Path $sharedFeed ("CompareVi.Shared.{0}.nupkg" -f $explicitVersion)
+    Test-Path -LiteralPath $nupkgPath | Should -BeTrue
+  }
+}

--- a/tools/Publish-Cli.ps1
+++ b/tools/Publish-Cli.ps1
@@ -18,10 +18,35 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+function Get-XmlNodeText {
+  param([AllowNull()]$Node)
+
+  if ($null -eq $Node) {
+    return ''
+  }
+
+  if ($Node -is [System.Collections.IEnumerable] -and -not ($Node -is [string]) -and -not ($Node -is [System.Xml.XmlNode])) {
+    foreach ($candidate in $Node) {
+      $text = Get-XmlNodeText -Node $candidate
+      if (-not [string]::IsNullOrWhiteSpace($text)) {
+        return $text
+      }
+    }
+
+    return ''
+  }
+
+  if ($Node -is [System.Xml.XmlNode]) {
+    return $Node.InnerText.Trim()
+  }
+
+  return ([string]$Node).Trim()
+}
+
 function Get-VersionFromProps {
   $propsPath = Join-Path $PSScriptRoot '..' 'Directory.Build.props' | Resolve-Path | Select-Object -ExpandProperty Path
   [xml]$xml = Get-Content -Raw $propsPath
-  $ver = $xml.Project.PropertyGroup.Version
+  $ver = Get-XmlNodeText -Node ($xml.Project.PropertyGroup.Version | Select-Object -First 1)
   if ([string]::IsNullOrWhiteSpace($ver)) { return '0.0.0' }
   return $ver
 }
@@ -29,14 +54,14 @@ function Get-VersionFromProps {
 function Get-SharedPackageVersionFromProps {
   $propsPath = Join-Path $PSScriptRoot '..' 'Directory.Build.props' | Resolve-Path | Select-Object -ExpandProperty Path
   [xml]$xml = Get-Content -Raw $propsPath
-  $packageVersion = $xml.Project.PropertyGroup.CompareViSharedPackageVersion | Select-Object -First 1
+  $packageVersion = Get-XmlNodeText -Node ($xml.Project.PropertyGroup.CompareViSharedPackageVersion | Select-Object -First 1)
   if (-not [string]::IsNullOrWhiteSpace($packageVersion) -and $packageVersion -notmatch '^\$\(.+\)$') {
-    return [string]$packageVersion
+    return $packageVersion
   }
 
-  $version = $xml.Project.PropertyGroup.Version | Select-Object -First 1
+  $version = Get-XmlNodeText -Node ($xml.Project.PropertyGroup.Version | Select-Object -First 1)
   if (-not [string]::IsNullOrWhiteSpace($version)) {
-    return [string]$version
+    return $version
   }
 
   throw "Unable to resolve CompareVi.Shared package version from Directory.Build.props"
@@ -45,10 +70,10 @@ function Get-SharedPackageVersionFromProps {
 function Get-SharedPackageVersion {
   param([string]$CsprojPath)
   [xml]$xml = Get-Content -Raw $CsprojPath
-  $packageVersion = $xml.Project.PropertyGroup.PackageVersion | Select-Object -First 1
-  if (-not [string]::IsNullOrWhiteSpace($packageVersion) -and $packageVersion -notmatch '^\$\(.+\)$') { return [string]$packageVersion }
-  $version = $xml.Project.PropertyGroup.Version | Select-Object -First 1
-  if (-not [string]::IsNullOrWhiteSpace($version) -and $version -notmatch '^\$\(.+\)$') { return [string]$version }
+  $packageVersion = Get-XmlNodeText -Node ($xml.Project.PropertyGroup.PackageVersion | Select-Object -First 1)
+  if (-not [string]::IsNullOrWhiteSpace($packageVersion) -and $packageVersion -notmatch '^\$\(.+\)$') { return $packageVersion }
+  $version = Get-XmlNodeText -Node ($xml.Project.PropertyGroup.Version | Select-Object -First 1)
+  if (-not [string]::IsNullOrWhiteSpace($version) -and $version -notmatch '^\$\(.+\)$') { return $version }
   return Get-SharedPackageVersionFromProps
 }
 
@@ -165,7 +190,11 @@ Write-Host "Publishing comparevi-cli version $version" -ForegroundColor Cyan
 $projFull = Resolve-Path $ProjectPath | Select-Object -ExpandProperty Path
 $sharedProjFull = Resolve-Path $SharedProjectPath | Select-Object -ExpandProperty Path
 $root = Resolve-Path '.' | Select-Object -ExpandProperty Path
-$outRoot = Join-Path $root $OutputRoot
+$outRoot = if ([System.IO.Path]::IsPathRooted($OutputRoot)) {
+  $OutputRoot
+} else {
+  Join-Path $root $OutputRoot
+}
 Ensure-Dir $outRoot
 
 $sharedFeed = if ([System.IO.Path]::IsPathRooted($CompareViSharedPackageFeed)) {


### PR DESCRIPTION
## Summary
This follow-up fixes the next tools-tag release blocker uncovered by `v0.6.3-tools.5`. `Publish-Cli.ps1` was resolving `CompareViSharedPackageVersion` from `Directory.Build.props` as a raw XML element instead of its text content, which made the package feed prep step pass `System.Xml.XmlElement` into `dotnet pack` and forced the release job back to project-source fallback.

## Change Surface
- add XML-text normalization in `tools/Publish-Cli.ps1` so `Version`, `PackageVersion`, and `CompareViSharedPackageVersion` are read as actual text values
- allow rooted `OutputRoot` values so future agents and tests can run the publisher against isolated temp directories
- add `tests/Publish-Cli.Tests.ps1` to exercise the package-first shared-feed path both from the props-backed default version and from an explicit override version

## Validation
- `Import-Module Pester -RequiredVersion 5.7.1 -Force; Invoke-Pester -Path 'tests/Publish-Cli.Tests.ps1' -CI`
- `pwsh -NoLogo -NoProfile -File tools/Publish-Cli.ps1 -ProjectPath src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj -SharedProjectPath src/CompareVi.Shared/CompareVi.Shared.csproj -Rids win-x64 -OutputRoot tests/results/_agent/_tmp_publish_cli -SharedSourceReportPath tests/results/_agent/_tmp_publish_cli/shared-source-resolution.json -CompareViSharedSource package-first -PrepareSharedPackageFeed -FailOnSharedFallback -FrameworkDependent:$false -SelfContained:$false`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`

Refs #930
Refs #936
