### PR TITLE
#930 #942 Restore release-to-tools-image workflow fan-out

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
     environment:
       name: production
     permissions:
+      actions: write
       contents: write
       attestations: write
       id-token: write
@@ -322,6 +323,24 @@ jobs:
             artifacts/cli/SHA256SUMS.txt
             artifacts/cli/sbom.spdx.json
             artifacts/cli/provenance.json
+
+      - name: Dispatch Publish Tools Image workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const releaseVersion = '${{ steps.comparevi_tools.outputs.comparevi_tools_release_version }}';
+            const releaseChannel = releaseVersion.includes('-rc.') ? 'rc' : 'stable';
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish-tools-image.yml',
+              ref: '${{ github.ref_name }}',
+              inputs: {
+                version: releaseVersion,
+                channel: releaseChannel
+              }
+            });
+            core.info(`Dispatched publish-tools-image workflow for ${releaseVersion} (${releaseChannel}).`);
 
   validate-cli-artifacts:
     runs-on: ${{ matrix.os }}

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -58,3 +58,22 @@ test('publish-tools-image workflow resolves context through the dedicated helper
   assert.match(workflow, /steps\.context\.outputs\.stable_family_version/);
   assert.match(workflow, /steps\.context\.outputs\.is_tools_tag/);
 });
+
+test('release workflow explicitly dispatches publish-tools-image with actions write permission', () => {
+  const workflowPath = path.join(workflowsRoot, 'release.yml');
+  const workflowRaw = readFileSync(workflowPath, 'utf8');
+  const workflow = yaml.load(workflowRaw);
+  const releaseJob = workflow?.jobs?.release;
+  const dispatchStep = releaseJob?.steps?.find((step) => step?.name === 'Dispatch Publish Tools Image workflow');
+
+  assert.equal(releaseJob?.permissions?.actions, 'write');
+  assert.ok(dispatchStep, 'release workflow should dispatch publish-tools-image explicitly');
+  assert.equal(dispatchStep.uses, 'actions/github-script@v7');
+  assert.match(dispatchStep.with.script, /workflow_id:\s*'publish-tools-image\.yml'/);
+  assert.match(dispatchStep.with.script, /ref:\s*'\$\{\{\s*github\.ref_name\s*\}\}'/);
+  assert.match(
+    dispatchStep.with.script,
+    /const releaseVersion = '\$\{\{\s*steps\.comparevi_tools\.outputs\.comparevi_tools_release_version\s*\}\}';/
+  );
+  assert.match(dispatchStep.with.script, /const releaseChannel = releaseVersion\.includes\('-rc\.'\) \? 'rc' : 'stable';/);
+});


### PR DESCRIPTION
## Summary
This restores the tools-image publish fan-out for workflow-created releases by having `release.yml` dispatch `publish-tools-image.yml` directly after the GitHub Release is published. The release job now opts into `actions: write`, which is required for `createWorkflowDispatch`, so tools-tag and semver releases no longer rely on suppressed release-event chaining from a `GITHUB_TOKEN`-created release.

Advances #930.
Closes #942.

## Change Surface
- `.github/workflows/release.yml`
- `tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs`

## Validation
- `node --test tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs`
- `./bin/actionlint -color`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
