### PR TITLE
#1071 Pin GitHub instruction precedence contract

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,12 @@
 
 - Use GitHub Copilot CLI only in the local `draft-review` loop.
 - Run it through the repo-owned wrapper surfaces under `tools/local-collab/providers/`.
+- Precedence:
+  - `AGENTS.md` is the repo-wide policy authority.
+  - This file narrows GitHub Copilot CLI behavior for the local review plane.
+  - `.github/instructions/*.instructions.md` may add phase guidance but must not
+    widen review, queue, or promotion authority beyond this file and
+    `AGENTS.md`.
 - Keep review runs head-scoped and focused on the current staged diff or current branch delta only.
 - Preserve and honor:
   - `AGENTS.md`

--- a/.github/instructions/draft-only-copilot-review.instructions.md
+++ b/.github/instructions/draft-only-copilot-review.instructions.md
@@ -1,5 +1,11 @@
 # Draft-Only Copilot Review for Agent PRs
 
+- Precedence:
+  - `AGENTS.md` remains the repo-wide policy authority.
+  - `.github/copilot-instructions.md` remains the Copilot CLI authority for the
+    local review plane.
+  - This file is a phase-specific overlay and must not widen review, queue, or
+    promotion authority beyond those sources.
 - Scope: agent-authored pull requests in `compare-vi-cli-action`.
 - Keep the pull request in draft while implementation, local parity, and comment
   resolution are still in progress.

--- a/.github/instructions/final-ready-validation.instructions.md
+++ b/.github/instructions/final-ready-validation.instructions.md
@@ -1,5 +1,11 @@
 # Ready-for-Review Means Final Validation
 
+- Precedence:
+  - `AGENTS.md` remains the repo-wide policy authority.
+  - `.github/copilot-instructions.md` remains the Copilot CLI authority for the
+    local review plane.
+  - This file is a phase-specific overlay and must not widen review, queue, or
+    promotion authority beyond those sources.
 - Use `ready_for_review` only when the current head is locally reviewed and is
   ready for final hosted validation.
 - Before marking ready, require all of the following on the current head:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,13 @@ artifacts under `tests/results/_agent/`.
 - Repo-owned Copilot CLI instructions live in `.github/copilot-instructions.md`.
   Use the local Copilot CLI review plane only for draft-review acceleration and
   keep hosted validation authoritative for final promotion.
+- Instruction precedence for future agents:
+  - `AGENTS.md` is the repo-wide policy and standing-priority authority.
+  - `.github/copilot-instructions.md` narrows GitHub Copilot CLI behavior for
+    the local draft-review plane only.
+  - `.github/instructions/*.instructions.md` are GitHub-native phase overlays
+    and must not widen review, queue, or promotion authority beyond `AGENTS.md`
+    and `.github/copilot-instructions.md`.
 
 ## Working Rules
 

--- a/tools/priority/__tests__/github-instructions-contract.test.mjs
+++ b/tools/priority/__tests__/github-instructions-contract.test.mjs
@@ -34,6 +34,8 @@ test('Copilot instructions capture the local-first CLI review boundary', () => {
   const copilotInstructions = normalizeWhitespace(fs.readFileSync(copilotInstructionsPath, 'utf8'));
 
   assert.match(copilotInstructions, /GitHub Copilot CLI only in the local `draft-review` loop/i);
+  assert.match(copilotInstructions, /`?AGENTS\.md`? is the repo-wide policy authority/i);
+  assert.match(copilotInstructions, /`?\.github\/instructions\/\*\.instructions\.md`? .* must not widen review, queue, or promotion authority/i);
   assert.match(copilotInstructions, /hosted required checks and final ready-validation remain authoritative/i);
   assert.match(copilotInstructions, /head SHA changes .* stale and rerun the local review/i);
 });
@@ -42,10 +44,16 @@ test('draft-only instruction content captures the required Copilot review contra
   const draftOnly = normalizeWhitespace(readInstruction('draft-only-copilot-review.instructions.md'));
   const readyValidation = normalizeWhitespace(readInstruction('final-ready-validation.instructions.md'));
 
+  assert.match(draftOnly, /`?AGENTS\.md`? remains the repo-wide policy authority/i);
+  assert.match(draftOnly, /`?\.github\/copilot-instructions\.md`? remains the Copilot CLI authority/i);
+  assert.match(draftOnly, /must not widen review, queue, or promotion authority/i);
   assert.match(draftOnly, /only while the pull request is draft/i);
   assert.match(draftOnly, /Do not use `ready_for_review` to solicit a second Copilot pass/i);
   assert.match(draftOnly, /Resolve current-head Copilot comments before leaving draft/i);
 
+  assert.match(readyValidation, /`?AGENTS\.md`? remains the repo-wide policy authority/i);
+  assert.match(readyValidation, /`?\.github\/copilot-instructions\.md`? remains the Copilot CLI authority/i);
+  assert.match(readyValidation, /must not widen review, queue, or promotion authority/i);
   assert.match(readyValidation, /Use `ready_for_review` only when the current head is locally reviewed/i);
   assert.match(readyValidation, /Do not request or wait for a second Copilot review after `ready_for_review`/i);
   assert.match(readyValidation, /return the pull request to draft and restart the local-plus-Copilot review loop/i);
@@ -57,4 +65,6 @@ test('AGENTS points future agents at the GitHub instructions surface', () => {
   assert.match(agents, /\.github\/copilot-instructions\.md/);
   assert.match(agents, /draft-only Copilot review contract/i);
   assert.match(agents, /local Copilot CLI review plane only for draft-review acceleration/i);
+  assert.match(agents, /`?AGENTS\.md`? is the repo-wide policy and standing-priority authority/i);
+  assert.match(agents, /must not widen review, queue, or promotion authority/i);
 });


### PR DESCRIPTION
# Summary

Pins the precedence and non-widening authority contract across `AGENTS.md`, `.github/copilot-instructions.md`, and `.github/instructions/*.instructions.md`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- adds explicit instruction precedence to `AGENTS.md`
- adds explicit precedence and non-widening authority guidance to `.github/copilot-instructions.md`
- adds the same phase-overlay constraint to both checked-in GitHub instruction files
- tightens the GitHub instruction contract test so precedence drift fails fast

## Validation Evidence

- `node --test tools/priority/__tests__/github-instructions-contract.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

## Notes

- This is a narrow `#1071` hardening slice on top of the already-merged `#1077` and `#1078` instruction surfaces.
- It does not change workflow or daemon behavior; it hardens the checked-in instruction contract only.

Refs #1071
Refs #1068