### PR TITLE
#1077 Close Copilot CLI instruction and contract gap

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Copilot CLI Local Review Contract
+
+- Use GitHub Copilot CLI only in the local `draft-review` loop.
+- Run it through the repo-owned wrapper surfaces under `tools/local-collab/providers/`.
+- Keep review runs head-scoped and focused on the current staged diff or current branch delta only.
+- Preserve and honor:
+  - `AGENTS.md`
+  - `.github/instructions/draft-only-copilot-review.instructions.md`
+  - `.github/instructions/final-ready-validation.instructions.md`
+- Do not treat local Copilot CLI output as merge, queue, or promotion authority.
+- Hosted required checks and final ready-validation remain authoritative for promotion.
+- If the head SHA changes after a local review receipt is created, treat the receipt as stale and rerun the local review.
+- Prefer least-privilege CLI execution. Do not widen tools/permissions without an explicit tracked policy change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,9 @@ artifacts under `tests/results/_agent/`.
   `.github/instructions/*.instructions.md`. Keep them aligned with the
   draft-only Copilot review contract: draft is the only Copilot iteration
   state, and `ready_for_review` means final validation / promotion intent only.
+- Repo-owned Copilot CLI instructions live in `.github/copilot-instructions.md`.
+  Use the local Copilot CLI review plane only for draft-review acceleration and
+  keep hosted validation authoritative for final promotion.
 
 ## Working Rules
 

--- a/tools/priority/__tests__/copilot-cli-review.test.mjs
+++ b/tools/priority/__tests__/copilot-cli-review.test.mjs
@@ -79,8 +79,12 @@ test('buildReviewPrompt includes collaboration planes and instruction presence',
       diffText: 'diff --git a/docs/example.md b/docs/example.md'
     },
     instructionSources: {
-      present: ['AGENTS.md', '.github/instructions/draft-only-copilot-review.instructions.md'],
-      missing: ['.github/copilot-instructions.md']
+      present: [
+        'AGENTS.md',
+        '.github/copilot-instructions.md',
+        '.github/instructions/draft-only-copilot-review.instructions.md'
+      ],
+      missing: []
     },
     profileName: 'preCommit',
     repoRoot: '/tmp/repo'

--- a/tools/priority/__tests__/github-instructions-contract.test.mjs
+++ b/tools/priority/__tests__/github-instructions-contract.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const instructionsDir = path.join(repoRoot, '.github', 'instructions');
+const copilotInstructionsPath = path.join(repoRoot, '.github', 'copilot-instructions.md');
 const agentsPath = path.join(repoRoot, 'AGENTS.md');
 
 function readInstruction(name) {
@@ -18,6 +19,7 @@ function normalizeWhitespace(value) {
 
 test('draft-only GitHub instructions exist as a repo-owned surface', () => {
   assert.equal(fs.existsSync(instructionsDir), true, '.github/instructions must exist.');
+  assert.equal(fs.existsSync(copilotInstructionsPath), true, '.github/copilot-instructions.md must exist.');
   const instructionFiles = fs.readdirSync(instructionsDir)
     .filter((entry) => entry.endsWith('.instructions.md'))
     .sort();
@@ -26,6 +28,14 @@ test('draft-only GitHub instructions exist as a repo-owned surface', () => {
     'draft-only-copilot-review.instructions.md',
     'final-ready-validation.instructions.md',
   ]);
+});
+
+test('Copilot instructions capture the local-first CLI review boundary', () => {
+  const copilotInstructions = normalizeWhitespace(fs.readFileSync(copilotInstructionsPath, 'utf8'));
+
+  assert.match(copilotInstructions, /GitHub Copilot CLI only in the local `draft-review` loop/i);
+  assert.match(copilotInstructions, /hosted required checks and final ready-validation remain authoritative/i);
+  assert.match(copilotInstructions, /head SHA changes .* stale and rerun the local review/i);
 });
 
 test('draft-only instruction content captures the required Copilot review contract', () => {
@@ -44,5 +54,7 @@ test('draft-only instruction content captures the required Copilot review contra
 test('AGENTS points future agents at the GitHub instructions surface', () => {
   const agents = fs.readFileSync(agentsPath, 'utf8');
   assert.match(agents, /\.github\/instructions\/\*\.instructions\.md/);
+  assert.match(agents, /\.github\/copilot-instructions\.md/);
   assert.match(agents, /draft-only Copilot review contract/i);
+  assert.match(agents, /local Copilot CLI review plane only for draft-review acceleration/i);
 });


### PR DESCRIPTION
# Summary

Closes the remaining `#1077` gap after the local-collaboration slices already landed on `develop`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- adds `.github/copilot-instructions.md` as the repo-owned Copilot CLI instruction layer
- points `AGENTS.md` at the local-first Copilot CLI review boundary
- tightens instruction and wrapper contract tests so the Copilot CLI path cannot silently drift from the documented draft-review / ready-validation split

## Validation Evidence

- `node --test tools/priority/__tests__/github-instructions-contract.test.mjs tools/priority/__tests__/copilot-cli-review.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

## Notes

- The larger implementation surface from the stale `#1085` branch is already merged through the closed `#1079` child slices (`#1080`, `#1081`, `#1082`, `#1083`, `#1089`, `#1090`, `#1091`, `#1101`, `#1106`).
- This PR only closes the remaining instruction/documentation contract gap needed to finish `#1077` cleanly.

Closes #1077
Refs #1079