### PR TITLE
#1091 Add local VI history operator assistance receipts

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "intake:route": "pwsh -NoLogo -NoProfile -File tools/Resolve-GitHubIntakeRoute.ps1",
     "lint:md": "node tools/lint-markdown.mjs --all",
     "lint:md:changed": "node tools/lint-markdown.mjs",
+    "local-collab:assist:vi-history": "node tools/local-collab/assist/vi-history/run-operator-assistance.mjs",
     "local-collab:kpi": "node tools/local-collab/kpi/rollup-local-collab-kpi.mjs",
     "workflow:drift:ensure": "node tools/workflows/run-workflow-enclave.mjs --ensure-only",
     "workflow:drift:check": "node tools/workflows/run-workflow-enclave.mjs --default-scope --check",

--- a/tools/local-collab/assist/vi-history/__tests__/run-operator-assistance.test.mjs
+++ b/tools/local-collab/assist/vi-history/__tests__/run-operator-assistance.test.mjs
@@ -1,0 +1,276 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import {
+  LOCAL_COLLAB_VI_HISTORY_ASSIST_LATEST_SCHEMA,
+  LOCAL_COLLAB_VI_HISTORY_ASSIST_SCHEMA,
+  assessLatestViHistoryOperatorAssistance,
+  parseArgs,
+  runViHistoryOperatorAssistance
+} from '../run-operator-assistance.mjs';
+
+async function createGitRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'local-collab-vi-history-assist-'));
+  spawnSync('git', ['init', '--initial-branch=develop'], { cwd: repoRoot, encoding: 'utf8' });
+  await mkdir(path.join(repoRoot, 'tools'), { recursive: true });
+  await writeFile(path.join(repoRoot, 'tools', 'Compare-VIHistory.ps1'), '# placeholder', 'utf8');
+  await writeFile(path.join(repoRoot, 'tools', 'Inspect-VIHistorySuiteArtifacts.ps1'), '# placeholder', 'utf8');
+  await mkdir(path.join(repoRoot, 'fixtures', 'vi-attr'), { recursive: true });
+  await writeFile(path.join(repoRoot, 'fixtures', 'vi-attr', 'Head.vi'), 'base', 'utf8');
+  await writeFile(path.join(repoRoot, 'README.md'), '# root\n', 'utf8');
+  spawnSync('git', ['add', '.'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+
+  await writeFile(path.join(repoRoot, 'README.md'), '# root 2\n', 'utf8');
+  spawnSync('git', ['add', 'README.md'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'docs only'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+
+  await writeFile(path.join(repoRoot, 'fixtures', 'vi-attr', 'Head.vi'), 'touch-1', 'utf8');
+  spawnSync('git', ['add', 'fixtures/vi-attr/Head.vi'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'touch vi'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+
+  await mkdir(path.join(repoRoot, 'docs'), { recursive: true });
+  await writeFile(path.join(repoRoot, 'docs', 'note.md'), 'note', 'utf8');
+  spawnSync('git', ['add', 'docs/note.md'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'docs note'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+
+  await writeFile(path.join(repoRoot, 'fixtures', 'vi-attr', 'Head.vi'), 'touch-2', 'utf8');
+  spawnSync('git', ['add', 'fixtures/vi-attr/Head.vi'], { cwd: repoRoot, encoding: 'utf8' });
+  spawnSync(
+    'git',
+    ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'touch vi again'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+
+  return repoRoot;
+}
+
+function createFakeCommandRunner(repoRoot) {
+  return async ({ args }) => {
+    const scriptPath = args[3];
+    if (scriptPath.endsWith('Compare-VIHistory.ps1')) {
+      const resultsDir = args[args.indexOf('-ResultsDir') + 1];
+      const absoluteResultsDir = path.resolve(repoRoot, resultsDir);
+      const historyReportMarkdownPath = path.join(absoluteResultsDir, 'history-report.md');
+      const historyReportHtmlPath = path.join(absoluteResultsDir, 'history-report.html');
+      const historySummaryPath = path.join(absoluteResultsDir, 'history-summary.json');
+      const aggregateManifestPath = path.join(absoluteResultsDir, 'manifest.json');
+      const historySummary = {
+        schema: 'comparevi-tools/history-facade@v1',
+        target: {
+          path: 'fixtures/vi-attr/Head.vi',
+          sourceBranchRef: 'HEAD',
+          branchBudget: {
+            maxCommitCount: 8,
+            commitCount: 5,
+            status: 'ok',
+            reason: 'within-limit'
+          }
+        },
+        execution: {
+          status: 'ok',
+          manifestPath: aggregateManifestPath
+        },
+        summary: {
+          comparisons: 2,
+          diffs: 1,
+          signalDiffs: 1,
+          errors: 0
+        },
+        reports: {
+          markdownPath: historyReportMarkdownPath,
+          htmlPath: historyReportHtmlPath
+        }
+      };
+      await mkdir(absoluteResultsDir, { recursive: true });
+      await writeFile(historyReportMarkdownPath, '# history report\n', 'utf8');
+      await writeFile(historyReportHtmlPath, '<html><body>history</body></html>', 'utf8');
+      await writeFile(historySummaryPath, JSON.stringify(historySummary, null, 2), 'utf8');
+      await writeFile(
+        aggregateManifestPath,
+        JSON.stringify({ schema: 'vi-compare/history-suite@v1', stats: { processed: 2 } }, null, 2),
+        'utf8'
+      );
+      return {
+        status: 0,
+        stdout: '',
+        stderr: ''
+      };
+    }
+
+    if (scriptPath.endsWith('Inspect-VIHistorySuiteArtifacts.ps1')) {
+      const outputJsonPath = args[args.indexOf('-OutputJsonPath') + 1];
+      const outputHtmlPath = args[args.indexOf('-OutputHtmlPath') + 1];
+      await writeFile(
+        outputJsonPath,
+        JSON.stringify(
+          {
+            schema: 'vi-history-suite-inspection@v1',
+            overallStatus: 'ok',
+            summary: {
+              comparisons: 2,
+              missingReports: 0
+            }
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+      await writeFile(outputHtmlPath, '<html><body>inspection</body></html>', 'utf8');
+      return {
+        status: 0,
+        stdout: '',
+        stderr: ''
+      };
+    }
+
+    throw new Error(`Unexpected command invocation: ${args.join(' ')}`);
+  };
+}
+
+async function runWithFakeCommands(repoRoot, options = {}) {
+  return runViHistoryOperatorAssistance({
+    repoRoot,
+    targetPath: 'fixtures/vi-attr/Head.vi',
+    branchRef: 'HEAD',
+    maxBranchCommits: 8,
+    maxPairs: 2,
+    runCommandFn: createFakeCommandRunner(repoRoot),
+    ...options
+  });
+}
+
+test('parseArgs enforces bounded VI history assistance requests', () => {
+  const parsed = parseArgs([
+    'node',
+    'run-operator-assistance.mjs',
+    '--repo-root',
+    '/tmp/repo',
+    '--target-path',
+    'fixtures/vi-attr/Head.vi',
+    '--branch-ref',
+    'HEAD',
+    '--max-branch-commits',
+    '16',
+    '--max-pairs',
+    '2'
+  ]);
+
+  assert.equal(parsed.repoRoot, '/tmp/repo');
+  assert.equal(parsed.targetPath, 'fixtures/vi-attr/Head.vi');
+  assert.equal(parsed.branchRef, 'HEAD');
+  assert.equal(parsed.maxBranchCommits, 16);
+  assert.equal(parsed.maxPairs, 2);
+});
+
+test('runViHistoryOperatorAssistance writes deterministic receipts and latest indexes', async () => {
+  const repoRoot = await createGitRepo();
+  const result = await runWithFakeCommands(repoRoot);
+
+  assert.equal(result.receipt.schema, LOCAL_COLLAB_VI_HISTORY_ASSIST_SCHEMA);
+  assert.equal(result.latestIndex.schema, LOCAL_COLLAB_VI_HISTORY_ASSIST_LATEST_SCHEMA);
+  assert.equal(result.receipt.request.targetPath, 'fixtures/vi-attr/Head.vi');
+  assert.equal(result.receipt.history.totalCommitsScanned, 5);
+  assert.equal(result.receipt.history.touchingCommitCount, 3);
+  assert.equal(result.receipt.history.selectedPairCount, 2);
+  assert.equal(result.receipt.history.processedComparisons, 2);
+  assert.equal(result.receipt.inspection.overallStatus, 'ok');
+  assert.match(result.receipt.artifacts.historyReportMarkdownPath, /history-report\.md$/);
+  assert.match(result.receipt.artifacts.suiteManifestPath, /suite-manifest\.json$/);
+
+  const persistedReceipt = JSON.parse(await readFile(result.receiptPath, 'utf8'));
+  const persistedLatest = JSON.parse(await readFile(result.latestIndexPath, 'utf8'));
+  assert.equal(persistedReceipt.status, 'passed');
+  assert.equal(persistedLatest.status, 'passed');
+
+  const assessed = await assessLatestViHistoryOperatorAssistance({
+    repoRoot,
+    targetPath: 'fixtures/vi-attr/Head.vi',
+    expectedHeadSha: result.receipt.git.headSha
+  });
+  assert.equal(assessed.ok, true);
+  assert.equal(assessed.status, 'valid');
+});
+
+test('runViHistoryOperatorAssistance fails closed on stale head requests', async () => {
+  const repoRoot = await createGitRepo();
+
+  await assert.rejects(
+    () =>
+      runWithFakeCommands(repoRoot, {
+        expectedHeadSha: 'deadbeef'
+      }),
+    /Stale VI history assistance request/
+  );
+});
+
+test('runViHistoryOperatorAssistance fails closed when the bounded branch range does not touch the VI', async () => {
+  const repoRoot = await createGitRepo();
+
+  await assert.rejects(
+    () =>
+      runWithFakeCommands(repoRoot, {
+        targetPath: 'README.md',
+        baselineRef: 'HEAD~1'
+      }),
+    /No commits touching 'README\.md'/
+  );
+});
+
+test('runViHistoryOperatorAssistance fails closed on missing targets', async () => {
+  const repoRoot = await createGitRepo();
+
+  await assert.rejects(
+    () =>
+      runWithFakeCommands(repoRoot, {
+        targetPath: 'fixtures/vi-attr/Missing.vi'
+      }),
+    /VI history target not found/
+  );
+});
+
+test('assessLatestViHistoryOperatorAssistance fails closed on corrupt latest indexes', async () => {
+  const repoRoot = await createGitRepo();
+  const latestIndexPath = path.join(
+    repoRoot,
+    'tests',
+    'results',
+    '_agent',
+    'local-collab',
+    'assist',
+    'vi-history',
+    'latest',
+    'fixtures__vi-attr__Head-vi.json'
+  );
+  await mkdir(path.dirname(latestIndexPath), { recursive: true });
+  await writeFile(latestIndexPath, '{not-json', 'utf8');
+
+  const result = await assessLatestViHistoryOperatorAssistance({
+    repoRoot,
+    targetPath: 'fixtures/vi-attr/Head.vi',
+    latestIndexPath
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'invalid-index');
+});

--- a/tools/local-collab/assist/vi-history/run-operator-assistance.mjs
+++ b/tools/local-collab/assist/vi-history/run-operator-assistance.mjs
@@ -1,0 +1,625 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const LOCAL_COLLAB_VI_HISTORY_ASSIST_SCHEMA = 'comparevi/local-collab-vi-history-assistance@v1';
+export const LOCAL_COLLAB_VI_HISTORY_ASSIST_LATEST_SCHEMA = 'comparevi/local-collab-vi-history-assistance-latest@v1';
+export const DEFAULT_LOCAL_COLLAB_VI_HISTORY_ASSIST_ROOT = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'local-collab',
+  'assist',
+  'vi-history'
+);
+export const DEFAULT_COMPARE_VI_HISTORY_SCRIPT = path.join('tools', 'Compare-VIHistory.ps1');
+export const DEFAULT_HISTORY_INSPECTOR_SCRIPT = path.join('tools', 'Inspect-VIHistorySuiteArtifacts.ps1');
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function normalizeInteger(value, fallback = 0) {
+  if (Number.isInteger(value)) {
+    return value;
+  }
+  const normalized = Number.parseInt(normalizeText(value), 10);
+  return Number.isInteger(normalized) ? normalized : fallback;
+}
+
+function normalizePositiveInteger(value, name) {
+  const normalized = normalizeInteger(value, Number.NaN);
+  if (!Number.isInteger(normalized) || normalized <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return normalized;
+}
+
+function normalizePathFragment(value, fallback = 'target') {
+  const normalized = normalizeText(value)
+    .replace(/\\/g, '/')
+    .replace(/[^a-zA-Z0-9/_-]+/g, '-')
+    .replace(/\/+/g, '/')
+    .replace(/^-+|-+$/g, '')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\//g, '__');
+  return normalized || fallback;
+}
+
+function toRepoRelativePath(repoRoot, targetPath, description = 'path') {
+  const absolutePath = path.resolve(targetPath);
+  const relativePath = path.relative(repoRoot, absolutePath);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`${description} must stay within the repository root: ${targetPath}`);
+  }
+  return relativePath.replace(/\\/g, '/');
+}
+
+function resolveTargetPath(repoRoot, targetPath) {
+  const requestedTargetPath = normalizeText(targetPath);
+  if (!requestedTargetPath) {
+    throw new Error('targetPath is required.');
+  }
+  const absolutePath = path.resolve(repoRoot, requestedTargetPath);
+  if (!existsSync(absolutePath)) {
+    throw new Error(`VI history target not found: ${requestedTargetPath}`);
+  }
+  return {
+    absolutePath,
+    relativePath: toRepoRelativePath(repoRoot, absolutePath, 'VI history target')
+  };
+}
+
+function runGit(repoRoot, args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  const stdout = normalizeText(result.stdout);
+  const stderr = normalizeText(result.stderr);
+  if (result.status !== 0) {
+    throw new Error(stderr || stdout || `git ${args.join(' ')} failed`);
+  }
+  return stdout;
+}
+
+function resolveGitCommit(repoRoot, ref) {
+  const normalized = normalizeText(ref);
+  if (!normalized) {
+    throw new Error('A git ref is required.');
+  }
+  return runGit(repoRoot, ['rev-parse', `${normalized}^{commit}`]);
+}
+
+function resolveGitContext(repoRoot, branchRef, baselineRef) {
+  const headSha = resolveGitCommit(repoRoot, 'HEAD');
+  const branchSha = resolveGitCommit(repoRoot, branchRef);
+  const baselineSha = normalizeText(baselineRef) ? resolveGitCommit(repoRoot, baselineRef) : '';
+  return {
+    headSha,
+    branchSha,
+    baselineSha
+  };
+}
+
+function buildFirstParentRange(branchSha, baselineSha) {
+  if (baselineSha && baselineSha !== branchSha) {
+    return `${baselineSha}..${branchSha}`;
+  }
+  return branchSha;
+}
+
+function countRangeCommits(repoRoot, range) {
+  return normalizePositiveInteger(runGit(repoRoot, ['rev-list', '--count', '--first-parent', range]), 'range commit count');
+}
+
+function listTouchingCommits(repoRoot, range, targetPath) {
+  const output = runGit(repoRoot, ['rev-list', '--first-parent', range, '--', targetPath]);
+  return output
+    .split(/\r?\n/)
+    .map((value) => normalizeText(value))
+    .filter(Boolean);
+}
+
+function defaultResultsDir(repoRoot, targetPath, headSha) {
+  return path.join(
+    repoRoot,
+    DEFAULT_LOCAL_COLLAB_VI_HISTORY_ASSIST_ROOT,
+    'results',
+    normalizePathFragment(targetPath),
+    headSha
+  );
+}
+
+function defaultReceiptPath(repoRoot, targetPath, headSha) {
+  return path.join(
+    repoRoot,
+    DEFAULT_LOCAL_COLLAB_VI_HISTORY_ASSIST_ROOT,
+    'receipts',
+    normalizePathFragment(targetPath),
+    `${headSha}.json`
+  );
+}
+
+function defaultLatestIndexPath(repoRoot, targetPath) {
+  return path.join(
+    repoRoot,
+    DEFAULT_LOCAL_COLLAB_VI_HISTORY_ASSIST_ROOT,
+    'latest',
+    `${normalizePathFragment(targetPath)}.json`
+  );
+}
+
+function defaultCommandRunner({ command, args, cwd }) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  return {
+    status: Number.isInteger(result.status) ? result.status : 1,
+    stdout: normalizeText(result.stdout),
+    stderr: normalizeText(result.stderr)
+  };
+}
+
+function parseJsonFileContents(raw, description) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Unable to parse ${description}: ${normalizeText(error?.message) || 'invalid JSON'}`);
+  }
+}
+
+async function loadJsonFile(filePath, description) {
+  const raw = await readFile(filePath, 'utf8');
+  return parseJsonFileContents(raw, description);
+}
+
+async function ensureSuiteManifestCompatibility(resultsDir) {
+  const aggregateManifestPath = path.join(resultsDir, 'manifest.json');
+  const suiteManifestPath = path.join(resultsDir, 'suite-manifest.json');
+  if (!existsSync(aggregateManifestPath)) {
+    throw new Error(`VI history aggregate manifest missing: ${aggregateManifestPath}`);
+  }
+  if (!existsSync(suiteManifestPath)) {
+    await copyFile(aggregateManifestPath, suiteManifestPath);
+  }
+  return {
+    aggregateManifestPath,
+    suiteManifestPath
+  };
+}
+
+function buildCompactSummary(receiptPath, receipt) {
+  return {
+    schema: LOCAL_COLLAB_VI_HISTORY_ASSIST_SCHEMA,
+    receiptPath,
+    status: receipt.status,
+    targetPath: receipt.request.targetPath,
+    headSha: receipt.git.headSha,
+    totalCommitsScanned: receipt.history.totalCommitsScanned,
+    touchingCommitCount: receipt.history.touchingCommitCount,
+    processedComparisons: receipt.history.processedComparisons,
+    inspectionStatus: receipt.inspection.overallStatus
+  };
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = Array.isArray(argv) ? argv.slice(2) : [];
+  const parsed = {
+    repoRoot: process.cwd(),
+    targetPath: '',
+    branchRef: 'HEAD',
+    baselineRef: '',
+    expectedHeadSha: '',
+    maxBranchCommits: 0,
+    maxPairs: 2,
+    resultsDir: '',
+    receiptPath: '',
+    latestIndexPath: ''
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    switch (token) {
+      case '--repo-root':
+        parsed.repoRoot = normalizeText(args[index + 1]) || parsed.repoRoot;
+        index += 1;
+        break;
+      case '--target-path':
+        parsed.targetPath = normalizeText(args[index + 1]);
+        index += 1;
+        break;
+      case '--branch-ref':
+        parsed.branchRef = normalizeText(args[index + 1]) || parsed.branchRef;
+        index += 1;
+        break;
+      case '--baseline-ref':
+        parsed.baselineRef = normalizeText(args[index + 1]);
+        index += 1;
+        break;
+      case '--expected-head-sha':
+        parsed.expectedHeadSha = normalizeText(args[index + 1]);
+        index += 1;
+        break;
+      case '--max-branch-commits':
+        parsed.maxBranchCommits = normalizePositiveInteger(args[index + 1], 'maxBranchCommits');
+        index += 1;
+        break;
+      case '--max-pairs':
+        parsed.maxPairs = normalizePositiveInteger(args[index + 1], 'maxPairs');
+        index += 1;
+        break;
+      case '--results-dir':
+        parsed.resultsDir = normalizeText(args[index + 1]);
+        index += 1;
+        break;
+      case '--receipt-path':
+        parsed.receiptPath = normalizeText(args[index + 1]);
+        index += 1;
+        break;
+      case '--latest-index-path':
+        parsed.latestIndexPath = normalizeText(args[index + 1]);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+
+  if (!normalizeText(parsed.targetPath)) {
+    throw new Error('--target-path is required.');
+  }
+  if (!normalizeText(parsed.branchRef)) {
+    throw new Error('--branch-ref is required.');
+  }
+  if (!Number.isInteger(parsed.maxBranchCommits) || parsed.maxBranchCommits <= 0) {
+    throw new Error('--max-branch-commits is required.');
+  }
+  return parsed;
+}
+
+export async function runViHistoryOperatorAssistance(options = {}) {
+  const repoRoot = path.resolve(normalizeText(options.repoRoot) || process.cwd());
+  const target = resolveTargetPath(repoRoot, options.targetPath);
+  const branchRef = normalizeText(options.branchRef) || 'HEAD';
+  const baselineRef = normalizeText(options.baselineRef);
+  const expectedHeadSha = normalizeText(options.expectedHeadSha);
+  const maxBranchCommits = normalizePositiveInteger(options.maxBranchCommits, 'maxBranchCommits');
+  const maxPairs = normalizePositiveInteger(options.maxPairs ?? 2, 'maxPairs');
+  const runCommandFn = typeof options.runCommandFn === 'function' ? options.runCommandFn : defaultCommandRunner;
+  const compareScriptPath = path.resolve(repoRoot, DEFAULT_COMPARE_VI_HISTORY_SCRIPT);
+  const inspectorScriptPath = path.resolve(repoRoot, DEFAULT_HISTORY_INSPECTOR_SCRIPT);
+
+  if (!existsSync(compareScriptPath)) {
+    throw new Error(`Compare-VIHistory.ps1 not found: ${compareScriptPath}`);
+  }
+  if (!existsSync(inspectorScriptPath)) {
+    throw new Error(`Inspect-VIHistorySuiteArtifacts.ps1 not found: ${inspectorScriptPath}`);
+  }
+
+  const git = resolveGitContext(repoRoot, branchRef, baselineRef);
+  if (expectedHeadSha && git.headSha !== expectedHeadSha) {
+    throw new Error(`Stale VI history assistance request: expected head ${expectedHeadSha} but current head is ${git.headSha}.`);
+  }
+  if (git.branchSha !== git.headSha) {
+    throw new Error(`VI history assistance only supports the current branch head. '${branchRef}' resolved to ${git.branchSha}, current HEAD is ${git.headSha}.`);
+  }
+
+  const range = buildFirstParentRange(git.branchSha, git.baselineSha);
+  const totalCommitsScanned = countRangeCommits(repoRoot, range);
+  if (totalCommitsScanned > maxBranchCommits) {
+    throw new Error(`VI history source branch exceeds the commit safeguard (${totalCommitsScanned} > ${maxBranchCommits}).`);
+  }
+
+  const touchingCommits = listTouchingCommits(repoRoot, range, target.relativePath);
+  if (touchingCommits.length === 0) {
+    throw new Error(`No commits touching '${target.relativePath}' were found in the bounded first-parent range.`);
+  }
+
+  const resultsDir = path.resolve(
+    repoRoot,
+    normalizeText(options.resultsDir) || defaultResultsDir(repoRoot, target.relativePath, git.headSha)
+  );
+  const receiptPath = path.resolve(
+    repoRoot,
+    normalizeText(options.receiptPath) || defaultReceiptPath(repoRoot, target.relativePath, git.headSha)
+  );
+  const latestIndexPath = path.resolve(
+    repoRoot,
+    normalizeText(options.latestIndexPath) || defaultLatestIndexPath(repoRoot, target.relativePath)
+  );
+
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(path.dirname(receiptPath), { recursive: true });
+  await mkdir(path.dirname(latestIndexPath), { recursive: true });
+
+  const compareResult = await Promise.resolve(
+    runCommandFn({
+      command: 'pwsh',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-File',
+        compareScriptPath,
+        '-TargetPath',
+        target.relativePath,
+        '-StartRef',
+        git.branchSha,
+        '-SourceBranchRef',
+        branchRef,
+        '-MaxBranchCommits',
+        String(maxBranchCommits),
+        '-MaxPairs',
+        String(maxPairs),
+        '-ResultsDir',
+        resultsDir,
+        '-RenderReport',
+        '-ReportFormat',
+        'html'
+      ],
+      cwd: repoRoot
+    })
+  );
+  if (compareResult.status !== 0) {
+    throw new Error(compareResult.stderr || compareResult.stdout || 'Compare-VIHistory.ps1 failed.');
+  }
+
+  const { aggregateManifestPath, suiteManifestPath } = await ensureSuiteManifestCompatibility(resultsDir);
+  const historyReportMarkdownPath = path.join(resultsDir, 'history-report.md');
+  const historyReportHtmlPath = path.join(resultsDir, 'history-report.html');
+  const historySummaryPath = path.join(resultsDir, 'history-summary.json');
+  const historyInspectionJsonPath = path.join(resultsDir, 'history-suite-inspection.json');
+  const historyInspectionHtmlPath = path.join(resultsDir, 'history-suite-inspection.html');
+
+  for (const requiredPath of [historyReportMarkdownPath, historyReportHtmlPath, historySummaryPath]) {
+    if (!existsSync(requiredPath)) {
+      throw new Error(`VI history assistance missing required artifact: ${requiredPath}`);
+    }
+  }
+
+  const inspectResult = await Promise.resolve(
+    runCommandFn({
+      command: 'pwsh',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-File',
+        inspectorScriptPath,
+        '-ResultsDir',
+        resultsDir,
+        '-HistoryReportPath',
+        historyReportHtmlPath,
+        '-HistorySummaryPath',
+        historySummaryPath,
+        '-OutputJsonPath',
+        historyInspectionJsonPath,
+        '-OutputHtmlPath',
+        historyInspectionHtmlPath,
+        '-GitHubOutputPath',
+        '',
+        '-GitHubStepSummaryPath',
+        ''
+      ],
+      cwd: repoRoot
+    })
+  );
+  if (inspectResult.status !== 0) {
+    throw new Error(inspectResult.stderr || inspectResult.stdout || 'Inspect-VIHistorySuiteArtifacts.ps1 failed.');
+  }
+
+  const historySummary = await loadJsonFile(historySummaryPath, 'history summary JSON');
+  const inspection = await loadJsonFile(historyInspectionJsonPath, 'VI history inspection JSON');
+  const generatedAt = new Date().toISOString();
+  const processedComparisons = normalizeInteger(historySummary?.summary?.comparisons);
+  const selectedPairCount = Math.min(touchingCommits.length, maxPairs);
+
+  const receipt = {
+    schema: LOCAL_COLLAB_VI_HISTORY_ASSIST_SCHEMA,
+    receiptId: `vi-history:${normalizePathFragment(target.relativePath)}:${git.headSha}`,
+    generatedAt,
+    repoRoot,
+    request: {
+      targetPath: target.relativePath,
+      branchRef,
+      baselineRef: baselineRef || null,
+      expectedHeadSha: expectedHeadSha || null,
+      maxBranchCommits,
+      maxPairs
+    },
+    git: {
+      headSha: git.headSha,
+      branchSha: git.branchSha,
+      baselineSha: git.baselineSha || null,
+      range
+    },
+    history: {
+      totalCommitsScanned,
+      touchingCommitCount: touchingCommits.length,
+      touchingCommitShas: touchingCommits,
+      selectedPairCount,
+      processedComparisons,
+      diffs: normalizeInteger(historySummary?.summary?.diffs),
+      signalDiffs: normalizeInteger(historySummary?.summary?.signalDiffs),
+      errors: normalizeInteger(historySummary?.summary?.errors)
+    },
+    artifacts: {
+      resultsDir: toRepoRelativePath(repoRoot, resultsDir, 'VI history results directory'),
+      aggregateManifestPath: toRepoRelativePath(repoRoot, aggregateManifestPath, 'VI history aggregate manifest'),
+      suiteManifestPath: toRepoRelativePath(repoRoot, suiteManifestPath, 'VI history suite manifest'),
+      historyReportMarkdownPath: toRepoRelativePath(repoRoot, historyReportMarkdownPath, 'VI history markdown report'),
+      historyReportHtmlPath: toRepoRelativePath(repoRoot, historyReportHtmlPath, 'VI history HTML report'),
+      historySummaryPath: toRepoRelativePath(repoRoot, historySummaryPath, 'VI history summary'),
+      historyInspectionJsonPath: toRepoRelativePath(repoRoot, historyInspectionJsonPath, 'VI history inspection JSON'),
+      historyInspectionHtmlPath: toRepoRelativePath(repoRoot, historyInspectionHtmlPath, 'VI history inspection HTML')
+    },
+    inspection: {
+      schema: normalizeText(inspection?.schema) || null,
+      overallStatus: normalizeText(inspection?.overallStatus) || 'unknown',
+      summary: inspection?.summary && typeof inspection.summary === 'object' ? inspection.summary : {}
+    },
+    status: normalizeText(inspection?.overallStatus) === 'ok' ? 'passed' : 'failed',
+    outcome: normalizeText(inspection?.overallStatus) === 'ok' ? 'completed' : 'blocked'
+  };
+
+  const latestIndex = {
+    schema: LOCAL_COLLAB_VI_HISTORY_ASSIST_LATEST_SCHEMA,
+    updatedAt: generatedAt,
+    targetPath: target.relativePath,
+    headSha: git.headSha,
+    receiptId: receipt.receiptId,
+    receiptPath: toRepoRelativePath(repoRoot, receiptPath, 'VI history assistance receipt'),
+    status: receipt.status,
+    outcome: receipt.outcome
+  };
+
+  await writeFile(receiptPath, JSON.stringify(receipt, null, 2), 'utf8');
+  await writeFile(latestIndexPath, JSON.stringify(latestIndex, null, 2), 'utf8');
+
+  return {
+    receipt,
+    receiptPath,
+    latestIndex,
+    latestIndexPath,
+    summary: buildCompactSummary(toRepoRelativePath(repoRoot, receiptPath, 'VI history assistance receipt'), receipt)
+  };
+}
+
+export async function assessLatestViHistoryOperatorAssistance(options = {}) {
+  const repoRoot = path.resolve(normalizeText(options.repoRoot) || process.cwd());
+  const targetPath = normalizeText(options.targetPath);
+  if (!targetPath) {
+    throw new Error('targetPath is required to assess the latest VI history assistance receipt.');
+  }
+  const latestIndexPath = path.resolve(
+    repoRoot,
+    normalizeText(options.latestIndexPath) || defaultLatestIndexPath(repoRoot, targetPath)
+  );
+
+  if (!existsSync(latestIndexPath)) {
+    return {
+      ok: false,
+      status: 'missing-index',
+      reason: `No latest VI history assistance index exists for '${targetPath}'.`,
+      latestIndexPath,
+      receiptPath: null,
+      receipt: null
+    };
+  }
+
+  let latestIndex;
+  try {
+    latestIndex = await loadJsonFile(latestIndexPath, 'VI history latest index');
+  } catch (error) {
+    return {
+      ok: false,
+      status: 'invalid-index',
+      reason: normalizeText(error?.message) || 'Latest VI history assistance index is invalid.',
+      latestIndexPath,
+      receiptPath: null,
+      receipt: null
+    };
+  }
+
+  if (
+    normalizeText(latestIndex?.schema) !== LOCAL_COLLAB_VI_HISTORY_ASSIST_LATEST_SCHEMA ||
+    normalizeText(latestIndex?.targetPath) !== targetPath ||
+    !normalizeText(latestIndex?.headSha) ||
+    !normalizeText(latestIndex?.receiptPath)
+  ) {
+    return {
+      ok: false,
+      status: 'invalid-index',
+      reason: 'Latest VI history assistance index is missing required fields.',
+      latestIndexPath,
+      receiptPath: null,
+      receipt: null
+    };
+  }
+
+  const receiptPath = path.resolve(repoRoot, latestIndex.receiptPath);
+  let receipt;
+  try {
+    if (!existsSync(receiptPath)) {
+      return {
+        ok: false,
+        status: 'missing-receipt',
+        reason: 'Latest VI history assistance receipt file is missing.',
+        latestIndexPath,
+        receiptPath,
+        receipt: null
+      };
+    }
+    receipt = await loadJsonFile(receiptPath, 'VI history assistance receipt');
+  } catch (error) {
+    return {
+      ok: false,
+      status: 'invalid-receipt',
+      reason: normalizeText(error?.message) || 'VI history assistance receipt is invalid.',
+      latestIndexPath,
+      receiptPath,
+      receipt: null
+    };
+  }
+
+  if (
+    normalizeText(receipt?.schema) !== LOCAL_COLLAB_VI_HISTORY_ASSIST_SCHEMA ||
+    normalizeText(receipt?.request?.targetPath) !== targetPath ||
+    normalizeText(receipt?.receiptId) !== normalizeText(latestIndex?.receiptId) ||
+    normalizeText(receipt?.git?.headSha) !== normalizeText(latestIndex?.headSha)
+  ) {
+    return {
+      ok: false,
+      status: 'invalid-receipt',
+      reason: 'VI history assistance receipt does not match the latest index contract.',
+      latestIndexPath,
+      receiptPath,
+      receipt
+    };
+  }
+
+  const expectedHeadSha = normalizeText(options.expectedHeadSha);
+  if (expectedHeadSha && normalizeText(receipt?.git?.headSha) !== expectedHeadSha) {
+    return {
+      ok: false,
+      status: 'stale',
+      reason: `Latest VI history assistance receipt is stale for '${targetPath}'.`,
+      latestIndexPath,
+      receiptPath,
+      receipt
+    };
+  }
+
+  return {
+    ok: true,
+    status: 'valid',
+    reason: `Latest VI history assistance receipt is valid for '${targetPath}'.`,
+    latestIndexPath,
+    receiptPath,
+    receipt
+  };
+}
+
+export async function main(argv = process.argv) {
+  const parsed = parseArgs(argv);
+  const result = await runViHistoryOperatorAssistance(parsed);
+  process.stdout.write(`${JSON.stringify(result.summary, null, 2)}\n`);
+  return 0;
+}
+
+const isEntrypoint = fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || '');
+
+if (isEntrypoint) {
+  const exitCode = await main(process.argv);
+  process.exit(exitCode);
+}


### PR DESCRIPTION
# Summary

Adds a local-collab VI History Suite assistance front door for bounded single-VI questions on the current branch.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1091
- Parent standing-priority context: #1079
- Added `tools/local-collab/assist/vi-history/run-operator-assistance.mjs`
- Added focused tests in `tools/local-collab/assist/vi-history/__tests__/run-operator-assistance.test.mjs`
- Added `local-collab:assist:vi-history` command in `package.json`

## What Changed

- wraps `tools/Compare-VIHistory.ps1` and `tools/Inspect-VIHistorySuiteArtifacts.ps1` behind a stable local-collab front door
- emits deterministic assistance receipts and per-target latest indexes under `tests/results/_agent/local-collab/assist/vi-history/`
- records bounded branch scan count separately from VI-touching commit count
- fails closed on stale head, missing target, corrupt latest index, or under-scoped requests
- keeps operator-facing artifacts linked in the receipt for future-agent reuse after compaction

## Validation Evidence

- Commands run:
  - `node --check tools/local-collab/assist/vi-history/run-operator-assistance.mjs`
  - `node --check tools/local-collab/assist/vi-history/__tests__/run-operator-assistance.test.mjs`
  - `node --test tools/local-collab/assist/vi-history/__tests__/run-operator-assistance.test.mjs tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs tools/local-collab/orchestrator/__tests__/run-phase.test.mjs tools/hooks/__tests__/local-collaboration-contract.test.mjs`
- Key artifacts:
  - deterministic receipt and latest-index paths are asserted in the new focused test suite
- Risk-based checks not run:
  - no real host-side LVCompare VI-history run was executed in this slice; the wrapper contract is covered with focused git-backed tests and fake PowerShell backends

## Reviewer Focus

- verify the receipt/index contract for sparse-touch VI history requests
- verify the fail-closed stale-head and missing-target behavior
- verify the front door stays under `tools/local-collab/**` instead of re-expanding `tools/priority/**`

Closes #1091
Refs #1079
