### PR TITLE
#1103 Gate pre-commit and pre-push on local agent review

### DIFF
--- a/docs/schemas/delivery-agent-policy-v1.schema.json
+++ b/docs/schemas/delivery-agent-policy-v1.schema.json
@@ -55,6 +55,12 @@
       "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean" },
+        "reviewProviders": {
+          "type": "array",
+          "items": {
+            "enum": ["copilot-cli", "codex-cli", "simulation", "ollama"]
+          }
+        },
         "bodyMarkers": {
           "type": "array",
           "items": { "type": "string" }

--- a/tools/hooks/__tests__/local-collaboration-contract.test.mjs
+++ b/tools/hooks/__tests__/local-collaboration-contract.test.mjs
@@ -33,6 +33,7 @@ test('delivery agent policy routes daemon local review through the orchestrator 
     '--phase',
     'daemon'
   ]);
+  assert.deepEqual(policy.localReviewLoop.reviewProviders, ['copilot-cli']);
 });
 
 test('PrePush-Checks emits orchestration context when invoked through the local collaboration front door', () => {
@@ -40,4 +41,11 @@ test('PrePush-Checks emits orchestration context when invoked through the local 
   assert.match(source, /LOCAL_COLLAB_ORCHESTRATED/);
   assert.match(source, /LOCAL_COLLAB_PHASE/);
   assert.match(source, /local collaboration orchestrator active/);
+});
+
+test('run-phase wires hook phases through agent-review-policy before commit and push finalization', () => {
+  const source = readRepoFile(path.join('tools', 'local-collab', 'orchestrator', 'run-phase.mjs'));
+  assert.match(source, /agent-review-policy/);
+  assert.match(source, /Blocking local collaboration hook failure in/);
+  assert.match(source, /Skipped core pre-push checks because local agent review failed/);
 });

--- a/tools/hooks/core/runner.mjs
+++ b/tools/hooks/core/runner.mjs
@@ -236,6 +236,8 @@ export class HookRunner {
       name,
       status: 'ok',
       exitCode: 0,
+      rawStatus: 'ok',
+      rawExitCode: 0,
       durationMs: 0,
       stdout: '',
       stderr: '',
@@ -246,6 +248,8 @@ export class HookRunner {
       const result = fn();
       step.status = result?.status ?? 'ok';
       step.exitCode = result?.exitCode ?? 0;
+      step.rawStatus = step.status;
+      step.rawExitCode = step.exitCode;
       step.stdout = truncate(result?.stdout ?? '');
       step.stderr = truncate(result?.stderr ?? '');
       if (result?.note) {
@@ -254,6 +258,8 @@ export class HookRunner {
     } catch (err) {
       step.status = 'failed';
       step.exitCode = err?.exitCode ?? 1;
+      step.rawStatus = step.status;
+      step.rawExitCode = step.exitCode;
       step.stderr = truncate(err?.stderr ?? '');
       step.error = err instanceof Error ? err.message : String(err);
       step.severity = 'error';
@@ -374,8 +380,8 @@ export class HookRunner {
   }
 }
 
-export function listStagedFiles() {
-  const { status, stdout } = runCommand('git', ['diff', '--cached', '--name-only', '--diff-filter=ACM']);
+export function listStagedFiles(repoRoot = process.cwd()) {
+  const { status, stdout } = runCommand('git', ['-C', repoRoot, 'diff', '--cached', '--name-only', '--diff-filter=ACM']);
   if (status !== 0) {
     throw new Error('git diff --cached failed while collecting staged files.');
   }

--- a/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
+++ b/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
@@ -135,3 +135,80 @@ test('runLocalCollaborationPhase records codex authoring receipts for post-commi
   assert.equal(ledgerReceipt.executionPlane, 'windows-host');
   assert.deepEqual(ledgerReceipt.filesTouched, ['README.md']);
 });
+
+test('runLocalCollaborationPhase gates pre-commit on local agent review and records receipt linkage', async () => {
+  const repoRoot = await createGitRepo();
+  await writeFile(path.join(repoRoot, 'notes.txt'), 'hello\n', 'utf8');
+  spawnSync('git', ['add', 'notes.txt'], { cwd: repoRoot, encoding: 'utf8' });
+
+  const result = await runLocalCollaborationPhase({
+    phase: 'pre-commit',
+    repoRoot,
+    providers: ['simulation'],
+    invokeAgentReviewPolicyFn: () => ({
+      exitCode: 0,
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0
+        },
+        providerSelection: {
+          selectionSource: 'explicit-request'
+        },
+        requestedProviders: ['simulation']
+      }
+    })
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.receipt.phase, 'pre-commit');
+  assert.equal(result.receipt.delegate.agentReview.receiptPath, 'tests/results/_hooks/pre-commit-agent-review-policy.json');
+  assert.equal(result.receipt.delegate.agentReview.receiptStatus, 'passed');
+  assert.deepEqual(result.receipt.delegate.agentReview.requestedProviders, ['simulation']);
+
+  const hookSummary = JSON.parse(await readFile(result.receipt.delegate.summaryPath, 'utf8'));
+  const reviewStep = hookSummary.steps.find((step) => step.name === 'agent-review-policy');
+  assert.ok(reviewStep);
+  assert.equal(reviewStep.status, 'ok');
+  assert.equal(reviewStep.rawExitCode, 0);
+  assert.match(reviewStep.note, /pre-commit-agent-review-policy\.json/);
+});
+
+test('runLocalCollaborationPhase blocks pre-push before heavy checks when local agent review fails', async () => {
+  const repoRoot = await createGitRepo();
+
+  const result = await runLocalCollaborationPhase({
+    phase: 'pre-push',
+    repoRoot,
+    providers: ['simulation'],
+    invokeAgentReviewPolicyFn: () => ({
+      exitCode: 1,
+      receipt: {
+        overall: {
+          status: 'failed',
+          actionableFindingCount: 1
+        },
+        providerSelection: {
+          selectionSource: 'explicit-request'
+        },
+        requestedProviders: ['simulation']
+      }
+    })
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.receipt.phase, 'pre-push');
+  assert.equal(result.receipt.delegate.agentReview.receiptStatus, 'failed');
+  assert.deepEqual(result.receipt.delegate.agentReview.requestedProviders, ['simulation']);
+
+  const hookSummary = JSON.parse(await readFile(result.receipt.delegate.summaryPath, 'utf8'));
+  const reviewStep = hookSummary.steps.find((step) => step.name === 'agent-review-policy');
+  assert.ok(reviewStep);
+  assert.equal(reviewStep.status, 'failed');
+  assert.equal(reviewStep.rawExitCode, 1);
+  assert.match(
+    hookSummary.notes.join('\n'),
+    /Skipped core pre-push checks because local agent review failed/
+  );
+  assert.equal(hookSummary.steps.some((step) => step.name === 'pre-push-checks'), false);
+});

--- a/tools/local-collab/orchestrator/run-phase.mjs
+++ b/tools/local-collab/orchestrator/run-phase.mjs
@@ -7,6 +7,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { HookRunner, info, listStagedFiles } from '../../hooks/core/runner.mjs';
 import { resolveGitContext, writeLocalCollaborationLedgerReceipt } from '../ledger/local-review-ledger.mjs';
+import { AGENT_REVIEW_POLICY_PROFILE_RECEIPT_PATHS } from '../providers/agent-review-policy.mjs';
 
 export const LOCAL_COLLAB_ORCHESTRATOR_SCHEMA = 'comparevi/local-collab-orchestrator@v1';
 export const LOCAL_COLLAB_PHASES = ['pre-commit', 'post-commit', 'pre-push', 'daemon'];
@@ -41,6 +42,7 @@ export const DEFAULT_ORCHESTRATOR_RECEIPT_ROOT = path.join(
   'orchestrator'
 );
 export const DEFAULT_DAEMON_DELEGATE_COMMAND = ['node', 'tools/priority/docker-desktop-review-loop.mjs'];
+export const AGENT_REVIEW_POLICY_COMMAND = ['node', 'tools/local-collab/providers/agent-review-policy.mjs'];
 
 function normalizeText(value) {
   if (value == null) {
@@ -91,7 +93,7 @@ function runGit(repoRoot, args) {
 
 function collectFilesTouchedForPhase(repoRoot, phase, git = {}) {
   if (phase === 'pre-commit') {
-    return normalizeStringList(listStagedFiles());
+    return normalizeStringList(listStagedFiles(repoRoot));
   }
 
   if (phase === 'post-commit') {
@@ -219,13 +221,145 @@ function normalizeCommandResult(result = {}) {
   };
 }
 
-function invokePreCommitDelegate(repoRoot) {
+function tryParseJson(raw) {
+  const normalized = normalizeText(raw);
+  if (!normalized) {
+    return null;
+  }
+  try {
+    return JSON.parse(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function hardFailHookStep(runner, step, reason) {
+  const rawExitCode = Number.isInteger(step?.rawExitCode) ? step.rawExitCode : step?.exitCode;
+  if (!rawExitCode) {
+    return;
+  }
+  step.status = 'failed';
+  step.exitCode = rawExitCode;
+  step.severity = 'error';
+  runner.status = 'failed';
+  runner.exitCode = rawExitCode;
+  if (reason) {
+    runner.addNote(reason);
+  }
+}
+
+function invokeHookAgentReviewStep({ runner, repoRoot, phase, env, providerSelection, invokeAgentReviewPolicyFn }) {
+  const configuredReceiptPath = AGENT_REVIEW_POLICY_PROFILE_RECEIPT_PATHS[phase];
+  const normalizedReceiptPath = configuredReceiptPath.replace(/\\/g, '/');
+  const args = [
+    ...AGENT_REVIEW_POLICY_COMMAND.slice(1),
+    '--repo-root',
+    repoRoot,
+    '--profile',
+    phase,
+    '--receipt-path',
+    configuredReceiptPath
+  ];
+  for (const providerId of providerSelection.providers) {
+    args.push('--review-provider', providerId);
+  }
+
+  let parsedReceipt = null;
+  const step = runner.runStep('agent-review-policy', () => {
+    const commandResult = typeof invokeAgentReviewPolicyFn === 'function'
+      ? (() => {
+          const injected = invokeAgentReviewPolicyFn({
+            repoRoot,
+            phase,
+            env,
+            providerSelection,
+            receiptPath: configuredReceiptPath
+          }) ?? {};
+          parsedReceipt = injected.receipt ?? null;
+          const status = Number.isInteger(injected.exitCode)
+            ? injected.exitCode
+            : normalizeText(parsedReceipt?.overall?.status) === 'failed'
+              ? 1
+              : 0;
+          return {
+            status,
+            stdout: normalizeText(injected.stdout) || (parsedReceipt ? JSON.stringify(parsedReceipt, null, 2) : ''),
+            stderr: normalizeText(injected.stderr)
+          };
+        })()
+      : normalizeCommandResult(
+          spawnSync(AGENT_REVIEW_POLICY_COMMAND[0], args, {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            env: {
+              ...env
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+          })
+        );
+    parsedReceipt ??= tryParseJson(commandResult.stdout);
+    const requestedProviders = Array.isArray(parsedReceipt?.requestedProviders)
+      ? parsedReceipt.requestedProviders.filter(Boolean)
+      : [];
+    const noteParts = [
+      `receipt=${normalizedReceiptPath}`,
+      `selectionSource=${normalizeText(parsedReceipt?.providerSelection?.selectionSource) || providerSelection.selectionSource}`
+    ];
+    if (requestedProviders.length > 0) {
+      noteParts.push(`providers=${requestedProviders.join(',')}`);
+    } else {
+      noteParts.push('providers=(none)');
+    }
+    return {
+      status:
+        commandResult.status === 0
+          ? normalizeText(parsedReceipt?.overall?.status) === 'skipped'
+            ? 'skipped'
+            : 'ok'
+          : 'failed',
+      exitCode: commandResult.status,
+      stdout: commandResult.stdout,
+      stderr: commandResult.stderr,
+      note: noteParts.join(' ')
+    };
+  });
+
+  if ((step.rawExitCode ?? step.exitCode) !== 0) {
+    hardFailHookStep(
+      runner,
+      step,
+      `Blocking local collaboration hook failure in ${phase}: agent-review-policy reported actionable findings or provider failure.`
+    );
+  }
+
+  return {
+    receiptPath: normalizedReceiptPath,
+    receiptStatus: normalizeText(parsedReceipt?.overall?.status) || null,
+    selectionSource:
+      normalizeText(parsedReceipt?.providerSelection?.selectionSource) || providerSelection.selectionSource,
+    requestedProviders: Array.isArray(parsedReceipt?.requestedProviders)
+      ? parsedReceipt.requestedProviders.filter(Boolean)
+      : [],
+    actionableFindingCount: Number.isInteger(parsedReceipt?.overall?.actionableFindingCount)
+      ? parsedReceipt.overall.actionableFindingCount
+      : 0
+  };
+}
+
+function invokePreCommitDelegate(
+  repoRoot,
+  {
+    env = process.env,
+    providerSelection = { selectionSource: 'default-empty', providers: [] },
+    invokeAgentReviewPolicyFn
+  } = {}
+) {
   const runner = new HookRunner('pre-commit', { repoRoot });
 
   info('[pre-commit] Collecting staged files');
   let stagedFiles = [];
   runner.runStep('collect-staged', () => {
-    stagedFiles = listStagedFiles();
+    stagedFiles = listStagedFiles(repoRoot);
     return {
       status: 'ok',
       exitCode: 0,
@@ -245,22 +379,27 @@ function invokePreCommitDelegate(repoRoot) {
   }
 
   const psFiles = stagedFiles.filter((file) => file.match(/\.(ps1|psm1|psd1)$/i));
-  if (psFiles.length === 0) {
+  if (psFiles.length > 0) {
+    const scriptPath = path.join('tools', 'hooks', 'scripts', 'pre-commit.ps1');
+    info('[pre-commit] Running PowerShell validation script');
+    runner.runPwshStep('powershell-validation', scriptPath, [], {
+      env: {
+        HOOKS_STAGED_FILES_JSON: JSON.stringify(psFiles)
+      }
+    });
+  } else {
     info('[pre-commit] No staged PowerShell files detected; skipping PowerShell lint.');
     runner.addNote('No staged PowerShell files detected; PowerShell lint skipped.');
-    runner.writeSummary();
-    return {
-      exitCode: 0,
-      summaryPath: path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit.json')
-    };
   }
 
-  const scriptPath = path.join('tools', 'hooks', 'scripts', 'pre-commit.ps1');
-  info('[pre-commit] Running PowerShell validation script');
-  runner.runPwshStep('powershell-validation', scriptPath, [], {
-    env: {
-      HOOKS_STAGED_FILES_JSON: JSON.stringify(psFiles)
-    }
+  info('[pre-commit] Running local agent review providers');
+  const agentReview = invokeHookAgentReviewStep({
+    runner,
+    repoRoot,
+    phase: 'pre-commit',
+    env,
+    providerSelection,
+    invokeAgentReviewPolicyFn
   });
   runner.writeSummary();
 
@@ -272,19 +411,40 @@ function invokePreCommitDelegate(repoRoot) {
 
   return {
     exitCode: runner.exitCode,
-    summaryPath: path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit.json')
+    summaryPath: path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-commit.json'),
+    agentReview
   };
 }
 
-function invokePrePushDelegate(repoRoot) {
+function invokePrePushDelegate(
+  repoRoot,
+  {
+    env = process.env,
+    providerSelection = { selectionSource: 'default-empty', providers: [] },
+    invokeAgentReviewPolicyFn
+  } = {}
+) {
   const runner = new HookRunner('pre-push', { repoRoot });
-  info('[pre-push] Running core pre-push checks');
-  runner.runPwshStep('pre-push-checks', path.join('tools', 'PrePush-Checks.ps1'), [], {
-    env: {
-      LOCAL_COLLAB_ORCHESTRATED: '1',
-      LOCAL_COLLAB_PHASE: 'pre-push'
-    }
+  info('[pre-push] Running local agent review providers');
+  const agentReview = invokeHookAgentReviewStep({
+    runner,
+    repoRoot,
+    phase: 'pre-push',
+    env,
+    providerSelection,
+    invokeAgentReviewPolicyFn
   });
+  if (runner.exitCode === 0) {
+    info('[pre-push] Running core pre-push checks');
+    runner.runPwshStep('pre-push-checks', path.join('tools', 'PrePush-Checks.ps1'), [], {
+      env: {
+        LOCAL_COLLAB_ORCHESTRATED: '1',
+        LOCAL_COLLAB_PHASE: 'pre-push'
+      }
+    });
+  } else {
+    runner.addNote('Skipped core pre-push checks because local agent review failed.');
+  }
   runner.writeSummary();
   if (runner.exitCode !== 0) {
     info('[pre-push] Hook failed; inspect tests/results/_hooks/pre-push.json for details.');
@@ -293,7 +453,8 @@ function invokePrePushDelegate(repoRoot) {
   }
   return {
     exitCode: runner.exitCode,
-    summaryPath: path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-push.json')
+    summaryPath: path.join(repoRoot, 'tests', 'results', '_hooks', 'pre-push.json'),
+    agentReview
   };
 }
 
@@ -344,9 +505,17 @@ export async function runLocalCollaborationPhase(options = {}) {
   if (typeof delegateFns[phase] === 'function') {
     result = await delegateFns[phase]({ repoRoot, phase, env, delegateArgs: options.delegateArgs ?? [] });
   } else if (phase === 'pre-commit') {
-    result = invokePreCommitDelegate(repoRoot);
+    result = invokePreCommitDelegate(repoRoot, {
+      env,
+      providerSelection,
+      invokeAgentReviewPolicyFn: options.invokeAgentReviewPolicyFn
+    });
   } else if (phase === 'pre-push') {
-    result = invokePrePushDelegate(repoRoot);
+    result = invokePrePushDelegate(repoRoot, {
+      env,
+      providerSelection,
+      invokeAgentReviewPolicyFn: options.invokeAgentReviewPolicyFn
+    });
   } else if (phase === 'daemon') {
     result = invokeDaemonDelegate(repoRoot, options.delegateArgs ?? []);
   } else if (phase === 'post-commit') {
@@ -360,6 +529,7 @@ export async function runLocalCollaborationPhase(options = {}) {
   const filesTouched = explicitFilesTouched.length > 0
     ? explicitFilesTouched
     : collectFilesTouchedForPhase(repoRoot, phase, git);
+  const agentReviewReceiptPath = normalizeText(result.agentReview?.receiptPath);
   const receipt = {
     schema: LOCAL_COLLAB_ORCHESTRATOR_SCHEMA,
     phase,
@@ -384,7 +554,19 @@ export async function runLocalCollaborationPhase(options = {}) {
           ? [...DEFAULT_DAEMON_DELEGATE_COMMAND, '--repo-root', repoRoot, ...(options.delegateArgs ?? [])]
           : null,
       summaryPath: normalizeText(result.summaryPath) || null,
-      note: normalizeText(result.note) || null
+      note: normalizeText(result.note) || null,
+      agentReview:
+        result.agentReview && typeof result.agentReview === 'object'
+          ? {
+              receiptPath: normalizeText(result.agentReview.receiptPath) || null,
+              receiptStatus: normalizeText(result.agentReview.receiptStatus) || null,
+              selectionSource: normalizeText(result.agentReview.selectionSource) || null,
+              requestedProviders: normalizeStringList(result.agentReview.requestedProviders),
+              actionableFindingCount: Number.isInteger(result.agentReview.actionableFindingCount)
+                ? result.agentReview.actionableFindingCount
+                : 0
+            }
+          : null
     }
   };
   await writeFile(orchestratorReceiptPath, JSON.stringify(receipt, null, 2), 'utf8');
@@ -406,10 +588,15 @@ export async function runLocalCollaborationPhase(options = {}) {
     outcome: receipt.outcome,
     filesTouched: receipt.filesTouched,
     commitCreated: receipt.commitCreated,
-    sourcePaths: [orchestratorReceiptPath, normalizeText(result.summaryPath)].filter(Boolean),
+    sourcePaths: [
+      orchestratorReceiptPath,
+      normalizeText(result.summaryPath),
+      agentReviewReceiptPath ? path.resolve(repoRoot, agentReviewReceiptPath) : ''
+    ].filter(Boolean),
     metadata: {
       orchestratorReceiptPath: path.relative(repoRoot, orchestratorReceiptPath).replace(/\\/g, '/'),
-      delegateSummaryPath: normalizeText(result.summaryPath) || null
+      delegateSummaryPath: normalizeText(result.summaryPath) || null,
+      agentReviewReceiptPath: agentReviewReceiptPath || null
     }
   });
   receipt.ledger = {

--- a/tools/local-collab/providers/agent-review-policy.mjs
+++ b/tools/local-collab/providers/agent-review-policy.mjs
@@ -32,13 +32,13 @@ export const DEFAULT_AGENT_REVIEW_POLICY_RECEIPT_PATH = path.join(
   'agent-review-policy',
   'receipt.json'
 );
-export const SUPPORTED_AGENT_REVIEW_PROVIDERS = SUPPORTED_LOCAL_REVIEW_PROVIDERS;
-export const SUPPORTED_AGENT_REVIEW_PROFILES = SUPPORTED_LOCAL_REVIEW_PROFILES;
-const PROFILE_RECEIPT_PATHS = {
+export const AGENT_REVIEW_POLICY_PROFILE_RECEIPT_PATHS = {
   'pre-commit': path.join('tests', 'results', '_hooks', 'pre-commit-agent-review-policy.json'),
   daemon: DEFAULT_AGENT_REVIEW_POLICY_RECEIPT_PATH,
   'pre-push': path.join('tests', 'results', '_hooks', 'pre-push-agent-review-policy.json')
 };
+export const SUPPORTED_AGENT_REVIEW_PROVIDERS = SUPPORTED_LOCAL_REVIEW_PROVIDERS;
+export const SUPPORTED_AGENT_REVIEW_PROFILES = SUPPORTED_LOCAL_REVIEW_PROFILES;
 
 function normalizeText(value) {
   if (value == null) {
@@ -140,7 +140,7 @@ export function parseArgs(argv = process.argv) {
 
   options.request.reviewProviders = normalizeLocalReviewProviderList(options.request.reviewProviders);
   if (!normalizeText(options.request.agentReviewPolicyReceiptPath)) {
-    options.request.agentReviewPolicyReceiptPath = PROFILE_RECEIPT_PATHS[options.request.profile];
+    options.request.agentReviewPolicyReceiptPath = AGENT_REVIEW_POLICY_PROFILE_RECEIPT_PATHS[options.request.profile];
   }
   return options;
 }
@@ -185,10 +185,6 @@ export async function loadAgentReviewPolicy(repoRoot) {
               ...DEFAULT_SIMULATION_REVIEW_POLICY,
               enabled: localReviewLoop.simulationReview === true
             },
-      codexCli:
-        localReviewLoop.codexCliReviewConfig && typeof localReviewLoop.codexCliReviewConfig === 'object'
-          ? localReviewLoop.codexCliReviewConfig
-          : { enabled: false },
       ollama:
         localReviewLoop.ollamaReviewConfig && typeof localReviewLoop.ollamaReviewConfig === 'object'
           ? localReviewLoop.ollamaReviewConfig
@@ -258,7 +254,9 @@ export async function runAgentReviewPolicy({
   const requestedProviders = providerSelection.providers;
   const receiptPathInfo = resolveRepoPath(
     repoRoot,
-    normalizeText(request.agentReviewPolicyReceiptPath) || PROFILE_RECEIPT_PATHS[executionProfile] || normalizedPolicy.receiptPath
+    normalizeText(request.agentReviewPolicyReceiptPath) ||
+      AGENT_REVIEW_POLICY_PROFILE_RECEIPT_PATHS[executionProfile] ||
+      normalizedPolicy.receiptPath
   );
   const repoGitState = resolveRepoGitStateFn(repoRoot) ?? {};
 

--- a/tools/priority/__tests__/agent-review-policy.test.mjs
+++ b/tools/priority/__tests__/agent-review-policy.test.mjs
@@ -260,7 +260,7 @@ test('runAgentReviewPolicy fails closed when an explicitly selected reserved pro
     repoRoot,
     request: {
       requested: true,
-      reviewProviders: ['codex-cli']
+      reviewProviders: ['ollama']
     },
     resolveRepoGitStateFn: () => ({
       headSha: 'abc123',
@@ -271,9 +271,62 @@ test('runAgentReviewPolicy fails closed when an explicitly selected reserved pro
   });
 
   assert.equal(result.status, 'failed');
-  assert.equal(result.receipt.overall.failedProvider, 'codex-cli');
-  assert.equal(result.receipt.providers['codex-cli'].status, 'failed');
-  assert.match(result.receipt.providers['codex-cli'].reason, /not implemented yet/i);
+  assert.equal(result.receipt.overall.failedProvider, 'ollama');
+  assert.equal(result.receipt.providers.ollama.status, 'failed');
+  assert.match(result.receipt.providers.ollama.reason, /not implemented yet/i);
+});
+
+test('runAgentReviewPolicy records WSL-backed Codex CLI effort metadata', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'agent-review-policy-codex-pass-'));
+  const result = await runAgentReviewPolicy({
+    repoRoot,
+    request: {
+      requested: true,
+      reviewProviders: ['codex-cli']
+    },
+    runCodexCliReviewFn: async () => ({
+      providerId: 'codex-cli',
+      status: 'passed',
+      reason: 'Codex CLI passed.',
+      executionPlane: 'wsl2',
+      providerRuntime: 'codex-cli',
+      requestedModel: 'gpt-5-codex',
+      effectiveModel: 'gpt-5-codex',
+      inputTokens: 210,
+      cachedInputTokens: 80,
+      outputTokens: 55,
+      receiptPath: 'tests/results/docker-tools-parity/codex-cli-review/receipt.json',
+      receipt: {
+        executionPlane: 'wsl2',
+        providerRuntime: 'codex-cli',
+        usage: {
+          inputTokens: 210,
+          cachedInputTokens: 80,
+          outputTokens: 55
+        },
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Codex CLI passed.'
+        }
+      }
+    }),
+    resolveRepoGitStateFn: () => ({
+      headSha: 'abc123',
+      branch: 'issue/test',
+      upstreamDevelopMergeBase: 'base123',
+      dirtyTracked: false
+    })
+  });
+
+  assert.equal(result.status, 'passed');
+  assert.equal(result.receipt.providers['codex-cli'].executionPlane, 'wsl2');
+  assert.equal(result.receipt.providers['codex-cli'].providerRuntime, 'codex-cli');
+  assert.equal(result.receipt.providers['codex-cli'].requestedModel, 'gpt-5-codex');
+  assert.equal(result.receipt.providers['codex-cli'].inputTokens, 210);
+  assert.equal(result.receipt.overall.inputTokens, 210);
+  assert.equal(result.receipt.overall.cachedInputTokens, 80);
+  assert.equal(result.receipt.overall.outputTokens, 55);
 });
 
 test('runAgentReviewPolicy records policy-default provider selection when no explicit providers are requested', async () => {

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -47,6 +47,7 @@ test('delivery-agent policy schema validates the checked-in policy contract', as
   });
   assert.deepEqual(data.localReviewLoop, {
     enabled: true,
+    reviewProviders: ['copilot-cli'],
     bodyMarkers: ['Daemon-first local iteration extension'],
     receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
     command: ['node', 'tools/local-collab/orchestrator/run-phase.mjs', '--phase', 'daemon'],

--- a/tools/priority/delivery-agent.policy.json
+++ b/tools/priority/delivery-agent.policy.json
@@ -26,6 +26,9 @@
   },
   "localReviewLoop": {
     "enabled": true,
+    "reviewProviders": [
+      "copilot-cli"
+    ],
     "bodyMarkers": [
       "Daemon-first local iteration extension"
     ],


### PR DESCRIPTION
# Summary

Gates the local collaboration hook phases on `agent-review-policy` so `pre-commit` and `pre-push` now run the provider concentrator as a real blocking step instead of only delegating lint/check scripts.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1103
- Hook/orchestrator changes:
  - `tools/local-collab/orchestrator/run-phase.mjs`
  - `tools/hooks/core/runner.mjs`
- Provider/policy changes:
  - `tools/local-collab/providers/agent-review-policy.mjs`
  - `tools/priority/delivery-agent.policy.json`
  - `docs/schemas/delivery-agent-policy-v1.schema.json`
- Contract coverage updates:
  - `tools/local-collab/orchestrator/__tests__/run-phase.test.mjs`
  - `tools/hooks/__tests__/local-collaboration-contract.test.mjs`
  - `tools/priority/__tests__/agent-review-policy.test.mjs`
  - `tools/priority/__tests__/delivery-agent-schema.test.mjs`

## What Changed

- `pre-commit` now:
  - collects staged files against the target repo root
  - still runs PowerShell lint when staged PowerShell files exist
  - always runs `agent-review-policy` for staged local review when files are staged
  - records the agent-review receipt path in both hook and orchestrator artifacts
- `pre-push` now:
  - runs `agent-review-policy` first
  - blocks immediately on actionable local review findings or provider failures
  - skips the heavyweight `PrePush-Checks.ps1` path when local review already failed
- Checked-in local review defaults now set `reviewProviders = ["copilot-cli"]` so hook phases do not silently skip review when no override is supplied.
- Hook failures from `agent-review-policy` are treated as blocking transaction-boundary failures even when generic hook enforcement would otherwise downgrade ordinary local warnings.

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs build`
  - `node --test tools/local-collab/orchestrator/__tests__/run-phase.test.mjs tools/hooks/__tests__/local-collaboration-contract.test.mjs tools/local-collab/providers/__tests__/agent-review-policy.test.mjs tools/priority/__tests__/agent-review-policy.test.mjs tools/priority/__tests__/delivery-agent-schema.test.mjs`
- Result:
  - `41/41` passing

## Risks and Follow-ups

- Residual risks: this slice establishes the blocking hook gate and default provider path, but it does not yet add phase-specific provider defaults beyond the shared policy default.
- Follow-up issues or deferred work: broader `#1079` local collaboration protocol work continues after this slice lands.
- Deployment, approval, or rollback notes: `ready_for_review` remains final hosted validation intent only; the actual repeat review loop stays local-first.

## Reviewer Focus

- Verify that `pre-commit` and `pre-push` now fail closed on `agent-review-policy` failures and that the receipt linkage is preserved in orchestrator/hook artifacts.
- Verify that the checked-in policy default (`copilot-cli`) is intentional and that the hook-provider selection order remains deterministic.

Closes #1103
