### PR TITLE
#1053 Mirror Docker parity verification into _agent summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,8 @@ artifacts under `tests/results/_agent/`.
   `-NILinuxReviewSuiteHistoryBaselineRef`, and
   `-NILinuxReviewSuiteHistoryMaxCommitCount`. Read
   `tests/results/docker-tools-parity/review-loop-receipt.json` first after
-  compaction; it points to
+  compaction; it now also mirrors the current requirements-verification state to
+  `tests/results/_agent/verification/docker-review-loop-summary.json` and points to
   `tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json`
   and the rest of the authoritative local review artifacts. When the daemon is
   active, the same summary is mirrored into

--- a/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
+++ b/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
@@ -43,6 +43,10 @@ pwsh -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -RequirementsVerific
 - Every run now also emits the combined top-level receipt
   `tests/results/docker-tools-parity/review-loop-receipt.json`. Read that file first after compaction; it records
   per-check status, links to the current NI Linux and requirements artifacts, and lists the recommended review order.
+- The same run also refreshes
+  `tests/results/_agent/verification/docker-review-loop-summary.json`, a bounded `_agent`-facing bridge that points to
+  the authoritative Docker/Desktop requirements verification artifacts. Future agents should prefer that file over stale
+  legacy `_agent/verification/verification-summary.json` snapshots when resuming local review work.
 - When the unattended delivery daemon consumes that receipt, it now mirrors the normalized summary into
   `tests/results/_agent/runtime/delivery-agent-state.json` and the active lane record under
   `tests/results/_agent/runtime/delivery-agent-lanes/`. Future agents should read the runtime-state `localReviewLoop`

--- a/docs/plans/VALIDATION_MATRIX.md
+++ b/docs/plans/VALIDATION_MATRIX.md
@@ -116,7 +116,9 @@ Audience: contributors without the full local toolchain or anyone mirroring CI b
   `vi-history-review-loop-receipt.json`. When
   `-RequirementsVerification` is set, the helper emits the requirements verification summary and trace matrix outputs.
   Every run also refreshes `tests/results/docker-tools-parity/review-loop-receipt.json`; future agents should read
-  that file first after compaction.
+  that file first after compaction. The helper also refreshes
+  `tests/results/_agent/verification/docker-review-loop-summary.json` so the `_agent` surface points back to the
+  authoritative Docker/Desktop requirements verification artifacts instead of stale generic gate output.
 - **Failure modes** - Missing Docker daemon, authentication gaps (when the tools image is private), or missing GH
   tokens during priority sync. Exit code is the first failing container code.
 - **When to run** - Before publishing documentation, when validating the tools image, or after editing workflows to

--- a/docs/schemas/docker-tools-parity-agent-verification-v1.schema.json
+++ b/docs/schemas/docker-tools-parity-agent-verification-v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.labview-community-ci-cd.example/compare-vi-cli-action/docker-tools-parity-agent-verification-v1.schema.json",
+  "title": "Docker Tools Parity Agent Verification Summary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "authoritativeSource",
+    "reviewLoopReceiptPath",
+    "overall",
+    "requirementsCoverage",
+    "artifacts",
+    "recommendedReviewOrder"
+  ],
+  "properties": {
+    "schema": {
+      "const": "docker-tools-parity-agent-verification@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "authoritativeSource": {
+      "const": "docker-tools-parity"
+    },
+    "reviewLoopReceiptPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "overall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "failedCheck",
+        "message",
+        "exitCode"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "running",
+            "passed",
+            "failed"
+          ]
+        },
+        "failedCheck": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "exitCode": {
+          "type": "integer"
+        }
+      }
+    },
+    "requirementsCoverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requirementTotal",
+        "requirementCovered",
+        "requirementUncovered",
+        "uncoveredRequirementIds",
+        "unknownRequirementIds"
+      ],
+      "properties": {
+        "requirementTotal": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "requirementCovered": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "requirementUncovered": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "uncoveredRequirementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unknownRequirementIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reviewLoopReceiptPath",
+        "requirementsSummaryPath",
+        "traceMatrixJsonPath",
+        "traceMatrixHtmlPath"
+      ],
+      "properties": {
+        "reviewLoopReceiptPath": {
+          "type": "string"
+        },
+        "requirementsSummaryPath": {
+          "type": "string"
+        },
+        "traceMatrixJsonPath": {
+          "type": "string"
+        },
+        "traceMatrixHtmlPath": {
+          "type": "string"
+        }
+      }
+    },
+    "recommendedReviewOrder": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/tools/Run-NonLVChecksInDocker.ps1
+++ b/tools/Run-NonLVChecksInDocker.ps1
@@ -380,6 +380,7 @@ function Write-DockerParityReviewLoopReceipt {
   $receiptRelativePath = Get-RepoRelativePath -RepoRoot $RepoRoot -Path $ReceiptPath
   $niResultsRootResolved = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $NILinuxResultsRoot))
   $requirementsResultsRootResolved = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $RequirementsResultsRoot))
