### PR TITLE
Fix rollback drill remote fallback (#936)

### DIFF
--- a/tools/priority/__tests__/rollback-release.test.mjs
+++ b/tools/priority/__tests__/rollback-release.test.mjs
@@ -201,3 +201,58 @@ test('runRollback uses origin fallback for dry-run planning when upstream is una
   assert.equal(resolution.branches[0].remote, 'origin');
   assert.equal(resolution.summary.status, 'pass');
 });
+
+test('runRollback uses injected ref resolver throughout apply and sync-origin flows', async () => {
+  const policy = normalizeReleaseRollbackPolicy({});
+  const seenRefs = [];
+  const forcePushCalls = [];
+  const refCounts = new Map();
+  const targetCommit = 'deadbeef';
+
+  const resolution = await runRollback(
+    {
+      ...parseArgs(['node', 'rollback-release.mjs']),
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      apply: true,
+      syncOrigin: true
+    },
+    {
+      repoRoot: '/repo',
+      policy,
+      fetchReleaseRecords: () => [
+        { tag_name: 'v1.2.3', draft: false, prerelease: false, published_at: '2026-03-05T00:00:00Z' },
+        { tag_name: 'v1.2.2', draft: false, prerelease: false, published_at: '2026-03-01T00:00:00Z' }
+      ],
+      remoteResolver: () => ({
+        configuredRemote: 'upstream',
+        effectiveRemote: 'mirror',
+        fallbackReason: null
+      }),
+      fetchRemoteRefs: () => {},
+      resolveTagCommit: () => targetCommit,
+      tryResolveRef: (_repoRoot, ref) => {
+        seenRefs.push(ref);
+        const count = (refCounts.get(ref) || 0) + 1;
+        refCounts.set(ref, count);
+        return count === 1 ? `lease:${ref}` : targetCommit;
+      },
+      forcePushBranch: (_repoRoot, remote, branch, commit, leaseCommit) => {
+        forcePushCalls.push({ remote, branch, commit, leaseCommit });
+      },
+      policySync: () => ({
+        executed: true,
+        status: 'pass',
+        exitCode: 0,
+        stdout: '',
+        stderr: ''
+      })
+    }
+  );
+
+  assert.ok(seenRefs.includes('mirror/main'));
+  assert.ok(seenRefs.includes('mirror/develop'));
+  assert.ok(seenRefs.includes('origin/main'));
+  assert.ok(seenRefs.includes('origin/develop'));
+  assert.equal(forcePushCalls.length, 4);
+  assert.equal(resolution.summary.status, 'pass');
+});

--- a/tools/priority/rollback-release.mjs
+++ b/tools/priority/rollback-release.mjs
@@ -450,7 +450,7 @@ export async function runRollback(options, dependencies = {}) {
     const originBranches = targetBranches.map((name) => ({
       name,
       remote: 'origin',
-      before: tryResolveRef(repoRoot, `origin/${name}`),
+      before: tryResolveRefFn(repoRoot, `origin/${name}`),
       after: null,
       pushed: false,
       matchesTarget: false


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #936
- Issue title: CompareVI.Tools tag releases: fix tools-tag release and image refresh path
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/936
- Standing priority at PR creation: No
- Base branch: `develop`
- Head branch: `issue/936-tools-tag-release-refresh-5`
- Template variant: `default`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

This repairs the rollback drill path that now blocks CompareVI.Tools tag promotion after the trust gate. `rollback-release.mjs` no longer assumes an `upstream` remote exists on hosted runners; when the configured rollback remote is missing but `origin` matches the canonical repository, it falls back to `origin` and records that decision in the report.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#936`, the remaining CompareVI.Tools helper-tag release path blockers.
- Files, tools, workflows, or policies touched: `tools/priority/rollback-release.mjs` and `tools/priority/__tests__/rollback-release.test.mjs`.
- Cross-repo or external-consumer impact: unblocks GitHub Release publication for helper tags so the `Publish Tools Image` release-event workflow can refresh `ghcr.io/LabVIEW-Community-CI-CD/comparevi-tools` for downstream consumers.
- Required checks, merge-queue behavior, or approval flows affected: normal Validate/agent-review policy path only; the behavioral impact is on `release-rollback-drill.yml` and the rollback health gate inside `release.yml`.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/rollback-release.test.mjs tools/priority/__tests__/rollback-drill-health.test.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- Key artifacts, logs, or workflow runs:
  - failing release run `22846184258`
  - failing rollback drill run `22846328575`
- Risk-based checks not run:
  - No full release rerun yet; that requires the PR to merge so the rollback drill can succeed on `develop`.

## Risks and Follow-ups

- Residual risks: if the rollback drill uncovers a separate rollback-pointer/history problem after the remote fix, the next tools tag may still pause later in the drill path.
- Follow-up issues or deferred work: none added yet; `#936` remains the live tracker until the helper tag release and tools-image refresh both succeed.
- Deployment, approval, or rollback notes: after merge, rerun the rollback drill on `develop`, then cut the next helper tag from the merge commit and approve the production environment for the release workflow.

## Reviewer Focus

- Please verify: the `origin` fallback only activates when it matches the canonical repo slug, so fork clones still fail closed instead of rolling back the wrong remote.
- Areas where the reasoning is subtle: hosted runners for upstream repos only have `origin`, while local admin/fork workflows still rely on explicit `upstream` semantics.
- Manual spot checks requested: none.