### PR TITLE
#1053 Stamp Docker parity receipts with current git head

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,10 @@ artifacts under `tests/results/_agent/`.
   compaction; it now also mirrors the current requirements-verification state to
   `tests/results/_agent/verification/docker-review-loop-summary.json` and points to
   `tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json`
-  and the rest of the authoritative local review artifacts. When the daemon is
+  and the rest of the authoritative local review artifacts. The receipt now
+  includes `git.headSha`, `git.branch`, and `git.upstreamDevelopMergeBase`; use
+  those fields to confirm the local parity result belongs to the current branch
+  head before trusting it. When the daemon is
   active, the same summary is mirrored into
   `tests/results/_agent/runtime/delivery-agent-state.json` and
   `tests/results/_agent/runtime/delivery-agent-lanes/*.json` under the

--- a/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
+++ b/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
@@ -42,7 +42,9 @@ pwsh -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -RequirementsVerific
   - `trace-matrix.html`
 - Every run now also emits the combined top-level receipt
   `tests/results/docker-tools-parity/review-loop-receipt.json`. Read that file first after compaction; it records
-  per-check status, links to the current NI Linux and requirements artifacts, and lists the recommended review order.
+  per-check status, links to the current NI Linux and requirements artifacts, lists the recommended review order, and
+  now stamps the local review with `git.headSha`, `git.branch`, and `git.upstreamDevelopMergeBase` so future agents can
+  reject stale green receipts after the branch head changes.
 - The same run also refreshes
   `tests/results/_agent/verification/docker-review-loop-summary.json`, a bounded `_agent`-facing bridge that points to
   the authoritative Docker/Desktop requirements verification artifacts. Future agents should prefer that file over stale

--- a/docs/plans/VALIDATION_MATRIX.md
+++ b/docs/plans/VALIDATION_MATRIX.md
@@ -24,6 +24,9 @@ single source of truth when deciding which helper to run locally, invoke from VS
   - Exit semantics: first failing container exit (`0` happy, `3` = drift).
   - Artifacts: container logs, optional `dist/comparevi-cli/*`, and the combined
     `tests/results/docker-tools-parity/review-loop-receipt.json`.
+  - Receipt freshness: the review-loop receipt is now stamped with `git.headSha`
+    and related branch metadata so daemon/local consumers can fail closed on
+    stale green parity after the branch head changes.
 - **`tools/Check-WorkflowDrift.ps1`**
   - Scope: workflow rewrite drift via the pinned `ruamel.yaml` enclave under `tools/workflows/**`.
   - Typical invocation: `pwsh -File tools/Check-WorkflowDrift.ps1`.

--- a/docs/schemas/delivery-agent-runtime-state-v1.schema.json
+++ b/docs/schemas/delivery-agent-runtime-state-v1.schema.json
@@ -55,6 +55,19 @@
         "receiptPath": { "type": ["string", "null"] },
         "receiptStatus": { "type": ["string", "null"] },
         "failedCheck": { "type": ["string", "null"] },
+        "currentHeadSha": { "type": ["string", "null"] },
+        "receiptHeadSha": { "type": ["string", "null"] },
+        "receiptFreshForHead": { "type": ["boolean", "null"] },
+        "git": {
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "properties": {
+            "headSha": { "type": ["string", "null"] },
+            "branch": { "type": ["string", "null"] },
+            "upstreamDevelopMergeBase": { "type": ["string", "null"] },
+            "dirtyTracked": { "type": "boolean" }
+          }
+        },
         "requirementsVerificationRequested": { "type": "boolean" },
         "markdownlintRequested": { "type": "boolean" },
         "niLinuxReviewSuiteRequested": { "type": "boolean" },
@@ -107,6 +120,19 @@
             "receiptPath": { "type": ["string", "null"] },
             "receiptStatus": { "type": ["string", "null"] },
             "failedCheck": { "type": ["string", "null"] },
