### PR TITLE
#1078 Keep hooks:multi fast and honor hook enforcement

### DIFF
--- a/tools/hooks/__tests__/local-collaboration-contract.test.mjs
+++ b/tools/hooks/__tests__/local-collaboration-contract.test.mjs
@@ -51,3 +51,9 @@ test('run-phase wires hook phases through agent-review-policy before commit and 
   assert.match(source, /github-actions-default/);
   assert.match(source, /simulation/);
 });
+
+test('hooks multi keeps wrapper parity fast by skipping heavy pre-push scenario matrices', () => {
+  const source = readRepoFile(path.join('tools', 'hooks', 'core', 'run-multi.mjs'));
+  assert.match(source, /PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS/);
+  assert.match(source, /PREPUSH_SKIP_NI_IMAGE_FLAG_SCENARIOS/);
+});

--- a/tools/hooks/core/run-multi.mjs
+++ b/tools/hooks/core/run-multi.mjs
@@ -19,6 +19,10 @@ if (process.platform === 'win32') {
   }
 }
 const toPosix = (value) => value.replace(/\\/g, '/');
+const fastPrePushEnv = {
+  PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: process.env.PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS || '1',
+  PREPUSH_SKIP_NI_IMAGE_FLAG_SCENARIOS: process.env.PREPUSH_SKIP_NI_IMAGE_FLAG_SCENARIOS || '1'
+};
 
 info('[hooks multi] base plane: ' + runner.environment.plane);
 info('[hooks multi] enforcement: ' + runner.enforcement);
@@ -71,6 +75,7 @@ function runWrapper(entry) {
       HOOKS_ENFORCE: runner.enforcement,
       DETERMINISTIC: '1',
       HOOKS_NODE: process.execPath,
+      ...fastPrePushEnv,
       ...(pwshPath ? { HOOKS_PWSH: pwshPath } : {}),
     },
   });

