### PR TITLE
#1106 Bootstrap personal-fork policy guard with shadow overlays

### DIFF
--- a/.github/workflows/policy-guard-upstream.yml
+++ b/.github/workflows/policy-guard-upstream.yml
@@ -72,6 +72,25 @@ jobs:
       shell: pwsh
       run: pwsh -NoLogo -NoProfile -File tools/Assert-NoAmbiguousRemoteRefs.ps1
 
+    - name: Overlay personal-fork policy surfaces
+      if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != github.repository_owner
+      run: >
+        node tools/policy/export-personal-fork-policy-shadow.mjs
+        --repo "${{ github.event.pull_request.head.repo.full_name }}"
+        --ref "${{ github.event.pull_request.head.sha }}"
+        --workspace-root .
+        --report tests/results/_agent/policy/policy-shadow-export.json
+
+    - name: Assert policy guard contract
+      shell: pwsh
+      run: |
+        pwsh -NoLogo -NoProfile -File tools/Assert-PolicyGuardCheckContract.ps1
+
+    - name: Assert promotion contract alignment
+      shell: pwsh
+      run: |
+        pwsh -NoLogo -NoProfile -File tools/Assert-PromotionContractAlignment.ps1 -OutputJsonPath tests/results/_agent/policy/promotion-contract-alignment.json
+
     - name: Run policy guard
       shell: pwsh
       run: |
@@ -89,6 +108,8 @@ jobs:
         name: policy-drift-${{ github.run_id }}
         path: |
           tests/results/_agent/policy/policy-drift-report.json
+          tests/results/_agent/policy/policy-shadow-export.json
+          tests/results/_agent/policy/promotion-contract-alignment.json
           tests/results/_agent/health/policy-guard-workspace-health.json
           tests/results/_agent/deployments/environment-gate-policy.json
         if-no-files-found: error