+            "currentHeadSha": { "type": ["string", "null"] },
+            "receiptHeadSha": { "type": ["string", "null"] },
+            "receiptFreshForHead": { "type": ["boolean", "null"] },
+            "git": {
+              "type": ["object", "null"],
+              "additionalProperties": true,
+              "properties": {
+                "headSha": { "type": ["string", "null"] },
+                "branch": { "type": ["string", "null"] },
+                "upstreamDevelopMergeBase": { "type": ["string", "null"] },
+                "dirtyTracked": { "type": "boolean" }
+              }
+            },
             "requirementsVerificationRequested": { "type": "boolean" },
             "markdownlintRequested": { "type": "boolean" },
             "niLinuxReviewSuiteRequested": { "type": "boolean" },

--- a/docs/schemas/docker-tools-parity-agent-verification-v1.schema.json
+++ b/docs/schemas/docker-tools-parity-agent-verification-v1.schema.json
@@ -8,6 +8,7 @@
     "schema",
     "generatedAt",
     "authoritativeSource",
+    "git",
     "reviewLoopReceiptPath",
     "overall",
     "requirementsCoverage",
@@ -24,6 +25,37 @@
     },
     "authoritativeSource": {
       "const": "docker-tools-parity"
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "headSha",
+        "branch",
+        "upstreamDevelopMergeBase",
+        "dirtyTracked"
+      ],
+      "properties": {
+        "headSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "upstreamDevelopMergeBase": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dirtyTracked": {
+          "type": "boolean"
+        }
+      }
     },
     "reviewLoopReceiptPath": {
       "type": "string",

--- a/docs/schemas/docker-tools-parity-review-loop-v1.schema.json
+++ b/docs/schemas/docker-tools-parity-review-loop-v1.schema.json
@@ -9,6 +9,7 @@
     "generatedAt",
     "repoRoot",
     "resultsRoot",
+    "git",
     "overall",
     "checks",
     "artifacts",
@@ -30,6 +31,37 @@
     "resultsRoot": {
       "type": "string",
       "minLength": 1
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "headSha",
+        "branch",
+        "upstreamDevelopMergeBase",
+        "dirtyTracked"
+      ],
+      "properties": {
+        "headSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "upstreamDevelopMergeBase": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dirtyTracked": {
+          "type": "boolean"
+        }
+      }
     },
     "overall": {
       "type": "object",

--- a/tools/Run-NonLVChecksInDocker.ps1
+++ b/tools/Run-NonLVChecksInDocker.ps1
@@ -335,6 +335,37 @@ function Read-JsonHashtable {
   return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable)
 }
 