--- a/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
+++ b/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
@@ -192,8 +192,8 @@ test('runLocalCollaborationPhase gates pre-commit on local agent review and reco
 test('runLocalCollaborationPhase defaults hosted pre-commit reviews to simulation', async () => {
   const repoRoot = await createGitRepo();
   await mkdir(path.join(repoRoot, 'tmp', 'hooks'), { recursive: true });
-  await writeFile(path.join(repoRoot, 'tmp', 'hooks', 'sample.ps1'), "Write-Output 'hook parity sample'\n", 'utf8');
-  spawnSync('git', ['add', 'tmp/hooks/sample.ps1'], { cwd: repoRoot, encoding: 'utf8' });
+  await writeFile(path.join(repoRoot, 'tmp', 'hooks', 'sample.txt'), 'hook parity sample\n', 'utf8');
+  spawnSync('git', ['add', 'tmp/hooks/sample.txt'], { cwd: repoRoot, encoding: 'utf8' });
 
   let observedSelection = null;
   const result = await runLocalCollaborationPhase({
@@ -230,7 +230,7 @@ test('runLocalCollaborationPhase defaults hosted pre-commit reviews to simulatio
   assert.deepEqual(result.receipt.delegate.agentReview.requestedProviders, ['simulation']);
 });
 
-test('runLocalCollaborationPhase blocks pre-push before heavy checks when local agent review fails', async () => {
+test('runLocalCollaborationPhase keeps pre-push non-blocking in local warn mode when local agent review fails', async () => {
   const repoRoot = await createGitRepo();
 
   const result = await runLocalCollaborationPhase({
@@ -249,14 +249,54 @@ test('runLocalCollaborationPhase blocks pre-push before heavy checks when local 
         },
         requestedProviders: ['simulation']
       }
-    })
+    }),
+    env: {
+      ...process.env,
+      HOOKS_ENFORCE: 'warn'
+    }
   });
 
-  assert.equal(result.exitCode, 1);
+  assert.equal(result.exitCode, 0);
   assert.equal(result.receipt.phase, 'pre-push');
   assert.equal(result.receipt.delegate.agentReview.receiptStatus, 'failed');
   assert.deepEqual(result.receipt.delegate.agentReview.requestedProviders, ['simulation']);
 
+  const hookSummary = JSON.parse(await readFile(result.receipt.delegate.summaryPath, 'utf8'));
+  const reviewStep = hookSummary.steps.find((step) => step.name === 'agent-review-policy');
+  assert.ok(reviewStep);
+  assert.equal(reviewStep.status, 'warn');
+  assert.equal(reviewStep.rawExitCode, 1);
+  assert.match(reviewStep.note, /converted to warning by HOOKS_ENFORCE=warn/);
+  assert.equal(hookSummary.steps.some((step) => step.name === 'pre-push-checks'), true);
+});
+
+test('runLocalCollaborationPhase blocks pre-push before heavy checks in fail mode when local agent review fails', async () => {
+  const repoRoot = await createGitRepo();
+
+  const result = await runLocalCollaborationPhase({
+    phase: 'pre-push',
+    repoRoot,
+    providers: ['simulation'],
+    invokeAgentReviewPolicyFn: () => ({
+      exitCode: 1,
+      receipt: {
+        overall: {
+          status: 'failed',
+          actionableFindingCount: 1
+        },
+        providerSelection: {
+          selectionSource: 'explicit-request'
+        },
+        requestedProviders: ['simulation']
+      }
+    }),
+    env: {
+      ...process.env,
+      HOOKS_ENFORCE: 'fail'
+    }
+  });
+
+  assert.equal(result.exitCode, 1);
   const hookSummary = JSON.parse(await readFile(result.receipt.delegate.summaryPath, 'utf8'));
   const reviewStep = hookSummary.steps.find((step) => step.name === 'agent-review-policy');
   assert.ok(reviewStep);

--- a/tools/local-collab/orchestrator/run-phase.mjs
+++ b/tools/local-collab/orchestrator/run-phase.mjs
@@ -337,7 +337,9 @@ function invokeHookAgentReviewStep({ runner, repoRoot, phase, env, providerSelec
     };
   });
 
-  if ((step.rawExitCode ?? step.exitCode) !== 0) {
+  // Respect the hook runner's post-enforcement exit code so warn/off modes do not
+  // get re-promoted to hard failures after the summary has already downgraded them.
+  if (step.exitCode !== 0) {
     hardFailHookStep(
       runner,
       step,
@@ -367,7 +369,7 @@ function invokePreCommitDelegate(
     invokeAgentReviewPolicyFn
   } = {}
 ) {
-  const runner = new HookRunner('pre-commit', { repoRoot });
+  const runner = new HookRunner('pre-commit', { repoRoot, env });
 
   info('[pre-commit] Collecting staged files');
   let stagedFiles = [];
@@ -437,7 +439,7 @@ function invokePrePushDelegate(
     invokeAgentReviewPolicyFn
   } = {}
 ) {
-  const runner = new HookRunner('pre-push', { repoRoot });
+  const runner = new HookRunner('pre-push', { repoRoot, env });
   info('[pre-push] Running local agent review providers');
   const agentReview = invokeHookAgentReviewStep({
     runner,
@@ -480,8 +482,8 @@ function invokeDaemonDelegate(repoRoot, delegateArgs) {
   return normalizeCommandResult(result);
 }
 
-function invokePostCommitDelegate(repoRoot) {
-  const runner = new HookRunner('post-commit', { repoRoot });
+function invokePostCommitDelegate(repoRoot, env = process.env) {
+  const runner = new HookRunner('post-commit', { repoRoot, env });
   info('[post-commit] Recording local collaboration authoring receipt');
   runner.runStep('record-authoring-receipt', () => ({
     status: 'ok',
@@ -532,7 +534,7 @@ export async function runLocalCollaborationPhase(options = {}) {
   } else if (phase === 'daemon') {
     result = invokeDaemonDelegate(repoRoot, options.delegateArgs ?? []);
   } else if (phase === 'post-commit') {
-    result = invokePostCommitDelegate(repoRoot);
+    result = invokePostCommitDelegate(repoRoot, env);
   } else {
     throw new Error(`Unsupported local collaboration phase: ${phase}`);
   }


### PR DESCRIPTION
# Summary

Honors hook enforcement after `agent-review-policy` runs and keeps `hooks:multi` on the fast parity path instead of re-running the full NI-image matrix.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- makes the local-collaboration orchestrator respect post-enforcement hook exit codes instead of re-promoting raw failures
- passes the supplied hook env through to `HookRunner` so `HOOKS_ENFORCE` is honored consistently in test and wrapper-driven paths
- makes `hooks:multi` skip heavy NI-image pre-push scenario matrices so wrapper parity stays fast locally
- adds regression coverage for warn-vs-fail pre-push behavior and the fast hook-parity contract

## Validation Evidence

- `node --test tools/local-collab/orchestrator/__tests__/run-phase.test.mjs tools/hooks/__tests__/local-collaboration-contract.test.mjs`
- `node tools/npm/run-script.mjs hooks:multi`
- `node tools/npm/run-script.mjs hooks:schema`

## Notes

- This tackles the remaining `#1078` hook-parity note after `#1109` merged.
- `hooks:multi` now completes in seconds locally instead of timing out behind the NI-image matrix.

Refs #1078
Refs #1068