### PR TITLE
#1053 Persist daemon local review-loop state for resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,12 @@ artifacts under `tests/results/_agent/`.
   `tests/results/docker-tools-parity/review-loop-receipt.json` first after
   compaction; it points to
   `tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json`
-  and the rest of the authoritative local review artifacts.
+  and the rest of the authoritative local review artifacts. When the daemon is
+  active, the same summary is mirrored into
+  `tests/results/_agent/runtime/delivery-agent-state.json` and
+  `tests/results/_agent/runtime/delivery-agent-lanes/*.json` under the
+  `localReviewLoop` node so future agents can resume from runtime state before
+  reopening deeper receipts.
 - Keep bulky diagnostics out of source. Large logs and artifacts belong in
   issue attachments or generated artifact folders, not in committed history.
 - Use vendor resolvers from `tools/VendorTools.psm1` rather than ad-hoc PATH

--- a/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
+++ b/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
@@ -43,6 +43,10 @@ pwsh -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -RequirementsVerific
 - Every run now also emits the combined top-level receipt
   `tests/results/docker-tools-parity/review-loop-receipt.json`. Read that file first after compaction; it records
   per-check status, links to the current NI Linux and requirements artifacts, and lists the recommended review order.
+- When the unattended delivery daemon consumes that receipt, it now mirrors the normalized summary into
+  `tests/results/_agent/runtime/delivery-agent-state.json` and the active lane record under
+  `tests/results/_agent/runtime/delivery-agent-lanes/`. Future agents should read the runtime-state `localReviewLoop`
+  node first when resuming a daemon-driven lane, then open the deeper Docker/Desktop receipt paths only when needed.
 
 ## Review-loop policy
 

--- a/docs/schemas/delivery-agent-runtime-state-v1.schema.json
+++ b/docs/schemas/delivery-agent-runtime-state-v1.schema.json
@@ -44,6 +44,26 @@
         "maxActiveCodingLanes": { "type": "integer", "minimum": 1 }
       }
     },
+    "localReviewLoop": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "requested": { "type": "boolean" },
+        "status": { "type": ["string", "null"] },
+        "source": { "type": ["string", "null"] },
+        "reason": { "type": ["string", "null"] },
+        "receiptPath": { "type": ["string", "null"] },
+        "receiptStatus": { "type": ["string", "null"] },
+        "failedCheck": { "type": ["string", "null"] },
+        "requirementsVerificationRequested": { "type": "boolean" },
+        "markdownlintRequested": { "type": "boolean" },
+        "niLinuxReviewSuiteRequested": { "type": "boolean" },
+        "recommendedReviewOrder": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        }
+      }
+    },
     "activeLane": {
       "type": "object",
       "additionalProperties": true,
@@ -75,7 +95,27 @@
         "outcome": { "type": ["string", "null"] },
         "reason": { "type": ["string", "null"] },
         "retryable": { "type": "boolean" },
-        "nextWakeCondition": { "type": ["string", "null"] }
+        "nextWakeCondition": { "type": ["string", "null"] },
+        "localReviewLoop": {
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "properties": {
+            "requested": { "type": "boolean" },
+            "status": { "type": ["string", "null"] },
+            "source": { "type": ["string", "null"] },
+            "reason": { "type": ["string", "null"] },
+            "receiptPath": { "type": ["string", "null"] },
+            "receiptStatus": { "type": ["string", "null"] },
+            "failedCheck": { "type": ["string", "null"] },
+            "requirementsVerificationRequested": { "type": "boolean" },
+            "markdownlintRequested": { "type": "boolean" },
+            "niLinuxReviewSuiteRequested": { "type": "boolean" },
+            "recommendedReviewOrder": {
+              "type": ["array", "null"],
+              "items": { "type": "string" }
+            }
+          }
+        }
       }
     },
     "artifacts": { "type": "object", "additionalProperties": true }

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -210,7 +210,22 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
       },
       evidence: {
         delivery: {
-          laneLifecycle: 'ready-merge'
+          laneLifecycle: 'ready-merge',
+          localReviewLoop: {
+            requested: true,
+            source: 'standing-issue-body',
+            receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+            markdownlint: true,
+            requirementsVerification: true,
+            niLinuxReviewSuite: true,
+            singleViHistory: {
+              enabled: true,
+              targetPath: 'fixtures/vi-attr/Head.vi',
+              branchRef: 'develop',
+              baselineRef: '',
+              maxCommitCount: 256
+            }
+          }
         }
       }
     },
@@ -222,7 +237,43 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
         laneLifecycle: 'complete',
         blockerClass: 'none',
         retryable: false,
