### PR TITLE
#1069 Add draft-only Copilot GitHub instructions

### DIFF
--- a/.github/instructions/draft-only-copilot-review.instructions.md
+++ b/.github/instructions/draft-only-copilot-review.instructions.md
@@ -1,0 +1,12 @@
+# Draft-Only Copilot Review for Agent PRs
+
+- Scope: agent-authored pull requests in `compare-vi-cli-action`.
+- Keep the pull request in draft while implementation, local parity, and comment
+  resolution are still in progress.
+- Request or expect Copilot review only while the pull request is draft.
+- Do not use `ready_for_review` to solicit a second Copilot pass.
+- Resolve current-head Copilot comments before leaving draft.
+- If a new commit lands, treat older Copilot review state as stale and repeat
+  the draft-phase review loop on the new head.
+- For standing-priority lanes, automation owns draft/ready transitions unless a
+  human explicitly intervenes.

--- a/.github/instructions/final-ready-validation.instructions.md
+++ b/.github/instructions/final-ready-validation.instructions.md
@@ -1,0 +1,16 @@
+# Ready-for-Review Means Final Validation
+
+- Use `ready_for_review` only when the current head is locally reviewed and is
+  ready for final hosted validation.
+- Before marking ready, require all of the following on the current head:
+  - the Docker/Desktop review receipt exists
+  - the receipt is passing
+  - the receipt is tracked-clean
+  - the receipt covers all requested review surfaces
+  - no unresolved current-head Copilot comments remain
+- Do not request or wait for a second Copilot review after `ready_for_review`.
+- Treat merge, merge-queue admission, and admin promotion as blocked if the
+  current head changed after draft review or if unresolved current-head Copilot
+  comments remain.
+- If a new commit lands after ready, return the pull request to draft and
+  restart the local-plus-Copilot review loop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,10 @@ artifacts under `tests/results/_agent/`.
 - Treat the GitHub wiki as a curated portal only. Checked-in repo docs remain
   authoritative, and published wiki history lives in
   `LabVIEW-Community-CI-CD/compare-vi-cli-action.wiki.git`.
+- Repo-owned GitHub instructions live under
+  `.github/instructions/*.instructions.md`. Keep them aligned with the
+  draft-only Copilot review contract: draft is the only Copilot iteration
+  state, and `ready_for_review` means final validation / promotion intent only.
 
 ## Working Rules
 

--- a/tools/priority/__tests__/github-instructions-contract.test.mjs
+++ b/tools/priority/__tests__/github-instructions-contract.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const instructionsDir = path.join(repoRoot, '.github', 'instructions');
+const agentsPath = path.join(repoRoot, 'AGENTS.md');
+
+function readInstruction(name) {
+  return fs.readFileSync(path.join(instructionsDir, name), 'utf8');
+}
+
+function normalizeWhitespace(value) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+test('draft-only GitHub instructions exist as a repo-owned surface', () => {
+  assert.equal(fs.existsSync(instructionsDir), true, '.github/instructions must exist.');
+  const instructionFiles = fs.readdirSync(instructionsDir)
+    .filter((entry) => entry.endsWith('.instructions.md'))
+    .sort();
+
+  assert.deepEqual(instructionFiles, [
+    'draft-only-copilot-review.instructions.md',
+    'final-ready-validation.instructions.md',
+  ]);
+});
+
+test('draft-only instruction content captures the required Copilot review contract', () => {
+  const draftOnly = normalizeWhitespace(readInstruction('draft-only-copilot-review.instructions.md'));
+  const readyValidation = normalizeWhitespace(readInstruction('final-ready-validation.instructions.md'));
+
+  assert.match(draftOnly, /only while the pull request is draft/i);
+  assert.match(draftOnly, /Do not use `ready_for_review` to solicit a second Copilot pass/i);
+  assert.match(draftOnly, /Resolve current-head Copilot comments before leaving draft/i);
+
+  assert.match(readyValidation, /Use `ready_for_review` only when the current head is locally reviewed/i);
+  assert.match(readyValidation, /Do not request or wait for a second Copilot review after `ready_for_review`/i);
+  assert.match(readyValidation, /return the pull request to draft and restart the local-plus-Copilot review loop/i);
+});
+
+test('AGENTS points future agents at the GitHub instructions surface', () => {
+  const agents = fs.readFileSync(agentsPath, 'utf8');
+  assert.match(agents, /\.github\/instructions\/\*\.instructions\.md/);
+  assert.match(agents, /draft-only Copilot review contract/i);
+});


### PR DESCRIPTION
# Summary

Adds the repo-owned GitHub instructions layer for the draft-only Copilot review contract tracked by #1069.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1069
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1069
- Files, tools, workflows, or policies touched:
  - `.github/instructions/draft-only-copilot-review.instructions.md`
  - `.github/instructions/final-ready-validation.instructions.md`
  - `AGENTS.md`
  - `tools/priority/__tests__/github-instructions-contract.test.mjs`
- Cross-repo or external-consumer impact: GitHub-native authoring surfaces gain repo-owned instructions for the
  draft-only Copilot review contract.
- Required checks, merge-queue behavior, or approval flows affected: No behavior change yet; this PR adds the
  instruction layer and the contract test that keeps it aligned.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/github-instructions-contract.test.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -SkipActionlint -SkipDocs -SkipWorkflow -SkipDotnetCliBuild`
- Key artifacts, logs, or workflow runs:
  - Docker tools parity markdownlint summary: `0 error(s)`
- Risk-based checks not run:
  - No workflow or daemon behavior changes are included in this slice.

## Risks and Follow-ups

- Residual risks: This PR only adds the instruction surface; it does not yet enforce the draft-only contract in the
  runtime or workflow layers.
- Follow-up issues or deferred work: #1067 implements the actual routing, gate, and daemon behavior after this
  instruction layer lands.
- Deployment, approval, or rollback notes: Safe to revert as a documentation-and-contract-only slice if needed.

## Reviewer Focus

- Please verify the instruction wording matches the intended draft-only Copilot operating model.
- Please verify the AGENTS alignment note and contract test are scoped narrowly to the new instruction surface.

Closes #1069
