### PR TITLE
Update for standing priority #1036

### DIFF
--- a/tools/priority/__tests__/hook-parity-required-check-contract.test.mjs
+++ b/tools/priority/__tests__/hook-parity-required-check-contract.test.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readdirSync, readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+const prohibitedRequiredContexts = ['ubuntu-latest', 'windows-latest']
+  .map((runner) => `hook-parity (${runner})`);
+
+const textExtensions = new Set([
+  '.json',
+  '.md',
+  '.mjs',
+  '.js',
+  '.ps1',
+  '.psm1',
+  '.ts',
+  '.yml',
+  '.yaml',
+]);
+
+const excludedDirectories = new Set([
+  '.git',
+  'dist',
+  'node_modules',
+  'tests/results',
+  'tests\\results',
+]);
+
+function walk(relativeDir) {
+  const absoluteDir = path.join(repoRoot, relativeDir);
+  const entries = readdirSync(absoluteDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const relativePath = relativeDir ? path.join(relativeDir, entry.name) : entry.name;
+    const normalizedRelativePath = relativePath.replace(/\\/g, '/');
+    if (entry.isDirectory()) {
+      if (excludedDirectories.has(normalizedRelativePath) || excludedDirectories.has(entry.name)) {
+        continue;
+      }
+      files.push(...walk(relativePath));
+      continue;
+    }
+
+    if (!textExtensions.has(path.extname(entry.name))) {
+      continue;
+    }
+
+    files.push(relativePath);
+  }
+
+  return files;
+}
+
+test('canonical required-check mappings do not include stale hook-parity contexts', () => {
+  const policyPath = path.join(repoRoot, 'tools', 'policy', 'branch-required-checks.json');
+  const policy = JSON.parse(readFileSync(policyPath, 'utf8'));
+
+  for (const context of prohibitedRequiredContexts) {
+    assert.doesNotMatch(JSON.stringify(policy), new RegExp(context.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});
+
+test('checked-in policy and guidance do not mention stale hook-parity required contexts', () => {
+  const files = walk('');
+  const offenders = [];
+
+  for (const relativePath of files) {
+    const normalizedRelativePath = relativePath.replace(/\\/g, '/');
+    if (normalizedRelativePath === '.github/workflows/validate.yml') {
+      continue;
+    }
+
+    const raw = readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    for (const context of prohibitedRequiredContexts) {
+      if (raw.includes(context)) {
+        offenders.push(`${normalizedRelativePath}: ${context}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `stale hook-parity required-check contexts must stay out of checked-in policy and docs: ${offenders.join(', ')}`,
+  );
+});


### PR DESCRIPTION
# Summary

Locks in the current `develop` policy state for #1036 by adding a repo-wide regression that forbids the stale required-check strings `hook-parity (ubuntu-latest)` and `hook-parity (windows-latest)` from reappearing in checked-in policy or guidance.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1036
- Files, tools, workflows, or policies touched:
  - `tools/priority/__tests__/hook-parity-required-check-contract.test.mjs`
- Cross-repo or external-consumer impact: None.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/hook-parity-required-check-contract.test.mjs`
- Key artifacts, logs, or workflow runs:
  - Local contract run passed `2/2`
- Risk-based checks not run:
  - Full CI is deferred to the PR workflow run.

## Risks and Follow-ups

- Residual risks: This only guards the exact stale required-check strings; broader required-check contract drift remains covered by the existing policy tests.
- Follow-up issues or deferred work: None.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: the new guard is scoped to stale required-check contracts and does not forbid the live `hook-parity` workflow job itself.
- Areas where the reasoning is subtle: the repo is already clean; this PR is guarding against regression, not changing live branch protection.
- Manual spot checks requested: None.

Closes #1036