-        nextWakeCondition: 'next-scheduler-cycle'
+        nextWakeCondition: 'next-scheduler-cycle',
+        localReviewLoop: {
+          status: 'passed',
+          source: 'docker-desktop-review-loop',
+          reason: 'Docker/Desktop review loop passed.',
+          receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+          receipt: {
+            overall: {
+              status: 'passed',
+              failedCheck: '',
+              message: '',
+              exitCode: 0
+            },
+            artifacts: {
+              reviewLoopReceiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+              historyReviewReceiptPath: 'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json',
+              requirementsSummaryPath: 'tests/results/docker-tools-parity/requirements-verification/verification-summary.json'
+            },
+            niLinuxHistoryReview: {
+              targetPath: 'fixtures/vi-attr/Head.vi',
+              effectiveBranchRef: 'develop',
+              maxCommitCount: 256,
+              touchAware: true
+            },
+            requirementsCoverage: {
+              requirementTotal: 9,
+              requirementCovered: 9,
+              requirementUncovered: 0,
+              uncoveredRequirementIds: null,
+              unknownRequirementIds: null
+            },
+            recommendedReviewOrder: [
+              'tests/results/docker-tools-parity/review-loop-receipt.json',
+              'tests/results/docker-tools-parity/ni-linux-review-suite/review-suite-summary.html'
+            ]
+          }
+        }
       }
     },
     statePath: path.join(repoRoot, 'tests/results/_agent/runtime/delivery-agent-state.json'),
@@ -231,6 +282,19 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
   const ajv = makeAjv();
   const validate = ajv.compile(schema);
   assert.equal(validate(state), true, JSON.stringify(validate.errors, null, 2));
+  assert.equal(state.localReviewLoop.status, 'passed');
+  assert.equal(state.localReviewLoop.receiptStatus, 'passed');
+  assert.equal(state.localReviewLoop.niLinuxReviewSuiteRequested, true);
+  assert.equal(state.localReviewLoop.singleViHistory.targetPath, 'fixtures/vi-attr/Head.vi');
+  assert.equal(
+    state.localReviewLoop.artifacts.historyReviewReceiptPath,
+    'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json'
+  );
+  assert.equal(state.activeLane.localReviewLoop.receiptStatus, 'passed');
+  assert.equal(
+    state.artifacts.localReviewLoopReceiptPath,
+    'tests/results/docker-tools-parity/review-loop-receipt.json'
+  );
 });
 
 test('delivery memory schema validates suite-aware terminal PR history', async () => {

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -1847,6 +1847,21 @@ test('comparevi canonical execution delegates to the delivery broker instead of 
           turnBudget: {
             maxMinutes: 20,
             maxToolCalls: 12
+          },
+          localReviewLoop: {
+            requested: true,
+            source: 'selected-issue-body',
+            receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+            markdownlint: true,
+            requirementsVerification: true,
+            niLinuxReviewSuite: true,
+            singleViHistory: {
+              enabled: true,
+              targetPath: 'fixtures/vi-attr/Head.vi',
+              branchRef: 'develop',
+              baselineRef: '',
+              maxCommitCount: 256
+            }
           }
         }
       }
@@ -2056,7 +2071,39 @@ test('comparevi canonical execution persists a broker-managed ready-for-review r
           ],
           filesTouched: ['tools/priority/runtime-supervisor.mjs'],
           pullRequestUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1015',
-          notes: 'Broker restored ready-for-review so Copilot can issue a fresh current-head review.'
+          notes: 'Broker restored ready-for-review so Copilot can issue a fresh current-head review.',
+          localReviewLoop: {
+            status: 'passed',
+            source: 'docker-desktop-review-loop',
+            reason: 'Docker/Desktop review loop passed.',
+            receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+            receipt: {
+              overall: {
+                status: 'passed',
+                failedCheck: '',
+                message: '',
+                exitCode: 0
+              },
+              artifacts: {
+                reviewLoopReceiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+                historyReviewReceiptPath:
+                  'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json',
+                requirementsSummaryPath:
+                  'tests/results/docker-tools-parity/requirements-verification/verification-summary.json'
+              },
+              requirementsCoverage: {
+                requirementTotal: 9,
+                requirementCovered: 9,
+                requirementUncovered: 0,
+                uncoveredRequirementIds: null,
+                unknownRequirementIds: null
+              },
+              recommendedReviewOrder: [
+                'tests/results/docker-tools-parity/review-loop-receipt.json',
+                'tests/results/docker-tools-parity/ni-linux-review-suite/review-suite-summary.html'
+              ]
+            }
+          }
         }
       })
     }
