### PR TITLE
#1090 Move the local review provider front door into tools/local-collab

### DIFF
--- a/tools/local-collab/providers/__tests__/agent-review-policy.test.mjs
+++ b/tools/local-collab/providers/__tests__/agent-review-policy.test.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  loadAgentReviewPolicy,
+  normalizeAgentReviewPolicy,
+  parseArgs,
+  runAgentReviewPolicy
+} from '../agent-review-policy.mjs';
+
+test('normalizeAgentReviewPolicy leaves space for Copilot, Codex, Simulation, and Ollama providers', () => {
+  const policy = normalizeAgentReviewPolicy({
+    reviewProviders: ['copilot-cli', 'simulation', 'codex-cli', 'ollama']
+  });
+  assert.deepEqual(policy.reviewProviders, ['copilot-cli', 'simulation', 'codex-cli', 'ollama']);
+  assert.equal(policy.codexCli.enabled, false);
+  assert.equal(policy.ollama.enabled, false);
+});
+
+test('parseArgs defaults hook profiles to profile-scoped receipt paths', () => {
+  const options = parseArgs([
+    'node',
+    'tools/priority/agent-review-policy.mjs',
+    '--repo-root',
+    '/tmp/repo',
+    '--review-provider',
+    'copilot-cli',
+    '--profile',
+    'pre-commit'
+  ]);
+
+  assert.equal(options.repoRoot, '/tmp/repo');
+  assert.equal(options.request.profile, 'pre-commit');
+  assert.deepEqual(options.request.reviewProviders, ['copilot-cli']);
+  assert.match(options.request.agentReviewPolicyReceiptPath, /_hooks[\\/]pre-commit-agent-review-policy\.json$/);
+});
+
+test('loadAgentReviewPolicy reads local review provider selection from delivery-agent policy', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-load-'));
+  await mkdir(path.join(repoRoot, 'tools', 'priority'), { recursive: true });
+  await writeFile(
+    path.join(repoRoot, 'tools', 'priority', 'delivery-agent.policy.json'),
+    JSON.stringify({
+      localReviewLoop: {
+        reviewProviders: ['copilot-cli', 'simulation'],
+        copilotCliReview: true,
+        simulationReview: true,
+        simulationReviewConfig: {
+          enabled: true,
+          scenario: 'actionable-findings'
+        }
+      }
+    }),
+    'utf8'
+  );
+
+  const policy = await loadAgentReviewPolicy(repoRoot);
+  assert.deepEqual(policy.reviewProviders, ['copilot-cli', 'simulation']);
+  assert.equal(policy.simulation.enabled, true);
+  assert.equal(policy.simulation.scenario, 'actionable-findings');
+});
+
+test('runAgentReviewPolicy skips cleanly when no providers are requested', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-skip-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'skipped');
+  assert.equal(result.receipt.overall.status, 'skipped');
+});
+
+test('runAgentReviewPolicy combines Copilot CLI and Simulation providers into one deterministic receipt', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-pass-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['copilot-cli', 'simulation']
+    },
+    runCopilotCliReviewFn: async () => ({
+      providerId: 'copilot-cli',
+      status: 'passed',
+      reason: 'Copilot CLI passed.',
+      receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Copilot CLI passed.'
+        }
+      }
+    }),
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'passed',
+      reason: 'Simulation passed.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Simulation passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providerSelection.selectionSource, 'explicit-request');
+  assert.deepEqual(result.receipt.providerSelection.explicitProviders, ['copilot-cli', 'simulation']);
+  assert.deepEqual(result.receipt.providerSelection.policyProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.impliedProviders, []);
+  assert.deepEqual(result.receipt.requestedProviders, ['copilot-cli', 'simulation']);
+  assert.equal(result.receipt.providers['copilot-cli'].status, 'passed');
+  assert.equal(result.receipt.providers.simulation.status, 'passed');
+});
+
+test('runAgentReviewPolicy forwards the requested execution profile to the Copilot CLI provider', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-profile-'));
+  let observedProfile = null;
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      profile: 'pre-push',
+      reviewProviders: ['copilot-cli']
+    },
+    runCopilotCliReviewFn: async (options) => {
+      observedProfile = options.profile;
+      return {
+        providerId: 'copilot-cli',
+        status: 'passed',
+        reason: 'Copilot CLI passed.',
+        receiptPath: 'tests/results/_hooks/pre-push-copilot-cli-review.json',
+        receipt: {
+          overall: {
+            status: 'passed',
+            actionableFindingCount: 0,
+            message: 'Copilot CLI passed.'
+          }
+        }
+      };
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(observedProfile, 'pre-push');
+  assert.equal(result.receipt.profile, 'pre-push');
+  assert.match(result.receiptPath, /_hooks[\\/]pre-push-agent-review-policy\.json$/);
+});
+
+test('runAgentReviewPolicy preserves explicit provider ordering in the combined receipt', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-order-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['simulation', 'copilot-cli']
+    },
+    runCopilotCliReviewFn: async () => ({
+      providerId: 'copilot-cli',
+      status: 'passed',
+      reason: 'Copilot CLI passed.',
+      receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Copilot CLI passed.'
+        }
+      }
+    }),
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'passed',
+      reason: 'Simulation passed.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Simulation passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.deepEqual(result.receipt.requestedProviders, ['simulation', 'copilot-cli']);
+  assert.deepEqual(result.receipt.executedProviders, ['simulation', 'copilot-cli']);
+  assert.deepEqual(result.receipt.recommendedReviewOrder, ['simulation', 'copilot-cli']);
+});
+
+test('runAgentReviewPolicy fails closed when the Simulation provider surfaces a regression seam', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-fail-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      simulationReview: true
+    },
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'failed',
+      reason: 'Simulation injected a stale-head failure.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'failed',
+          actionableFindingCount: 1,
+          message: 'Simulation injected a stale-head failure.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.failedProvider, 'simulation');
+});
+
+test('runAgentReviewPolicy fails closed when an explicitly selected reserved provider is not implemented', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-reserved-provider-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['codex-cli']
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.failedProvider, 'codex-cli');
+  assert.equal(result.receipt.providers['codex-cli'].status, 'failed');
+  assert.match(result.receipt.providers['codex-cli'].reason, /not implemented yet/i);
+});
+
+test('runAgentReviewPolicy records policy-default provider selection when no explicit providers are requested', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-policy-default-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true
+    },
+    policy: {
+      reviewProviders: ['simulation']
+    },
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'passed',
+      reason: 'Simulation passed.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Simulation passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providerSelection.selectionSource, 'policy-default');
+  assert.deepEqual(result.receipt.providerSelection.explicitProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.policyProviders, ['simulation']);
+  assert.deepEqual(result.receipt.providerSelection.impliedProviders, []);
+  assert.deepEqual(result.receipt.requestedProviders, ['simulation']);
+});
+
+test('runAgentReviewPolicy records legacy-boolean fallback provider selection when deriving providers from booleans', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-legacy-fallback-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      copilotCliReview: true
+    },
+    runCopilotCliReviewFn: async () => ({
+      providerId: 'copilot-cli',
+      status: 'passed',
+      reason: 'Copilot CLI passed.',
+      receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Copilot CLI passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providerSelection.selectionSource, 'legacy-boolean-fallback');
+  assert.deepEqual(result.receipt.providerSelection.explicitProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.policyProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.impliedProviders, ['copilot-cli']);
+  assert.deepEqual(result.receipt.requestedProviders, ['copilot-cli']);
+});

--- a/tools/local-collab/providers/__tests__/local-review-providers.test.mjs
+++ b/tools/local-collab/providers/__tests__/local-review-providers.test.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  describeLocalReviewProvider,
+  executeLocalReviewProvider,
+  normalizeLocalReviewProfile,
+  normalizeLocalReviewProviderId,
+  normalizeLocalReviewProviderList,
+  normalizeLocalReviewProviderPolicies
+} from '../local-review-providers.mjs';
+
+test('normalizeLocalReviewProviderId accepts supported provider ids and rejects unknown ones', () => {
+  assert.equal(normalizeLocalReviewProviderId('copilot-cli'), 'copilot-cli');
+  assert.equal(normalizeLocalReviewProviderId('  simulation  '), 'simulation');
+  assert.throws(() => normalizeLocalReviewProviderId('review-bot'), /Unsupported local review provider/i);
+});
+
+test('normalizeLocalReviewProviderList deduplicates while preserving requested order', () => {
+  const providers = normalizeLocalReviewProviderList(['simulation', 'copilot-cli', 'simulation', 'codex-cli']);
+  assert.deepEqual(providers, ['simulation', 'copilot-cli', 'codex-cli']);
+});
+
+test('normalizeLocalReviewProfile defaults to daemon and rejects unsupported profiles', () => {
+  assert.equal(normalizeLocalReviewProfile(''), 'daemon');
+  assert.equal(normalizeLocalReviewProfile('pre-push'), 'pre-push');
+  assert.throws(() => normalizeLocalReviewProfile('commit-msg'), /Unsupported local review profile/i);
+});
+
+test('normalizeLocalReviewProviderPolicies keeps executable and reserved providers distinct', () => {
+  const policies = normalizeLocalReviewProviderPolicies({
+    reviewProviders: ['copilot-cli', 'simulation', 'codex-cli', 'ollama']
+  });
+  assert.deepEqual(policies.reviewProviders, ['copilot-cli', 'simulation', 'codex-cli', 'ollama']);
+  assert.equal(policies.codexCli.enabled, false);
+  assert.equal(policies.ollama.enabled, false);
+});
+
+test('executeLocalReviewProvider routes Copilot CLI through the provider registry', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-review-provider-copilot-'));
+  let observedOptions = null;
+  const result = await executeLocalReviewProvider({
+    providerId: 'copilot-cli',
+    repoRoot,
+    executionProfile: 'pre-commit',
+    policies: {
+      reviewProviders: ['copilot-cli'],
+      copilotCli: {
+        enabled: true,
+        model: 'gpt-5.5-mini'
+      }
+    },
+    runCopilotCliReviewFn: async (options) => {
+      observedOptions = options;
+      return {
+        status: 'passed',
+        reason: 'Copilot CLI passed.',
+        receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+        receipt: {
+          overall: {
+            status: 'passed',
+            actionableFindingCount: 0,
+            message: 'Copilot CLI passed.'
+          }
+        }
+      };
+    }
+  });
+
+  assert.equal(result.providerId, 'copilot-cli');
+  assert.equal(result.status, 'passed');
+  assert.equal(observedOptions.profile, 'pre-commit');
+  assert.equal(observedOptions.policy.model, 'gpt-5.5-mini');
+});
+
+test('executeLocalReviewProvider routes Simulation through the provider registry', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-review-provider-simulation-'));
+  let observedOptions = null;
+  const result = await executeLocalReviewProvider({
+    providerId: 'simulation',
+    repoRoot,
+    executionProfile: 'daemon',
+    policies: {
+      reviewProviders: ['simulation'],
+      simulation: {
+        enabled: true,
+        scenario: 'provider-failure'
+      }
+    },
+    runSimulationReviewFn: async (options) => {
+      observedOptions = options;
+      return {
+        status: 'failed',
+        reason: 'Simulation failed.',
+        receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+        receipt: {
+          overall: {
+            status: 'failed',
+            actionableFindingCount: 0,
+            message: 'Simulation failed.'
+          }
+        }
+      };
+    }
+  });
+
+  assert.equal(result.providerId, 'simulation');
+  assert.equal(result.status, 'failed');
+  assert.equal(observedOptions.policy.scenario, 'provider-failure');
+});
+
+test('executeLocalReviewProvider fails closed for reserved providers', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-review-provider-reserved-'));
+  const result = await executeLocalReviewProvider({
+    providerId: 'codex-cli',
+    repoRoot,
+    repoGitState: {
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    }
+  });
+
+  assert.equal(result.providerId, 'codex-cli');
+  assert.equal(result.status, 'failed');
+  assert.match(result.reason, /not implemented yet/i);
+});
+
+test('describeLocalReviewProvider marks executable and reserved providers correctly', () => {
+  assert.deepEqual(describeLocalReviewProvider('copilot-cli'), {
+    providerId: 'copilot-cli',
+    executable: true,
+    reserved: false,
+    supportsProfiles: ['pre-commit', 'daemon', 'pre-push']
+  });
+  assert.deepEqual(describeLocalReviewProvider('ollama'), {
+    providerId: 'ollama',
+    executable: false,
+    reserved: true,
+    supportsProfiles: ['pre-commit', 'daemon', 'pre-push']
+  });
+});

