### PR TITLE
#1053 Make handoff prefer Docker parity verification

### DIFF
--- a/AGENT_HANDOFF.txt
+++ b/AGENT_HANDOFF.txt
@@ -33,6 +33,7 @@ Live repository state belongs in the machine-generated artifacts under
 - `.agent_priority_cache.json`
 - `tests/results/_agent/issue/router.json`
 - `tests/results/_agent/issue/no-standing-priority.json`
+- `tests/results/_agent/verification/docker-review-loop-summary.json`
 - `tests/results/_agent/handoff/entrypoint-status.json`
 - `tests/results/_agent/handoff/*.json`
 - `tests/results/_agent/sessions/*.json`

--- a/docs/knowledgebase/Agent-Handoff-Surfaces.md
+++ b/docs/knowledgebase/Agent-Handoff-Surfaces.md
@@ -16,7 +16,8 @@ entrypoint and machine-generated live state.
 - It refreshes `tests/results/_agent/handoff/entrypoint-status.json`, which is
   the canonical machine-readable index for future agents.
 - It also refreshes the standing-priority summary, router copy, watcher
-  telemetry, and session capsule surfaces under `tests/results/_agent/`.
+  telemetry, Docker/Desktop verification summary mirror, and session capsule
+  surfaces under `tests/results/_agent/`.
 
 ## Consumer Paths
 
@@ -34,7 +35,9 @@ entrypoint and machine-generated live state.
 - `.agent_priority_cache.json`
 - `tests/results/_agent/issue/router.json`
 - `tests/results/_agent/issue/no-standing-priority.json`
+- `tests/results/_agent/verification/docker-review-loop-summary.json`
 - `tests/results/_agent/handoff/entrypoint-status.json`
+- `tests/results/_agent/handoff/docker-review-loop-summary.json`
 - `tests/results/_agent/handoff/*.json`
 - `tests/results/_agent/sessions/*.json`
 

--- a/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
+++ b/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
@@ -47,8 +47,8 @@ pwsh -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -RequirementsVerific
   reject stale green receipts after the branch head changes.
 - The same run also refreshes
   `tests/results/_agent/verification/docker-review-loop-summary.json`, a bounded `_agent`-facing bridge that points to
-  the authoritative Docker/Desktop requirements verification artifacts. Future agents should prefer that file over stale
-  legacy `_agent/verification/verification-summary.json` snapshots when resuming local review work.
+  the authoritative Docker/Desktop requirements verification artifacts. Future agents should treat this file as the
+  authoritative `_agent` verification surface when resuming local review work.
 - When the unattended delivery daemon consumes that receipt, it now mirrors the normalized summary into
   `tests/results/_agent/runtime/delivery-agent-state.json` and the active lane record under
   `tests/results/_agent/runtime/delivery-agent-lanes/`. Future agents should read the runtime-state `localReviewLoop`

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -129,8 +129,8 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 
   ```powershell
   pwsh -NoLogo -NonInteractive -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 \
-    -JsonPath tests/results/_agent/verification/verification-summary.json \
-    -SchemaPath docs/schemas/requirements-verification-v1.schema.json
+    -JsonPath tests/results/_agent/verification/docker-review-loop-summary.json \
+    -SchemaPath docs/schemas/docker-tools-parity-agent-verification-v1.schema.json
   ```
 
 - Assert check naming drift guard (workflow + policy contract alignment):

--- a/docs/schemas/handoff-entrypoint-status-v1.schema.json
+++ b/docs/schemas/handoff-entrypoint-status-v1.schema.json
@@ -91,6 +91,7 @@
         "priorityCache",
         "router",
         "noStandingPriority",
+        "dockerReviewLoopSummary",
         "entrypointStatus",
         "handoffGlob",
         "sessionGlob"
@@ -99,6 +100,7 @@
         "priorityCache": { "type": "string", "minLength": 1 },
         "router": { "type": "string", "minLength": 1 },
         "noStandingPriority": { "type": "string", "minLength": 1 },
+        "dockerReviewLoopSummary": { "type": "string", "minLength": 1 },
         "entrypointStatus": { "type": "string", "minLength": 1 },
         "handoffGlob": { "type": "string", "minLength": 1 },
         "sessionGlob": { "type": "string", "minLength": 1 }

