### PR TITLE
#1078 Pin Copilot CLI permission and session defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,4 +10,6 @@
 - Do not treat local Copilot CLI output as merge, queue, or promotion authority.
 - Hosted required checks and final ready-validation remain authoritative for promotion.
 - If the head SHA changes after a local review receipt is created, treat the receipt as stale and rerun the local review.
-- Prefer least-privilege CLI execution. Do not widen tools/permissions without an explicit tracked policy change.
+- Prefer least-privilege CLI execution. Keep `allowAllTools=false`, keep the explicit
+  tool allowlist empty unless a tracked policy change widens it, and do not
+  reuse prior CLI sessions across branch heads.

--- a/docs/schemas/delivery-agent-policy-v1.schema.json
+++ b/docs/schemas/delivery-agent-policy-v1.schema.json
@@ -61,6 +61,28 @@
             "enum": ["copilot-cli", "codex-cli", "simulation", "ollama"]
           }
         },
+        "copilotCliReview": { "type": "boolean" },
+        "copilotCliReviewConfig": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "model": { "type": "string" },
+            "promptOnly": { "type": "boolean" },
+            "disableBuiltinMcps": { "type": "boolean" },
+            "allowAllTools": { "type": "boolean" },
+            "availableTools": { "type": "string" },
+            "sessionPolicy": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "reuse": { "enum": ["fresh-per-head", "fresh-per-invocation"] },
+                "scope": { "enum": ["current-head", "current-diff"] },
+                "recordPromptArtifacts": { "type": "boolean" }
+              }
+            }
+          }
+        },
         "bodyMarkers": {
           "type": "array",
           "items": { "type": "string" }

--- a/tools/local-collab/providers/copilot-cli-review.mjs
+++ b/tools/local-collab/providers/copilot-cli-review.mjs
@@ -19,6 +19,11 @@ export const DEFAULT_COPILOT_CLI_REVIEW_POLICY = {
   disableBuiltinMcps: true,
   allowAllTools: false,
   availableTools: '',
+  sessionPolicy: {
+    reuse: 'fresh-per-head',
+    scope: 'current-head',
+    recordPromptArtifacts: true
+  },
   convergence: {
     minPasses: 2,
     maxPasses: 4,
@@ -294,6 +299,21 @@ function normalizeConvergencePolicy(value = {}) {
   };
 }
 
+function normalizeSessionPolicy(value = {}) {
+  const session = value && typeof value === 'object' ? value : {};
+  return {
+    reuse:
+      normalizeText(session.reuse).toLowerCase() === 'fresh-per-invocation'
+        ? 'fresh-per-invocation'
+        : 'fresh-per-head',
+    scope:
+      normalizeText(session.scope).toLowerCase() === 'current-diff'
+        ? 'current-diff'
+        : 'current-head',
+    recordPromptArtifacts: session.recordPromptArtifacts !== false
+  };
+}
+
 export function normalizeCopilotCliReviewPolicy(value = {}) {
   const policy = value && typeof value === 'object' ? value : {};
   const profiles = policy.profiles && typeof policy.profiles === 'object' ? policy.profiles : {};
@@ -309,6 +329,10 @@ export function normalizeCopilotCliReviewPolicy(value = {}) {
       policy.availableTools === ''
         ? ''
         : normalizeText(policy.availableTools) || DEFAULT_COPILOT_CLI_REVIEW_POLICY.availableTools,
+    sessionPolicy: normalizeSessionPolicy({
+      ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.sessionPolicy,
+      ...(policy.sessionPolicy && typeof policy.sessionPolicy === 'object' ? policy.sessionPolicy : {})
+    }),
     convergence: normalizeConvergencePolicy({
       ...DEFAULT_COPILOT_CLI_REVIEW_POLICY.convergence,
       ...(policy.convergence && typeof policy.convergence === 'object' ? policy.convergence : {})
@@ -710,8 +734,20 @@ export async function runCopilotCliReview({
       command: 'copilot',
       promptOnly: normalizedPolicy.promptOnly === true,
       disableBuiltinMcps: normalizedPolicy.disableBuiltinMcps === true,
+      allowAllTools: normalizedPolicy.allowAllTools === true,
       availableTools: normalizedPolicy.availableTools,
       exitCode: null
+    },
+    permissionPolicy: {
+      promptOnly: normalizedPolicy.promptOnly === true,
+      disableBuiltinMcps: normalizedPolicy.disableBuiltinMcps === true,
+      allowAllTools: normalizedPolicy.allowAllTools === true,
+      availableTools: normalizedPolicy.availableTools
+    },
+    sessionPolicy: {
+      ...normalizedPolicy.sessionPolicy,
+      reusedPriorSession: false,
+      checkpointKey: null
     },
     convergence: {
       ...normalizedPolicy.convergence,
@@ -793,6 +829,10 @@ export async function runCopilotCliReview({
     profileName,
     repoRoot
   });
+  receipt.sessionPolicy = {
+    ...receipt.sessionPolicy,
+    checkpointKey: `${profileName}:${context.git.headSha || 'unknown'}:${context.baseRef || 'none'}`
+  };
   await writeFile(artifactPaths.promptPath, prompt, 'utf8');
 
   const args = [

--- a/tools/priority/__tests__/copilot-cli-review.test.mjs
+++ b/tools/priority/__tests__/copilot-cli-review.test.mjs
@@ -29,6 +29,11 @@ test('normalizeCopilotCliReviewPolicy keeps the prompt-only no-tool default', ()
   assert.equal(policy.allowAllTools, false);
   assert.equal(policy.availableTools, '');
   assert.equal(policy.promptOnly, true);
+  assert.deepEqual(policy.sessionPolicy, {
+    reuse: 'fresh-per-head',
+    scope: 'current-head',
+    recordPromptArtifacts: true
+  });
   assert.deepEqual(policy.convergence, {
     minPasses: 2,
     maxPasses: 4,
@@ -49,7 +54,12 @@ test('loadCopilotCliReviewPolicy reads copilotCliReviewConfig and honors the boo
         copilotCliReview: false,
         copilotCliReviewConfig: {
           model: 'gpt-5.5-mini',
-          availableTools: 'grep,cat'
+          availableTools: 'grep,cat',
+          sessionPolicy: {
+            reuse: 'fresh-per-invocation',
+            scope: 'current-diff',
+            recordPromptArtifacts: false
+          }
         }
       }
     }, null, 2),
@@ -60,6 +70,11 @@ test('loadCopilotCliReviewPolicy reads copilotCliReviewConfig and honors the boo
   assert.equal(policy.enabled, false);
   assert.equal(policy.model, 'gpt-5.5-mini');
   assert.equal(policy.availableTools, 'grep,cat');
+  assert.deepEqual(policy.sessionPolicy, {
+    reuse: 'fresh-per-invocation',
+    scope: 'current-diff',
+    recordPromptArtifacts: false
+  });
 });
 
 test('buildReviewPrompt includes collaboration planes and instruction presence', () => {
@@ -145,6 +160,17 @@ test('runCopilotCliReview writes a deterministic passed receipt for staged revie
   assert.equal(result.status, 'passed');
   assert.equal(result.receipt.overall.status, 'passed');
   assert.equal(result.receipt.copilot.model, 'gpt-5.4-mini');
+  assert.equal(result.receipt.copilot.allowAllTools, false);
+  assert.deepEqual(result.receipt.permissionPolicy, {
+    promptOnly: true,
+    disableBuiltinMcps: true,
+    allowAllTools: false,
+    availableTools: ''
+  });
+  assert.equal(result.receipt.sessionPolicy.reuse, 'fresh-per-head');
+  assert.equal(result.receipt.sessionPolicy.scope, 'current-head');
+  assert.equal(result.receipt.sessionPolicy.reusedPriorSession, false);
+  assert.match(result.receipt.sessionPolicy.checkpointKey, /^preCommit:/);
   assert.equal(result.receipt.context.selectedFiles[0], 'README.md');
   assert.equal(result.receipt.convergence.passCount, 2);
   assert.equal(result.receipt.convergence.stoppedReason, 'clean-pass');

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -48,6 +48,20 @@ test('delivery-agent policy schema validates the checked-in policy contract', as
   assert.deepEqual(data.localReviewLoop, {
     enabled: true,
     reviewProviders: ['copilot-cli'],
+    copilotCliReview: true,
+    copilotCliReviewConfig: {
+      enabled: true,
+      model: 'gpt-5.4',
+      promptOnly: true,
+      disableBuiltinMcps: true,
+      allowAllTools: false,
+      availableTools: '',
+      sessionPolicy: {
+        reuse: 'fresh-per-head',
+        scope: 'current-head',
+        recordPromptArtifacts: true
+      }
+    },
     bodyMarkers: ['Daemon-first local iteration extension'],
     receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
     command: ['node', 'tools/local-collab/orchestrator/run-phase.mjs', '--phase', 'daemon'],

--- a/tools/priority/delivery-agent.policy.json
+++ b/tools/priority/delivery-agent.policy.json
@@ -29,6 +29,20 @@
     "reviewProviders": [
       "copilot-cli"
     ],
+    "copilotCliReview": true,
+    "copilotCliReviewConfig": {
+      "enabled": true,
+      "model": "gpt-5.4",
+      "promptOnly": true,
+      "disableBuiltinMcps": true,
+      "allowAllTools": false,
+      "availableTools": "",
+      "sessionPolicy": {
+        "reuse": "fresh-per-head",
+        "scope": "current-head",
+        "recordPromptArtifacts": true
+      }
+    },
     "bodyMarkers": [
       "Daemon-first local iteration extension"
     ],


### PR DESCRIPTION
# Summary

Pins the least-privilege GitHub Copilot CLI permission and session defaults for local draft review.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- makes `copilotCliReviewConfig` explicit in `tools/priority/delivery-agent.policy.json`
- extends the delivery-agent policy schema with Copilot CLI permission and session fields
- records the permission/session contract in the Copilot CLI review receipt
- tightens Copilot CLI, policy-schema, and instruction contract tests around least-privilege execution and fresh head-scoped sessions

## Validation Evidence

- `node --check tools/local-collab/providers/copilot-cli-review.mjs`
- `node --test tools/priority/__tests__/copilot-cli-review.test.mjs tools/priority/__tests__/delivery-agent-schema.test.mjs tools/priority/__tests__/github-instructions-contract.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

## Notes

- This is the first `#1078` implementation slice.
- It does not widen the Copilot CLI tool surface; it locks the current least-privilege defaults into checked-in policy and receipts.

Closes #1078
Refs #1068