--- a/tools/policy/__tests__/export-personal-fork-policy-shadow.test.mjs
+++ b/tools/policy/__tests__/export-personal-fork-policy-shadow.test.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import {
+  POLICY_SHADOW_FILES,
+  exportPersonalForkPolicyShadow,
+  parseArgs,
+} from '../export-personal-fork-policy-shadow.mjs';
+
+test('parseArgs requires repo/ref and keeps report/workspace overrides', () => {
+  const options = parseArgs([
+    'node',
+    'tools/policy/export-personal-fork-policy-shadow.mjs',
+    '--repo',
+    'owner/repo',
+    '--ref',
+    'abc123',
+    '--workspace-root',
+    'shadow-root',
+    '--report',
+    'shadow-report.json',
+  ]);
+
+  assert.equal(options.repo, 'owner/repo');
+  assert.equal(options.ref, 'abc123');
+  assert.equal(options.workspaceRoot, 'shadow-root');
+  assert.equal(options.report, 'shadow-report.json');
+});
+
+test('exportPersonalForkPolicyShadow overlays policy surfaces from GitHub contents', async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'policy-shadow-'));
+  const reportPath = path.join(workspaceRoot, 'report.json');
+  const requested = [];
+  const encoded = new Map(
+    POLICY_SHADOW_FILES.map((relativePath) => [
+      relativePath,
+      {
+        type: 'file',
+        encoding: 'base64',
+        content: Buffer.from(`shadow:${relativePath}`, 'utf8').toString('base64'),
+        sha: `sha-${relativePath}`,
+        size: 7,
+      },
+    ]),
+  );
+
+  const result = await exportPersonalForkPolicyShadow({
+    repo: 'someone/compare-vi-cli-action',
+    ref: 'deadbeef',
+    workspaceRoot,
+    report: reportPath,
+    env: { GH_TOKEN: 'token-value' },
+    fetchFn: async (url, options) => {
+      requested.push({ url, options });
+      const matched = POLICY_SHADOW_FILES.find((candidate) => url.includes(encodeURIComponent(candidate.split('/').pop())));
+      const relativePath = POLICY_SHADOW_FILES.find((candidate) => url.includes(candidate.replace(/\//g, '%2F')));
+      const payload = encoded.get(relativePath ?? matched);
+      return {
+        ok: true,
+        async json() {
+          return payload;
+        },
+      };
+    },
+  });
+
+  assert.equal(result.repository, 'someone/compare-vi-cli-action');
+  assert.equal(result.ref, 'deadbeef');
+  assert.equal(result.files.length, POLICY_SHADOW_FILES.length);
+  assert.equal(requested.length, POLICY_SHADOW_FILES.length);
+
+  for (const relativePath of POLICY_SHADOW_FILES) {
+    const absolutePath = path.join(workspaceRoot, ...relativePath.split('/'));
+    const content = await readFile(absolutePath, 'utf8');
+    assert.equal(content, `shadow:${relativePath}`);
+  }
+
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(report.schema, 'policy/personal-fork-shadow-export@v1');
+  assert.equal(report.files.length, POLICY_SHADOW_FILES.length);
+});
+
+test('exportPersonalForkPolicyShadow fails closed on unsupported payload encoding', async () => {
+  await assert.rejects(
+    exportPersonalForkPolicyShadow({
+      repo: 'someone/compare-vi-cli-action',
+      ref: 'deadbeef',
+      workspaceRoot: await mkdtemp(path.join(os.tmpdir(), 'policy-shadow-fail-')),
+      env: { GH_TOKEN: 'token-value' },
+      fetchFn: async () => ({
+        ok: true,
+        async json() {
+          return {
+            type: 'file',
+            encoding: 'utf8',
+            content: 'bad',
+          };
+        },
+      }),
+    }),
+    /expected base64 content/,
+  );
+});

--- a/tools/policy/export-personal-fork-policy-shadow.mjs
+++ b/tools/policy/export-personal-fork-policy-shadow.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+export const POLICY_SHADOW_FILES = [
+  '.github/workflows/policy-guard-upstream.yml',
+  'tools/policy/branch-required-checks.json',
+  'tools/priority/policy.json',
+  'tools/policy/promotion-contract.json',
+];
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    repo: null,
+    ref: null,
+    workspaceRoot: '.',
+    report: null,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--repo') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --repo.');
+      }
+      options.repo = value;
+      index += 1;
+      continue;
+    }
+    if (arg === '--ref') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --ref.');
+      }
+      options.ref = value;
+      index += 1;
+      continue;
+    }
+    if (arg === '--workspace-root') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --workspace-root.');
+      }
+      options.workspaceRoot = value;
+      index += 1;
+      continue;
+    }
+    if (arg === '--report') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('Missing value for --report.');
+      }
+      options.report = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.repo) {
+    throw new Error('Missing required --repo.');
+  }
+  if (!options.ref) {
+    throw new Error('Missing required --ref.');
+  }
+
+  return options;
+}
+
+function encodeRepoPath(relativePath) {
+  return String(relativePath)
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+async function resolveToken({
+  env = process.env,
+  readFileFn = readFile,
+} = {}) {
+  const direct = [env.GH_TOKEN, env.GITHUB_TOKEN]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .find(Boolean);
+  if (direct) {
+    return direct;
+  }
+
+  const filePath = typeof env.GH_TOKEN_FILE === 'string' ? env.GH_TOKEN_FILE.trim() : '';
+  if (filePath) {
+    const fromFile = (await readFileFn(filePath, 'utf8')).trim();
+    if (fromFile) {
+      return fromFile;
+    }
+  }
+
+  return null;
+}
+
+async function requestGithubJson(url, token, fetchFn = globalThis.fetch) {
+  if (typeof fetchFn !== 'function') {
+    throw new Error('Global fetch is not available; provide fetchFn.');
+  }
+
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'policy-shadow-exporter',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetchFn(url, { headers });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub contents request failed (${response.status} ${response.statusText}): ${text}`);
+  }
+
+  return response.json();
+}
+
+export async function exportPersonalForkPolicyShadow({
+  repo,
+  ref,
+  workspaceRoot = '.',
+  report = null,
+  fetchFn = globalThis.fetch,
+  readFileFn = readFile,
+  writeFileFn = writeFile,
+  mkdirFn = mkdir,
+  env = process.env,
+} = {}) {
+  if (!repo) {
+    throw new Error('repo is required.');
+  }
+  if (!ref) {
+    throw new Error('ref is required.');
+  }
+
+  const token = await resolveToken({ env, readFileFn });
+  const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
+  const updatedFiles = [];
+
+  for (const relativePath of POLICY_SHADOW_FILES) {
+    const url =
+      `https://api.github.com/repos/${repo}/contents/${encodeRepoPath(relativePath)}?ref=${encodeURIComponent(ref)}`;
+    const payload = await requestGithubJson(url, token, fetchFn);
+    if (payload?.type !== 'file') {
+      throw new Error(`Unsupported GitHub contents payload for ${relativePath}: expected file.`);
+    }
+    if (payload?.encoding !== 'base64' || typeof payload?.content !== 'string') {
+      throw new Error(`Unsupported encoding for ${relativePath}: expected base64 content.`);
+    }
+
+    const absolutePath = path.join(resolvedWorkspaceRoot, ...relativePath.split('/'));
+    await mkdirFn(path.dirname(absolutePath), { recursive: true });
+    const content = Buffer.from(payload.content, 'base64').toString('utf8');
+    await writeFileFn(absolutePath, content, 'utf8');
+
+    updatedFiles.push({
+      path: relativePath,
+      sha: payload.sha ?? null,
+      size: typeof payload.size === 'number' ? payload.size : Buffer.byteLength(content, 'utf8'),
+    });
+  }
+
+  const result = {
+    schema: 'policy/personal-fork-shadow-export@v1',
+    generatedAt: new Date().toISOString(),
+    repository: repo,
+    ref,
+    workspaceRoot: resolvedWorkspaceRoot,
+    files: updatedFiles,
+  };
+
+  if (report) {
+    const reportPath = path.resolve(report);
+    await mkdirFn(path.dirname(reportPath), { recursive: true });
+    await writeFileFn(reportPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+  }
+
+  return result;
+}
+
+export async function main() {
+  const options = parseArgs();
+  const result = await exportPersonalForkPolicyShadow(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const isEntrypoint = (() => {
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : null;
+  return invoked === path.resolve(new URL(import.meta.url).pathname);
+})();
+
+if (isEntrypoint) {
+  await main();
+}

--- a/tools/priority/__tests__/workflow-checkout-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-checkout-contract.test.mjs
@@ -88,6 +88,8 @@ test('policy workflows keep explicit base-safe or mixed checkout expressions', (
     /ref:\s+\$\{\{\s*github\.event_name == 'pull_request' && github\.event\.pull_request\.head\.sha \|\| github\.event_name == 'pull_request_target' && github\.event\.pull_request\.head\.repo\.owner\.login == github\.repository_owner && github\.event\.pull_request\.head\.sha \|\| github\.event_name == 'pull_request_target' && github\.event\.pull_request\.base\.sha \|\| github\.sha\s*\}\}/
   );
   assert.match(policyGuard, /fetch-depth:\s*0/);
+  assert.match(policyGuard, /Overlay personal-fork policy surfaces/);
+  assert.match(policyGuard, /tools\/policy\/export-personal-fork-policy-shadow\.mjs/);
   assert.doesNotMatch(policyGuard, /checkout-workflow-context/);
 });
 


### PR DESCRIPTION
# Summary

Bootstraps personal-fork policy PR validation without executing untrusted fork code under `pull_request_target`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Adds `tools/policy/export-personal-fork-policy-shadow.mjs` to fetch PR-head policy surfaces from the personal fork via the GitHub contents API and overlay them into the trusted workspace.
- Updates `Policy Guard (Upstream)` to apply that overlay only for personal-fork `pull_request_target` runs before the existing trusted validators execute.
- Extends the workflow checkout contract and adds focused helper tests for the new bootstrap path.

## Validation Evidence

- `node --check tools/policy/export-personal-fork-policy-shadow.mjs`
- `node --test tools/policy/__tests__/export-personal-fork-policy-shadow.test.mjs`
- `node --test tools/priority/__tests__/workflow-checkout-contract.test.mjs`
- `Invoke-Pester -Path tests/PolicyGuardCheckContract.Tests.ps1 -CI`
- `pwsh -NoLogo -NoProfile -File tools/Assert-PromotionContractAlignment.ps1`
- `bin\\actionlint.exe .github\\workflows\\policy-guard-upstream.yml`

## Risks and Follow-ups

- This bootstraps the personal-fork path by overlaying a bounded set of policy/workflow files as data; it does not execute fork-supplied scripts with admin-scoped `pull_request_target` permissions.
- Future personal-fork policy PRs should no longer need the manual shadow-branch/status bridge once this lands.

Closes #1106
Refs #1079