--- a/tests/AgentHandoff.DockerParityVerification.Tests.ps1
+++ b/tests/AgentHandoff.DockerParityVerification.Tests.ps1
@@ -1,0 +1,80 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Agent Handoff Docker parity verification' -Tag 'Unit' {
+  It 'mirrors the authoritative Docker review-loop summary into the handoff bundle' {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $workspaceRoot = Join-Path $TestDrive 'repo'
+    $toolsDir = Join-Path $workspaceRoot 'tools'
+    $priorityDir = Join-Path $toolsDir 'priority'
+    $scriptPath = Join-Path $toolsDir 'Print-AgentHandoff.ps1'
+    $entrypointPath = Join-Path $toolsDir 'Test-AgentHandoffEntryPoint.ps1'
+    $issueDir = Join-Path $workspaceRoot 'tests' 'results' '_agent' 'issue'
+    $verificationDir = Join-Path $workspaceRoot 'tests' 'results' '_agent' 'verification'
+    $cachePath = Join-Path $workspaceRoot '.agent_priority_cache.json'
+    $resultsRoot = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Force -Path $toolsDir, $priorityDir, $issueDir, $verificationDir, $resultsRoot | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Print-AgentHandoff.ps1') -Destination $scriptPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Test-AgentHandoffEntryPoint.ps1') -Destination $entrypointPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'AGENT_HANDOFF.txt') -Destination (Join-Path $workspaceRoot 'AGENT_HANDOFF.txt') -Force
+
+    [pscustomobject][ordered]@{
+      schema = 'standing-priority/issue@v1'
+      number = 1053
+      title = 'Docker Desktop local-first review loop'
+      state = 'OPEN'
+      updatedAt = '2026-03-13T15:10:00Z'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1053'
+      labels = @('standing-priority', 'ci')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      bodyDigest = 'body-digest-1053'
+      digest = 'digest-1053'
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir '1053.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      schema = 'agent/priority-router@v1'
+      issue = [pscustomobject][ordered]@{
+        number = 1053
+        title = 'Docker Desktop local-first review loop'
+      }
+      updatedAt = '2026-03-13T15:10:00Z'
+      actions = @()
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir 'router.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      number = 1053
+      title = 'Docker Desktop local-first review loop'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1053'
+      cachedAtUtc = '2026-03-13T15:10:00Z'
+      repository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      state = 'OPEN'
+      labels = @('standing-priority', 'ci')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      lastSeenUpdatedAt = '2026-03-13T15:10:00Z'
+      issueDigest = 'digest-1053'
+      bodyDigest = 'body-digest-1053'
+      lastFetchSource = 'fixture'
+      lastFetchError = $null
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $cachePath -Encoding utf8
+
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'priority' '__fixtures__' 'handoff' 'docker-review-loop-summary.json') -Destination (Join-Path $verificationDir 'docker-review-loop-summary.json') -Force
+
+    Push-Location $workspaceRoot
+    try {
+      { & $scriptPath -ApplyToggles -ResultsRoot $resultsRoot } | Should -Not -Throw
+    } finally {
+      Pop-Location
+    }
+
+    $handoffSummaryPath = Join-Path $resultsRoot '_agent' 'handoff' 'docker-review-loop-summary.json'
+    Test-Path -LiteralPath $handoffSummaryPath | Should -BeTrue
+    $summary = Get-Content -LiteralPath $handoffSummaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $summary.schema | Should -Be 'docker-tools-parity-agent-verification@v1'
+    $summary.authoritativeSource | Should -Be 'docker-tools-parity'
+    $summary.git.headSha | Should -Be '433e8aa70326007be74c27ccf54c1ae91559b6f3'
+  }
+}

--- a/tests/Import-HandoffState.Tests.ps1
+++ b/tests/Import-HandoffState.Tests.ps1
@@ -20,4 +20,22 @@ Describe 'Import-HandoffState' -Tag 'Unit' {
 
     Remove-Variable -Name HandoffEntrypointStatus -Scope Global -ErrorAction SilentlyContinue
   }