@@ -2080,6 +2127,17 @@ test('comparevi canonical execution persists a broker-managed ready-for-review r
   assert.equal(persistedState.activeLane.nextWakeCondition, 'copilot-review-workflow-completed');
   assert.equal(persistedState.activeLane.pollIntervalSecondsHint, 10);
   assert.equal(persistedState.activeLane.reviewMonitor.workflowName, 'Copilot code review');
+  assert.equal(persistedState.localReviewLoop.status, 'passed');
+  assert.equal(persistedState.localReviewLoop.receiptStatus, 'passed');
+  assert.equal(persistedState.localReviewLoop.requirementsCoverage.requirementCovered, 9);
+  assert.equal(
+    persistedState.activeLane.localReviewLoop.artifacts.historyReviewReceiptPath,
+    'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json'
+  );
+  assert.equal(
+    persistedState.artifacts.localReviewLoopReceiptPath,
+    'tests/results/docker-tools-parity/review-loop-receipt.json'
+  );
 });
 
 test('delivery broker auto-slices epics by creating and linking a child issue', async () => {

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -1483,6 +1483,54 @@ function normalizeLifecycle(value, fallback = 'idle') {
   const normalized = normalizeText(value).toLowerCase();
   return DELIVERY_AGENT_LIFECYCLE_STATES.has(normalized) ? normalized : fallback;
 }
+
+function normalizeOptionalObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+function buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt }) {
+  const request = normalizeOptionalObject(taskPacket?.evidence?.delivery?.localReviewLoop);
+  const details = normalizeOptionalObject(executionReceipt?.details?.localReviewLoop);
+  const receipt = normalizeOptionalObject(details?.receipt);
+  const overall = normalizeOptionalObject(receipt?.overall);
+  const artifacts = normalizeOptionalObject(receipt?.artifacts);
+  const niLinuxHistoryReview = normalizeOptionalObject(receipt?.niLinuxHistoryReview);
+  const requirementsCoverage = normalizeOptionalObject(receipt?.requirementsCoverage);
+  const recommendedReviewOrder = uniqueStrings(Array.isArray(receipt?.recommendedReviewOrder) ? receipt.recommendedReviewOrder : []);
+  const singleViHistoryRequest = normalizeOptionalObject(request?.singleViHistory);
+
+  if (!request && !details && !receipt) {
+    return null;
+  }
+
+  return {
+    requested: request?.requested === true,
+    status: normalizeText(details?.status) || (request?.requested === true ? 'requested' : null),
+    source: normalizeText(details?.source) || normalizeText(request?.source) || null,
+    reason: normalizeText(details?.reason) || normalizeText(overall?.message) || null,
+    receiptPath: normalizeText(details?.receiptPath) || normalizeText(request?.receiptPath) || null,
+    receiptStatus: normalizeText(overall?.status) || null,
+    failedCheck: normalizeText(overall?.failedCheck) || null,
+    requirementsVerificationRequested: request?.requirementsVerification === true,
+    markdownlintRequested: request?.markdownlint === true,
+    niLinuxReviewSuiteRequested: request?.niLinuxReviewSuite === true,
+    singleViHistory:
+      singleViHistoryRequest?.enabled === true
+        ? {
+            enabled: true,
+            targetPath: normalizeText(singleViHistoryRequest.targetPath) || null,
+            branchRef: normalizeText(singleViHistoryRequest.branchRef) || null,
+            baselineRef: normalizeText(singleViHistoryRequest.baselineRef) || null,
+            maxCommitCount: coercePositiveInteger(singleViHistoryRequest.maxCommitCount)
+          }
+        : null,
+    artifacts,
+    niLinuxHistoryReview,
+    requirementsCoverage,
+    recommendedReviewOrder: recommendedReviewOrder.length > 0 ? recommendedReviewOrder : null
+  };
+}
+
 export function buildDeliveryAgentRuntimeRecord({
   now = new Date(),
   repository,
@@ -1530,6 +1578,7 @@ export function buildDeliveryAgentRuntimeRecord({
     coercePositiveInteger(taskPacket?.evidence?.delivery?.pullRequest?.pollIntervalSecondsHint) ??
     coercePositiveInteger(schedulerDecision?.artifacts?.pullRequest?.pollIntervalSecondsHint) ??
     null;
+  const localReviewLoop = buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt });
   return {
     schema: DELIVERY_AGENT_RUNTIME_STATE_SCHEMA,
     generatedAt: toIso(now),
@@ -1549,6 +1598,7 @@ export function buildDeliveryAgentRuntimeRecord({
     status: laneLifecycle === 'blocked' ? 'blocked' : laneLifecycle === 'idle' ? 'idle' : 'running',
     laneLifecycle,
     activeCodingLanes,
+    localReviewLoop,
     activeLane: {
       schema: DELIVERY_AGENT_LANE_STATE_SCHEMA,
       generatedAt: toIso(now),
@@ -1572,11 +1622,13 @@ export function buildDeliveryAgentRuntimeRecord({
       retryable: executionReceipt?.details?.retryable === true,
       nextWakeCondition: normalizeText(executionReceipt?.details?.nextWakeCondition) || null,
       pollIntervalSecondsHint,
-      reviewMonitor
+      reviewMonitor,
+      localReviewLoop
     },
     artifacts: {
       statePath,
-      lanePath
+      lanePath,
+      localReviewLoopReceiptPath: normalizeText(localReviewLoop?.receiptPath) || null
     }
   };
 }


### PR DESCRIPTION
Summary: persist the daemon localReviewLoop receipt summary into delivery runtime state and per-lane state so future agents can resume from tests/results/_agent/runtime after compaction. Validation: node --check tools/priority/delivery-agent.mjs; node --test tools/priority/__tests__/delivery-agent-schema.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs. Refs #1053