### PR TITLE
#1081 Add commit-scoped local review receipt ledger

### DIFF
--- a/tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs
+++ b/tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import {
+  LOCAL_COLLAB_LEDGER_LATEST_SCHEMA,
+  LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA,
+  assessLatestLocalCollaborationLedgerReceipt,
+  resolveGitContext,
+  writeLocalCollaborationLedgerReceipt
+} from '../local-review-ledger.mjs';
+
+async function createGitRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-collab-ledger-'));
+  spawnSync('git', ['init', '--initial-branch=develop'], { cwd: repoRoot, encoding: 'utf8' });
+  await writeFile(path.join(repoRoot, 'README.md'), '# test\n', 'utf8');
+  spawnSync('git', ['add', 'README.md'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  return repoRoot;
+}
+
+test('writeLocalCollaborationLedgerReceipt persists a per-phase per-head receipt and latest index', async () => {
+  const repoRoot = await createGitRepo();
+  const git = resolveGitContext(repoRoot);
+  const first = await writeLocalCollaborationLedgerReceipt({
+    repoRoot,
+    phase: 'pre-commit',
+    git,
+    forkPlane: 'personal',
+    persona: 'codex',
+    providers: ['copilot-cli'],
+    selectionSource: 'PRECOMMIT_AGENT_REVIEW_PROVIDERS',
+    startedAt: '2026-03-14T00:00:00.000Z',
+    finishedAt: '2026-03-14T00:00:01.000Z',
+    durationMs: 1000,
+    findingCount: 0,
+    status: 'passed',
+    outcome: 'completed'
+  });
+
+  const second = await writeLocalCollaborationLedgerReceipt({
+    repoRoot,
+    phase: 'pre-push',
+    git,
+    forkPlane: 'personal',
+    persona: 'codex',
+    providers: ['copilot-cli', 'simulation'],
+    selectionSource: 'HOOKS_AGENT_REVIEW_PROVIDERS',
+    startedAt: '2026-03-14T00:00:02.000Z',
+    finishedAt: '2026-03-14T00:00:03.000Z',
+    durationMs: 1000,
+    findingCount: 2,
+    status: 'failed',
+    outcome: 'blocked'
+  });
+
+  assert.equal(first.receipt.schema, LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA);
+  assert.equal(first.latestIndex.schema, LOCAL_COLLAB_LEDGER_LATEST_SCHEMA);
+  assert.equal(first.receipt.headSha, git.headSha);
+  assert.equal(first.receipt.baseSha, git.baseSha);
+  assert.equal(first.receipt.providerId, 'copilot-cli');
+  assert.equal(second.receipt.providerId, 'multi');
+  assert.ok(second.receipt.sourceReceiptIds.includes(first.receipt.receiptId));
+
+  const persisted = JSON.parse(await readFile(second.receiptPath, 'utf8'));
+  const latest = JSON.parse(await readFile(second.latestIndexPath, 'utf8'));
+  assert.equal(persisted.receiptId, second.receipt.receiptId);
+  assert.equal(latest.receiptId, second.receipt.receiptId);
+  assert.equal(latest.headSha, git.headSha);
+});
+
+test('assessLatestLocalCollaborationLedgerReceipt fails closed on corrupt latest indexes', async () => {
+  const repoRoot = await createGitRepo();
+  const latestIndexPath = path.join(
+    repoRoot,
+    'tests',
+    'results',
+    '_agent',
+    'local-collab',
+    'ledger',
+    'latest',
+    'pre-commit.json'
+  );
+  await mkdir(path.dirname(latestIndexPath), { recursive: true });
+  await writeFile(latestIndexPath, '{not-json', 'utf8');
+
+  const result = await assessLatestLocalCollaborationLedgerReceipt({
+    repoRoot,
+    phase: 'pre-commit'
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'invalid-index');
+});
+
+test('assessLatestLocalCollaborationLedgerReceipt reports stale receipts when the current head changed', async () => {
+  const repoRoot = await createGitRepo();
+  const initialGit = resolveGitContext(repoRoot);
+  await writeLocalCollaborationLedgerReceipt({
+    repoRoot,
+    phase: 'pre-commit',
+    git: initialGit,
+    forkPlane: 'personal',
+    persona: 'codex',
+    providers: ['copilot-cli'],
+    selectionSource: 'explicit',
+    startedAt: '2026-03-14T00:00:00.000Z',
+    finishedAt: '2026-03-14T00:00:01.000Z',
+    durationMs: 1000,
+    status: 'passed',
+    outcome: 'completed'
+  });
+
+  await writeFile(path.join(repoRoot, 'README.md'), '# changed\n', 'utf8');
+  spawnSync('git', ['add', 'README.md'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'second'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  const currentGit = resolveGitContext(repoRoot);
+
+  const result = await assessLatestLocalCollaborationLedgerReceipt({
+    repoRoot,
+    phase: 'pre-commit',
+    expectedHeadSha: currentGit.headSha
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'stale');
+});

--- a/tools/local-collab/ledger/local-review-ledger.mjs
+++ b/tools/local-collab/ledger/local-review-ledger.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export const LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA = 'comparevi/local-collab-ledger-receipt@v1';
+export const LOCAL_COLLAB_LEDGER_LATEST_SCHEMA = 'comparevi/local-collab-ledger-latest@v1';
+export const DEFAULT_LOCAL_COLLAB_LEDGER_ROOT = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'local-collab',
+  'ledger'
+);
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function normalizeArray(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.map((value) => normalizeText(value)).filter(Boolean);
+}
+
+function uniqueStrings(values) {
+  return [...new Set(normalizeArray(values))];
+}
+
+function normalizeInteger(value, fallback = 0) {
+  return Number.isInteger(value) ? value : fallback;
+}
+
+function normalizePathForReceipt(repoRoot, targetPath) {
+  const absolutePath = path.resolve(targetPath);
+  const relativePath = path.relative(repoRoot, absolutePath);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Path must stay within the repository root: ${targetPath}`);
+  }
+  return relativePath.replace(/\\/g, '/');
+}
+
+function runGit(repoRoot, args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  const stdout = normalizeText(result.stdout);
+  const stderr = normalizeText(result.stderr);
+  if (result.status !== 0) {
+    throw new Error(stderr || stdout || `git ${args.join(' ')} failed`);
+  }
+  return stdout;
+}
+
+function tryGit(repoRoot, args) {
+  try {
+    return runGit(repoRoot, args);
+  } catch {
+    return '';
+  }
+}
+
+export function resolveGitContext(repoRoot) {
+  const headSha = tryGit(repoRoot, ['rev-parse', 'HEAD']);
+  if (!headSha) {
+    throw new Error('Unable to resolve the current git HEAD for the local collaboration ledger.');
+  }
+
+  const mergeBaseCandidates = [
+    ['merge-base', 'HEAD', 'refs/remotes/upstream/develop'],
+    ['merge-base', 'HEAD', 'refs/remotes/origin/develop'],
+    ['merge-base', 'HEAD', 'develop'],
+    ['rev-parse', 'HEAD~1']
+  ];
+  const baseSha =
+    mergeBaseCandidates
+      .map((candidate) => tryGit(repoRoot, candidate))
+      .find(Boolean) || headSha;
+
+  return {
+    headSha,
+    baseSha
+  };
+}
+
+function deriveProviderId(providers) {
+  const normalized = uniqueStrings(providers);
+  if (normalized.length === 0) {
+    return 'none';
+  }
+  if (normalized.length === 1) {
+    return normalized[0];
+  }
+  return 'multi';
+}
+
+function defaultLedgerReceiptPath(repoRoot, phase, headSha) {
+  return path.join(repoRoot, DEFAULT_LOCAL_COLLAB_LEDGER_ROOT, 'receipts', phase, `${headSha}.json`);
+}
+
+function defaultLedgerLatestIndexPath(repoRoot, phase) {
+  return path.join(repoRoot, DEFAULT_LOCAL_COLLAB_LEDGER_ROOT, 'latest', `${phase}.json`);
+}
+
+async function readJsonFile(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function collectSiblingReceiptIds(repoRoot, headSha, excludedPhase) {
+  const latestRoot = path.join(repoRoot, DEFAULT_LOCAL_COLLAB_LEDGER_ROOT, 'latest');
+  if (!existsSync(latestRoot)) {
+    return [];
+  }
+
+  const entries = await readdir(latestRoot, { withFileTypes: true });
+  const receiptIds = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || path.extname(entry.name) !== '.json') {
+      continue;
+    }
+
+    const phase = normalizeText(path.basename(entry.name, '.json'));
+    if (!phase || phase === normalizeText(excludedPhase)) {
+      continue;
+    }
+
+    try {
+      const index = await readJsonFile(path.join(latestRoot, entry.name));
+      if (normalizeText(index?.headSha) === headSha) {
+        const receiptId = normalizeText(index?.receiptId);
+        if (receiptId) {
+          receiptIds.push(receiptId);
+        }
+      }
+    } catch {
+      // Corrupt sibling indexes should not prevent writing the current receipt.
+    }
+  }
+
+  return uniqueStrings(receiptIds);
+}
+
+export async function writeLocalCollaborationLedgerReceipt(options = {}) {
+  const repoRoot = path.resolve(normalizeText(options.repoRoot) || process.cwd());
+  const phase = normalizeText(options.phase);
+  if (!phase) {
+    throw new Error('phase is required to write a local collaboration ledger receipt.');
+  }
+
+  const git = options.git && typeof options.git === 'object' ? options.git : resolveGitContext(repoRoot);
+  const headSha = normalizeText(git.headSha);
+  const baseSha = normalizeText(git.baseSha) || headSha;
+  if (!headSha) {
+    throw new Error('headSha is required to write a local collaboration ledger receipt.');
+  }
+
+  const providers = uniqueStrings(options.providers);
+  const providerId = normalizeText(options.providerId) || deriveProviderId(providers);
+  const receiptId = normalizeText(options.receiptId) || `${phase}:${headSha}`;
+  const receiptPath = path.resolve(
+    repoRoot,
+    normalizeText(options.receiptPath) || defaultLedgerReceiptPath(repoRoot, phase, headSha)
+  );
+  const latestIndexPath = path.resolve(
+    repoRoot,
+    normalizeText(options.latestIndexPath) || defaultLedgerLatestIndexPath(repoRoot, phase)
+  );
+
+  await mkdir(path.dirname(receiptPath), { recursive: true });
+  await mkdir(path.dirname(latestIndexPath), { recursive: true });
+
+  const siblingReceiptIds = await collectSiblingReceiptIds(repoRoot, headSha, phase);
+  const receipt = {
+    schema: LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA,
+    receiptId,
+    phase,
+    repoRoot,
+    forkPlane: normalizeText(options.forkPlane) || null,
+    persona: normalizeText(options.persona) || null,
+    headSha,
+    baseSha,
+    providerId,
+    providers,
+    requestedModel: normalizeText(options.requestedModel) || null,
+    effectiveModel: normalizeText(options.effectiveModel) || null,
+    startedAt: normalizeText(options.startedAt) || null,
+    finishedAt: normalizeText(options.finishedAt) || null,
+    durationMs: normalizeInteger(options.durationMs),
+    findingCount: normalizeInteger(options.findingCount),
+    status: normalizeText(options.status) || null,
+    outcome: normalizeText(options.outcome) || null,
+    selectionSource: normalizeText(options.selectionSource) || null,
+    sourceReceiptIds: uniqueStrings([...(options.sourceReceiptIds ?? []), ...siblingReceiptIds]),
+    sourcePaths: uniqueStrings(options.sourcePaths),
+    metadata: options.metadata && typeof options.metadata === 'object' ? options.metadata : {}
+  };
+
+  const latestIndex = {
+    schema: LOCAL_COLLAB_LEDGER_LATEST_SCHEMA,
+    phase,
+    updatedAt: receipt.finishedAt || receipt.startedAt || new Date().toISOString(),
+    headSha,
+    receiptId,
+    receiptPath: normalizePathForReceipt(repoRoot, receiptPath),
+    status: receipt.status,
+    outcome: receipt.outcome
+  };
+
+  await writeFile(receiptPath, JSON.stringify(receipt, null, 2), 'utf8');
+  await writeFile(latestIndexPath, JSON.stringify(latestIndex, null, 2), 'utf8');
+
+  return {
+    git: { headSha, baseSha },
+    receipt,
+    receiptPath,
+    latestIndex,
+    latestIndexPath
+  };
+}
+
+export async function assessLatestLocalCollaborationLedgerReceipt(options = {}) {
+  const repoRoot = path.resolve(normalizeText(options.repoRoot) || process.cwd());
+  const phase = normalizeText(options.phase);
+  const expectedHeadSha = normalizeText(options.expectedHeadSha);
+  const latestIndexPath = path.resolve(
+    repoRoot,
+    normalizeText(options.latestIndexPath) || defaultLedgerLatestIndexPath(repoRoot, phase)
+  );
+
+  if (!existsSync(latestIndexPath)) {
+    return {
+      ok: false,
+      status: 'missing-index',
+      reason: `No latest local collaboration ledger index exists for phase '${phase}'.`,
+      latestIndexPath,
+      receipt: null,
+      receiptPath: null
+    };
+  }
+
+  let latestIndex;
+  try {
+    latestIndex = await readJsonFile(latestIndexPath);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 'invalid-index',
+      reason: normalizeText(error?.message) || 'Latest local collaboration ledger index is not valid JSON.',
+      latestIndexPath,
+      receipt: null,
+      receiptPath: null
+    };
+  }
+
+  if (
+    normalizeText(latestIndex?.schema) !== LOCAL_COLLAB_LEDGER_LATEST_SCHEMA ||
+    normalizeText(latestIndex?.phase) !== phase ||
+    !normalizeText(latestIndex?.receiptId) ||
+    !normalizeText(latestIndex?.receiptPath) ||
+    !normalizeText(latestIndex?.headSha)
+  ) {
+    return {
+      ok: false,
+      status: 'invalid-index',
+      reason: 'Latest local collaboration ledger index is missing required fields.',
+      latestIndexPath,
+      receipt: null,
+      receiptPath: null
+    };
+  }
+
+  const receiptPath = path.resolve(repoRoot, latestIndex.receiptPath);
+  try {
+    normalizePathForReceipt(repoRoot, receiptPath);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 'invalid-index',
+      reason: normalizeText(error?.message) || 'Latest local collaboration ledger receipt path escapes the repo root.',
+      latestIndexPath,
+      receipt: null,
+      receiptPath: null
+    };
+  }
+
+  if (!existsSync(receiptPath)) {
+    return {
+      ok: false,
+      status: 'missing-receipt',
+      reason: 'Latest local collaboration ledger receipt file is missing.',
+      latestIndexPath,
+      receipt: null,
+      receiptPath
+    };
+  }
+
+  let receipt;
+  try {
+    receipt = await readJsonFile(receiptPath);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 'invalid-receipt',
+      reason: normalizeText(error?.message) || 'Local collaboration ledger receipt is not valid JSON.',
+      latestIndexPath,
+      receipt: null,
+      receiptPath
+    };
+  }
+
+  if (
+    normalizeText(receipt?.schema) !== LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA ||
+    normalizeText(receipt?.phase) !== phase ||
+    normalizeText(receipt?.receiptId) !== normalizeText(latestIndex.receiptId) ||
+    normalizeText(receipt?.headSha) !== normalizeText(latestIndex.headSha)
+  ) {
+    return {
+      ok: false,
+      status: 'invalid-receipt',
+      reason: 'Local collaboration ledger receipt does not match the latest index contract.',
+      latestIndexPath,
+      receipt,
+      receiptPath
+    };
+  }
+
+  if (expectedHeadSha && normalizeText(receipt?.headSha) !== expectedHeadSha) {
+    return {
+      ok: false,
+      status: 'stale',
+      reason: `Latest local collaboration ledger receipt is stale for phase '${phase}'.`,
+      latestIndexPath,
+      receipt,
+      receiptPath
+    };
+  }
+
+  return {
+    ok: true,
+    status: 'valid',
+    reason: `Latest local collaboration ledger receipt is valid for phase '${phase}'.`,
+    latestIndexPath,
+    receipt,
+    receiptPath
+  };
+}

--- a/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
+++ b/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
@@ -2,13 +2,27 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
 import {
   LOCAL_COLLAB_ORCHESTRATOR_SCHEMA,
   parseArgs,
   resolvePhaseProviderSelection,
   runLocalCollaborationPhase
 } from '../run-phase.mjs';
+
+async function createGitRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-collab-orchestrator-'));
+  spawnSync('git', ['init', '--initial-branch=develop'], { cwd: repoRoot, encoding: 'utf8' });
+  await writeFile(path.join(repoRoot, 'README.md'), '# test\n', 'utf8');
+  spawnSync('git', ['add', 'README.md'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  return repoRoot;
+}
 
 test('parseArgs preserves delegate args for daemon phase', () => {
   const parsed = parseArgs([
@@ -53,7 +67,7 @@ test('resolvePhaseProviderSelection prefers explicit, then phase, then shared ov
 });
 
 test('runLocalCollaborationPhase writes deterministic daemon orchestrator receipts', async () => {
-  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-collab-orchestrator-'));
+  const repoRoot = await createGitRepo();
   const result = await runLocalCollaborationPhase({
     phase: 'daemon',
     repoRoot,
@@ -76,9 +90,15 @@ test('runLocalCollaborationPhase writes deterministic daemon orchestrator receip
   assert.equal(result.receipt.selectionSource, 'explicit');
   assert.deepEqual(result.receipt.providers, ['copilot-cli']);
   assert.match(result.receipt.delegate.command.join(' '), /tools\/priority\/docker-desktop-review-loop\.mjs/);
+  assert.equal(result.receipt.ledger.receiptId, `daemon:${result.receipt.headSha}`);
 
   const persisted = JSON.parse(await readFile(result.receiptPath, 'utf8'));
   assert.equal(persisted.schema, LOCAL_COLLAB_ORCHESTRATOR_SCHEMA);
   assert.equal(persisted.phase, 'daemon');
   assert.equal(persisted.status, 'passed');
+
+  const ledgerReceipt = JSON.parse(await readFile(result.ledgerReceiptPath, 'utf8'));
+  assert.equal(ledgerReceipt.phase, 'daemon');
+  assert.equal(ledgerReceipt.headSha, result.receipt.headSha);
+  assert.equal(ledgerReceipt.providerId, 'copilot-cli');
 });

--- a/tools/local-collab/orchestrator/run-phase.mjs
+++ b/tools/local-collab/orchestrator/run-phase.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { HookRunner, info, listStagedFiles } from '../../hooks/core/runner.mjs';
+import { resolveGitContext, writeLocalCollaborationLedgerReceipt } from '../ledger/local-review-ledger.mjs';
 
 export const LOCAL_COLLAB_ORCHESTRATOR_SCHEMA = 'comparevi/local-collab-orchestrator@v1';
 export const LOCAL_COLLAB_PHASES = ['pre-commit', 'post-commit', 'pre-push', 'daemon'];
@@ -260,6 +261,7 @@ export async function runLocalCollaborationPhase(options = {}) {
   const delegateFns = options.delegateFns && typeof options.delegateFns === 'object' ? options.delegateFns : {};
   const providerSelection = resolvePhaseProviderSelection(phase, env, options.providers);
   const identity = resolvePhaseIdentity(phase, env, options);
+  const git = resolveGitContext(repoRoot);
   const orchestratorReceiptPath = path.resolve(
     repoRoot,
     normalizeText(options.orchestratorReceiptPath) || defaultOrchestratorReceiptPath(repoRoot, phase)
@@ -289,6 +291,8 @@ export async function runLocalCollaborationPhase(options = {}) {
     repoRoot,
     forkPlane: identity.forkPlane,
     persona: identity.persona,
+    headSha: git.headSha,
+    baseSha: git.baseSha,
     startedAt: new Date(started).toISOString(),
     finishedAt: new Date(finished).toISOString(),
     durationMs: finished - started,
@@ -307,10 +311,39 @@ export async function runLocalCollaborationPhase(options = {}) {
   };
   await writeFile(orchestratorReceiptPath, JSON.stringify(receipt, null, 2), 'utf8');
 
+  const ledger = await writeLocalCollaborationLedgerReceipt({
+    repoRoot,
+    phase,
+    git,
+    forkPlane: receipt.forkPlane,
+    persona: receipt.persona,
+    providers: providerSelection.providers,
+    selectionSource: providerSelection.selectionSource,
+    startedAt: receipt.startedAt,
+    finishedAt: receipt.finishedAt,
+    durationMs: receipt.durationMs,
+    status: receipt.status,
+    outcome: receipt.outcome,
+    sourcePaths: [orchestratorReceiptPath, normalizeText(result.summaryPath)].filter(Boolean),
+    metadata: {
+      orchestratorReceiptPath: path.relative(repoRoot, orchestratorReceiptPath).replace(/\\/g, '/'),
+      delegateSummaryPath: normalizeText(result.summaryPath) || null
+    }
+  });
+  receipt.ledger = {
+    receiptId: ledger.receipt.receiptId,
+    receiptPath: path.relative(repoRoot, ledger.receiptPath).replace(/\\/g, '/'),
+    latestIndexPath: path.relative(repoRoot, ledger.latestIndexPath).replace(/\\/g, '/')
+  };
+  await writeFile(orchestratorReceiptPath, JSON.stringify(receipt, null, 2), 'utf8');
+
   return {
     exitCode: result.exitCode ?? 1,
     receipt,
     receiptPath: orchestratorReceiptPath,
+    ledgerReceipt: ledger.receipt,
+    ledgerReceiptPath: ledger.receiptPath,
+    ledgerLatestIndexPath: ledger.latestIndexPath,
     stdout: normalizeText(result.stdout),
     stderr: normalizeText(result.stderr)
   };


### PR DESCRIPTION
# Summary

Implements `#1081` by adding a durable local collaboration receipt ledger under `tools/local-collab/ledger/**` and wiring the local orchestrator to emit one commit-scoped receipt per phase/head plus a per-phase latest index.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1079`, child issue `#1081`
- Files, tools, workflows, or policies touched:
  - `tools/local-collab/ledger/local-review-ledger.mjs`
  - `tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs`
  - `tools/local-collab/orchestrator/run-phase.mjs`
  - `tools/local-collab/orchestrator/__tests__/run-phase.test.mjs`
- Cross-repo or external-consumer impact: none outside the local collaboration protocol surfaces
- Required checks, merge-queue behavior, or approval flows affected: local collaboration phases now persist deterministic per-head receipts that later daemon/KPI slices can consume

## Validation Evidence

- Commands run:
  - `node --check tools/local-collab/ledger/local-review-ledger.mjs`
  - `node --check tools/local-collab/orchestrator/run-phase.mjs`
  - `node --test tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs tools/local-collab/orchestrator/__tests__/run-phase.test.mjs tools/hooks/__tests__/local-collaboration-contract.test.mjs`
- Key artifacts, logs, or workflow runs:
  - deterministic ledger receipts now land under `tests/results/_agent/local-collab/ledger/receipts/<phase>/<head>.json`
  - per-phase latest pointers now land under `tests/results/_agent/local-collab/ledger/latest/<phase>.json`
- Risk-based checks not run:
  - full hosted workflow suite

## Risks and Follow-ups

- Residual risks: this slice does not yet add KPI rollups or VI History assistance consumers
- Follow-up issues or deferred work:
  - `#1082` per-fork KPI rollups
  - `#1091` VI History operator-assistance surface
- Deployment, approval, or rollback notes: standard `develop` required-check flow

## Reviewer Focus

- Please verify: the ledger schema is stable enough for downstream daemon/KPI consumers, and the stale/corrupt latest-index cases fail closed
- Areas where the reasoning is subtle: source receipt correlation is based on same-head phase linkage so later KPI aggregation does not infer relationships heuristically
- Manual spot checks requested: none

Closes #1081