+function Get-GitReviewLoopMetadata {
+  param([string]$RepoRoot)
+
+  $headSha = (& git -C $RepoRoot rev-parse HEAD 2>$null | Select-Object -First 1)
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($headSha)) {
+    throw 'Unable to resolve git HEAD for Docker/Desktop review-loop receipt generation.'
+  }
+
+  $branchName = (& git -C $RepoRoot branch --show-current 2>$null | Select-Object -First 1)
+  if ($LASTEXITCODE -ne 0) {
+    $branchName = ''
+  }
+
+  $mergeBase = (& git -C $RepoRoot merge-base HEAD upstream/develop 2>$null | Select-Object -First 1)
+  if ($LASTEXITCODE -ne 0) {
+    $mergeBase = ''
+  }
+
+  $trackedStatus = (& git -C $RepoRoot status --short --untracked-files=no 2>$null)
+  if ($LASTEXITCODE -ne 0) {
+    $trackedStatus = @()
+  }
+
+  return [ordered]@{
+    headSha = $headSha.Trim()
+    branch = if ([string]::IsNullOrWhiteSpace($branchName)) { $null } else { $branchName.Trim() }
+    upstreamDevelopMergeBase = if ([string]::IsNullOrWhiteSpace($mergeBase)) { $null } else { $mergeBase.Trim() }
+    dirtyTracked = @($trackedStatus).Count -gt 0
+  }
+}
+
 function Invoke-DockerParityStep {
   param(
     $StepRecord,
@@ -392,6 +423,7 @@ function Write-DockerParityReviewLoopReceipt {
   $historyReceipt = Read-JsonHashtable -Path $historyReviewReceiptPath
   $requirementsSummary = Read-JsonHashtable -Path $requirementsSummaryPath
   $traceMatrix = Read-JsonHashtable -Path $traceMatrixJsonPath
+  $gitMetadata = Get-GitReviewLoopMetadata -RepoRoot $RepoRoot
 
   $artifacts = [ordered]@{
     reviewLoopReceiptPath = $receiptRelativePath
@@ -441,6 +473,7 @@ function Write-DockerParityReviewLoopReceipt {
     generatedAt = (Get-Date).ToUniversalTime().ToString('o')
     repoRoot = $RepoRoot
     resultsRoot = 'tests/results/docker-tools-parity'
+    git = $gitMetadata
     overall = [ordered]@{
       status = $RunRecord.status
       failedCheck = $RunRecord.failedCheck
@@ -475,6 +508,7 @@ function Write-DockerParityReviewLoopReceipt {
     schema = 'docker-tools-parity-agent-verification@v1'
     generatedAt = (Get-Date).ToUniversalTime().ToString('o')
     authoritativeSource = 'docker-tools-parity'
+    git = $gitMetadata
     reviewLoopReceiptPath = $receiptRelativePath
     overall = $receipt.overall
     requirementsCoverage = $requirementsCoverage

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -243,7 +243,16 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
           source: 'docker-desktop-review-loop',
           reason: 'Docker/Desktop review loop passed.',
           receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+          currentHeadSha: '433e8aa70326007be74c27ccf54c1ae91559b6f3',
+          receiptHeadSha: '433e8aa70326007be74c27ccf54c1ae91559b6f3',
+          receiptFreshForHead: true,
           receipt: {
+            git: {
+              headSha: '433e8aa70326007be74c27ccf54c1ae91559b6f3',
+              branch: 'issue/origin-1053-agent-verification-receipt',
+              upstreamDevelopMergeBase: 'ccbdc75d4bfbcbe6580abb989b2d4e819e1a1e99',
+              dirtyTracked: false
+            },
             overall: {
               status: 'passed',
               failedCheck: '',
@@ -285,8 +294,12 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
   assert.equal(validate(state), true, JSON.stringify(validate.errors, null, 2));
   assert.equal(state.localReviewLoop.status, 'passed');
   assert.equal(state.localReviewLoop.receiptStatus, 'passed');
+  assert.equal(state.localReviewLoop.currentHeadSha, '433e8aa70326007be74c27ccf54c1ae91559b6f3');
+  assert.equal(state.localReviewLoop.receiptHeadSha, '433e8aa70326007be74c27ccf54c1ae91559b6f3');
+  assert.equal(state.localReviewLoop.receiptFreshForHead, true);
   assert.equal(state.localReviewLoop.niLinuxReviewSuiteRequested, true);
   assert.equal(state.localReviewLoop.singleViHistory.targetPath, 'fixtures/vi-attr/Head.vi');
+  assert.equal(state.localReviewLoop.git.branch, 'issue/origin-1053-agent-verification-receipt');
   assert.equal(
     state.localReviewLoop.artifacts.agentVerificationSummaryPath,
     'tests/results/_agent/verification/docker-review-loop-summary.json'

--- a/tools/priority/__tests__/docker-desktop-review-loop.test.mjs
+++ b/tools/priority/__tests__/docker-desktop-review-loop.test.mjs
@@ -175,6 +175,12 @@ test('runDockerDesktopReviewLoop returns passed when the receipt reports passed'
         receiptPath,
         `${JSON.stringify({
           schema: 'docker-tools-parity-review-loop@v1',
+          git: {
+            headSha: 'abc123',
+            branch: 'issue/test',
+            upstreamDevelopMergeBase: 'base123',
+            dirtyTracked: false
+          },
           overall: { status: 'passed', failedCheck: '', message: '', exitCode: 0 }
         })}\n`,
         'utf8'
@@ -184,11 +190,17 @@ test('runDockerDesktopReviewLoop returns passed when the receipt reports passed'
         stdout: '',
         stderr: ''
       };
-    }
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123'
+    })
   });
 
   assert.equal(result.status, 'passed');
   assert.equal(result.receipt.overall.status, 'passed');
+  assert.equal(result.receiptFreshForHead, true);
 });
 
 test('runDockerDesktopReviewLoop fails closed when the receipt reports a failed check', async () => {
@@ -251,6 +263,55 @@ test('runDockerDesktopReviewLoop fails closed with a deterministic reason when t
   assert.equal(result.status, 'failed');
   assert.match(result.reason, /corrupt receipt/i);
   assert.equal(result.receipt, null);
+});
+
+test('runDockerDesktopReviewLoop fails closed when the receipt head does not match the current repo head', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'docker-desktop-review-loop-stale-'));
+  const receiptPath = path.join(repoRoot, 'tests', 'results', 'docker-tools-parity', 'review-loop-receipt.json');
+
+  const result = await runDockerDesktopReviewLoop({
+    repoRoot,
+    request: {
+      requested: true,
+      receiptPath: path.relative(repoRoot, receiptPath),
+      markdownlint: true,
+      requirementsVerification: false,
+      niLinuxReviewSuite: false
+    },
+    runCommandFn: async () => {
+      await mkdir(path.dirname(receiptPath), { recursive: true });
+      await writeFile(
+        receiptPath,
+        `${JSON.stringify({
+          schema: 'docker-tools-parity-review-loop@v1',
+          git: {
+            headSha: 'stale-head',
+            branch: 'issue/test',
+            upstreamDevelopMergeBase: 'base123',
+            dirtyTracked: false
+          },
+          overall: { status: 'passed', failedCheck: '', message: '', exitCode: 0 }
+        })}\n`,
+        'utf8'
+      );
+      return {
+        status: 0,
+        stdout: '',
+        stderr: ''
+      };
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'current-head',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123'
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receiptFreshForHead, false);
+  assert.equal(result.receiptHeadSha, 'stale-head');
+  assert.equal(result.currentHeadSha, 'current-head');
+  assert.match(result.reason, /stale for the current HEAD/i);
 });
 
 test('runDockerDesktopReviewLoop rejects receipt paths outside docker parity results', async () => {

--- a/tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs
+++ b/tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs
@@ -27,6 +27,12 @@ test('docker parity agent verification schema validates the bounded _agent recei
     schema: 'docker-tools-parity-agent-verification@v1',
     generatedAt: '2026-03-13T09:00:00.000Z',
     authoritativeSource: 'docker-tools-parity',
+    git: {
+      headSha: '433e8aa70326007be74c27ccf54c1ae91559b6f3',
+      branch: 'issue/origin-1053-agent-verification-receipt',
+      upstreamDevelopMergeBase: 'ccbdc75d4bfbcbe6580abb989b2d4e819e1a1e99',
+      dirtyTracked: false
+    },
     reviewLoopReceiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
     overall: {
       status: 'passed',

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -1494,6 +1494,7 @@ function buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt }) {
   const receipt = normalizeOptionalObject(details?.receipt);
   const overall = normalizeOptionalObject(receipt?.overall);
   const artifacts = normalizeOptionalObject(receipt?.artifacts);
+  const git = normalizeOptionalObject(receipt?.git);
   const niLinuxHistoryReview = normalizeOptionalObject(receipt?.niLinuxHistoryReview);
   const requirementsCoverage = normalizeOptionalObject(receipt?.requirementsCoverage);
   const recommendedReviewOrder = uniqueStrings(Array.isArray(receipt?.recommendedReviewOrder) ? receipt.recommendedReviewOrder : []);
@@ -1511,6 +1512,17 @@ function buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt }) {
     receiptPath: normalizeText(details?.receiptPath) || normalizeText(request?.receiptPath) || null,
     receiptStatus: normalizeText(overall?.status) || null,
     failedCheck: normalizeText(overall?.failedCheck) || null,
+    currentHeadSha: normalizeText(details?.currentHeadSha) || null,
+    receiptHeadSha: normalizeText(details?.receiptHeadSha) || normalizeText(git?.headSha) || null,
+    receiptFreshForHead: typeof details?.receiptFreshForHead === 'boolean' ? details.receiptFreshForHead : null,
+    git: git
+      ? {
+          headSha: normalizeText(git.headSha) || null,
+          branch: normalizeText(git.branch) || null,
+          upstreamDevelopMergeBase: normalizeText(git.upstreamDevelopMergeBase) || null,
+          dirtyTracked: git.dirtyTracked === true
+        }
+      : null,
     requirementsVerificationRequested: request?.requirementsVerification === true,
     markdownlintRequested: request?.markdownlint === true,
     niLinuxReviewSuiteRequested: request?.niLinuxReviewSuite === true,
@@ -1850,6 +1862,9 @@ async function maybeRunLocalReviewLoop({
       normalizeText(result.stdout) ||
       'Docker/Desktop review loop did not return a status.',
     receiptPath,
+    currentHeadSha: normalizeText(reviewLoopResult?.currentHeadSha) || null,
+    receiptHeadSha: normalizeText(reviewLoopResult?.receiptHeadSha) || normalizeText(receiptFromFile?.git?.headSha) || null,
+    receiptFreshForHead: typeof reviewLoopResult?.receiptFreshForHead === 'boolean' ? reviewLoopResult.receiptFreshForHead : null,
     receipt: reviewLoopResult?.receipt ?? receiptFromFile ?? null
   };
 

--- a/tools/priority/docker-desktop-review-loop.mjs
+++ b/tools/priority/docker-desktop-review-loop.mjs
@@ -58,6 +58,45 @@ function normalizeCommandResult(result = {}) {
   };
 }
 
+function readGitCommand(repoRoot, args) {
+  const result = spawnSync('git', ['-C', repoRoot, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.status !== 0) {
+    return '';
+  }
+  return normalizeText(result.stdout);
+}
+
+export function resolveRepoGitState(repoRoot) {
+  const headSha = readGitCommand(repoRoot, ['rev-parse', 'HEAD']);
+  if (!headSha) {
+    return null;
+  }
+  const branch = readGitCommand(repoRoot, ['branch', '--show-current']) || null;
+  const upstreamDevelopMergeBase = readGitCommand(repoRoot, ['merge-base', 'HEAD', 'upstream/develop']) || null;
+  return {
+    headSha,
+    branch,
+    upstreamDevelopMergeBase
+  };
+}
+
+function normalizeReceiptGitMetadata(receipt = {}) {
+  const git = receipt && typeof receipt === 'object' && receipt.git && typeof receipt.git === 'object' ? receipt.git : {};
+  const headSha = normalizeText(git.headSha);
+  const branch = normalizeText(git.branch) || null;
+  const upstreamDevelopMergeBase = normalizeText(git.upstreamDevelopMergeBase) || null;
+  const dirtyTracked = git.dirtyTracked === true;
+  return {
+    headSha,
+    branch,
+    upstreamDevelopMergeBase,
+    dirtyTracked
+  };
+}
+
 function assertRepoContainedReceiptPath(repoRoot, receiptPath) {
   const normalized = normalizeText(receiptPath);
   if (!normalized) {
@@ -213,7 +252,8 @@ function defaultRunCommand(command, args, { cwd, env }) {
 export async function runDockerDesktopReviewLoop({
   repoRoot,
   request,
-  runCommandFn = defaultRunCommand
+  runCommandFn = defaultRunCommand,
+  resolveRepoGitStateFn = resolveRepoGitState
 }) {
   const normalized = normalizeRequest(request);
   const command = 'pwsh';
@@ -265,6 +305,35 @@ export async function runDockerDesktopReviewLoop({
       receipt: null
     };
   }
+  const currentGitState =
+    typeof resolveRepoGitStateFn === 'function' ? normalizeReceiptGitMetadata({ git: resolveRepoGitStateFn(repoRoot) ?? {} }) : null;
+  const receiptGit = normalizeReceiptGitMetadata(receipt);
+  if (receipt && !receiptGit.headSha) {
+    return {
+      status: 'failed',
+      source: 'docker-desktop-review-loop',
+      reason: 'Docker/Desktop review loop receipt is missing git.headSha metadata.',
+      commandLine,
+      receiptPath,
+      currentHeadSha: currentGitState?.headSha || null,
+      receiptHeadSha: null,
+      receiptFreshForHead: false,
+      receipt
+    };
+  }
+  if (receipt && currentGitState?.headSha && receiptGit.headSha && currentGitState.headSha !== receiptGit.headSha) {
+    return {
+      status: 'failed',
+      source: 'docker-desktop-review-loop',
+      reason: `Docker/Desktop review loop receipt is stale for the current HEAD (${receiptGit.headSha} != ${currentGitState.headSha}).`,
+      commandLine,
+      receiptPath,
+      currentHeadSha: currentGitState.headSha,
+      receiptHeadSha: receiptGit.headSha,
+      receiptFreshForHead: false,
+      receipt
+    };
+  }
   const overallStatus = normalizeText(receipt?.overall?.status).toLowerCase();
   const failedCheck = normalizeText(receipt?.overall?.failedCheck);
   const failureReason =
@@ -281,6 +350,9 @@ export async function runDockerDesktopReviewLoop({
       reason: failureReason,
       commandLine,
       receiptPath,
+      currentHeadSha: currentGitState?.headSha || null,
+      receiptHeadSha: receiptGit.headSha || null,
+      receiptFreshForHead: currentGitState?.headSha ? currentGitState.headSha === receiptGit.headSha : null,
       receipt
     };
   }
@@ -291,6 +363,9 @@ export async function runDockerDesktopReviewLoop({
     reason: 'Docker/Desktop review loop passed.',
     commandLine,
     receiptPath,
+    currentHeadSha: currentGitState?.headSha || null,
+    receiptHeadSha: receiptGit.headSha || null,
+    receiptFreshForHead: currentGitState?.headSha ? currentGitState.headSha === receiptGit.headSha : null,
     receipt
   };
 }


### PR DESCRIPTION
# Summary

Stamps the Docker/Desktop local review-loop receipt and the bounded `_agent` verification summary with current Git head metadata so the daemon and future agents can reject stale green receipts after the branch head changes.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1053
- Files touched:
  - `tools/Run-NonLVChecksInDocker.ps1`
  - `tools/priority/docker-desktop-review-loop.mjs`
  - `tools/priority/delivery-agent.mjs`
  - Docker parity / runtime schemas
  - Docker parity / runtime contract tests
  - `AGENTS.md`
  - `docs/knowledgebase/DOCKER_TOOLS_PARITY.md`
  - `docs/plans/VALIDATION_MATRIX.md`
- Cross-repo or external-consumer impact: none; this tightens local parity freshness and daemon resume semantics.
- Required checks / approvals affected: none directly; the daemon now fails closed when a Docker/Desktop receipt is green but belongs to an older head.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/docker-desktop-review-loop.test.mjs tools/priority/__tests__/delivery-agent-schema.test.mjs tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs`
  - `node --check tools/priority/docker-desktop-review-loop.mjs`
  - `node --check tools/priority/delivery-agent.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -SkipActionlint -SkipMarkdown -SkipDocs -SkipWorkflow -SkipDotnetCliBuild -RequirementsVerification`
- Key artifacts:
  - `tests/results/docker-tools-parity/review-loop-receipt.json`
  - `tests/results/_agent/verification/docker-review-loop-summary.json`
  - `tests/results/docker-tools-parity/requirements-verification/verification-summary.json`
- Current local receipt metadata:
  - `git.headSha = ccbdc75d4bfbcbe6580abb989b2d4e819e1a1e99`
  - `git.branch = issue/origin-1053-local-review-loop-freshness`
  - `git.dirtyTracked = true` during the uncommitted validation run that produced the receipt

## Risks and Follow-ups

- Residual risk: the receipt can still be produced on a dirty tracked tree; this slice makes that state explicit, but does not forbid it.
- Follow-up issues or deferred work: continue the remaining `#1053` daemon-first local-iteration slices after this lands.
- Deployment / rollback notes: none; local receipt and runtime-state contract only.

## Reviewer Focus

- Verify the receipt and bounded `_agent` summary now carry current-head Git metadata.
- Verify the Docker/Desktop wrapper fails closed when the receipt head does not match the current repo head.
- Verify the runtime-state `localReviewLoop` node now exposes the receipt freshness fields for post-compaction resume.

Refs #1053