+  $agentVerificationSummaryPath = Join-Path $RepoRoot 'tests/results/_agent/verification/docker-review-loop-summary.json'
 
   $reviewSuiteSummaryJsonPath = Join-Path $niResultsRootResolved 'review-suite-summary.json'
   $reviewSuiteSummaryHtmlPath = Join-Path $niResultsRootResolved 'review-suite-summary.html'
@@ -394,6 +395,7 @@ function Write-DockerParityReviewLoopReceipt {
 
   $artifacts = [ordered]@{
     reviewLoopReceiptPath = $receiptRelativePath
+    agentVerificationSummaryPath = Get-RepoRelativePath -RepoRoot $RepoRoot -Path $agentVerificationSummaryPath
     reviewSuiteSummaryJsonPath = if (Test-Path -LiteralPath $reviewSuiteSummaryJsonPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $reviewSuiteSummaryJsonPath } else { '' }
     reviewSuiteSummaryHtmlPath = if (Test-Path -LiteralPath $reviewSuiteSummaryHtmlPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $reviewSuiteSummaryHtmlPath } else { '' }
     historyReviewReceiptPath = if (Test-Path -LiteralPath $historyReviewReceiptPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $historyReviewReceiptPath } else { '' }
@@ -404,6 +406,7 @@ function Write-DockerParityReviewLoopReceipt {
 
   $recommendedReviewOrder = [System.Collections.Generic.List[string]]::new()
   $recommendedReviewOrder.Add('tests/results/docker-tools-parity/review-loop-receipt.json')
+  $recommendedReviewOrder.Add($artifacts.agentVerificationSummaryPath)
   if ($artifacts.reviewSuiteSummaryHtmlPath) {
     $recommendedReviewOrder.Add($artifacts.reviewSuiteSummaryHtmlPath)
   }
@@ -464,7 +467,34 @@ function Write-DockerParityReviewLoopReceipt {
     recommendedReviewOrder = @($recommendedReviewOrder)
   }
 
+  $agentVerificationDirectory = Split-Path -Parent $agentVerificationSummaryPath
+  if (-not (Test-Path -LiteralPath $agentVerificationDirectory -PathType Container)) {
+    New-Item -ItemType Directory -Path $agentVerificationDirectory -Force | Out-Null
+  }
+  $agentVerificationSummary = [ordered]@{
+    schema = 'docker-tools-parity-agent-verification@v1'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    authoritativeSource = 'docker-tools-parity'
+    reviewLoopReceiptPath = $receiptRelativePath
+    overall = $receipt.overall
+    requirementsCoverage = $requirementsCoverage
+    artifacts = [ordered]@{
+      reviewLoopReceiptPath = $receiptRelativePath
+      requirementsSummaryPath = $artifacts.requirementsSummaryPath
+      traceMatrixJsonPath = $artifacts.traceMatrixJsonPath
+      traceMatrixHtmlPath = $artifacts.traceMatrixHtmlPath
+    }
+    recommendedReviewOrder = @(
+      $artifacts.reviewLoopReceiptPath,
+      $artifacts.agentVerificationSummaryPath,
+      $artifacts.requirementsSummaryPath,
+      $artifacts.traceMatrixJsonPath,
+      $artifacts.traceMatrixHtmlPath
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  }
+
   $receipt | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $ReceiptPath -Encoding UTF8
+  $agentVerificationSummary | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $agentVerificationSummaryPath -Encoding UTF8
 }
 
 function Invoke-Container {

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -252,6 +252,7 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
             },
             artifacts: {
               reviewLoopReceiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+              agentVerificationSummaryPath: 'tests/results/_agent/verification/docker-review-loop-summary.json',
               historyReviewReceiptPath: 'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json',
               requirementsSummaryPath: 'tests/results/docker-tools-parity/requirements-verification/verification-summary.json'
             },
@@ -286,6 +287,10 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
   assert.equal(state.localReviewLoop.receiptStatus, 'passed');
   assert.equal(state.localReviewLoop.niLinuxReviewSuiteRequested, true);
   assert.equal(state.localReviewLoop.singleViHistory.targetPath, 'fixtures/vi-attr/Head.vi');
+  assert.equal(
+    state.localReviewLoop.artifacts.agentVerificationSummaryPath,
+    'tests/results/_agent/verification/docker-review-loop-summary.json'
+  );
   assert.equal(
     state.localReviewLoop.artifacts.historyReviewReceiptPath,
     'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json'

--- a/tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs
+++ b/tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function makeAjv() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+test('docker parity agent verification schema validates the bounded _agent receipt', async () => {
+  const schema = JSON.parse(
+    await readFile(
+      path.join(repoRoot, 'docs', 'schemas', 'docker-tools-parity-agent-verification-v1.schema.json'),
+      'utf8'
+    )
+  );
+  const data = {
+    schema: 'docker-tools-parity-agent-verification@v1',
+    generatedAt: '2026-03-13T09:00:00.000Z',
+    authoritativeSource: 'docker-tools-parity',
+    reviewLoopReceiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+    overall: {
+      status: 'passed',
+      failedCheck: '',
+      message: '',
+      exitCode: 0
+    },
+    requirementsCoverage: {
+      requirementTotal: 9,
+      requirementCovered: 9,
+      requirementUncovered: 0,
+      uncoveredRequirementIds: [],
+      unknownRequirementIds: []
+    },
+    artifacts: {
+      reviewLoopReceiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+      requirementsSummaryPath: 'tests/results/docker-tools-parity/requirements-verification/verification-summary.json',
+      traceMatrixJsonPath: 'tests/results/docker-tools-parity/requirements-verification/trace-matrix.json',
+      traceMatrixHtmlPath: 'tests/results/docker-tools-parity/requirements-verification/trace-matrix.html'
+    },
+    recommendedReviewOrder: [
+      'tests/results/docker-tools-parity/review-loop-receipt.json',
+      'tests/results/_agent/verification/docker-review-loop-summary.json',
+      'tests/results/docker-tools-parity/requirements-verification/verification-summary.json',
+      'tests/results/docker-tools-parity/requirements-verification/trace-matrix.json',
+      'tests/results/docker-tools-parity/requirements-verification/trace-matrix.html'
+    ]
+  };
+
+  const validate = makeAjv().compile(schema);
+  assert.equal(validate(data), true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -123,6 +123,7 @@ test('Run-NonLVChecksInDocker exposes Docker Desktop NI Linux review-suite parit
   assert.match(content, /tests\/results\/docker-tools-parity\/ni-linux-review-suite/);
   assert.match(content, /tests\/results\/docker-tools-parity\/requirements-verification/);
   assert.match(content, /tests\/results\/docker-tools-parity\/review-loop-receipt\.json/);
+  assert.match(content, /tests\/results\/_agent\/verification\/docker-review-loop-summary\.json/);
   assert.match(content, /Invoke-NILinuxReviewSuite\.ps1/);
   assert.match(content, /Verify-RequirementsGate\.ps1/);
   assert.match(content, /schema = 'docker-tools-parity-review-loop@v1'/);


### PR DESCRIPTION
# Summary

Mirrors the authoritative Docker/Desktop requirements verification result into a bounded `_agent` receipt so future agents and daemon resumes do not pick up stale generic verification output.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1053
- Files touched:
  - `tools/Run-NonLVChecksInDocker.ps1`
  - `docs/schemas/docker-tools-parity-agent-verification-v1.schema.json`
  - `AGENTS.md`
  - `docs/knowledgebase/DOCKER_TOOLS_PARITY.md`
  - `docs/plans/VALIDATION_MATRIX.md`
  - delivery/runtime contract tests
- Cross-repo or external-consumer impact: none; this is a local review-loop and agent-resume contract change.
- Required checks / approvals affected: none directly; this tightens local-first review guidance and receipt surfaces.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/workspace-health-contract.test.mjs tools/priority/__tests__/delivery-agent-schema.test.mjs tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -SkipActionlint -SkipMarkdown -SkipDocs -SkipWorkflow -SkipDotnetCliBuild -RequirementsVerification`
  - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -SkipActionlint -SkipDocs -SkipWorkflow -SkipDotnetCliBuild`
- Key artifacts:
  - `tests/results/docker-tools-parity/review-loop-receipt.json`
  - `tests/results/_agent/verification/docker-review-loop-summary.json`
  - `tests/results/docker-tools-parity/requirements-verification/verification-summary.json`
  - `tests/results/docker-tools-parity/requirements-verification/trace-matrix.json`
- Current local requirements coverage: `9/9` covered, `0` uncovered, `0` unknown.

## Risks and Follow-ups

- Residual risk: the host-local `lint:md:changed` path still skips when `markdownlint-cli2` is absent outside Docker, so the Docker/Desktop path remains the authoritative local lint surface on this machine.
- Follow-up issues or deferred work: continue remaining `#1053` local-first / daemon-first slices as needed.
- Deployment / rollback notes: none; bounded documentation and receipt-surface change only.

## Reviewer Focus

- Verify the new `_agent` summary points back to the authoritative Docker/Desktop artifacts.
- Verify the review-loop receipt and runtime-state surfaces remain coherent after future local parity runs.

Refs #1053