--- a/tools/local-collab/providers/agent-review-policy.mjs
+++ b/tools/local-collab/providers/agent-review-policy.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+  normalizeCopilotCliReviewPolicy,
+  resolveRepoGitState
+} from '../../priority/copilot-cli-review.mjs';
+import { DEFAULT_SIMULATION_REVIEW_POLICY, normalizeSimulationReviewPolicy, runSimulationReview } from '../../priority/simulation-review.mjs';
+import {
+  describeLocalReviewProvider,
+  executeLocalReviewProvider,
+  normalizeLocalReviewProfile,
+  normalizeLocalReviewProviderId,
+  normalizeLocalReviewProviderList,
+  normalizeLocalReviewProviderPolicies,
+  summarizeLocalReviewProviderResult,
+  SUPPORTED_LOCAL_REVIEW_PROFILES,
+  SUPPORTED_LOCAL_REVIEW_PROVIDERS
+} from './local-review-providers.mjs';
+import { isEntrypoint } from './shim-utils.mjs';
+
+export const AGENT_REVIEW_POLICY_RECEIPT_SCHEMA = 'priority/agent-review-policy@v1';
+export const DELIVERY_AGENT_POLICY_PATH = path.join('tools', 'priority', 'delivery-agent.policy.json');
+export const DEFAULT_AGENT_REVIEW_POLICY_RECEIPT_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'agent-review-policy',
+  'receipt.json'
+);
+export const SUPPORTED_AGENT_REVIEW_PROVIDERS = SUPPORTED_LOCAL_REVIEW_PROVIDERS;
+export const SUPPORTED_AGENT_REVIEW_PROFILES = SUPPORTED_LOCAL_REVIEW_PROFILES;
+const PROFILE_RECEIPT_PATHS = {
+  'pre-commit': path.join('tests', 'results', '_hooks', 'pre-commit-agent-review-policy.json'),
+  daemon: DEFAULT_AGENT_REVIEW_POLICY_RECEIPT_PATH,
+  'pre-push': path.join('tests', 'results', '_hooks', 'pre-push-agent-review-policy.json')
+};
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function toIso(value = new Date()) {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function resolveRepoPath(repoRoot, candidatePath) {
+  const normalized = normalizeText(candidatePath);
+  if (!normalized) {
+    throw new Error('Agent review policy receipt path must be a non-empty repo-relative path.');
+  }
+  if (path.isAbsolute(normalized)) {
+    throw new Error(`Agent review policy receipt path must stay under the repository root: ${normalized}`);
+  }
+  const resolved = path.resolve(repoRoot, normalized);
+  const relativeToRepo = path.relative(repoRoot, resolved);
+  if (!relativeToRepo || relativeToRepo.startsWith('..') || path.isAbsolute(relativeToRepo)) {
+    throw new Error(`Agent review policy receipt path escapes the repository root: ${normalized}`);
+  }
+  return {
+    normalized,
+    resolved
+  };
+}
+
+export function normalizeAgentReviewPolicy(value = {}) {
+  const raw = value && typeof value === 'object' ? value : {};
+  const normalizedPolicies = normalizeLocalReviewProviderPolicies(raw);
+  return {
+    receiptPath: normalizeText(raw.receiptPath) || DEFAULT_AGENT_REVIEW_POLICY_RECEIPT_PATH,
+    reviewProviders: normalizedPolicies.reviewProviders,
+    copilotCli: normalizedPolicies.copilotCli,
+    simulation: normalizedPolicies.simulation,
+    codexCli: normalizedPolicies.codexCli,
+    ollama: normalizedPolicies.ollama
+  };
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = Array.isArray(argv) ? [...argv] : [];
+  const options = {
+    repoRoot: process.cwd(),
+    request: {
+      requested: true,
+      profile: 'daemon',
+      reviewProviders: []
+    }
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === 'node' || normalizeText(token).endsWith('agent-review-policy.mjs')) {
+      continue;
+    }
+    switch (token) {
+      case '--repo-root':
+        if (args.length === 0) {
+          throw new Error('Missing value for --repo-root');
+        }
+        options.repoRoot = args.shift();
+        break;
+      case '--receipt-path':
+        if (args.length === 0) {
+          throw new Error('Missing value for --receipt-path');
+        }
+        options.request.agentReviewPolicyReceiptPath = args.shift();
+        break;
+      case '--profile':
+        if (args.length === 0) {
+          throw new Error('Missing value for --profile');
+        }
+        options.request.profile = normalizeLocalReviewProfile(args.shift());
+        break;
+      case '--review-provider':
+        if (args.length === 0) {
+          throw new Error('Missing value for --review-provider');
+        }
+        options.request.reviewProviders.push(normalizeLocalReviewProviderId(args.shift()));
+        break;
+      case '--copilot-cli-review':
+        options.request.copilotCliReview = true;
+        break;
+      case '--simulation-review':
+        options.request.simulationReview = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${token}`);
+    }
+  }
+
+  options.request.reviewProviders = normalizeLocalReviewProviderList(options.request.reviewProviders);
+  if (!normalizeText(options.request.agentReviewPolicyReceiptPath)) {
+    options.request.agentReviewPolicyReceiptPath = PROFILE_RECEIPT_PATHS[options.request.profile];
+  }
+  return options;
+}
+
+export async function loadAgentReviewPolicy(repoRoot) {
+  try {
+    const raw = JSON.parse(await readFile(path.join(repoRoot, DELIVERY_AGENT_POLICY_PATH), 'utf8'));
+    const localReviewLoop = raw?.localReviewLoop && typeof raw.localReviewLoop === 'object' ? raw.localReviewLoop : {};
+    return normalizeAgentReviewPolicy({
+      receiptPath: localReviewLoop.agentReviewPolicyReceiptPath,
+      reviewProviders: localReviewLoop.reviewProviders,
+      copilotCli:
+        localReviewLoop.copilotCliReviewConfig && typeof localReviewLoop.copilotCliReviewConfig === 'object'
+          ? {
+              ...localReviewLoop.copilotCliReviewConfig,
+              enabled: localReviewLoop.copilotCliReview !== false &&
+                localReviewLoop.copilotCliReviewConfig.enabled !== false
+            }
+          : {
+              ...DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+              enabled: localReviewLoop.copilotCliReview !== false
+            },
+      simulation:
+        localReviewLoop.simulationReviewConfig && typeof localReviewLoop.simulationReviewConfig === 'object'
+          ? {
+              ...localReviewLoop.simulationReviewConfig,
+              enabled: localReviewLoop.simulationReview === true &&
+                localReviewLoop.simulationReviewConfig.enabled !== false
+            }
+          : {
+              ...DEFAULT_SIMULATION_REVIEW_POLICY,
+              enabled: localReviewLoop.simulationReview === true
+            },
+      codexCli:
+        localReviewLoop.codexCliReviewConfig && typeof localReviewLoop.codexCliReviewConfig === 'object'
+          ? localReviewLoop.codexCliReviewConfig
+          : { enabled: false },
+      ollama:
+        localReviewLoop.ollamaReviewConfig && typeof localReviewLoop.ollamaReviewConfig === 'object'
+          ? localReviewLoop.ollamaReviewConfig
+          : { enabled: false }
+    });
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return normalizeAgentReviewPolicy({});
+    }
+    throw error;
+  }
+}
+
+function resolveRequestedProviders(request = {}, policy = {}) {
+  const normalizedRequestProviders = normalizeLocalReviewProviderList(request.reviewProviders);
+  const policyProviders = normalizeLocalReviewProviderList(policy.reviewProviders);
+  if (normalizedRequestProviders.length > 0) {
+    return {
+      providers: normalizedRequestProviders,
+      selectionSource: 'explicit-request',
+      explicitProviders: normalizedRequestProviders,
+      policyProviders,
+      impliedProviders: []
+    };
+  }
+  if (policyProviders.length > 0) {
+    return {
+      providers: [...policyProviders],
+      selectionSource: 'policy-default',
+      explicitProviders: [],
+      policyProviders,
+      impliedProviders: []
+    };
+  }
+  const providers = [];
+  if (request.copilotCliReview === true) {
+    providers.push('copilot-cli');
+  }
+  if (request.simulationReview === true) {
+    providers.push('simulation');
+  }
+  const impliedProviders = normalizeLocalReviewProviderList(providers);
+  return {
+    providers: impliedProviders,
+    selectionSource: impliedProviders.length > 0 ? 'legacy-boolean-fallback' : 'none',
+    explicitProviders: [],
+    policyProviders,
+    impliedProviders
+  };
+}
+
+export async function runAgentReviewPolicy({
+  repoRoot,
+  request = {},
+  policy = null,
+  runCopilotCliReviewFn,
+  runSimulationReviewFn = runSimulationReview,
+  resolveRepoGitStateFn = resolveRepoGitState
+}) {
+  const normalizedPolicy = normalizeAgentReviewPolicy(policy ?? await loadAgentReviewPolicy(repoRoot));
+  const executionProfile = normalizeLocalReviewProfile(request.profile);
+  const providerSelection = resolveRequestedProviders(request, normalizedPolicy);
+  const requestedProviders = providerSelection.providers;
+  const receiptPathInfo = resolveRepoPath(
+    repoRoot,
+    normalizeText(request.agentReviewPolicyReceiptPath) || PROFILE_RECEIPT_PATHS[executionProfile] || normalizedPolicy.receiptPath
+  );
+  const repoGitState = resolveRepoGitStateFn(repoRoot) ?? {};
+
+  if (request.requested !== true || requestedProviders.length === 0) {
+    const receipt = {
+      schema: AGENT_REVIEW_POLICY_RECEIPT_SCHEMA,
+      generatedAt: toIso(),
+      profile: executionProfile,
+      git: repoGitState,
+      providerSelection,
+      requestedProviders,
+      executedProviders: [],
+      overall: {
+        status: 'skipped',
+        actionableFindingCount: 0,
+        message: 'No local agent review providers were requested.',
+        exitCode: 0
+      },
+      providers: {}
+    };
+    await mkdir(path.dirname(receiptPathInfo.resolved), { recursive: true });
+    await writeFile(receiptPathInfo.resolved, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+    return {
+      status: 'skipped',
+      source: 'agent-review-policy',
+      reason: receipt.overall.message,
+      receiptPath: receiptPathInfo.normalized,
+      receipt
+    };
+  }
+
+  const providerResults = [];
+  for (const providerId of requestedProviders) {
+    const result = await executeLocalReviewProvider({
+      providerId,
+      repoRoot,
+      executionProfile,
+      repoGitState,
+      policies: normalizedPolicy,
+      runCopilotCliReviewFn,
+      runSimulationReviewFn,
+      resolveRepoGitStateFn
+    });
+    providerResults.push(summarizeLocalReviewProviderResult(result));
+  }
+
+  const failedProvider = providerResults.find((provider) => provider.status === 'failed') ?? null;
+  const passedProviders = providerResults.filter((provider) => provider.status === 'passed');
+  const overallStatus = failedProvider ? 'failed' : passedProviders.length > 0 ? 'passed' : 'skipped';
+  const overallMessage = failedProvider
+    ? failedProvider.reason || `Local agent review failed in provider ${failedProvider.providerId}.`
+    : overallStatus === 'passed'
+      ? 'Local agent review providers passed.'
+      : 'Local agent review providers were skipped.';
+  const receipt = {
+    schema: AGENT_REVIEW_POLICY_RECEIPT_SCHEMA,
+    generatedAt: toIso(),
+    profile: executionProfile,
+    git: repoGitState,
+    providerSelection,
+    requestedProviders,
+    executedProviders: providerResults.map((provider) => provider.providerId),
+    overall: {
+      status: overallStatus,
+      actionableFindingCount: providerResults.reduce(
+        (sum, provider) => sum + (Number.isInteger(provider.actionableFindingCount) ? provider.actionableFindingCount : 0),
+        0
+      ),
+      message: overallMessage,
+      exitCode: overallStatus === 'passed' || overallStatus === 'skipped' ? 0 : 1,
+      failedProvider: failedProvider?.providerId || null
+    },
+    providers: Object.fromEntries(
+      providerResults.map((provider) => [
+        provider.providerId,
+        {
+          status: provider.status,
+          reason: provider.reason,
+          receiptPath: provider.receiptPath,
+          actionableFindingCount: provider.actionableFindingCount,
+          convergence: provider.convergence,
+          scenario: provider.scenario
+        }
+      ])
+    ),
+    recommendedReviewOrder: providerResults.map((provider) => provider.providerId)
+  };
+  receipt.providerCatalog = Object.fromEntries(
+    requestedProviders.map((providerId) => [providerId, describeLocalReviewProvider(providerId)])
+  );
+
+  await mkdir(path.dirname(receiptPathInfo.resolved), { recursive: true });
+  await writeFile(receiptPathInfo.resolved, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+
+  return {
+    status: overallStatus,
+    source: 'agent-review-policy',
+    reason: overallMessage,
+    receiptPath: receiptPathInfo.normalized,
+    receipt
+  };
+}
+
+export async function main(argv = process.argv) {
+  const options = parseArgs(argv);
+  const result = await runAgentReviewPolicy(options);
+  process.stdout.write(`${JSON.stringify(result.receipt, null, 2)}\n`);
+  process.exitCode = result.status === 'failed' ? 1 : 0;
+}
+
+if (isEntrypoint(import.meta.url)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/local-collab/providers/local-review-providers.mjs
+++ b/tools/local-collab/providers/local-review-providers.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import {
+  DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+  normalizeCopilotCliReviewPolicy,
+  runCopilotCliReview
+} from '../../priority/copilot-cli-review.mjs';
+import {
+  DEFAULT_SIMULATION_REVIEW_POLICY,
+  normalizeSimulationReviewPolicy,
+  runSimulationReview
+} from '../../priority/simulation-review.mjs';
+
+export const SUPPORTED_LOCAL_REVIEW_PROVIDERS = ['copilot-cli', 'codex-cli', 'simulation', 'ollama'];
+export const EXECUTABLE_LOCAL_REVIEW_PROVIDERS = ['copilot-cli', 'simulation'];
+export const SUPPORTED_LOCAL_REVIEW_PROFILES = ['pre-commit', 'daemon', 'pre-push'];
+
+const EXECUTABLE_PROVIDER_SET = new Set(EXECUTABLE_LOCAL_REVIEW_PROVIDERS);
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function toIso(value = new Date()) {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+export function normalizeLocalReviewProviderId(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  if (!normalized) {
+    return '';
+  }
+  if (!SUPPORTED_LOCAL_REVIEW_PROVIDERS.includes(normalized)) {
+    throw new Error(`Unsupported local review provider: ${value}`);
+  }
+  return normalized;
+}
+
+export function normalizeLocalReviewProviderList(value) {
+  const rawList = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/[,\r\n]+/)
+      : [];
+  return Array.from(new Set(rawList.map(normalizeLocalReviewProviderId).filter(Boolean)));
+}
+
+export function normalizeLocalReviewProfile(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  if (!normalized) {
+    return 'daemon';
+  }
+  if (!SUPPORTED_LOCAL_REVIEW_PROFILES.includes(normalized)) {
+    throw new Error(`Unsupported local review profile: ${value}`);
+  }
+  return normalized;
+}
+
+export function normalizeLocalReviewProviderPolicies(value = {}) {
+  const raw = value && typeof value === 'object' ? value : {};
+  return {
+    reviewProviders: normalizeLocalReviewProviderList(raw.reviewProviders),
+    copilotCli: normalizeCopilotCliReviewPolicy(
+      raw.copilotCli && typeof raw.copilotCli === 'object' ? raw.copilotCli : DEFAULT_COPILOT_CLI_REVIEW_POLICY
+    ),
+    simulation: normalizeSimulationReviewPolicy(
+      raw.simulation && typeof raw.simulation === 'object' ? raw.simulation : DEFAULT_SIMULATION_REVIEW_POLICY
+    ),
+    codexCli: raw.codexCli && typeof raw.codexCli === 'object' ? { ...raw.codexCli } : { enabled: false },
+    ollama: raw.ollama && typeof raw.ollama === 'object' ? { ...raw.ollama } : { enabled: false }
+  };
+}
+
+export function buildUnsupportedLocalReviewProviderResult(providerId, repoGitState) {
+  return {
+    providerId,
+    status: 'failed',
+    source: 'agent-review-policy',
+    reason: `Provider ${providerId} is not implemented yet.`,
+    receiptPath: null,
+    receipt: {
+      schema: 'priority/agent-review-policy@v1',
+      generatedAt: toIso(),
+      provider: providerId,
+      git: repoGitState,
+      overall: {
+        status: 'failed',
+        actionableFindingCount: 0,
+        message: `Provider ${providerId} is not implemented yet.`,
+        exitCode: 1
+      }
+    }
+  };
+}
+
+export function summarizeLocalReviewProviderResult(result) {
+  const providerId = normalizeText(result?.providerId);
+  const receipt = result && typeof result === 'object' ? result.receipt : null;
+  const overall = receipt && typeof receipt === 'object' && receipt.overall && typeof receipt.overall === 'object'
+    ? receipt.overall
+    : {};
+  return {
+    providerId,
+    status: normalizeText(result?.status) || normalizeText(overall.status) || 'failed',
+    reason: normalizeText(result?.reason) || normalizeText(overall.message) || null,
+    receiptPath: normalizeText(result?.receiptPath) || null,
+    actionableFindingCount: Number.isInteger(overall.actionableFindingCount) ? overall.actionableFindingCount : 0,
+    convergence: result?.receipt?.convergence ?? null,
+    scenario: normalizeText(result?.receipt?.scenario) || null,
+    receipt
+  };
+}
+
+export async function executeLocalReviewProvider({
+  providerId,
+  repoRoot,
+  executionProfile = 'daemon',
+  repoGitState = {},
+  policies = {},
+  runCopilotCliReviewFn = runCopilotCliReview,
+  runSimulationReviewFn = runSimulationReview,
+  resolveRepoGitStateFn
+}) {
+  const normalizedProviderId = normalizeLocalReviewProviderId(providerId);
+  const normalizedProfile = normalizeLocalReviewProfile(executionProfile);
+  const normalizedPolicies = normalizeLocalReviewProviderPolicies(policies);
+
+  if (!EXECUTABLE_PROVIDER_SET.has(normalizedProviderId)) {
+    return buildUnsupportedLocalReviewProviderResult(normalizedProviderId, repoGitState);
+  }
+
+  if (normalizedProviderId === 'copilot-cli') {
+    const result = await runCopilotCliReviewFn({
+      repoRoot,
+      profile: normalizedProfile,
+      policy: normalizedPolicies.copilotCli
+    });
+    return {
+      ...result,
+      providerId: 'copilot-cli'
+    };
+  }
+
+  if (normalizedProviderId === 'simulation') {
+    const result = await runSimulationReviewFn({
+      repoRoot,
+      policy: normalizedPolicies.simulation,
+      resolveRepoGitStateFn
+    });
+    return {
+      ...result,
+      providerId: 'simulation'
+    };
+  }
+
+  return buildUnsupportedLocalReviewProviderResult(normalizedProviderId, repoGitState);
+}
+
+export function describeLocalReviewProvider(providerId) {
+  const normalizedProviderId = normalizeLocalReviewProviderId(providerId);
+  return {
+    providerId: normalizedProviderId,
+    executable: EXECUTABLE_PROVIDER_SET.has(normalizedProviderId),
+    reserved: !EXECUTABLE_PROVIDER_SET.has(normalizedProviderId),
+    supportsProfiles: normalizedProviderId === 'simulation'
+      ? ['daemon', 'pre-commit', 'pre-push']
+      : [...SUPPORTED_LOCAL_REVIEW_PROFILES]
+  };
+}

--- a/tools/local-collab/providers/shim-utils.mjs
+++ b/tools/local-collab/providers/shim-utils.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export function isEntrypoint(importMetaUrl, argv = process.argv) {
+  const entrypointPath = argv[1] ? path.resolve(argv[1]) : null;
+  const modulePath = fileURLToPath(importMetaUrl);
+  return Boolean(entrypointPath && modulePath === entrypointPath);
+}

--- a/tools/priority/__tests__/agent-review-policy.test.mjs
+++ b/tools/priority/__tests__/agent-review-policy.test.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  loadAgentReviewPolicy,
+  normalizeAgentReviewPolicy,
+  parseArgs,
+  runAgentReviewPolicy
+} from '../agent-review-policy.mjs';
+
+test('normalizeAgentReviewPolicy leaves space for Copilot, Codex, Simulation, and Ollama providers', () => {
+  const policy = normalizeAgentReviewPolicy({
+    reviewProviders: ['copilot-cli', 'simulation', 'codex-cli', 'ollama']
+  });
+  assert.deepEqual(policy.reviewProviders, ['copilot-cli', 'simulation', 'codex-cli', 'ollama']);
+  assert.equal(policy.codexCli.enabled, false);
+  assert.equal(policy.ollama.enabled, false);
+});
+
+test('parseArgs defaults hook profiles to profile-scoped receipt paths', () => {
+  const options = parseArgs([
+    'node',
+    'tools/priority/agent-review-policy.mjs',
+    '--repo-root',
+    '/tmp/repo',
+    '--review-provider',
+    'copilot-cli',
+    '--profile',
+    'pre-commit'
+  ]);
+
+  assert.equal(options.repoRoot, '/tmp/repo');
+  assert.equal(options.request.profile, 'pre-commit');
+  assert.deepEqual(options.request.reviewProviders, ['copilot-cli']);
+  assert.match(options.request.agentReviewPolicyReceiptPath, /_hooks[\\/]pre-commit-agent-review-policy\.json$/);
+});
+
+test('loadAgentReviewPolicy reads local review provider selection from delivery-agent policy', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-load-'));
+  await mkdir(path.join(repoRoot, 'tools', 'priority'), { recursive: true });
+  await writeFile(
+    path.join(repoRoot, 'tools', 'priority', 'delivery-agent.policy.json'),
+    JSON.stringify({
+      localReviewLoop: {
+        reviewProviders: ['copilot-cli', 'simulation'],
+        copilotCliReview: true,
+        simulationReview: true,
+        simulationReviewConfig: {
+          enabled: true,
+          scenario: 'actionable-findings'
+        }
+      }
+    }),
+    'utf8'
+  );
+
+  const policy = await loadAgentReviewPolicy(repoRoot);
+  assert.deepEqual(policy.reviewProviders, ['copilot-cli', 'simulation']);
+  assert.equal(policy.simulation.enabled, true);
+  assert.equal(policy.simulation.scenario, 'actionable-findings');
+});
+
+test('runAgentReviewPolicy skips cleanly when no providers are requested', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-skip-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'skipped');
+  assert.equal(result.receipt.overall.status, 'skipped');
+});
+
+test('runAgentReviewPolicy combines Copilot CLI and Simulation providers into one deterministic receipt', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-pass-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['copilot-cli', 'simulation']
+    },
+    runCopilotCliReviewFn: async () => ({
+      providerId: 'copilot-cli',
+      status: 'passed',
+      reason: 'Copilot CLI passed.',
+      receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Copilot CLI passed.'
+        }
+      }
+    }),
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'passed',
+      reason: 'Simulation passed.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Simulation passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providerSelection.selectionSource, 'explicit-request');
+  assert.deepEqual(result.receipt.providerSelection.explicitProviders, ['copilot-cli', 'simulation']);
+  assert.deepEqual(result.receipt.providerSelection.policyProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.impliedProviders, []);
+  assert.deepEqual(result.receipt.requestedProviders, ['copilot-cli', 'simulation']);
+  assert.equal(result.receipt.providers['copilot-cli'].status, 'passed');
+  assert.equal(result.receipt.providers.simulation.status, 'passed');
+});
+
+test('runAgentReviewPolicy forwards the requested execution profile to the Copilot CLI provider', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-profile-'));
+  let observedProfile = null;
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      profile: 'pre-push',
+      reviewProviders: ['copilot-cli']
+    },
+    runCopilotCliReviewFn: async (options) => {
+      observedProfile = options.profile;
+      return {
+        providerId: 'copilot-cli',
+        status: 'passed',
+        reason: 'Copilot CLI passed.',
+        receiptPath: 'tests/results/_hooks/pre-push-copilot-cli-review.json',
+        receipt: {
+          overall: {
+            status: 'passed',
+            actionableFindingCount: 0,
+            message: 'Copilot CLI passed.'
+          }
+        }
+      };
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(observedProfile, 'pre-push');
+  assert.equal(result.receipt.profile, 'pre-push');
+  assert.match(result.receiptPath, /_hooks[\\/]pre-push-agent-review-policy\.json$/);
+});
+
+test('runAgentReviewPolicy preserves explicit provider ordering in the combined receipt', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-order-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['simulation', 'copilot-cli']
+    },
+    runCopilotCliReviewFn: async () => ({
+      providerId: 'copilot-cli',
+      status: 'passed',
+      reason: 'Copilot CLI passed.',
+      receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Copilot CLI passed.'
+        }
+      }
+    }),
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'passed',
+      reason: 'Simulation passed.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Simulation passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.deepEqual(result.receipt.requestedProviders, ['simulation', 'copilot-cli']);
+  assert.deepEqual(result.receipt.executedProviders, ['simulation', 'copilot-cli']);
+  assert.deepEqual(result.receipt.recommendedReviewOrder, ['simulation', 'copilot-cli']);
+});
+
+test('runAgentReviewPolicy fails closed when the Simulation provider surfaces a regression seam', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-fail-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      simulationReview: true
+    },
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'failed',
+      reason: 'Simulation injected a stale-head failure.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'failed',
+          actionableFindingCount: 1,
+          message: 'Simulation injected a stale-head failure.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.failedProvider, 'simulation');
+});
+
+test('runAgentReviewPolicy fails closed when an explicitly selected reserved provider is not implemented', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-reserved-provider-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['codex-cli']
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.failedProvider, 'codex-cli');
+  assert.equal(result.receipt.providers['codex-cli'].status, 'failed');
+  assert.match(result.receipt.providers['codex-cli'].reason, /not implemented yet/i);
+});
+
+test('runAgentReviewPolicy records policy-default provider selection when no explicit providers are requested', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-policy-default-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true
+    },
+    policy: {
+      reviewProviders: ['simulation']
+    },
+    runSimulationReviewFn: async () => ({
+      providerId: 'simulation',
+      status: 'passed',
+      reason: 'Simulation passed.',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Simulation passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providerSelection.selectionSource, 'policy-default');
+  assert.deepEqual(result.receipt.providerSelection.explicitProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.policyProviders, ['simulation']);
+  assert.deepEqual(result.receipt.providerSelection.impliedProviders, []);
+  assert.deepEqual(result.receipt.requestedProviders, ['simulation']);
+});
+
+test('runAgentReviewPolicy records legacy-boolean fallback provider selection when deriving providers from booleans', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-legacy-fallback-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      copilotCliReview: true
+    },
+    runCopilotCliReviewFn: async () => ({
+      providerId: 'copilot-cli',
+      status: 'passed',
+      reason: 'Copilot CLI passed.',
+      receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Copilot CLI passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providerSelection.selectionSource, 'legacy-boolean-fallback');
+  assert.deepEqual(result.receipt.providerSelection.explicitProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.policyProviders, []);
+  assert.deepEqual(result.receipt.providerSelection.impliedProviders, ['copilot-cli']);
+  assert.deepEqual(result.receipt.requestedProviders, ['copilot-cli']);
+});

--- a/tools/priority/__tests__/copilot-cli-review.test.mjs
+++ b/tools/priority/__tests__/copilot-cli-review.test.mjs
@@ -1,0 +1,629 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+  buildReviewPrompt,
+  collectReviewContext,
+  loadCopilotCliReviewPolicy,
+  normalizeCopilotCliReviewPolicy,
+  runCopilotCliReview
+} from '../copilot-cli-review.mjs';
+
+function runGit(repoRoot, args) {
+  const result = spawnSync('git', ['-C', repoRoot, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout || `git ${args.join(' ')} failed`);
+  return result.stdout.trim();
+}
+
+test('normalizeCopilotCliReviewPolicy keeps the prompt-only no-tool default', () => {
+  const policy = normalizeCopilotCliReviewPolicy({});
+  assert.equal(policy.allowAllTools, false);
+  assert.equal(policy.availableTools, '');
+  assert.equal(policy.promptOnly, true);
+  assert.deepEqual(policy.convergence, {
+    minPasses: 2,
+    maxPasses: 4,
+    stopOnCleanPass: true,
+    stopOnNoNovelFindingsCount: 2,
+    promoteInstructionGapAfterRepeatedFindings: 2
+  });
+  assert.deepEqual(policy.collaboration, DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration);
+});
+
+test('loadCopilotCliReviewPolicy reads copilotCliReviewConfig and honors the boolean enable gate', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-policy-'));
+  await mkdir(path.join(repoRoot, 'tools', 'priority'), { recursive: true });
+  await writeFile(
+    path.join(repoRoot, 'tools', 'priority', 'delivery-agent.policy.json'),
+    JSON.stringify({
+      localReviewLoop: {
+        copilotCliReview: false,
+        copilotCliReviewConfig: {
+          model: 'gpt-5.5-mini',
+          availableTools: 'grep,cat'
+        }
+      }
+    }, null, 2),
+    'utf8'
+  );
+
+  const policy = await loadCopilotCliReviewPolicy(repoRoot);
+  assert.equal(policy.enabled, false);
+  assert.equal(policy.model, 'gpt-5.5-mini');
+  assert.equal(policy.availableTools, 'grep,cat');
+});
+
+test('buildReviewPrompt includes collaboration planes and instruction presence', () => {
+  const prompt = buildReviewPrompt({
+    collaboration: DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration,
+    context: {
+      mode: 'staged',
+      git: {
+        headSha: 'abc123',
+        branch: 'issue/test'
+      },
+      baseRef: null,
+      selectedFiles: ['docs/example.md'],
+      omittedFileCount: 0,
+      diffBytes: 12,
+      diffTruncated: false,
+      diffText: 'diff --git a/docs/example.md b/docs/example.md'
+    },
+    instructionSources: {
+      present: ['AGENTS.md', '.github/instructions/draft-only-copilot-review.instructions.md'],
+      missing: ['.github/copilot-instructions.md']
+    },
+    profileName: 'preCommit',
+    repoRoot: '/tmp/repo'
+  });
+
+  assert.match(prompt, /Authoring plane: personal \(codex\)/);
+  assert.match(prompt, /Review plane: origin \(copilot-cli\)/);
+  assert.match(prompt, /AGENTS\.md/);
+  assert.match(prompt, /\.github\/copilot-instructions\.md/);
+});
+
+test('runCopilotCliReview writes a deterministic passed receipt for staged review', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(repoRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(repoRoot, 'AGENTS.md'), '# Agent handbook\n', 'utf8');
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(repoRoot, ['add', 'AGENTS.md', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'init']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n\nupdated\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+
+  const result = await runCopilotCliReview({
+    repoRoot,
+    profile: 'pre-commit',
+    stagedFiles: ['README.md'],
+    policy: {
+      ...DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+      profiles: {
+        ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles,
+        preCommit: {
+          ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.preCommit,
+          receiptPath: 'tests/results/_hooks/pre-commit-copilot-cli-review.json'
+        }
+      }
+    },
+    runCommandFn: async () => ({
+      status: 0,
+      stdout: [
+        JSON.stringify({ type: 'session.tools_updated', data: { model: 'gpt-5.4-mini' } }),
+        JSON.stringify({
+          type: 'assistant.message',
+          data: {
+            content: JSON.stringify({
+              status: 'approved',
+              summary: 'No actionable local findings.',
+              findings: []
+            })
+          }
+        }),
+        JSON.stringify({ type: 'result', data: { ok: true } })
+      ].join('\n'),
+      stderr: ''
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.overall.status, 'passed');
+  assert.equal(result.receipt.copilot.model, 'gpt-5.4-mini');
+  assert.equal(result.receipt.context.selectedFiles[0], 'README.md');
+  assert.equal(result.receipt.convergence.passCount, 2);
+  assert.equal(result.receipt.convergence.stoppedReason, 'clean-pass');
+  assert.equal(result.receipt.passes.length, 2);
+  await access(path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit-copilot-cli-review.prompt.txt'));
+  await access(path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit-copilot-cli-review.jsonl'));
+  await access(path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit-copilot-cli-review.pass-1.jsonl'));
+  await access(path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit-copilot-cli-review.pass-2.jsonl'));
+});
+
+test('runCopilotCliReview forwards non-empty availableTools allowlists to the CLI invocation', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-tools-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(repoRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'init']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n\nupdated\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+
+  const invocations = [];
+  const result = await runCopilotCliReview({
+    repoRoot,
+    profile: 'pre-commit',
+    policy: {
+      ...DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+      availableTools: 'grep,cat'
+    },
+    runCommandFn: async (command, args) => {
+      invocations.push({ command, args });
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          type: 'assistant.message',
+          data: {
+            content: JSON.stringify({
+              status: 'approved',
+              summary: 'No actionable findings.',
+              findings: []
+            })
+          }
+        }),
+        stderr: ''
+      };
+    }
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.match(invocations[0].args.join(' '), /--available-tools grep,cat/);
+});
+
+test('runCopilotCliReview fails closed on actionable findings', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-findings-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(repoRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'init']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n\nupdated\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+
+  const result = await runCopilotCliReview({
+    repoRoot,
+    profile: 'pre-commit',
+    stagedFiles: ['README.md'],
+    runCommandFn: async () => ({
+      status: 0,
+      stdout: JSON.stringify({
+        type: 'assistant.message',
+        data: {
+          content: JSON.stringify({
+            status: 'changes-requested',
+            summary: 'Needs a fix.',
+            findings: [
+              {
+                severity: 'warning',
+                path: 'README.md',
+                line: 2,
+                title: 'Adjust wording',
+                body: 'This line needs a correction.',
+                actionable: true
+              }
+            ]
+          })
+        }
+      }),
+      stderr: ''
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.actionableFindingCount, 1);
+  assert.equal(result.receipt.findings[0].path, 'README.md');
+  assert.equal(result.receipt.convergence.passCount, 3);
+  assert.equal(result.receipt.convergence.stoppedReason, 'no-novel-findings');
+  assert.equal(result.receipt.convergence.instructionGapCandidate, true);
+  assert.equal(result.receipt.convergence.repeatedFindingFingerprints.length, 1);
+});
+
+test('runCopilotCliReview supports report-only profiles when failOnFindings is disabled', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-report-only-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(repoRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'init']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n\nupdated\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+
+  const result = await runCopilotCliReview({
+    repoRoot,
+    profile: 'pre-commit',
+    policy: {
+      ...DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+      profiles: {
+        ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles,
+        preCommit: {
+          ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.preCommit,
+          failOnFindings: false
+        }
+      }
+    },
+    runCommandFn: async () => ({
+      status: 0,
+      stdout: JSON.stringify({
+        type: 'assistant.message',
+        data: {
+          content: JSON.stringify({
+            status: 'changes-requested',
+            summary: 'Needs follow-up.',
+            findings: [
+              {
+                severity: 'warning',
+                path: 'README.md',
+                line: 2,
+                title: 'Adjust wording',
+                body: 'This line needs a correction.',
+                actionable: true
+              }
+            ]
+          })
+        }
+      }),
+      stderr: ''
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.overall.status, 'passed');
+  assert.match(result.receipt.overall.message, /report-only mode/i);
+  assert.equal(result.receipt.overall.actionableFindingCount, 1);
+});
+
+test('runCopilotCliReview accumulates novel findings across bounded passes', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-convergence-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(repoRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'init']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n\nupdated\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+
+  let invocation = 0;
+  const payloads = [
+    {
+      status: 'changes-requested',
+      summary: 'First finding.',
+      findings: [
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 2,
+          title: 'Adjust wording',
+          body: 'First finding body.',
+          actionable: true
+        }
+      ]
+    },
+    {
+      status: 'changes-requested',
+      summary: 'Second finding.',
+      findings: [
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 2,
+          title: 'Adjust wording',
+          body: 'First finding body.',
+          actionable: true
+        },
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 3,
+          title: 'Add coverage',
+          body: 'Second finding body.',
+          actionable: true
+        }
+      ]
+    },
+    {
+      status: 'changes-requested',
+      summary: 'No novel findings remain.',
+      findings: [
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 2,
+          title: 'Adjust wording',
+          body: 'First finding body.',
+          actionable: true
+        },
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 3,
+          title: 'Add coverage',
+          body: 'Second finding body.',
+          actionable: true
+        }
+      ]
+    },
+    {
+      status: 'changes-requested',
+      summary: 'Still no novel findings remain.',
+      findings: [
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 2,
+          title: 'Adjust wording',
+          body: 'First finding body.',
+          actionable: true
+        },
+        {
+          severity: 'warning',
+          path: 'README.md',
+          line: 3,
+          title: 'Add coverage',
+          body: 'Second finding body.',
+          actionable: true
+        }
+      ]
+    }
+  ];
+
+  const result = await runCopilotCliReview({
+    repoRoot,
+    profile: 'pre-commit',
+    stagedFiles: ['README.md'],
+    runCommandFn: async () => {
+      const payload = payloads[Math.min(invocation, payloads.length - 1)];
+      invocation += 1;
+      return {
+        status: 0,
+        stdout: [
+          JSON.stringify({ type: 'session.tools_updated', data: { model: 'gpt-5.4' } }),
+          JSON.stringify({
+            type: 'assistant.message',
+            data: {
+              content: JSON.stringify(payload)
+            }
+          })
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.actionableFindingCount, 2);
+  assert.equal(result.receipt.convergence.passCount, 4);
+  assert.equal(result.receipt.convergence.stoppedReason, 'no-novel-findings');
+  assert.equal(result.receipt.passes[0].novelActionableFindingCount, 1);
+  assert.equal(result.receipt.passes[1].novelActionableFindingCount, 1);
+  assert.equal(result.receipt.passes[2].novelActionableFindingCount, 0);
+  assert.equal(result.receipt.passes[3].noNovelFindingStreak, 2);
+});
+
+test('runCopilotCliReview resolves head-mode merge base from the validate base sha env when upstream refs are absent', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-head-env-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(repoRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(repoRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(repoRoot, ['add', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'init']);
+  const baseSha = runGit(repoRoot, ['rev-parse', 'HEAD']);
+  await writeFile(path.join(repoRoot, 'docs.md'), '# docs\n', 'utf8');
+  runGit(repoRoot, ['add', 'docs.md']);
+  runGit(repoRoot, ['commit', '-m', 'update']);
+
+  const previousValidateBaseSha = process.env.VALIDATE_BASE_SHA;
+  const previousValidateBaseRef = process.env.VALIDATE_BASE_REF;
+  try {
+    process.env.VALIDATE_BASE_SHA = baseSha;
+    process.env.VALIDATE_BASE_REF = 'develop';
+
+    const result = await runCopilotCliReview({
+      repoRoot,
+      profile: 'daemon',
+      runCommandFn: async () => ({
+        status: 0,
+        stdout: [
+          JSON.stringify({ type: 'session.tools_updated', data: { model: 'gpt-5.4' } }),
+          JSON.stringify({
+            type: 'assistant.message',
+            data: {
+              content: JSON.stringify({
+                status: 'approved',
+                summary: 'No actionable findings.',
+                findings: []
+              })
+            }
+          })
+        ].join('\n'),
+        stderr: ''
+      })
+    });
+
+    assert.equal(result.status, 'passed');
+    assert.equal(result.receipt.context.baseRef, baseSha);
+    assert.deepEqual(result.receipt.context.selectedFiles, ['docs.md']);
+  } finally {
+    if (previousValidateBaseSha == null) {
+      delete process.env.VALIDATE_BASE_SHA;
+    } else {
+      process.env.VALIDATE_BASE_SHA = previousValidateBaseSha;
+    }
+    if (previousValidateBaseRef == null) {
+      delete process.env.VALIDATE_BASE_REF;
+    } else {
+      process.env.VALIDATE_BASE_REF = previousValidateBaseRef;
+    }
+  }
+});
+
+test('runCopilotCliReview fetches the validate base in detached-head CI when only the PR head was checked out', async () => {
+  const sourceRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-source-'));
+  runGit(sourceRoot, ['init']);
+  runGit(sourceRoot, ['config', 'user.name', 'Agent Runner']);
+  runGit(sourceRoot, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(sourceRoot, 'README.md'), '# repo\n', 'utf8');
+  runGit(sourceRoot, ['add', 'README.md']);
+  runGit(sourceRoot, ['commit', '-m', 'init']);
+  runGit(sourceRoot, ['branch', '-M', 'develop']);
+  const baseSha = runGit(sourceRoot, ['rev-parse', 'HEAD']);
+  runGit(sourceRoot, ['switch', '-c', 'issue/test']);
+  await writeFile(path.join(sourceRoot, 'docs.md'), '# docs\n', 'utf8');
+  runGit(sourceRoot, ['add', 'docs.md']);
+  runGit(sourceRoot, ['commit', '-m', 'update']);
+
+  const remoteRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-remote-'));
+  runGit(path.dirname(remoteRoot), ['clone', '--bare', sourceRoot, remoteRoot]);
+
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'copilot-cli-review-detached-'));
+  runGit(repoRoot, ['init']);
+  runGit(repoRoot, ['remote', 'add', 'origin', remoteRoot]);
+  runGit(repoRoot, ['fetch', '--depth=1', 'origin', 'issue/test']);
+  runGit(repoRoot, ['checkout', '--detach', 'FETCH_HEAD']);
+
+  const previousGithubActions = process.env.GITHUB_ACTIONS;
+  const previousValidateBaseSha = process.env.VALIDATE_BASE_SHA;
+  const previousValidateBaseRef = process.env.VALIDATE_BASE_REF;
+  try {
+    process.env.GITHUB_ACTIONS = 'true';
+    process.env.VALIDATE_BASE_SHA = baseSha;
+    process.env.VALIDATE_BASE_REF = 'develop';
+
+    const result = await runCopilotCliReview({
+      repoRoot,
+      profile: 'daemon',
+      runCommandFn: async () => ({
+        status: 0,
+        stdout: [
+          JSON.stringify({ type: 'session.tools_updated', data: { model: 'gpt-5.4' } }),
+          JSON.stringify({
+            type: 'assistant.message',
+            data: {
+              content: JSON.stringify({
+                status: 'approved',
+                summary: 'No actionable findings.',
+                findings: []
+              })
+            }
+          })
+        ].join('\n'),
+        stderr: ''
+      })
+    });
+
+    assert.equal(result.status, 'passed');
+    assert.equal(result.receipt.context.baseRef, baseSha);
+    assert.deepEqual(result.receipt.context.selectedFiles, ['docs.md']);
+  } finally {
+    if (previousGithubActions == null) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = previousGithubActions;
+    }
+    if (previousValidateBaseSha == null) {
+      delete process.env.VALIDATE_BASE_SHA;
+    } else {
+      process.env.VALIDATE_BASE_SHA = previousValidateBaseSha;
+    }
+    if (previousValidateBaseRef == null) {
+      delete process.env.VALIDATE_BASE_REF;
+    } else {
+      process.env.VALIDATE_BASE_REF = previousValidateBaseRef;
+    }
+  }
+});
+
+test('collectReviewContext fails closed when staged file discovery errors', () => {
+  const repoRoot = 'C:/repo';
+  const runGitFn = (candidateRepoRoot, args) => {
+    assert.equal(candidateRepoRoot, repoRoot);
+    if (args.join(' ') === 'rev-parse HEAD') {
+      return { status: 0, stdout: 'abc123\n', stderr: '' };
+    }
+    if (args.join(' ') === 'branch --show-current') {
+      return { status: 0, stdout: 'issue/test\n', stderr: '' };
+    }
+    if (args.join(' ') === 'merge-base HEAD upstream/develop') {
+      return { status: 0, stdout: 'base123\n', stderr: '' };
+    }
+    if (args.join(' ') === 'status --short --untracked-files=no') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (args.join(' ') === 'diff --cached --name-only --diff-filter=ACMRT') {
+      return { status: 1, stdout: '', stderr: 'fatal: bad index\n' };
+    }
+    throw new Error(`Unexpected git command: ${args.join(' ')}`);
+  };
+
+  assert.throws(
+    () => collectReviewContext({ repoRoot, mode: 'staged', maxFiles: 5, maxDiffBytes: 1024, runGitFn }),
+    /fatal: bad index/
+  );
+});
+
+test('collectReviewContext fails closed when head-mode changed-file discovery errors', () => {
+  const repoRoot = 'C:/repo';
+  const runGitFn = (candidateRepoRoot, args) => {
+    assert.equal(candidateRepoRoot, repoRoot);
+    const key = args.join(' ');
+    if (key === 'rev-parse HEAD') {
+      return { status: 0, stdout: 'abc123\n', stderr: '' };
+    }
+    if (key === 'branch --show-current') {
+      return { status: 0, stdout: 'issue/test\n', stderr: '' };
+    }
+    if (key === 'merge-base HEAD upstream/develop') {
+      return { status: 0, stdout: 'base123\n', stderr: '' };
+    }
+    if (key === 'status --short --untracked-files=no') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (key === 'merge-base HEAD upstream/develop' || key === 'merge-base HEAD origin/develop') {
+      return { status: 0, stdout: 'base123\n', stderr: '' };
+    }
+    if (key === 'merge-base HEAD origin/develop') {
+      return { status: 0, stdout: 'base123\n', stderr: '' };
+    }
+    if (key === 'merge-base HEAD base123') {
+      return { status: 0, stdout: 'base123\n', stderr: '' };
+    }
+    if (key === 'diff --name-only --diff-filter=ACMRT base123..HEAD') {
+      return { status: 1, stdout: '', stderr: 'fatal: bad revision\n' };
+    }
+    if (key === 'rev-parse HEAD~1') {
+      return { status: 0, stdout: 'base123\n', stderr: '' };
+    }
+    throw new Error(`Unexpected git command: ${key}`);
+  };
+
+  assert.throws(
+    () => collectReviewContext({ repoRoot, mode: 'head', maxFiles: 5, maxDiffBytes: 1024, runGitFn }),
+    /fatal: bad revision/
+  );
+});

--- a/tools/priority/__tests__/local-review-providers.test.mjs
+++ b/tools/priority/__tests__/local-review-providers.test.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  describeLocalReviewProvider,
+  executeLocalReviewProvider,
+  normalizeLocalReviewProfile,
+  normalizeLocalReviewProviderId,
+  normalizeLocalReviewProviderList,
+  normalizeLocalReviewProviderPolicies
+} from '../local-review-providers.mjs';
+
+test('normalizeLocalReviewProviderId accepts supported provider ids and rejects unknown ones', () => {
+  assert.equal(normalizeLocalReviewProviderId('copilot-cli'), 'copilot-cli');
+  assert.equal(normalizeLocalReviewProviderId('  simulation  '), 'simulation');
+  assert.throws(() => normalizeLocalReviewProviderId('review-bot'), /Unsupported local review provider/i);
+});
+
+test('normalizeLocalReviewProviderList deduplicates while preserving requested order', () => {
+  const providers = normalizeLocalReviewProviderList(['simulation', 'copilot-cli', 'simulation', 'codex-cli']);
+  assert.deepEqual(providers, ['simulation', 'copilot-cli', 'codex-cli']);
+});
+
+test('normalizeLocalReviewProfile defaults to daemon and rejects unsupported profiles', () => {
+  assert.equal(normalizeLocalReviewProfile(''), 'daemon');
+  assert.equal(normalizeLocalReviewProfile('pre-push'), 'pre-push');
+  assert.throws(() => normalizeLocalReviewProfile('commit-msg'), /Unsupported local review profile/i);
+});
+
+test('normalizeLocalReviewProviderPolicies keeps executable and reserved providers distinct', () => {
+  const policies = normalizeLocalReviewProviderPolicies({
+    reviewProviders: ['copilot-cli', 'simulation', 'codex-cli', 'ollama']
+  });
+  assert.deepEqual(policies.reviewProviders, ['copilot-cli', 'simulation', 'codex-cli', 'ollama']);
+  assert.equal(policies.codexCli.enabled, false);
+  assert.equal(policies.ollama.enabled, false);
+});
+
+test('executeLocalReviewProvider routes Copilot CLI through the provider registry', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-review-provider-copilot-'));
+  let observedOptions = null;
+  const result = await executeLocalReviewProvider({
+    providerId: 'copilot-cli',
+    repoRoot,
+    executionProfile: 'pre-commit',
+    policies: {
+      reviewProviders: ['copilot-cli'],
+      copilotCli: {
+        enabled: true,
+        model: 'gpt-5.5-mini'
+      }
+    },
+    runCopilotCliReviewFn: async (options) => {
+      observedOptions = options;
+      return {
+        status: 'passed',
+        reason: 'Copilot CLI passed.',
+        receiptPath: 'tests/results/docker-tools-parity/copilot-cli-review/receipt.json',
+        receipt: {
+          overall: {
+            status: 'passed',
+            actionableFindingCount: 0,
+            message: 'Copilot CLI passed.'
+          }
+        }
+      };
+    }
+  });
+
+  assert.equal(result.providerId, 'copilot-cli');
+  assert.equal(result.status, 'passed');
+  assert.equal(observedOptions.profile, 'pre-commit');
+  assert.equal(observedOptions.policy.model, 'gpt-5.5-mini');
+});
+
+test('executeLocalReviewProvider routes Simulation through the provider registry', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-review-provider-simulation-'));
+  let observedOptions = null;
+  const result = await executeLocalReviewProvider({
+    providerId: 'simulation',
+    repoRoot,
+    executionProfile: 'daemon',
+    policies: {
+      reviewProviders: ['simulation'],
+      simulation: {
+        enabled: true,
+        scenario: 'provider-failure'
+      }
+    },
+    runSimulationReviewFn: async (options) => {
+      observedOptions = options;
+      return {
+        status: 'failed',
+        reason: 'Simulation failed.',
+        receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json',
+        receipt: {
+          overall: {
+            status: 'failed',
+            actionableFindingCount: 0,
+            message: 'Simulation failed.'
+          }
+        }
+      };
+    }
+  });
+
+  assert.equal(result.providerId, 'simulation');
+  assert.equal(result.status, 'failed');
+  assert.equal(observedOptions.policy.scenario, 'provider-failure');
+});
+
+test('executeLocalReviewProvider fails closed for reserved providers', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-review-provider-reserved-'));
+  const result = await executeLocalReviewProvider({
+    providerId: 'codex-cli',
+    repoRoot,
+    repoGitState: {
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    }
+  });
+
+  assert.equal(result.providerId, 'codex-cli');
+  assert.equal(result.status, 'failed');
+  assert.match(result.reason, /not implemented yet/i);
+});
+
+test('describeLocalReviewProvider marks executable and reserved providers correctly', () => {
+  assert.deepEqual(describeLocalReviewProvider('copilot-cli'), {
+    providerId: 'copilot-cli',
+    executable: true,
+    reserved: false,
+    supportsProfiles: ['pre-commit', 'daemon', 'pre-push']
+  });
+  assert.deepEqual(describeLocalReviewProvider('ollama'), {
+    providerId: 'ollama',
+    executable: false,
+    reserved: true,
+    supportsProfiles: ['pre-commit', 'daemon', 'pre-push']
+  });
+});

--- a/tools/priority/__tests__/simulation-review.test.mjs
+++ b/tools/priority/__tests__/simulation-review.test.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { normalizeSimulationReviewPolicy, runSimulationReview } from '../simulation-review.mjs';
+
+test('normalizeSimulationReviewPolicy keeps the deterministic clean-pass default', () => {
+  const policy = normalizeSimulationReviewPolicy({});
+  assert.equal(policy.enabled, false);
+  assert.equal(policy.scenario, 'clean-pass');
+  assert.match(policy.receiptPath, /simulation-review[\\/]+receipt\.json$/);
+});
+
+test('runSimulationReview passes cleanly for the clean-pass scenario', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'simulation-review-pass-'));
+  const result = await runSimulationReview({
+    repoRoot,
+    policy: {
+      enabled: true,
+      scenario: 'clean-pass',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json'
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.overall.status, 'passed');
+  assert.equal(result.receipt.git.headSha, 'abc123');
+  assert.equal(result.receipt.findings.length, 0);
+});
+
+test('runSimulationReview fails closed with actionable findings for the actionable-findings scenario', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'simulation-review-findings-'));
+  const result = await runSimulationReview({
+    repoRoot,
+    policy: {
+      enabled: true,
+      scenario: 'actionable-findings',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json'
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.status, 'failed');
+  assert.equal(result.receipt.overall.actionableFindingCount, 1);
+  assert.equal(result.receipt.findings[0].actionable, true);
+});
+
+test('runSimulationReview can exercise stale-head seams deterministically', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'simulation-review-stale-head-'));
+  const result = await runSimulationReview({
+    repoRoot,
+    policy: {
+      enabled: true,
+      scenario: 'stale-head',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json'
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.match(result.receipt.git.headSha, /-stale$/);
+  const persisted = JSON.parse(
+    await readFile(path.join(repoRoot, 'tests', 'results', 'docker-tools-parity', 'simulation-review', 'receipt.json'), 'utf8')
+  );
+  assert.equal(persisted.scenario, 'stale-head');
+});
+
+test('runSimulationReview marks the tracked tree dirty for the dirty-tracked scenario', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'simulation-review-dirty-tracked-'));
+  const result = await runSimulationReview({
+    repoRoot,
+    policy: {
+      enabled: true,
+      scenario: 'dirty-tracked',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json'
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.status, 'failed');
+  assert.equal(result.receipt.git.dirtyTracked, true);
+  assert.equal(result.receipt.findings.length, 0);
+});
+
+test('runSimulationReview reports deterministic provider failure without inventing findings', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'simulation-review-provider-failure-'));
+  const result = await runSimulationReview({
+    repoRoot,
+    policy: {
+      enabled: true,
+      scenario: 'provider-failure',
+      receiptPath: 'tests/results/docker-tools-parity/simulation-review/receipt.json'
+    },
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.receipt.overall.status, 'failed');
+  assert.equal(result.receipt.overall.actionableFindingCount, 0);
+  assert.equal(result.receipt.findings.length, 0);
+});

--- a/tools/priority/agent-review-policy.mjs
+++ b/tools/priority/agent-review-policy.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+export * from '../local-collab/providers/agent-review-policy.mjs';
+
+import { main } from '../local-collab/providers/agent-review-policy.mjs';
+import { isEntrypoint } from '../local-collab/providers/shim-utils.mjs';
+
+if (isEntrypoint(import.meta.url)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/priority/copilot-cli-review.mjs
+++ b/tools/priority/copilot-cli-review.mjs
@@ -1,0 +1,1079 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const COPILOT_CLI_REVIEW_SCHEMA = 'priority/copilot-cli-review@v1';
+export const DELIVERY_AGENT_POLICY_PATH = path.join('tools', 'priority', 'delivery-agent.policy.json');
+export const DEFAULT_COPILOT_CLI_MODEL = 'gpt-5.4';
+export const DEFAULT_COPILOT_CLI_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+
+export const DEFAULT_COPILOT_CLI_REVIEW_POLICY = {
+  enabled: true,
+  model: DEFAULT_COPILOT_CLI_MODEL,
+  promptOnly: true,
+  disableBuiltinMcps: true,
+  allowAllTools: false,
+  availableTools: '',
+  convergence: {
+    minPasses: 2,
+    maxPasses: 4,
+    stopOnCleanPass: true,
+    stopOnNoNovelFindingsCount: 2,
+    promoteInstructionGapAfterRepeatedFindings: 2
+  },
+  profiles: {
+    preCommit: {
+      enabled: true,
+      mode: 'staged',
+      receiptPath: path.join('tests', 'results', '_hooks', 'pre-commit-copilot-cli-review.json'),
+      failOnFindings: true,
+      maxFiles: 12,
+      maxDiffBytes: 12 * 1024
+    },
+    daemon: {
+      enabled: true,
+      mode: 'head',
+      receiptPath: path.join('tests', 'results', 'docker-tools-parity', 'copilot-cli-review', 'receipt.json'),
+      failOnFindings: true,
+      maxFiles: 24,
+      maxDiffBytes: 16 * 1024
+    },
+    prePush: {
+      enabled: true,
+      mode: 'head',
+      receiptPath: path.join('tests', 'results', '_hooks', 'pre-push-copilot-cli-review.json'),
+      failOnFindings: true,
+      maxFiles: 24,
+      maxDiffBytes: 16 * 1024
+    }
+  },
+  collaboration: {
+    coordinationRemote: 'upstream',
+    coordinationPersona: 'daemon',
+    authoringRemote: 'personal',
+    authoringPersona: 'codex',
+    reviewRemote: 'origin',
+    reviewPersona: 'copilot-cli'
+  }
+};
+
+const PROFILE_NAME_MAP = new Map([
+  ['pre-commit', 'preCommit'],
+  ['preCommit', 'preCommit'],
+  ['daemon', 'daemon'],
+  ['pre-push', 'prePush'],
+  ['prePush', 'prePush']
+]);
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function toIso(value = new Date()) {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function coercePositiveInteger(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeStringList(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeText(entry)).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/\r?\n/)
+      .map((entry) => normalizeText(entry))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function normalizeProfileName(value) {
+  const normalized = PROFILE_NAME_MAP.get(normalizeText(value));
+  if (!normalized) {
+    throw new Error(`Unsupported Copilot CLI review profile: ${value}`);
+  }
+  return normalized;
+}
+
+function buildCommandResult(result = {}) {
+  return {
+    status: Number.isInteger(result.status) ? result.status : 1,
+    stdout: normalizeText(result.stdout),
+    stderr: [
+      normalizeText(result.stderr),
+      normalizeText(result.error?.message),
+      normalizeText(result.signal ? `Process terminated by signal ${result.signal}.` : '')
+    ]
+      .filter(Boolean)
+      .join('\n')
+  };
+}
+
+function runCommand(command, args, { cwd, env } = {}) {
+  return buildCommandResult(
+    spawnSync(command, args, {
+      cwd,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: DEFAULT_COPILOT_CLI_MAX_BUFFER_BYTES
+    })
+  );
+}
+
+function runGit(repoRoot, args, env = process.env) {
+  return runCommand('git', ['-C', repoRoot, ...args], { cwd: repoRoot, env });
+}
+
+function buildMergeBaseCandidates(env = process.env) {
+  const baseRef = normalizeText(env.VALIDATE_BASE_REF) || normalizeText(env.GITHUB_BASE_REF);
+  const baseSha = normalizeText(env.VALIDATE_BASE_SHA) || normalizeText(env.GITHUB_BASE_SHA);
+  const candidates = [];
+
+  if (baseSha) {
+    candidates.push(['merge-base', 'HEAD', baseSha]);
+  }
+  if (baseRef) {
+    candidates.push(['merge-base', 'HEAD', `upstream/${baseRef}`]);
+    candidates.push(['merge-base', 'HEAD', `origin/${baseRef}`]);
+    candidates.push(['merge-base', 'HEAD', baseRef]);
+  }
+  candidates.push(['merge-base', 'HEAD', 'upstream/develop']);
+  candidates.push(['merge-base', 'HEAD', 'origin/develop']);
+  candidates.push(['rev-parse', 'HEAD~1']);
+  return {
+    baseSha,
+    baseRef,
+    candidates
+  };
+}
+
+function resolveRepoPath(repoRoot, candidatePath) {
+  const normalized = normalizeText(candidatePath);
+  if (!normalized) {
+    throw new Error('Path must be a non-empty repo-relative path.');
+  }
+  if (path.isAbsolute(normalized)) {
+    throw new Error(`Path must be repo-relative: ${normalized}`);
+  }
+  const resolved = path.resolve(repoRoot, normalized);
+  const relativeToRepo = path.relative(repoRoot, resolved);
+  if (!relativeToRepo || relativeToRepo.startsWith('..') || path.isAbsolute(relativeToRepo)) {
+    throw new Error(`Path escapes the repository root: ${normalized}`);
+  }
+  return {
+    normalized,
+    resolved
+  };
+}
+
+function truncateText(value, maxBytes) {
+  const source = String(value ?? '');
+  if (!source) {
+    return {
+      text: '',
+      bytes: 0,
+      truncated: false
+    };
+  }
+  const buffer = Buffer.from(source, 'utf8');
+  if (!Number.isInteger(maxBytes) || maxBytes <= 0 || buffer.length <= maxBytes) {
+    return {
+      text: source,
+      bytes: buffer.length,
+      truncated: false
+    };
+  }
+  const truncatedBuffer = buffer.subarray(0, maxBytes);
+  const truncatedText = truncatedBuffer.toString('utf8');
+  return {
+    text: `${truncatedText}\n\n[diff truncated by copilot-cli-review wrapper]`,
+    bytes: buffer.length,
+    truncated: true
+  };
+}
+
+function parseCopilotJsonLines(raw) {
+  const events = [];
+  for (const line of normalizeText(raw).split(/\r?\n/)) {
+    const trimmed = normalizeText(line);
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      events.push(JSON.parse(trimmed));
+    } catch (error) {
+      throw new Error(`Unable to parse Copilot CLI JSONL event: ${error.message}`);
+    }
+  }
+  const model =
+    events.find((event) => normalizeText(event?.type) === 'session.tools_updated')?.data?.model ??
+    null;
+  const assistantContent =
+    [...events]
+      .reverse()
+      .find((event) => normalizeText(event?.type) === 'assistant.message')?.data?.content ??
+    '';
+  return {
+    events,
+    model: normalizeText(model) || null,
+    assistantContent: normalizeText(assistantContent)
+  };
+}
+
+function normalizeFinding(value) {
+  const finding = value && typeof value === 'object' ? value : {};
+  const severity = normalizeText(finding.severity).toLowerCase() || 'warning';
+  return {
+    severity: ['error', 'warning', 'note'].includes(severity) ? severity : 'warning',
+    path: normalizeText(finding.path) || null,
+    line: Number.isInteger(finding.line) && finding.line > 0 ? finding.line : null,
+    title: normalizeText(finding.title) || 'Copilot CLI finding',
+    body: normalizeText(finding.body) || '',
+    actionable: finding.actionable !== false
+  };
+}
+
+function parseStructuredAssistantPayload(assistantContent) {
+  const trimmed = normalizeText(assistantContent);
+  if (!trimmed) {
+    throw new Error('Copilot CLI did not return an assistant message.');
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(`Copilot CLI assistant message was not valid JSON: ${error.message}`);
+  }
+  const findings = Array.isArray(parsed.findings) ? parsed.findings.map(normalizeFinding) : [];
+  const status = normalizeText(parsed.status).toLowerCase() || (findings.length > 0 ? 'changes-requested' : 'approved');
+  return {
+    status: status === 'approved' ? 'approved' : 'changes-requested',
+    summary: normalizeText(parsed.summary) || null,
+    findings
+  };
+}
+
+function normalizeProfilePolicy(value = {}) {
+  const profile = value && typeof value === 'object' ? value : {};
+  return {
+    enabled: profile.enabled !== false,
+    mode: normalizeText(profile.mode).toLowerCase() === 'staged' ? 'staged' : 'head',
+    receiptPath: normalizeText(profile.receiptPath),
+    failOnFindings: profile.failOnFindings !== false,
+    maxFiles: coercePositiveInteger(profile.maxFiles),
+    maxDiffBytes: coercePositiveInteger(profile.maxDiffBytes)
+  };
+}
+
+function normalizeConvergencePolicy(value = {}) {
+  const convergence = value && typeof value === 'object' ? value : {};
+  const maxPasses = Math.max(coercePositiveInteger(convergence.maxPasses, 4), 1);
+  const minPasses = Math.min(Math.max(coercePositiveInteger(convergence.minPasses, 1), 1), maxPasses);
+  return {
+    minPasses,
+    maxPasses,
+    stopOnCleanPass: convergence.stopOnCleanPass !== false,
+    stopOnNoNovelFindingsCount: coercePositiveInteger(convergence.stopOnNoNovelFindingsCount, 2),
+    promoteInstructionGapAfterRepeatedFindings: coercePositiveInteger(
+      convergence.promoteInstructionGapAfterRepeatedFindings,
+      2
+    )
+  };
+}
+
+export function normalizeCopilotCliReviewPolicy(value = {}) {
+  const policy = value && typeof value === 'object' ? value : {};
+  const profiles = policy.profiles && typeof policy.profiles === 'object' ? policy.profiles : {};
+  const collaboration = policy.collaboration && typeof policy.collaboration === 'object' ? policy.collaboration : {};
+  return {
+    ...DEFAULT_COPILOT_CLI_REVIEW_POLICY,
+    ...policy,
+    model: normalizeText(policy.model) || DEFAULT_COPILOT_CLI_REVIEW_POLICY.model,
+    promptOnly: policy.promptOnly !== false,
+    disableBuiltinMcps: policy.disableBuiltinMcps !== false,
+    allowAllTools: policy.allowAllTools === true,
+    availableTools:
+      policy.availableTools === ''
+        ? ''
+        : normalizeText(policy.availableTools) || DEFAULT_COPILOT_CLI_REVIEW_POLICY.availableTools,
+    convergence: normalizeConvergencePolicy({
+      ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.convergence,
+      ...(policy.convergence && typeof policy.convergence === 'object' ? policy.convergence : {})
+    }),
+    profiles: {
+      preCommit: {
+        ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.preCommit,
+        ...normalizeProfilePolicy({
+          ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.preCommit,
+          ...profiles.preCommit
+        })
+      },
+      daemon: {
+        ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.daemon,
+        ...normalizeProfilePolicy({
+          ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.daemon,
+          ...profiles.daemon
+        })
+      },
+      prePush: {
+        ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.prePush,
+        ...normalizeProfilePolicy({
+          ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.profiles.prePush,
+          ...profiles.prePush
+        })
+      }
+    },
+    collaboration: {
+      ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration,
+      ...collaboration,
+      coordinationRemote:
+        normalizeText(collaboration.coordinationRemote) ||
+        DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration.coordinationRemote,
+      coordinationPersona:
+        normalizeText(collaboration.coordinationPersona) ||
+        DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration.coordinationPersona,
+      authoringRemote:
+        normalizeText(collaboration.authoringRemote) ||
+        DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration.authoringRemote,
+      authoringPersona:
+        normalizeText(collaboration.authoringPersona) ||
+        DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration.authoringPersona,
+      reviewRemote:
+        normalizeText(collaboration.reviewRemote) ||
+        DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration.reviewRemote,
+      reviewPersona:
+        normalizeText(collaboration.reviewPersona) ||
+        DEFAULT_COPILOT_CLI_REVIEW_POLICY.collaboration.reviewPersona
+    }
+  };
+}
+
+function normalizeFingerprintText(value) {
+  return normalizeText(value).replace(/\s+/g, ' ').toLowerCase();
+}
+
+function buildFindingFingerprint(finding) {
+  return [
+    normalizeFingerprintText(finding.severity),
+    normalizeFingerprintText(finding.path),
+    Number.isInteger(finding.line) ? String(finding.line) : '',
+    normalizeFingerprintText(finding.title),
+    normalizeFingerprintText(finding.body).slice(0, 160)
+  ].join('|');
+}
+
+function dedupeFindings(findings = []) {
+  const unique = [];
+  const seen = new Set();
+  for (const finding of findings) {
+    const fingerprint = buildFindingFingerprint(finding);
+    if (seen.has(fingerprint)) {
+      continue;
+    }
+    seen.add(fingerprint);
+    unique.push({
+      ...finding,
+      fingerprint
+    });
+  }
+  return unique;
+}
+
+export async function loadCopilotCliReviewPolicy(repoRoot) {
+  try {
+    const raw = JSON.parse(await readFile(path.join(repoRoot, DELIVERY_AGENT_POLICY_PATH), 'utf8'));
+    const localReviewLoop = raw?.localReviewLoop && typeof raw.localReviewLoop === 'object' ? raw.localReviewLoop : {};
+    const config =
+      localReviewLoop.copilotCliReviewConfig && typeof localReviewLoop.copilotCliReviewConfig === 'object'
+        ? localReviewLoop.copilotCliReviewConfig
+        : {};
+    return normalizeCopilotCliReviewPolicy({
+      ...config,
+      enabled: localReviewLoop.copilotCliReview !== false && config.enabled !== false
+    });
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return normalizeCopilotCliReviewPolicy({});
+    }
+    throw error;
+  }
+}
+
+export function resolveRepoGitState(repoRoot, runGitFn = runGit) {
+  const head = runGitFn(repoRoot, ['rev-parse', 'HEAD']);
+  const branch = runGitFn(repoRoot, ['branch', '--show-current']);
+  const mergeBase = runGitFn(repoRoot, ['merge-base', 'HEAD', 'upstream/develop']);
+  const dirty = runGitFn(repoRoot, ['status', '--short', '--untracked-files=no']);
+  return {
+    headSha: normalizeText(head.stdout) || null,
+    branch: normalizeText(branch.stdout) || null,
+    upstreamDevelopMergeBase: normalizeText(mergeBase.stdout) || null,
+    dirtyTracked: normalizeText(dirty.stdout).length > 0
+  };
+}
+
+function resolveMergeBase(repoRoot, env = process.env, runGitFn = runGit) {
+  const { baseRef, baseSha, candidates } = buildMergeBaseCandidates(env);
+  for (const candidate of candidates) {
+    const result = runGitFn(repoRoot, candidate);
+    if (result.status === 0 && normalizeText(result.stdout)) {
+      return normalizeText(result.stdout);
+    }
+  }
+  if (env.GITHUB_ACTIONS === 'true' && baseSha) {
+    for (const remote of ['origin', 'upstream']) {
+      const fetchResult = runGitFn(repoRoot, ['fetch', '--no-tags', '--prune', '--depth=1', remote, baseSha], env);
+      if (fetchResult.status !== 0) {
+        continue;
+      }
+      for (const candidate of [
+        ['merge-base', 'HEAD', baseSha],
+        ['merge-base', 'HEAD', 'FETCH_HEAD'],
+        ['rev-parse', baseSha]
+      ]) {
+        const result = runGitFn(repoRoot, candidate, env);
+        if (result.status === 0 && normalizeText(result.stdout)) {
+          return normalizeText(result.stdout);
+        }
+      }
+    }
+  }
+  if (baseRef && env.GITHUB_ACTIONS === 'true') {
+    for (const remote of ['origin', 'upstream']) {
+      const fetchResult = runGitFn(repoRoot, ['fetch', '--no-tags', '--prune', '--depth=1', remote, baseRef], env);
+      if (fetchResult.status !== 0) {
+        continue;
+      }
+      for (const candidate of [
+        ['merge-base', 'HEAD', `refs/remotes/${remote}/${baseRef}`],
+        ['merge-base', 'HEAD', 'FETCH_HEAD']
+      ]) {
+        const result = runGitFn(repoRoot, candidate, env);
+        if (result.status === 0 && normalizeText(result.stdout)) {
+          return normalizeText(result.stdout);
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function parseOptionalJsonArgument(raw) {
+  const normalized = normalizeText(raw);
+  if (!normalized) {
+    return [];
+  }
+  if (normalized.startsWith('@')) {
+    throw new Error('File-backed staged-files arguments are not supported; pass JSON directly.');
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(normalized);
+  } catch (error) {
+    throw new Error(`Unable to parse staged files JSON: ${error.message}`);
+  }
+  return normalizeStringList(parsed);
+}
+
+async function collectInstructionSources(repoRoot) {
+  const githubDir = path.join(repoRoot, '.github');
+  const instructionsDir = path.join(githubDir, 'instructions');
+  const present = [];
+  const missing = [];
+
+  const addPresent = (filePath) => {
+    if (existsSync(filePath)) {
+      present.push(path.relative(repoRoot, filePath).replace(/\\/g, '/'));
+    } else {
+      missing.push(path.relative(repoRoot, filePath).replace(/\\/g, '/'));
+    }
+  };
+
+  addPresent(path.join(repoRoot, 'AGENTS.md'));
+  addPresent(path.join(githubDir, 'copilot-instructions.md'));
+
+  if (existsSync(instructionsDir)) {
+    const entries = await readdir(instructionsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith('.instructions.md')) {
+        present.push(path.relative(repoRoot, path.join(instructionsDir, entry.name)).replace(/\\/g, '/'));
+      }
+    }
+  }
+
+  return {
+    present: Array.from(new Set(present)).sort(),
+    missing: Array.from(new Set(missing)).sort()
+  };
+}
+
+export function collectReviewContext({
+  repoRoot,
+  mode,
+  stagedFiles = [],
+  maxFiles,
+  maxDiffBytes,
+  env = process.env,
+  runGitFn = runGit
+}) {
+  const gitState = resolveRepoGitState(repoRoot, runGitFn);
+  const normalizedMode = mode === 'staged' ? 'staged' : 'head';
+  let changedFiles = [];
+  let diffArgs = [];
+  let baseRef = null;
+
+  if (normalizedMode === 'staged') {
+    if (stagedFiles.length > 0) {
+      changedFiles = stagedFiles;
+    } else {
+      const stagedDiff = runGitFn(repoRoot, ['diff', '--cached', '--name-only', '--diff-filter=ACMRT'], env);
+      if (stagedDiff.status !== 0) {
+        throw new Error(normalizeText(stagedDiff.stderr) || 'Unable to collect staged files for Copilot CLI review.');
+      }
+      changedFiles = normalizeStringList(stagedDiff.stdout);
+    }
+    diffArgs = ['diff', '--cached', '--unified=3', '--no-ext-diff'];
+  } else {
+    baseRef = resolveMergeBase(repoRoot, env, runGitFn);
+    if (!baseRef) {
+      throw new Error('Unable to resolve a merge base for Copilot CLI review.');
+    }
+    const headDiff = runGitFn(repoRoot, ['diff', '--name-only', '--diff-filter=ACMRT', `${baseRef}..HEAD`], env);
+    if (headDiff.status !== 0) {
+      throw new Error(normalizeText(headDiff.stderr) || 'Unable to collect changed files for Copilot CLI review.');
+    }
+    changedFiles = normalizeStringList(headDiff.stdout);
+    diffArgs = ['diff', '--unified=3', '--no-ext-diff', `${baseRef}..HEAD`];
+  }
+
+  const selectedFiles = changedFiles.slice(0, maxFiles);
+  if (selectedFiles.length === 0) {
+    return {
+      mode: normalizedMode,
+      git: gitState,
+      baseRef,
+      selectedFiles: [],
+      omittedFileCount: 0,
+      diffText: '',
+      diffBytes: 0,
+      diffTruncated: false
+    };
+  }
+
+  const diffResult = runGitFn(repoRoot, [...diffArgs, '--', ...selectedFiles], env);
+  if (diffResult.status !== 0) {
+    throw new Error(normalizeText(diffResult.stderr) || 'Unable to compute review diff.');
+  }
+  const diff = truncateText(diffResult.stdout, maxDiffBytes);
+  return {
+    mode: normalizedMode,
+    git: gitState,
+    baseRef,
+    selectedFiles,
+    omittedFileCount: Math.max(changedFiles.length - selectedFiles.length, 0),
+    diffText: diff.text,
+    diffBytes: diff.bytes,
+    diffTruncated: diff.truncated
+  };
+}
+
+export function buildReviewPrompt({
+  collaboration,
+  context,
+  instructionSources,
+  profileName,
+  repoRoot
+}) {
+  const selectedFiles = context.selectedFiles.map((entry) => `- ${entry}`).join('\n') || '- none';
+  const promptSections = [
+    'You are performing a deterministic local code review for compare-vi-cli-action.',
+    '',
+    'Review contract:',
+    `- Profile: ${profileName}`,
+    `- Repository root: ${repoRoot}`,
+    `- Review mode: ${context.mode}`,
+    `- Coordination plane: ${collaboration.coordinationRemote} (${collaboration.coordinationPersona})`,
+    `- Authoring plane: ${collaboration.authoringRemote} (${collaboration.authoringPersona})`,
+    `- Review plane: ${collaboration.reviewRemote} (${collaboration.reviewPersona})`,
+    `- Head SHA: ${context.git.headSha || 'unknown'}`,
+    `- Branch: ${context.git.branch || 'unknown'}`,
+    `- Merge base: ${context.baseRef || context.git.upstreamDevelopMergeBase || 'n/a'}`,
+    '',
+    'Instruction sources detected:',
+    ...(instructionSources.present.length > 0 ? instructionSources.present.map((entry) => `- ${entry}`) : ['- none']),
+    '',
+    'Instruction sources missing:',
+    ...(instructionSources.missing.length > 0 ? instructionSources.missing.map((entry) => `- ${entry}`) : ['- none']),
+    '',
+    'Changed files selected for review:',
+    selectedFiles,
+    context.omittedFileCount > 0 ? `- omitted additional files: ${context.omittedFileCount}` : '',
+    context.diffTruncated ? `- diff truncated after ${context.diffBytes} UTF-8 bytes` : '',
+    '',
+    'Review focus:',
+    '- correctness and deterministic behavior',
+    '- hook / daemon / local-review contract safety',
+    '- draft-review versus ready-validation semantics',
+    '- regressions that would waste repeated GitHub Actions cycles',
+    '',
+    'Return exactly one JSON object with this shape and nothing else:',
+    '{',
+    '  "status": "approved" | "changes-requested",',
+    '  "summary": "one-line review summary",',
+    '  "findings": [',
+    '    {',
+    '      "severity": "error" | "warning" | "note",',
+    '      "path": "repo-relative path or null",',
+    '      "line": 123 | null,',
+    '      "title": "short finding title",',
+    '      "body": "specific actionable explanation",',
+    '      "actionable": true | false',
+    '    }',
+    '  ]',
+    '}',
+    '',
+    'If there are no actionable findings, set "status" to "approved" and "findings" to [].',
+    'Do not ask questions. Review only the supplied diff/context.',
+    '',
+    'Diff to review:',
+    context.diffText || '[no diff selected]'
+  ].filter(Boolean);
+  return promptSections.join('\n');
+}
+
+function buildArtifactPaths(resolvedReceiptPath) {
+  const directory = path.dirname(resolvedReceiptPath);
+  const stem = path.basename(resolvedReceiptPath, path.extname(resolvedReceiptPath));
+  return {
+    promptPath: path.join(directory, `${stem}.prompt.txt`),
+    responsePath: path.join(directory, `${stem}.jsonl`),
+    responsePathForPass(passNumber) {
+      return path.join(directory, `${stem}.pass-${passNumber}.jsonl`);
+    }
+  };
+}
+
+export async function runCopilotCliReview({
+  repoRoot,
+  profile = 'daemon',
+  receiptPath = '',
+  stagedFiles = [],
+  policy = null,
+  runCommandFn = runCommand
+}) {
+  const normalizedPolicy = normalizeCopilotCliReviewPolicy(policy ?? await loadCopilotCliReviewPolicy(repoRoot));
+  const profileName = normalizeProfileName(profile);
+  const profilePolicy = normalizedPolicy.profiles[profileName];
+  const resolvedReceiptPathInfo = resolveRepoPath(
+    repoRoot,
+    normalizeText(receiptPath) || profilePolicy.receiptPath
+  );
+
+  await mkdir(path.dirname(resolvedReceiptPathInfo.resolved), { recursive: true });
+  const artifactPaths = buildArtifactPaths(resolvedReceiptPathInfo.resolved);
+
+  const baseReceipt = {
+    schema: COPILOT_CLI_REVIEW_SCHEMA,
+    generatedAt: toIso(),
+    repoRoot,
+    profile: profileName,
+    mode: profilePolicy.mode,
+    collaboration: normalizedPolicy.collaboration,
+    instructionSources: {
+      present: [],
+      missing: []
+    },
+    git: resolveRepoGitState(repoRoot),
+    context: {
+      selectedFiles: [],
+      omittedFileCount: 0,
+      diffBytes: 0,
+      diffTruncated: false,
+      baseRef: null
+    },
+    copilot: {
+      executed: false,
+      model: normalizedPolicy.model,
+      command: 'copilot',
+      promptOnly: normalizedPolicy.promptOnly === true,
+      disableBuiltinMcps: normalizedPolicy.disableBuiltinMcps === true,
+      availableTools: normalizedPolicy.availableTools,
+      exitCode: null
+    },
+    convergence: {
+      ...normalizedPolicy.convergence,
+      passCount: 0,
+      stoppedReason: 'not-started',
+      noNovelFindingStreak: 0,
+      cleanPassCount: 0,
+      instructionGapCandidate: false,
+      instructionGapReason: '',
+      repeatedFindingFingerprints: []
+    },
+    overall: {
+      status: 'skipped',
+      actionableFindingCount: 0,
+      message: 'Copilot CLI review skipped.',
+      exitCode: 0
+    },
+    findings: [],
+    passes: [],
+    artifacts: {
+      receiptPath: resolvedReceiptPathInfo.normalized,
+      promptPath: path.relative(repoRoot, artifactPaths.promptPath).replace(/\\/g, '/'),
+      responsePath: path.relative(repoRoot, artifactPaths.responsePath).replace(/\\/g, '/')
+    }
+  };
+
+  if (normalizedPolicy.enabled !== true || profilePolicy.enabled !== true) {
+    await writeFile(resolvedReceiptPathInfo.resolved, `${JSON.stringify(baseReceipt, null, 2)}\n`, 'utf8');
+    return {
+      status: 'skipped',
+      reason: 'Copilot CLI review is disabled by policy.',
+      receiptPath: resolvedReceiptPathInfo.normalized,
+      receipt: baseReceipt
+    };
+  }
+
+  const instructionSources = await collectInstructionSources(repoRoot);
+  const context = collectReviewContext({
+    repoRoot,
+    mode: profilePolicy.mode,
+    stagedFiles,
+    maxFiles: profilePolicy.maxFiles,
+    maxDiffBytes: profilePolicy.maxDiffBytes
+  });
+
+  const receipt = {
+    ...baseReceipt,
+    instructionSources,
+    git: context.git,
+    context: {
+      selectedFiles: context.selectedFiles,
+      omittedFileCount: context.omittedFileCount,
+      diffBytes: context.diffBytes,
+      diffTruncated: context.diffTruncated,
+      baseRef: context.baseRef
+    }
+  };
+
+  if (context.selectedFiles.length === 0) {
+    receipt.overall = {
+      status: 'skipped',
+      actionableFindingCount: 0,
+      message: profilePolicy.mode === 'staged' ? 'No staged files selected for Copilot CLI review.' : 'No changed files selected for Copilot CLI review.',
+      exitCode: 0
+    };
+    await writeFile(resolvedReceiptPathInfo.resolved, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+    return {
+      status: 'skipped',
+      reason: receipt.overall.message,
+      receiptPath: resolvedReceiptPathInfo.normalized,
+      receipt
+    };
+  }
+
+  const prompt = buildReviewPrompt({
+    collaboration: normalizedPolicy.collaboration,
+    context,
+    instructionSources,
+    profileName,
+    repoRoot
+  });
+  await writeFile(artifactPaths.promptPath, prompt, 'utf8');
+
+  const args = [
+    '--output-format',
+    'json',
+    '--stream',
+    'off',
+    '--no-ask-user'
+  ];
+    if (normalizedPolicy.allowAllTools === true) {
+      args.push('--allow-all-tools');
+    }
+    if (normalizedPolicy.availableTools === '') {
+      args.push('--available-tools=');
+    } else if (normalizeText(normalizedPolicy.availableTools)) {
+      args.push('--available-tools', normalizedPolicy.availableTools);
+    }
+    if (normalizedPolicy.disableBuiltinMcps === true) {
+      args.push('--disable-builtin-mcps');
+    }
+  if (normalizeText(normalizedPolicy.model)) {
+    args.push('--model', normalizedPolicy.model);
+  }
+  args.push('--prompt', prompt);
+  const aggregatedFindings = [];
+  const findingOccurrences = new Map();
+  let noNovelFindingStreak = 0;
+  let cleanPassCount = 0;
+  let stoppedReason = 'max-passes';
+  let failureReason = '';
+  let lastPassExitCode = 0;
+
+  for (let passIndex = 1; passIndex <= normalizedPolicy.convergence.maxPasses; passIndex += 1) {
+    const startedAt = new Date();
+    const commandResult = buildCommandResult(
+      await runCommandFn('copilot', args, {
+        cwd: repoRoot,
+        env: process.env
+      })
+    );
+    lastPassExitCode = commandResult.status;
+    const passResponsePath = artifactPaths.responsePathForPass(passIndex);
+    await writeFile(passResponsePath, `${commandResult.stdout}\n`, 'utf8');
+    if (passIndex === 1) {
+      await writeFile(artifactPaths.responsePath, `${commandResult.stdout}\n`, 'utf8');
+    }
+
+    let structured = null;
+    let parsedJsonl = null;
+    let passFailureReason = '';
+    try {
+      parsedJsonl = parseCopilotJsonLines(commandResult.stdout);
+      receipt.copilot.model = parsedJsonl.model || receipt.copilot.model;
+      structured = parseStructuredAssistantPayload(parsedJsonl.assistantContent);
+    } catch (error) {
+      passFailureReason = normalizeText(error?.message);
+    }
+
+    if (commandResult.status !== 0) {
+      passFailureReason =
+        normalizeText(commandResult.stderr) ||
+        normalizeText(commandResult.stdout) ||
+        passFailureReason ||
+        'Copilot CLI review command failed.';
+    }
+
+    const passFindings = dedupeFindings(structured?.findings ?? []);
+    const passActionableFindings = passFindings.filter((entry) => entry.actionable !== false);
+    const novelActionableFindings = [];
+    const repeatedActionableFingerprints = [];
+
+    for (const finding of passActionableFindings) {
+      if (!findingOccurrences.has(finding.fingerprint)) {
+        novelActionableFindings.push(finding);
+        aggregatedFindings.push(finding);
+        findingOccurrences.set(finding.fingerprint, 1);
+      } else {
+        repeatedActionableFingerprints.push(finding.fingerprint);
+        findingOccurrences.set(finding.fingerprint, findingOccurrences.get(finding.fingerprint) + 1);
+      }
+    }
+
+    if (passActionableFindings.length === 0) {
+      cleanPassCount += 1;
+      noNovelFindingStreak = 0;
+    } else if (novelActionableFindings.length === 0) {
+      noNovelFindingStreak += 1;
+    } else {
+      noNovelFindingStreak = 0;
+    }
+
+    receipt.passes.push({
+      passNumber: passIndex,
+      startedAt: toIso(startedAt),
+      completedAt: toIso(),
+      durationMs: Math.max(Date.now() - startedAt.getTime(), 0),
+      status:
+        passFailureReason
+          ? 'failed'
+          : structured?.status === 'approved' && passActionableFindings.length === 0
+            ? 'approved'
+            : 'changes-requested',
+      summary:
+        passFailureReason ||
+        structured?.summary ||
+        (passActionableFindings.length === 0
+          ? 'Copilot CLI review reported no actionable findings.'
+          : 'Copilot CLI review reported actionable findings.'),
+      actionableFindingCount: passActionableFindings.length,
+      novelActionableFindingCount: novelActionableFindings.length,
+      noNovelFindingStreak,
+      repeatedActionableFingerprints,
+      model: receipt.copilot.model,
+      responsePath: path.relative(repoRoot, passResponsePath).replace(/\\/g, '/'),
+      findings: passFindings
+    });
+
+    if (passFailureReason) {
+      failureReason = passFailureReason;
+      stoppedReason = 'command-failed';
+      break;
+    }
+
+    const currentUnionActionableCount = aggregatedFindings.length;
+    if (
+      currentUnionActionableCount === 0 &&
+      normalizedPolicy.convergence.stopOnCleanPass === true &&
+      passIndex >= normalizedPolicy.convergence.minPasses
+    ) {
+      stoppedReason = 'clean-pass';
+      break;
+    }
+
+    if (
+      currentUnionActionableCount > 0 &&
+      normalizedPolicy.convergence.stopOnNoNovelFindingsCount > 0 &&
+      noNovelFindingStreak >= normalizedPolicy.convergence.stopOnNoNovelFindingsCount
+    ) {
+      stoppedReason = 'no-novel-findings';
+      break;
+    }
+  }
+
+  receipt.copilot = {
+    ...receipt.copilot,
+    executed: receipt.passes.length > 0,
+    exitCode: lastPassExitCode
+  };
+
+  const repeatedFindingFingerprints = [...findingOccurrences.entries()]
+    .filter(([, count]) => count >= normalizedPolicy.convergence.promoteInstructionGapAfterRepeatedFindings)
+    .map(([fingerprint]) => fingerprint)
+    .sort();
+  const instructionGapCandidate =
+    aggregatedFindings.length > 0 &&
+    repeatedFindingFingerprints.length > 0 &&
+    (stoppedReason === 'no-novel-findings' || stoppedReason === 'max-passes');
+  const instructionGapReason = instructionGapCandidate
+    ? 'Repeated local Copilot CLI findings converged without novel issues; refine Codex/Copilot instruction surfaces.'
+    : '';
+
+  const findingsShouldFail = profilePolicy.failOnFindings !== false;
+  const overallStatus =
+    failureReason || (aggregatedFindings.length > 0 && findingsShouldFail)
+      ? 'failed'
+      : 'passed';
+  const overallMessage =
+    failureReason ||
+    (aggregatedFindings.length > 0
+      ? findingsShouldFail
+        ? `Copilot CLI review reported ${aggregatedFindings.length} unique actionable finding(s) across ${receipt.passes.length} pass(es).`
+        : `Copilot CLI review recorded ${aggregatedFindings.length} unique actionable finding(s) across ${receipt.passes.length} pass(es) in report-only mode.`
+      : `Copilot CLI review converged cleanly after ${receipt.passes.length} pass(es).`);
+
+  receipt.findings = aggregatedFindings.map(({ fingerprint, ...finding }) => finding);
+  receipt.convergence = {
+    ...receipt.convergence,
+    passCount: receipt.passes.length,
+    stoppedReason,
+    noNovelFindingStreak,
+    cleanPassCount,
+    instructionGapCandidate,
+    instructionGapReason,
+    repeatedFindingFingerprints
+  };
+  receipt.overall = {
+    status: overallStatus,
+    actionableFindingCount: aggregatedFindings.length,
+    message: overallMessage,
+    exitCode: lastPassExitCode
+  };
+  await writeFile(resolvedReceiptPathInfo.resolved, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  return {
+    status: overallStatus,
+    reason: overallMessage,
+    receiptPath: resolvedReceiptPathInfo.normalized,
+    receipt
+  };
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    help: false,
+    repoRoot: process.cwd(),
+    profile: 'daemon',
+    receiptPath: '',
+    stagedFiles: []
+  };
+
+  const valueHandlers = new Map([
+    ['--repo-root', (value) => { options.repoRoot = value; }],
+    ['--profile', (value) => { options.profile = value; }],
+    ['--receipt-path', (value) => { options.receiptPath = value; }],
+    ['--staged-files-json', (value) => { options.stagedFiles = parseOptionalJsonArgument(value); }]
+  ]);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (!valueHandlers.has(token)) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith('-')) {
+      throw new Error(`Missing value for ${token}.`);
+    }
+    index += 1;
+    valueHandlers.get(token)(value);
+  }
+
+  return options;
+}
+
+function printUsage() {
+  console.log('Usage: node tools/priority/copilot-cli-review.mjs [options]');
+  console.log('');
+  console.log('Run a deterministic local Copilot CLI review for a hook or daemon profile.');
+  console.log('');
+  console.log('Options:');
+  console.log('  --repo-root <path>           Repository root (default: current working directory).');
+  console.log('  --profile <name>             Review profile: pre-commit, daemon, or pre-push.');
+  console.log('  --receipt-path <path>        Override the profile receipt path.');
+  console.log('  --staged-files-json <json>   JSON array of staged repo-relative paths (pre-commit only).');
+  console.log('  -h, --help                   Show help.');
+}
+
+export async function main(argv = process.argv) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    return 1;
+  }
+
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+
+  try {
+    const result = await runCopilotCliReview({
+      repoRoot: path.resolve(options.repoRoot),
+      profile: options.profile,
+      receiptPath: options.receiptPath,
+      stagedFiles: options.stagedFiles
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return result.status === 'failed' ? 1 : 0;
+  } catch (error) {
+    console.error(error?.stack || error?.message || String(error));
+    return 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  const exitCode = await main(process.argv);
+  process.exit(exitCode);
+}

--- a/tools/priority/local-review-providers.mjs
+++ b/tools/priority/local-review-providers.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+export * from '../local-collab/providers/local-review-providers.mjs';

--- a/tools/priority/simulation-review.mjs
+++ b/tools/priority/simulation-review.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { resolveRepoGitState } from './copilot-cli-review.mjs';
+
+export const SIMULATION_REVIEW_SCHEMA = 'priority/simulation-review@v1';
+export const DEFAULT_SIMULATION_REVIEW_POLICY = {
+  enabled: false,
+  scenario: 'clean-pass',
+  receiptPath: path.join('tests', 'results', 'docker-tools-parity', 'simulation-review', 'receipt.json'),
+  summary: '',
+  findings: []
+};
+
+const SUPPORTED_SCENARIOS = new Set([
+  'clean-pass',
+  'actionable-findings',
+  'provider-failure',
+  'stale-head',
+  'dirty-tracked'
+]);
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function toIso(value = new Date()) {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function normalizeSeverity(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  return ['error', 'warning', 'note'].includes(normalized) ? normalized : 'warning';
+}
+
+function normalizeFinding(value) {
+  const finding = value && typeof value === 'object' ? value : {};
+  const line = Number(finding.line);
+  return {
+    severity: normalizeSeverity(finding.severity),
+    path: normalizeText(finding.path) || null,
+    line: Number.isInteger(line) && line > 0 ? line : null,
+    title: normalizeText(finding.title) || 'Simulation finding',
+    body: normalizeText(finding.body) || '',
+    actionable: finding.actionable !== false
+  };
+}
+
+function normalizeFindings(value) {
+  return Array.isArray(value) ? value.map(normalizeFinding) : [];
+}
+
+function resolveRepoPath(repoRoot, candidatePath) {
+  const normalized = normalizeText(candidatePath);
+  if (!normalized) {
+    throw new Error('Simulation review receipt path must be a non-empty repo-relative path.');
+  }
+  if (path.isAbsolute(normalized)) {
+    throw new Error(`Simulation review receipt path must stay under the repository root: ${normalized}`);
+  }
+  const resolved = path.resolve(repoRoot, normalized);
+  const relativeToRepo = path.relative(repoRoot, resolved);
+  if (!relativeToRepo || relativeToRepo.startsWith('..') || path.isAbsolute(relativeToRepo)) {
+    throw new Error(`Simulation review receipt path escapes the repository root: ${normalized}`);
+  }
+  return {
+    normalized,
+    resolved
+  };
+}
+
+function buildDefaultScenarioFindings(scenario) {
+  if (scenario !== 'actionable-findings') {
+    return [];
+  }
+  return [
+    {
+      severity: 'warning',
+      path: 'tools/priority/delivery-agent.mjs',
+      line: 1,
+      title: 'Simulated seam finding',
+      body: 'The Simulation provider intentionally emitted an actionable finding for seam coverage.',
+      actionable: true
+    }
+  ];
+}
+
+export function normalizeSimulationReviewPolicy(value) {
+  const raw = value && typeof value === 'object' ? value : {};
+  const scenario = normalizeText(raw.scenario).toLowerCase();
+  return {
+    ...DEFAULT_SIMULATION_REVIEW_POLICY,
+    ...raw,
+    enabled: raw.enabled === true,
+    scenario: SUPPORTED_SCENARIOS.has(scenario) ? scenario : DEFAULT_SIMULATION_REVIEW_POLICY.scenario,
+    receiptPath: normalizeText(raw.receiptPath) || DEFAULT_SIMULATION_REVIEW_POLICY.receiptPath,
+    summary: normalizeText(raw.summary),
+    findings: normalizeFindings(raw.findings)
+  };
+}
+
+export async function runSimulationReview({
+  repoRoot,
+  policy = null,
+  resolveRepoGitStateFn = resolveRepoGitState
+}) {
+  const normalizedPolicy = normalizeSimulationReviewPolicy(policy);
+  const receiptPathInfo = resolveRepoPath(repoRoot, normalizedPolicy.receiptPath);
+  const repoGitState = resolveRepoGitStateFn(repoRoot) ?? {};
+  const receiptGit = {
+    headSha: normalizeText(repoGitState.headSha) || null,
+    branch: normalizeText(repoGitState.branch) || null,
+    upstreamDevelopMergeBase: normalizeText(repoGitState.upstreamDevelopMergeBase) || null,
+    dirtyTracked: repoGitState.dirtyTracked === true
+  };
+
+  let status = 'passed';
+  let summary = normalizedPolicy.summary || 'Simulation review passed cleanly.';
+  let findings = normalizedPolicy.findings.length > 0 ? [...normalizedPolicy.findings] : buildDefaultScenarioFindings(normalizedPolicy.scenario);
+
+  if (normalizedPolicy.scenario === 'actionable-findings') {
+    status = 'failed';
+    summary = normalizedPolicy.summary || 'Simulation review produced actionable findings.';
+  } else if (normalizedPolicy.scenario === 'provider-failure') {
+    status = 'failed';
+    summary = normalizedPolicy.summary || 'Simulation review provider failed intentionally.';
+  } else if (normalizedPolicy.scenario === 'stale-head') {
+    status = 'failed';
+    summary = normalizedPolicy.summary || 'Simulation review produced a stale-head receipt intentionally.';
+    receiptGit.headSha = receiptGit.headSha ? `${receiptGit.headSha}-stale` : 'stale-head';
+  } else if (normalizedPolicy.scenario === 'dirty-tracked') {
+    status = 'failed';
+    summary = normalizedPolicy.summary || 'Simulation review marked the tracked tree dirty intentionally.';
+    receiptGit.dirtyTracked = true;
+  } else {
+    findings = [];
+  }
+
+  const actionableFindingCount = findings.filter((finding) => finding.actionable !== false).length;
+  const receipt = {
+    schema: SIMULATION_REVIEW_SCHEMA,
+    generatedAt: toIso(),
+    provider: 'simulation',
+    scenario: normalizedPolicy.scenario,
+    git: receiptGit,
+    overall: {
+      status,
+      actionableFindingCount,
+      message: summary,
+      exitCode: status === 'passed' ? 0 : 1
+    },
+    findings,
+    recommendedReviewOrder: ['simulationReview']
+  };
+
+  await mkdir(path.dirname(receiptPathInfo.resolved), { recursive: true });
+  await writeFile(receiptPathInfo.resolved, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+
+  return {
+    providerId: 'simulation',
+    status,
+    source: 'simulation-review',
+    reason: summary,
+    receiptPath: receiptPathInfo.normalized,
+    receipt
+  };
+}


### PR DESCRIPTION
## Summary
- moves the local review provider front door into `tools/local-collab/providers/**`
- keeps `tools/priority/agent-review-policy.mjs` and `tools/priority/local-review-providers.mjs` as compatibility shims
- preserves executable providers (`copilot-cli`, `simulation`) while keeping `codex-cli` and `ollama` fail-closed

## Validation
- `node --check tools/local-collab/providers/local-review-providers.mjs`
- `node --check tools/local-collab/providers/agent-review-policy.mjs`
- `node --check tools/priority/local-review-providers.mjs`
- `node --check tools/priority/agent-review-policy.mjs`
- `node --test tools/local-collab/providers/__tests__/local-review-providers.test.mjs tools/local-collab/providers/__tests__/agent-review-policy.test.mjs tools/priority/__tests__/local-review-providers.test.mjs tools/priority/__tests__/agent-review-policy.test.mjs`

Refs #1090