### PR TITLE
#1083 Add codex operator post-commit hook receipts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hooks:multi": "node tools/hooks/core/run-multi.mjs",
     "hooks:plane": "node tools/hooks/core/plane-info.mjs",
     "hooks:pre-commit": "node tools/hooks/core/pre-commit.mjs",
+    "hooks:post-commit": "node tools/hooks/core/post-commit.mjs",
     "hooks:pre-push": "node tools/hooks/core/pre-push.mjs",
     "hooks:preflight": "node tools/hooks/core/preflight.mjs",
     "hooks:schema": "node tools/hooks/core/validate-summaries.mjs",

--- a/tools/hooks/__tests__/local-collaboration-contract.test.mjs
+++ b/tools/hooks/__tests__/local-collaboration-contract.test.mjs
@@ -12,10 +12,14 @@ function readRepoFile(relativePath) {
 
 test('hook core entrypoints route through the local collaboration orchestrator', () => {
   const preCommit = readRepoFile(path.join('tools', 'hooks', 'core', 'pre-commit.mjs'));
+  const postCommit = readRepoFile(path.join('tools', 'hooks', 'core', 'post-commit.mjs'));
   const prePush = readRepoFile(path.join('tools', 'hooks', 'core', 'pre-push.mjs'));
 
   assert.match(preCommit, /local-collab\/orchestrator\/run-phase\.mjs/);
   assert.match(preCommit, /phase:\s*'pre-commit'/);
+
+  assert.match(postCommit, /local-collab\/orchestrator\/run-phase\.mjs/);
+  assert.match(postCommit, /phase:\s*'post-commit'/);
 
   assert.match(prePush, /local-collab\/orchestrator\/run-phase\.mjs/);
   assert.match(prePush, /phase:\s*'pre-push'/);

--- a/tools/hooks/core/post-commit.mjs
+++ b/tools/hooks/core/post-commit.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { runLocalCollaborationPhase } from '../../local-collab/orchestrator/run-phase.mjs';
+
+const result = await runLocalCollaborationPhase({
+  phase: 'post-commit',
+  repoRoot: process.cwd(),
+  env: process.env
+});
+
+process.exit(result.exitCode);

--- a/tools/hooks/core/run-multi.mjs
+++ b/tools/hooks/core/run-multi.mjs
@@ -30,8 +30,10 @@ const combos = [];
 
 if (bashPath && fs.existsSync(bashPath)) {
   const preCommitShellScript = toPosix(path.join('tools', 'hooks', 'pre-commit'));
+  const postCommitShellScript = toPosix(path.join('tools', 'hooks', 'post-commit'));
   const prePushShellScript = toPosix(path.join('tools', 'hooks', 'pre-push'));
   combos.push({ hook: 'pre-commit', label: 'shell', command: bashPath, args: [preCommitShellScript] });
+  combos.push({ hook: 'post-commit', label: 'shell', command: bashPath, args: [postCommitShellScript] });
   combos.push({ hook: 'pre-push', label: 'shell', command: bashPath, args: [prePushShellScript] });
 } else {
   info('[hooks multi] bash not available; skipping shell wrappers.');
@@ -39,6 +41,7 @@ if (bashPath && fs.existsSync(bashPath)) {
 
 if (pwshPath) {
   combos.push({ hook: 'pre-commit', label: 'pwsh', command: pwshPath, args: ['-NoLogo', '-NoProfile', '-File', path.join('tools', 'hooks', 'pre-commit.ps1')] });
+  combos.push({ hook: 'post-commit', label: 'pwsh', command: pwshPath, args: ['-NoLogo', '-NoProfile', '-File', path.join('tools', 'hooks', 'post-commit.ps1')] });
   combos.push({ hook: 'pre-push', label: 'pwsh', command: pwshPath, args: ['-NoLogo', '-NoProfile', '-File', path.join('tools', 'hooks', 'pre-push.ps1')] });
 } else {
   info('[hooks multi] PowerShell not available; skipping PowerShell wrappers.');

--- a/tools/hooks/post-commit
+++ b/tools/hooks/post-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODE_BIN="${HOOKS_NODE:-node}"
+CORE_SCRIPT="${SCRIPT_DIR}/core/post-commit.mjs"
+
+if [[ "$NODE_BIN" == *:* ]] || [[ "$NODE_BIN" == /* ]]; then
+  if [[ ! -x "$NODE_BIN" ]]; then
+    echo "[hooks] Node binary not executable at $NODE_BIN; skipping post-commit." >&2
+    exit 0
+  fi
+  if grep -qi microsoft /proc/version 2>/dev/null && [[ "$NODE_BIN" == *.exe ]]; then
+    echo "[hooks] Running under WSL with Windows node.exe; skipping post-commit." >&2
+    exit 0
+  fi
+else
+  if ! command -v "$NODE_BIN" >/dev/null 2>&1; then
+    echo "[hooks] Node binary '$NODE_BIN' not found on PATH; skipping post-commit." >&2
+    exit 0
+  fi
+fi
+
+exec "$NODE_BIN" "$CORE_SCRIPT"

--- a/tools/hooks/post-commit.ps1
+++ b/tools/hooks/post-commit.ps1
@@ -1,0 +1,33 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $PSCommandPath
+$node = if ($env:HOOKS_NODE) { $env:HOOKS_NODE } else { 'node' }
+$core = Join-Path $scriptRoot 'core' 'post-commit.mjs'
+
+$nodePathLike = $node -match '[:\\/]'
+if ($nodePathLike) {
+  if (-not (Test-Path -LiteralPath $node -PathType Leaf)) {
+    Write-Warning "[hooks] Node binary not executable at '$node'; skipping post-commit."
+    exit 0
+  }
+} elseif (-not (Get-Command $node -ErrorAction SilentlyContinue)) {
+  Write-Warning "[hooks] Node binary '$node' not found; skipping post-commit."
+  exit 0
+}
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $node
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $false
+$psi.RedirectStandardError = $false
+$psi.ArgumentList.Add($core)
+$psi.WorkingDirectory = (git rev-parse --show-toplevel)
+
+$process = [System.Diagnostics.Process]::Start($psi)
+$process.WaitForExit()
+exit $process.ExitCode

--- a/tools/hooks/post-commit.sample
+++ b/tools/hooks/post-commit.sample
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+# Sample post-commit hook. Enable hooks with:
+#   git config core.hooksPath tools/hooks
+# Then copy/rename this file to 'post-commit'.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host '[post-commit] Recording local collaboration authoring receipt'
+& (Join-Path $PSScriptRoot 'post-commit.ps1')
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "post-commit failed (exit=$LASTEXITCODE)."
+  exit $LASTEXITCODE
+}
+Write-Host '[post-commit] OK'

--- a/tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs
+++ b/tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs
@@ -41,7 +41,8 @@ test('writeLocalCollaborationLedgerReceipt persists a per-phase per-head receipt
     durationMs: 1000,
     findingCount: 0,
     status: 'passed',
-    outcome: 'completed'
+    outcome: 'completed',
+    filesTouched: ['tools/hooks/core/pre-commit.mjs']
   });
 
   const second = await writeLocalCollaborationLedgerReceipt({
@@ -57,7 +58,9 @@ test('writeLocalCollaborationLedgerReceipt persists a per-phase per-head receipt
     durationMs: 1000,
     findingCount: 2,
     status: 'failed',
-    outcome: 'blocked'
+    outcome: 'blocked',
+    filesTouched: ['tools/hooks/core/pre-push.mjs'],
+    commitCreated: true
   });
 
   assert.equal(first.receipt.schema, LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA);
@@ -66,6 +69,8 @@ test('writeLocalCollaborationLedgerReceipt persists a per-phase per-head receipt
   assert.equal(first.receipt.baseSha, git.baseSha);
   assert.equal(first.receipt.providerId, 'copilot-cli');
   assert.equal(second.receipt.providerId, 'multi');
+  assert.deepEqual(first.receipt.filesTouched, ['tools/hooks/core/pre-commit.mjs']);
+  assert.equal(second.receipt.commitCreated, true);
   assert.ok(second.receipt.sourceReceiptIds.includes(first.receipt.receiptId));
 
   const persisted = JSON.parse(await readFile(second.receiptPath, 'utf8'));

--- a/tools/local-collab/ledger/local-review-ledger.mjs
+++ b/tools/local-collab/ledger/local-review-ledger.mjs
@@ -197,6 +197,8 @@ export async function writeLocalCollaborationLedgerReceipt(options = {}) {
     findingCount: normalizeInteger(options.findingCount),
     status: normalizeText(options.status) || null,
     outcome: normalizeText(options.outcome) || null,
+    filesTouched: uniqueStrings(options.filesTouched),
+    commitCreated: options.commitCreated === true,
     selectionSource: normalizeText(options.selectionSource) || null,
     sourceReceiptIds: uniqueStrings([...(options.sourceReceiptIds ?? []), ...siblingReceiptIds]),
     sourcePaths: uniqueStrings(options.sourcePaths),

--- a/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
+++ b/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
@@ -102,3 +102,32 @@ test('runLocalCollaborationPhase writes deterministic daemon orchestrator receip
   assert.equal(ledgerReceipt.headSha, result.receipt.headSha);
   assert.equal(ledgerReceipt.providerId, 'copilot-cli');
 });
+
+test('runLocalCollaborationPhase records codex authoring receipts for post-commit', async () => {
+  const repoRoot = await createGitRepo();
+  await writeFile(path.join(repoRoot, 'README.md'), '# changed\n', 'utf8');
+  spawnSync('git', ['add', 'README.md'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'second'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+
+  const result = await runLocalCollaborationPhase({
+    phase: 'post-commit',
+    repoRoot
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.receipt.phase, 'post-commit');
+  assert.equal(result.receipt.forkPlane, 'personal');
+  assert.equal(result.receipt.persona, 'codex');
+  assert.equal(result.receipt.commitCreated, true);
+  assert.deepEqual(result.receipt.filesTouched, ['README.md']);
+  assert.match(result.receipt.delegate.summaryPath, /tests[\\/]results[\\/]_hooks[\\/]post-commit\.json$/);
+
+  const ledgerReceipt = JSON.parse(await readFile(result.ledgerReceiptPath, 'utf8'));
+  assert.equal(ledgerReceipt.phase, 'post-commit');
+  assert.equal(ledgerReceipt.commitCreated, true);
+  assert.deepEqual(ledgerReceipt.filesTouched, ['README.md']);
+});

--- a/tools/local-collab/orchestrator/run-phase.mjs
+++ b/tools/local-collab/orchestrator/run-phase.mjs
@@ -43,6 +43,13 @@ function normalizeText(value) {
   return String(value).trim();
 }
 
+function normalizeStringList(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))];
+}
+
 function parseProviderList(value) {
   const normalized = normalizeText(value);
   if (!normalized) {
@@ -60,6 +67,43 @@ function isPhase(value) {
 
 function defaultOrchestratorReceiptPath(repoRoot, phase) {
   return path.join(repoRoot, DEFAULT_ORCHESTRATOR_RECEIPT_ROOT, `${phase}.json`);
+}
+
+function runGit(repoRoot, args) {
+  const result = spawnSync('git', ['-C', repoRoot, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  const stdout = normalizeText(result.stdout);
+  const stderr = normalizeText(result.stderr);
+  if (result.status !== 0) {
+    throw new Error(stderr || stdout || `git ${args.join(' ')} failed`);
+  }
+  return stdout;
+}
+
+function collectFilesTouchedForPhase(repoRoot, phase, git = {}) {
+  if (phase === 'pre-commit') {
+    return normalizeStringList(listStagedFiles());
+  }
+
+  if (phase === 'post-commit') {
+    return normalizeStringList(runGit(repoRoot, ['show', '--pretty=format:', '--name-only', '--diff-filter=ACMRT', 'HEAD']).split(/\r?\n/));
+  }
+
+  if (phase === 'pre-push' || phase === 'daemon') {
+    const baseSha = normalizeText(git.baseSha);
+    const headSha = normalizeText(git.headSha);
+    if (!baseSha || !headSha) {
+      return [];
+    }
+    return normalizeStringList(
+      runGit(repoRoot, ['diff', '--name-only', '--diff-filter=ACMRT', `${baseSha}..${headSha}`]).split(/\r?\n/)
+    );
+  }
+
+  return [];
 }
 
 export function parseArgs(argv = process.argv) {
@@ -247,10 +291,22 @@ function invokeDaemonDelegate(repoRoot, delegateArgs) {
   return normalizeCommandResult(result);
 }
 
-function invokePostCommitDelegate() {
-  return {
+function invokePostCommitDelegate(repoRoot) {
+  const runner = new HookRunner('post-commit', { repoRoot });
+  info('[post-commit] Recording local collaboration authoring receipt');
+  runner.runStep('record-authoring-receipt', () => ({
+    status: 'ok',
     exitCode: 0,
-    note: 'post-commit orchestration is reserved for later slices'
+    stdout: '',
+    stderr: '',
+    note: 'Post-commit authoring receipt recorded.'
+  }));
+  runner.addNote('Codex/operator commits are governed by the same local collaboration contract as review hooks.');
+  runner.writeSummary();
+  info('[post-commit] OK');
+  return {
+    exitCode: runner.exitCode,
+    summaryPath: path.join(repoRoot, 'tests', 'results', '_hooks', 'post-commit.json')
   };
 }
 
@@ -279,12 +335,16 @@ export async function runLocalCollaborationPhase(options = {}) {
   } else if (phase === 'daemon') {
     result = invokeDaemonDelegate(repoRoot, options.delegateArgs ?? []);
   } else if (phase === 'post-commit') {
-    result = invokePostCommitDelegate();
+    result = invokePostCommitDelegate(repoRoot);
   } else {
     throw new Error(`Unsupported local collaboration phase: ${phase}`);
   }
 
   const finished = Date.now();
+  const explicitFilesTouched = normalizeStringList(options.filesTouched);
+  const filesTouched = explicitFilesTouched.length > 0
+    ? explicitFilesTouched
+    : collectFilesTouchedForPhase(repoRoot, phase, git);
   const receipt = {
     schema: LOCAL_COLLAB_ORCHESTRATOR_SCHEMA,
     phase,
@@ -298,6 +358,8 @@ export async function runLocalCollaborationPhase(options = {}) {
     durationMs: finished - started,
     status: result.exitCode === 0 ? 'passed' : 'failed',
     outcome: result.exitCode === 0 ? 'completed' : 'blocked',
+    filesTouched,
+    commitCreated: phase === 'post-commit',
     selectionSource: providerSelection.selectionSource,
     providers: providerSelection.providers,
     delegate: {
@@ -324,6 +386,8 @@ export async function runLocalCollaborationPhase(options = {}) {
     durationMs: receipt.durationMs,
     status: receipt.status,
     outcome: receipt.outcome,
+    filesTouched: receipt.filesTouched,
+    commitCreated: receipt.commitCreated,
     sourcePaths: [orchestratorReceiptPath, normalizeText(result.summaryPath)].filter(Boolean),
     metadata: {
       orchestratorReceiptPath: path.relative(repoRoot, orchestratorReceiptPath).replace(/\\/g, '/'),


### PR DESCRIPTION
# Summary

Implements issue #1083 by bringing the Codex/operator plane fully under the repo-owned hook contract.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1083 under standing issue #1079
- Files, tools, workflows, or policies touched:
  - `tools/local-collab/orchestrator/run-phase.mjs`
  - `tools/local-collab/ledger/local-review-ledger.mjs`
  - `tools/hooks/core/post-commit.mjs`
  - `tools/hooks/post-commit`
  - `tools/hooks/post-commit.ps1`
  - `tools/hooks/post-commit.sample`
  - `tools/hooks/core/run-multi.mjs`
  - `tools/hooks/__tests__/local-collaboration-contract.test.mjs`
  - `package.json`
- Cross-repo or external-consumer impact: none; this is the local collaboration protocol.
- Required checks, merge-queue behavior, or approval flows affected: none.

## Validation Evidence

- Commands run:
  - `node --check tools/local-collab/orchestrator/run-phase.mjs`
  - `node --check tools/hooks/core/post-commit.mjs`
  - `node --test tools/local-collab/orchestrator/__tests__/run-phase.test.mjs tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs tools/hooks/__tests__/local-collaboration-contract.test.mjs`
  - `node tools/npm/run-script.mjs hooks:post-commit`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_hooks/post-commit.json`
  - `tests/results/_agent/local-collab/orchestrator/post-commit.json`
  - `tests/results/_agent/local-collab/ledger/latest/post-commit.json`
- Risk-based checks not run:
  - `hooks:multi` was not rerun because it would invoke the full pre-push gate; this slice used focused hook/orchestrator coverage instead.

## Risks and Follow-ups

- Residual risks: `post-commit` currently records authoring receipts but does not yet invoke a separate Codex CLI adapter; that stays in later `#1079` children.
- Follow-up issues or deferred work:
  - `#1091` VI History operator assistance
  - future Codex CLI adapter work under `#1079`
- Deployment, approval, or rollback notes: standard develop PR flow.

## Reviewer Focus

- Please verify:
  - `post-commit` now uses the same orchestrator front door as other local collaboration phases
  - authoring receipts record `filesTouched` and `commitCreated`
  - `run-multi` now has a real `post-commit` parity surface instead of a placeholder
- Areas where the reasoning is subtle:
  - `filesTouched` is phase-specific: staged files for `pre-commit`, `HEAD` commit files for `post-commit`, branch delta for `pre-push` and `daemon`.
- Manual spot checks requested:
  - `node tools/npm/run-script.mjs hooks:post-commit`

Closes #1083