+
+  It 'surfaces the Docker review-loop summary when present' {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools' 'priority' 'Import-HandoffState.ps1'
+    $fixturePath = Join-Path $repoRoot 'tools' 'priority' '__fixtures__' 'handoff' 'docker-review-loop-summary.json'
+    $handoffDir = Join-Path $TestDrive 'handoff'
+    New-Item -ItemType Directory -Force -Path $handoffDir | Out-Null
+    Copy-Item -LiteralPath $fixturePath -Destination (Join-Path $handoffDir 'docker-review-loop-summary.json') -Force
+
+    $output = & $scriptPath -HandoffDir $handoffDir *>&1 | Out-String
+
+    $output | Should -Match '\[handoff\] Docker review loop summary'
+    $output | Should -Match 'status\s+: passed'
+    $output | Should -Match 'head\s+: 433e8aa70326007be74c27ccf54c1ae91559b6f3'
+    $global:DockerReviewLoopHandoffSummary.schema | Should -Be 'docker-tools-parity-agent-verification@v1'
+
+    Remove-Variable -Name DockerReviewLoopHandoffSummary -Scope Global -ErrorAction SilentlyContinue
+  }
 }

--- a/tests/Test-AgentHandoffEntryPoint.Tests.ps1
+++ b/tests/Test-AgentHandoffEntryPoint.Tests.ps1
@@ -27,6 +27,7 @@ Describe 'Agent Handoff entrypoint contract' -Tag 'Unit' {
     $status.commands.bootstrap | Should -Be 'pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1'
     $status.commands.printHandoff | Should -Be 'pwsh -NoLogo -NoProfile -File tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim'
     $status.artifacts.entrypointStatus | Should -Be 'tests/results/_agent/handoff/entrypoint-status.json'
+    $status.artifacts.dockerReviewLoopSummary | Should -Be 'tests/results/_agent/verification/docker-review-loop-summary.json'
     $status.artifacts.router | Should -Be 'tests/results/_agent/issue/router.json'
     $status.artifacts.noStandingPriority | Should -Be 'tests/results/_agent/issue/no-standing-priority.json'
     @($status.violations).Count | Should -Be 0

--- a/tools/Print-AgentHandoff.ps1
+++ b/tools/Print-AgentHandoff.ps1
@@ -540,6 +540,7 @@ function Write-AgentSessionCapsule {
     @{ name = 'handoff.watcherTelemetry'; path = Join-Path $handoffDir 'watcher-telemetry.json' },
     @{ name = 'handoff.releaseSummary'; path = Join-Path $handoffDir 'release-summary.json' },
     @{ name = 'handoff.issueSummary'; path = Join-Path $handoffDir 'issue-summary.json' },
+    @{ name = 'handoff.dockerReviewLoopSummary'; path = Join-Path $handoffDir 'docker-review-loop-summary.json' },
     @{ name = 'handoff.router'; path = Join-Path $handoffDir 'issue-router.json' },
     @{ name = 'handoff.localStatus'; path = Join-Path $handoffDir 'local-status.txt' },
     @{ name = 'handoff.localDiff'; path = Join-Path $handoffDir 'local-diff.txt' },
@@ -1151,6 +1152,78 @@ try {
   }
 } catch {
   Write-Warning ("Failed to load SemVer summary: {0}" -f $_.Exception.Message)
+}
+
+try {
+  $dockerReviewLoopSummaryPath = Join-Path (Resolve-Path '.').Path 'tests/results/_agent/verification/docker-review-loop-summary.json'
+  if (Test-Path -LiteralPath $dockerReviewLoopSummaryPath -PathType Leaf) {
+    $dockerReviewLoopSummary = Get-Content -LiteralPath $dockerReviewLoopSummaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    Write-Host ''
+    Write-Host '[Docker Review Loop Summary]' -ForegroundColor Cyan
+    Write-Host ("  source   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.authoritativeSource))
+    if ($dockerReviewLoopSummary.PSObject.Properties['overall'] -and $dockerReviewLoopSummary.overall) {
+      Write-Host ("  status   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.status))
+      if ($dockerReviewLoopSummary.overall.failedCheck) {
+        Write-Host ("  failed   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.failedCheck))
+      }
+      if ($dockerReviewLoopSummary.overall.message) {
+        Write-Host ("  message  : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.message))
+      }
+      Write-Host ("  exitCode : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.exitCode))
+    }
+    if ($dockerReviewLoopSummary.PSObject.Properties['git'] -and $dockerReviewLoopSummary.git) {
+      Write-Host ("  branch   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.git.branch))
+      Write-Host ("  head     : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.git.headSha))
+      Write-Host ("  mergeBase: {0}" -f (Format-NullableValue $dockerReviewLoopSummary.git.upstreamDevelopMergeBase))
+      Write-Host ("  dirty    : {0}" -f (Format-BoolLabel $dockerReviewLoopSummary.git.dirtyTracked))
+    }
+    if ($dockerReviewLoopSummary.PSObject.Properties['requirementsCoverage'] -and $dockerReviewLoopSummary.requirementsCoverage) {
+      $coverage = $dockerReviewLoopSummary.requirementsCoverage
+      Write-Host ("  reqs     : total={0} covered={1} uncovered={2}" -f (Format-NullableValue $coverage.requirementTotal), (Format-NullableValue $coverage.requirementCovered), (Format-NullableValue $coverage.requirementUncovered))
+      if ($coverage.uncoveredRequirementIds -and @($coverage.uncoveredRequirementIds).Count -gt 0) {
+        Write-Host ("  uncovered: {0}" -f ((@($coverage.uncoveredRequirementIds) -join ', ')))
+      }
+      if ($coverage.unknownRequirementIds -and @($coverage.unknownRequirementIds).Count -gt 0) {
+        Write-Host ("  unknown  : {0}" -f ((@($coverage.unknownRequirementIds) -join ', ')))
+      }
+    }
+    $handoffDir = Join-Path $ResultsRoot '_agent/handoff'
+    New-Item -ItemType Directory -Force -Path $handoffDir | Out-Null
+    $dockerReviewLoopSummaryDest = Join-Path $handoffDir 'docker-review-loop-summary.json'
+    $dockerReviewLoopSummarySourceFull = $dockerReviewLoopSummaryPath
+    $dockerReviewLoopSummaryDestFull = $dockerReviewLoopSummaryDest
+    try { $dockerReviewLoopSummarySourceFull = [System.IO.Path]::GetFullPath($dockerReviewLoopSummaryPath) } catch {}
+    try { $dockerReviewLoopSummaryDestFull = [System.IO.Path]::GetFullPath($dockerReviewLoopSummaryDest) } catch {}
+    if (-not [string]::Equals($dockerReviewLoopSummarySourceFull, $dockerReviewLoopSummaryDestFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+      Copy-Item -LiteralPath $dockerReviewLoopSummaryPath -Destination $dockerReviewLoopSummaryDest -Force
+    } else {
+      Write-Verbose 'Docker review-loop summary already present at destination; skipping copy.'
+    }
+
+    if ($env:GITHUB_STEP_SUMMARY) {
+      $dockerReviewLines = @(
+        '### Docker Review Loop Summary',
+        '',
+        ('- Source: {0}' -f (Format-NullableValue $dockerReviewLoopSummary.authoritativeSource))
+      )
+      if ($dockerReviewLoopSummary.PSObject.Properties['overall'] -and $dockerReviewLoopSummary.overall) {
+        $dockerReviewLines += ('- Status: {0}  Failed check: {1}  Exit: {2}' -f (Format-NullableValue $dockerReviewLoopSummary.overall.status), (Format-NullableValue $dockerReviewLoopSummary.overall.failedCheck), (Format-NullableValue $dockerReviewLoopSummary.overall.exitCode))
+        if ($dockerReviewLoopSummary.overall.message) {
+          $dockerReviewLines += ('- Message: {0}' -f (Format-NullableValue $dockerReviewLoopSummary.overall.message))
+        }
+      }
+      if ($dockerReviewLoopSummary.PSObject.Properties['git'] -and $dockerReviewLoopSummary.git) {
+        $dockerReviewLines += ('- Git: branch={0} head={1} mergeBase={2} dirty={3}' -f (Format-NullableValue $dockerReviewLoopSummary.git.branch), (Format-NullableValue $dockerReviewLoopSummary.git.headSha), (Format-NullableValue $dockerReviewLoopSummary.git.upstreamDevelopMergeBase), (Format-BoolLabel $dockerReviewLoopSummary.git.dirtyTracked))
+      }
+      if ($dockerReviewLoopSummary.PSObject.Properties['requirementsCoverage'] -and $dockerReviewLoopSummary.requirementsCoverage) {
+        $coverage = $dockerReviewLoopSummary.requirementsCoverage
+        $dockerReviewLines += ('- Requirements: total={0} covered={1} uncovered={2}' -f (Format-NullableValue $coverage.requirementTotal), (Format-NullableValue $coverage.requirementCovered), (Format-NullableValue $coverage.requirementUncovered))
+      }
+      ($dockerReviewLines -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+    }
+  }
+} catch {
+  Write-Warning ("Failed to load Docker review-loop summary: {0}" -f $_.Exception.Message)
 }
 
 try {

--- a/tools/Test-AgentHandoffEntryPoint.ps1
+++ b/tools/Test-AgentHandoffEntryPoint.ps1
@@ -33,6 +33,7 @@ $requiredArtifacts = @(
   '.agent_priority_cache.json',
   'tests/results/_agent/issue/router.json',
   'tests/results/_agent/issue/no-standing-priority.json',
+  'tests/results/_agent/verification/docker-review-loop-summary.json',
   'tests/results/_agent/handoff/entrypoint-status.json',
   'tests/results/_agent/handoff/*.json',
   'tests/results/_agent/sessions/*.json'
@@ -50,6 +51,7 @@ $artifactCatalog = [ordered]@{
   priorityCache = '.agent_priority_cache.json'
   router = 'tests/results/_agent/issue/router.json'
   noStandingPriority = 'tests/results/_agent/issue/no-standing-priority.json'
+  dockerReviewLoopSummary = 'tests/results/_agent/verification/docker-review-loop-summary.json'
   entrypointStatus = 'tests/results/_agent/handoff/entrypoint-status.json'
   handoffGlob = 'tests/results/_agent/handoff/*.json'
   sessionGlob = 'tests/results/_agent/sessions/*.json'

--- a/tools/priority/Import-HandoffState.ps1
+++ b/tools/priority/Import-HandoffState.ps1
@@ -39,6 +39,7 @@ $hookSummary  = Read-HandoffJson -Name 'hook-summary.json'
 $watcherTelemetry = Read-HandoffJson -Name 'watcher-telemetry.json'
 $releaseSummary = Read-HandoffJson -Name 'release-summary.json'
 $testSummary = Read-HandoffJson -Name 'test-summary.json'
+$dockerReviewLoopSummary = Read-HandoffJson -Name 'docker-review-loop-summary.json'
 $entrypointStatus = Read-HandoffJson -Name 'entrypoint-status.json'
 
 if ($issueSummary) {
@@ -148,6 +149,29 @@ if ($testSummary) {
     Write-Host ("  {0} => exit {1}" -f ($entry.command ?? '(unknown)'), (Format-NullableValue $entry.exitCode))
   }
   Set-Variable -Name TestHandoffSummary -Scope Global -Value $testSummary -Force
+}
+
+if ($dockerReviewLoopSummary) {
+  Write-Host '[handoff] Docker review loop summary' -ForegroundColor Cyan
+  if ($dockerReviewLoopSummary.PSObject.Properties['overall'] -and $dockerReviewLoopSummary.overall) {
+    Write-Host ("  status   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.status))
+    Write-Host ("  failed   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.failedCheck))
+    Write-Host ("  exitCode : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.exitCode))
+    if ($dockerReviewLoopSummary.overall.message) {
+      Write-Host ("  message  : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.overall.message))
+    }
+  }
+  if ($dockerReviewLoopSummary.PSObject.Properties['git'] -and $dockerReviewLoopSummary.git) {
+    Write-Host ("  branch   : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.git.branch))
+    Write-Host ("  head     : {0}" -f (Format-NullableValue $dockerReviewLoopSummary.git.headSha))
+    Write-Host ("  mergeBase: {0}" -f (Format-NullableValue $dockerReviewLoopSummary.git.upstreamDevelopMergeBase))
+    Write-Host ("  dirty    : {0}" -f (Format-BoolLabel $dockerReviewLoopSummary.git.dirtyTracked))
+  }
+  if ($dockerReviewLoopSummary.PSObject.Properties['requirementsCoverage'] -and $dockerReviewLoopSummary.requirementsCoverage) {
+    $coverage = $dockerReviewLoopSummary.requirementsCoverage
+    Write-Host ("  reqs     : total={0} covered={1} uncovered={2}" -f (Format-NullableValue $coverage.requirementTotal), (Format-NullableValue $coverage.requirementCovered), (Format-NullableValue $coverage.requirementUncovered))
+  }
+  Set-Variable -Name DockerReviewLoopHandoffSummary -Scope Global -Value $dockerReviewLoopSummary -Force
 }
 
 if ($entrypointStatus) {

--- a/tools/priority/__fixtures__/handoff/docker-review-loop-summary.json
+++ b/tools/priority/__fixtures__/handoff/docker-review-loop-summary.json
@@ -1,0 +1,38 @@
+{
+  "schema": "docker-tools-parity-agent-verification@v1",
+  "generatedAt": "2026-03-13T09:00:00.000Z",
+  "authoritativeSource": "docker-tools-parity",
+  "git": {
+    "headSha": "433e8aa70326007be74c27ccf54c1ae91559b6f3",
+    "branch": "issue/origin-1053-agent-verification-authority",
+    "upstreamDevelopMergeBase": "ccbdc75d4bfbcbe6580abb989b2d4e819e1a1e99",
+    "dirtyTracked": false
+  },
+  "reviewLoopReceiptPath": "tests/results/docker-tools-parity/review-loop-receipt.json",
+  "overall": {
+    "status": "passed",
+    "failedCheck": "",
+    "message": "",
+    "exitCode": 0
+  },
+  "requirementsCoverage": {
+    "requirementTotal": 11,
+    "requirementCovered": 11,
+    "requirementUncovered": 0,
+    "uncoveredRequirementIds": [],
+    "unknownRequirementIds": []
+  },
+  "artifacts": {
+    "reviewLoopReceiptPath": "tests/results/docker-tools-parity/review-loop-receipt.json",
+    "requirementsSummaryPath": "tests/results/docker-tools-parity/requirements-verification/verification-summary.json",
+    "traceMatrixJsonPath": "tests/results/docker-tools-parity/requirements-verification/trace-matrix.json",
+    "traceMatrixHtmlPath": "tests/results/docker-tools-parity/requirements-verification/trace-matrix.html"
+  },
+  "recommendedReviewOrder": [
+    "tests/results/docker-tools-parity/review-loop-receipt.json",
+    "tests/results/_agent/verification/docker-review-loop-summary.json",
+    "tests/results/docker-tools-parity/requirements-verification/verification-summary.json",
+    "tests/results/docker-tools-parity/requirements-verification/trace-matrix.json",
+    "tests/results/docker-tools-parity/requirements-verification/trace-matrix.html"
+  ]
+}

--- a/tools/priority/__fixtures__/handoff/entrypoint-status.json
+++ b/tools/priority/__fixtures__/handoff/entrypoint-status.json
@@ -26,6 +26,7 @@
     "priorityCache": ".agent_priority_cache.json",
     "router": "tests/results/_agent/issue/router.json",
     "noStandingPriority": "tests/results/_agent/issue/no-standing-priority.json",
+    "dockerReviewLoopSummary": "tests/results/_agent/verification/docker-review-loop-summary.json",
     "entrypointStatus": "tests/results/_agent/handoff/entrypoint-status.json",
     "handoffGlob": "tests/results/_agent/handoff/*.json",
     "sessionGlob": "tests/results/_agent/sessions/*.json"

--- a/tools/priority/__tests__/handoff-entrypoint-contract.test.mjs
+++ b/tools/priority/__tests__/handoff-entrypoint-contract.test.mjs
@@ -26,6 +26,7 @@ test('AGENT_HANDOFF stays bounded and points agents to live state artifacts', ()
   assert.match(handoff, /\.agent_priority_cache\.json/);
   assert.match(handoff, /tests\/results\/_agent\/issue\/router\.json/);
   assert.match(handoff, /tests\/results\/_agent\/issue\/no-standing-priority\.json/);
+  assert.match(handoff, /tests\/results\/_agent\/verification\/docker-review-loop-summary\.json/);
   assert.match(handoff, /tests\/results\/_agent\/handoff\/entrypoint-status\.json/);
   assert.match(handoff, /tests\/results\/_agent\/handoff\/\*\.json/);
   assert.match(handoff, /tests\/results\/_agent\/sessions\/\*\.json/);
@@ -52,16 +53,20 @@ test('handoff entrypoint contract is wired into automation and operator docs', (
   assert.match(runHandoffTests, /handoff:entrypoint:check/);
   assert.match(printHandoff, /Test-AgentHandoffEntryPoint\.ps1/);
   assert.match(printHandoff, /-ResultsRoot \$ResultsRoot -Quiet/);
+  assert.match(printHandoff, /docker-review-loop-summary\.json/);
   assert.match(importHandoff, /entrypoint-status\.json/);
+  assert.match(importHandoff, /docker-review-loop-summary\.json/);
   assert.match(importHandoff, /\[handoff\] Entrypoint index/);
   assert.match(agents, /handoff:entrypoint:check/);
   assert.match(agents, /priority:handoff/);
   assert.match(agents, /machine-readable index/i);
+  assert.match(agents, /docker-review-loop-summary\.json/);
   assert.match(developerGuide, /handoff:entrypoint:check/);
   assert.match(developerGuide, /priority:handoff/);
   assert.match(developerGuide, /machine-readable index/i);
   assert.match(handoffGuide, /AGENT_HANDOFF\.txt/);
   assert.match(handoffGuide, /entrypoint-status\.json/);
+  assert.match(handoffGuide, /docker-review-loop-summary\.json/);
   assert.match(handoffGuide, /priority:handoff/);
   assert.match(handoffGuide, /queue-empty/);
 });

--- a/tools/priority/__tests__/handoff-schema.test.mjs
+++ b/tools/priority/__tests__/handoff-schema.test.mjs
@@ -77,3 +77,11 @@ test('handoff entrypoint status matches schema', () => {
     'tools/priority/__fixtures__/handoff/entrypoint-status.json'
   );
 });
+
+test('handoff docker review loop summary matches schema', () => {
+  validateFixture(
+    'docker review loop summary',
+    'docs/schemas/docker-tools-parity-agent-verification-v1.schema.json',
+    'tools/priority/__fixtures__/handoff/docker-review-loop-summary.json'
+  );
+});


### PR DESCRIPTION
# Summary

Refs #1053.

Make the handoff bundle treat Docker/Desktop review-loop verification as the authoritative agent-facing surface.

## Agent Metadata

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Standing-Priority: `#1053`

## Change Surface

- Mirror `tests/results/_agent/verification/docker-review-loop-summary.json` into the generated handoff bundle.
- Surface that summary directly from `priority:handoff` / `Import-HandoffState`.
- Extend the handoff entrypoint contract so future agents can discover the Docker parity verification surface without raw path spelunking.
- Replace the stale feature-policy doc example that still pointed at `_agent/verification/verification-summary.json`.

## Validation

- `node --test tools/priority/__tests__/handoff-entrypoint-contract.test.mjs tools/priority/__tests__/handoff-schema.test.mjs tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs`
- `Invoke-Pester -Path tests/Import-HandoffState.Tests.ps1,tests/Test-AgentHandoffEntryPoint.Tests.ps1,tests/AgentHandoff.Local.Tests.ps1,tests/AgentHandoff.QueueEmpty.Tests.ps1,tests/AgentHandoff.DockerParityVerification.Tests.ps1 -Output Detailed`

## Reviewer Focus

- Confirm the handoff/export path now prefers the Docker/Desktop verification bridge.
- Confirm `AGENT_HANDOFF.txt`, entrypoint metadata, and importer output all agree on the authoritative surface.
- Confirm the doc example under feature-branch policy no longer teaches the stale generic verification-summary path.
