### PR TITLE
#1075 Re-draft when ready-validation clearance head goes stale

### DIFF
--- a/docs/schemas/delivery-agent-runtime-state-v1.schema.json
+++ b/docs/schemas/delivery-agent-runtime-state-v1.schema.json
@@ -117,6 +117,18 @@
         "retryable": { "type": "boolean" },
         "nextWakeCondition": { "type": ["string", "null"] },
         "reviewPhase": { "type": ["string", "null"] },
+        "readyValidationClearance": {
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "properties": {
+            "status": { "type": ["string", "null"] },
+            "receiptPath": { "type": ["string", "null"] },
+            "readyHeadSha": { "type": ["string", "null"] },
+            "currentHeadSha": { "type": ["string", "null"] },
+            "staleForCurrentHead": { "type": ["boolean", "null"] },
+            "reason": { "type": ["string", "null"] }
+          }
+        },
         "localReviewLoop": {
           "type": ["object", "null"],
           "additionalProperties": true,

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -294,6 +294,14 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
         blockerClass: 'none',
         retryable: false,
         nextWakeCondition: 'next-scheduler-cycle',
+        readyValidationClearance: {
+          status: 'current',
+          receiptPath: 'tests/results/_agent/runtime/ready-validation-clearance/LabVIEW-Community-CI-CD-compare-vi-cli-action-pr-88.json',
+          readyHeadSha: '433e8aa70326007be74c27ccf54c1ae91559b6f3',
+          currentHeadSha: '433e8aa70326007be74c27ccf54c1ae91559b6f3',
+          staleForCurrentHead: false,
+          reason: 'PR remains in ready-validation on the same cleared head.'
+        },
         localReviewLoop: {
           status: 'passed',
           source: 'docker-desktop-review-loop',
@@ -372,6 +380,15 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
     'tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json'
   );
   assert.equal(state.activeLane.localReviewLoop.receiptStatus, 'passed');
+  assert.equal(state.activeLane.readyValidationClearance.status, 'current');
+  assert.equal(
+    state.activeLane.readyValidationClearance.receiptPath,
+    'tests/results/_agent/runtime/ready-validation-clearance/LabVIEW-Community-CI-CD-compare-vi-cli-action-pr-88.json'
+  );
+  assert.equal(
+    state.activeLane.readyValidationClearance.readyHeadSha,
+    '433e8aa70326007be74c27ccf54c1ae91559b6f3'
+  );
   assert.equal(
     state.artifacts.localReviewLoopReceiptPath,
     'tests/results/docker-tools-parity/review-loop-receipt.json'

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -3270,6 +3270,131 @@ test('delivery broker returns a prematurely ready PR to draft when draft-phase r
   assert.equal(brokerResult.details.reviewMonitor, null);
 });
 
+test('delivery broker returns a ready PR to draft when the current head no longer matches stored ready-validation clearance', async () => {
+  const tempRepo = await mkdtemp(path.join(os.tmpdir(), 'delivery-broker-redraft-head-mismatch-'));
+  runGit(tempRepo, ['init']);
+  runGit(tempRepo, ['config', 'user.name', 'Agent Runner']);
+  runGit(tempRepo, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(tempRepo, 'README.md'), '# temp\n', 'utf8');
+  runGit(tempRepo, ['add', 'README.md']);
+  runGit(tempRepo, ['commit', '-m', 'init']);
+  const readyValidationDir = path.join(tempRepo, 'tests', 'results', '_agent', 'runtime', 'ready-validation-clearance');
+  await mkdir(readyValidationDir, { recursive: true });
+  const readyValidationPath = path.join(
+    readyValidationDir,
+    'LabVIEW-Community-CI-CD-compare-vi-cli-action-pr-1067.json'
+  );
+  await writeFile(
+    readyValidationPath,
+    `${JSON.stringify({
+      schema: 'priority/ready-validation-clearance@v1',
+      generatedAt: '2026-03-14T00:00:00.000Z',
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      pullRequestNumber: 1067,
+      pullRequestUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1067',
+      readyHeadSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      status: 'current',
+      reason: 'PR entered ready-validation on the current head after clean draft-phase review clearance.',
+      localReviewLoop: null
+    })}\n`,
+    'utf8'
+  );
+
+  const helperCalls = [];
+  const brokerResult = await runDeliveryTurnBroker({
+    repoRoot: tempRepo,
+    taskPacket: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      status: 'waiting-ci',
+      objective: {
+        summary: 'Advance issue #1075'
+      },
+      evidence: {
+        delivery: {
+          laneLifecycle: 'waiting-ci',
+          pullRequest: {
+            number: 1067,
+            url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1067',
+            isDraft: false,
+            headRefOid: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            copilotReviewSignal: {
+              hasCurrentHeadReview: true,
+              actionableCommentCount: 0,
+              actionableThreadCount: 0
+            },
+            copilotReviewWorkflow: {
+              status: 'COMPLETED',
+              conclusion: 'SUCCESS'
+            }
+          },
+          mutationEnvelope: {
+            copilotReviewStrategy: 'draft-only-explicit',
+            maxActiveCodingLanes: 1
+          },
+          turnBudget: {
+            maxMinutes: 20,
+            maxToolCalls: 12
+          }
+        }
+      }
+    },
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({
+        schema: 'priority/delivery-agent-policy@v1',
+        backlogAuthority: 'issues',
+        implementationRemote: 'origin',
+        copilotReviewStrategy: 'draft-only-explicit',
+        autoSlice: true,
+        autoMerge: true,
+        maxActiveCodingLanes: 1,
+        allowPolicyMutations: false,
+        allowReleaseAdmin: false,
+        stopWhenNoOpenEpics: true,
+        codingTurnCommand: ['node', 'mock-broker']
+      }),
+      runCommandFn: async (command, args) => {
+        helperCalls.push([command, ...args].join(' '));
+        assert.equal(command, 'gh');
+        assert.deepEqual(args, [
+          'pr',
+          'ready',
+          '1067',
+          '--repo',
+          'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          '--undo'
+        ]);
+        return {
+          status: 0,
+          stdout: 'converted to draft\n',
+          stderr: ''
+        };
+      }
+    }
+  });
+
+  assert.equal(brokerResult.status, 'completed');
+  assert.equal(brokerResult.outcome, 'waiting-review');
+  assert.equal(brokerResult.details.reviewPhase, 'draft-review');
+  assert.equal(helperCalls.length, 1);
+  assert.equal(brokerResult.details.readyValidationClearance.status, 'invalidated-head-mismatch');
+  assert.equal(
+    brokerResult.details.readyValidationClearance.readyHeadSha,
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  );
+  assert.equal(
+    brokerResult.details.readyValidationClearance.currentHeadSha,
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+  );
+  assert.equal(brokerResult.details.readyValidationClearance.staleForCurrentHead, true);
+  assert.match(brokerResult.reason, /current head changed after ready-validation clearance was recorded/i);
+
+  const persistedClearance = JSON.parse(await readFile(readyValidationPath, 'utf8'));
+  assert.equal(persistedClearance.status, 'invalidated-head-mismatch');
+  assert.equal(persistedClearance.readyHeadSha, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  assert.equal(persistedClearance.currentHeadSha, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+  assert.match(persistedClearance.reason, /no longer matches current head/i);
+});
+
 test('delivery broker keeps ready PR waiting-review state in ready-validation when the PR is not draft', async () => {
   const brokerResult = await runDeliveryTurnBroker({
     repoRoot: '/tmp/repo',

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -19,6 +19,7 @@ import {
 export const DELIVERY_AGENT_POLICY_SCHEMA = 'priority/delivery-agent-policy@v1';
 export const DELIVERY_AGENT_RUNTIME_STATE_SCHEMA = 'priority/delivery-agent-runtime-state@v1';
 export const DELIVERY_AGENT_LANE_STATE_SCHEMA = 'priority/delivery-agent-lane-state@v1';
+export const READY_VALIDATION_CLEARANCE_SCHEMA = 'priority/ready-validation-clearance@v1';
 export const DELIVERY_AGENT_POLICY_RELATIVE_PATH = path.join('tools', 'priority', 'delivery-agent.policy.json');
 export const DELIVERY_AGENT_STATE_FILENAME = 'delivery-agent-state.json';
 export const DELIVERY_AGENT_LANES_DIRNAME = 'delivery-agent-lanes';
@@ -178,6 +179,20 @@ function resolveExecutionRoot(repoRoot, taskPacket) {
   return workerCheckoutPath ? resolvePath(repoRoot, workerCheckoutPath) : repoRoot;
 }
 
+function resolveReadyValidationClearancePath({ repoRoot, repository, pullRequestNumber }) {
+  const repositorySegment = sanitizeSegment(repository || 'repo');
+  const pullRequestSegment = sanitizeSegment(`pr-${pullRequestNumber || 'unknown'}`);
+  return path.join(
+    repoRoot,
+    'tests',
+    'results',
+    '_agent',
+    'runtime',
+    'ready-validation-clearance',
+    `${repositorySegment}-${pullRequestSegment}.json`
+  );
+}
+
 function isJsonParseError(error) {
   return error instanceof SyntaxError || error?.name === 'SyntaxError';
 }
@@ -210,6 +225,7 @@ function parseJsonObjectOutput(raw, source = 'command output') {
 
 async function writeJsonAtomically(filePath, payload) {
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(tempPath, payload, 'utf8');
   try {
     await rename(tempPath, filePath);
@@ -222,6 +238,89 @@ async function writeJsonAtomically(filePath, payload) {
   } finally {
     await rm(tempPath, { force: true });
   }
+}
+
+async function loadReadyValidationClearance({ repoRoot, repository, pullRequestNumber }) {
+  const clearancePath = resolveReadyValidationClearancePath({ repoRoot, repository, pullRequestNumber });
+  const payload = await readJsonIfPresent(clearancePath, { deleteCorrupt: true });
+  if (!payload || typeof payload !== 'object') {
+    return {
+      path: clearancePath,
+      receipt: null
+    };
+  }
+  return {
+    path: clearancePath,
+    receipt: payload
+  };
+}
+
+async function persistReadyValidationClearance({
+  repoRoot,
+  repository,
+  pullRequest,
+  localReviewLoop = null,
+  readyHeadShaOverride = null,
+  currentHeadShaOverride = null,
+  status = 'current',
+  reason = ''
+}) {
+  const pullRequestNumber = coercePositiveInteger(pullRequest?.number);
+  if (!pullRequestNumber) {
+    throw new Error('pullRequest.number is required to persist ready-validation clearance.');
+  }
+  const receiptPath = resolveReadyValidationClearancePath({ repoRoot, repository, pullRequestNumber });
+  const receipt = {
+    schema: READY_VALIDATION_CLEARANCE_SCHEMA,
+    generatedAt: toIso(),
+    repository: normalizeText(repository) || null,
+    pullRequestNumber,
+    pullRequestUrl: normalizeText(pullRequest?.url) || null,
+    readyHeadSha: normalizeText(readyHeadShaOverride) || normalizeText(pullRequest?.headRefOid) || null,
+    currentHeadSha: normalizeText(currentHeadShaOverride) || normalizeText(pullRequest?.headRefOid) || null,
+    status: normalizeText(status) || 'current',
+    reason: normalizeText(reason) || null,
+    localReviewLoop: localReviewLoop && typeof localReviewLoop === 'object'
+      ? {
+          receiptPath: normalizeText(localReviewLoop.receiptPath) || null,
+          receiptHeadSha: normalizeText(localReviewLoop.receiptHeadSha) || null,
+          currentHeadSha: normalizeText(localReviewLoop.currentHeadSha) || null,
+          receiptFreshForHead:
+            typeof localReviewLoop.receiptFreshForHead === 'boolean' ? localReviewLoop.receiptFreshForHead : null,
+          requestedCoverageSatisfied:
+            typeof localReviewLoop.requestedCoverageSatisfied === 'boolean'
+              ? localReviewLoop.requestedCoverageSatisfied
+              : null
+        }
+      : null
+  };
+  await writeJsonAtomically(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  return {
+    receiptPath,
+    receipt
+  };
+}
+
+async function invalidateReadyValidationClearance({
+  repoRoot,
+  repository,
+  pullRequest,
+  localReviewLoop = null,
+  readyHeadShaOverride = null,
+  currentHeadShaOverride = null,
+  status = 'invalidated',
+  reason = ''
+}) {
+  return persistReadyValidationClearance({
+    repoRoot,
+    repository,
+    pullRequest,
+    localReviewLoop,
+    readyHeadShaOverride,
+    currentHeadShaOverride,
+    status,
+    reason
+  });
 }
 
 function normalizeCommandList(value) {
@@ -1566,6 +1665,26 @@ function buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt }) {
   };
 }
 
+function buildReadyValidationClearanceRuntimeState({ taskPacket, executionReceipt }) {
+  const details = normalizeOptionalObject(executionReceipt?.details?.readyValidationClearance);
+  const pullRequest = normalizeOptionalObject(taskPacket?.evidence?.delivery?.pullRequest);
+  if (!details && !pullRequest) {
+    return null;
+  }
+  return {
+    status: normalizeText(details?.status) || null,
+    receiptPath: normalizeText(details?.receiptPath) || null,
+    readyHeadSha: normalizeText(details?.readyHeadSha) || null,
+    currentHeadSha:
+      normalizeText(details?.currentHeadSha) ||
+      normalizeText(pullRequest?.headRefOid) ||
+      null,
+    staleForCurrentHead:
+      typeof details?.staleForCurrentHead === 'boolean' ? details.staleForCurrentHead : null,
+    reason: normalizeText(details?.reason) || null
+  };
+}
+
 export function buildDeliveryAgentRuntimeRecord({
   now = new Date(),
   repository,
@@ -1614,6 +1733,7 @@ export function buildDeliveryAgentRuntimeRecord({
     coercePositiveInteger(schedulerDecision?.artifacts?.pullRequest?.pollIntervalSecondsHint) ??
     null;
   const localReviewLoop = buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt });
+  const readyValidationClearance = buildReadyValidationClearanceRuntimeState({ taskPacket, executionReceipt });
   return {
     schema: DELIVERY_AGENT_RUNTIME_STATE_SCHEMA,
     generatedAt: toIso(now),
@@ -1660,7 +1780,8 @@ export function buildDeliveryAgentRuntimeRecord({
       reviewPhase: normalizeText(executionReceipt?.details?.reviewPhase) || null,
       pollIntervalSecondsHint,
       reviewMonitor,
-      localReviewLoop
+      localReviewLoop,
+      readyValidationClearance
     },
     artifacts: {
       statePath,
@@ -1888,6 +2009,13 @@ async function enforceDraftOnlyReviewContract({
   }
 
   const localReviewRequested = taskPacket?.evidence?.delivery?.localReviewLoop?.requested === true;
+  const repository = normalizeText(taskPacket?.repository);
+  const currentHeadSha = normalizeText(pullRequest?.headRefOid) || null;
+  const readyValidationClearance = await loadReadyValidationClearance({
+    repoRoot,
+    repository,
+    pullRequestNumber: pullRequest.number
+  });
   let localReviewLoopReceipt = null;
   let localReviewLoopHelperCalls = [];
   let localReviewLoopFilesTouched = [];
@@ -1978,6 +2106,13 @@ async function enforceDraftOnlyReviewContract({
 
   const reviewClearance = evaluateDraftPhaseCopilotClearance(pullRequest);
   const localReviewSatisfiedFlag = !localReviewRequested || localReviewLoopSatisfied(localReviewLoopReceipt);
+  const storedReadyHeadSha = normalizeText(readyValidationClearance.receipt?.readyHeadSha) || null;
+  const readyHeadMismatch = Boolean(
+    pullRequest.isDraft !== true &&
+      currentHeadSha &&
+      storedReadyHeadSha &&
+      currentHeadSha !== storedReadyHeadSha
+  );
 
   if (pullRequest.isDraft === true) {
     if (reviewClearance.ok && localReviewSatisfiedFlag) {
@@ -2010,6 +2145,14 @@ async function enforceDraftOnlyReviewContract({
           }
         };
       }
+      const persistedClearance = await persistReadyValidationClearance({
+        repoRoot,
+        repository,
+        pullRequest,
+        localReviewLoop: localReviewLoopReceipt,
+        status: 'current',
+        reason: 'PR entered ready-validation on the current head after clean draft-phase review clearance.'
+      });
       return {
         status: 'completed',
         outcome: 'waiting-ci',
@@ -2024,7 +2167,15 @@ async function enforceDraftOnlyReviewContract({
           reviewPhase: 'ready-validation',
           helperCallsExecuted: uniqueStrings([...localReviewLoopHelperCalls, toReady.helperCall]),
           filesTouched: localReviewLoopFilesTouched,
-          localReviewLoop: localReviewLoopReceipt
+          localReviewLoop: localReviewLoopReceipt,
+          readyValidationClearance: {
+            status: 'current',
+            receiptPath: persistedClearance.receiptPath,
+            readyHeadSha: normalizeText(persistedClearance.receipt?.readyHeadSha) || currentHeadSha,
+            currentHeadSha,
+            staleForCurrentHead: false,
+            reason: normalizeText(persistedClearance.receipt?.reason) || null
+          }
         }
       };
     }
@@ -2050,14 +2201,25 @@ async function enforceDraftOnlyReviewContract({
         reviewPhase: 'draft-review',
         helperCallsExecuted: localReviewLoopHelperCalls,
         filesTouched: localReviewLoopFilesTouched,
-        localReviewLoop: localReviewLoopReceipt
+        localReviewLoop: localReviewLoopReceipt,
+        readyValidationClearance:
+          readyValidationClearance.receipt && storedReadyHeadSha
+            ? {
+                status: normalizeText(readyValidationClearance.receipt.status) || null,
+                receiptPath: readyValidationClearance.path,
+                readyHeadSha: storedReadyHeadSha,
+                currentHeadSha,
+                staleForCurrentHead: currentHeadSha ? currentHeadSha !== storedReadyHeadSha : null,
+                reason: normalizeText(readyValidationClearance.receipt.reason) || null
+              }
+            : null
       }
     };
   }
 
-  if (!reviewClearance.ok || !localReviewSatisfiedFlag) {
+  if (readyHeadMismatch || !reviewClearance.ok || !localReviewSatisfiedFlag) {
     const toDraft = await setPullRequestReadyState({
-      repository: normalizeText(taskPacket?.repository),
+      repository,
       pullRequest,
       ready: false,
       repoRoot,
@@ -2081,15 +2243,42 @@ async function enforceDraftOnlyReviewContract({
           reviewPhase: 'draft-review',
           helperCallsExecuted: uniqueStrings([...localReviewLoopHelperCalls, toDraft.helperCall]),
           filesTouched: localReviewLoopFilesTouched,
-          localReviewLoop: localReviewLoopReceipt
+          localReviewLoop: localReviewLoopReceipt,
+          readyValidationClearance: {
+            status: normalizeText(readyValidationClearance.receipt?.status) || null,
+            receiptPath: readyValidationClearance.path,
+            readyHeadSha: storedReadyHeadSha,
+            currentHeadSha,
+            staleForCurrentHead: readyHeadMismatch,
+            reason:
+              readyHeadMismatch
+                ? `Ready-validation clearance head ${storedReadyHeadSha} does not match current head ${currentHeadSha}.`
+                : normalizeText(readyValidationClearance.receipt?.reason) || null
+          }
         }
       };
     }
+    const invalidatedClearance = await invalidateReadyValidationClearance({
+      repoRoot,
+      repository,
+      pullRequest,
+      localReviewLoop: localReviewLoopReceipt,
+      readyHeadShaOverride: storedReadyHeadSha,
+      currentHeadShaOverride: currentHeadSha,
+      status: readyHeadMismatch ? 'invalidated-head-mismatch' : 'invalidated',
+      reason: readyHeadMismatch
+        ? `Ready-validation clearance head ${storedReadyHeadSha} no longer matches current head ${currentHeadSha}.`
+        : localReviewRequested && !localReviewSatisfiedFlag
+          ? 'Ready-validation clearance invalidated because local Docker/Desktop review clearance no longer matches the current head.'
+          : 'Ready-validation clearance invalidated because current-head draft-phase Copilot review clearance is missing or unresolved.'
+    });
     return {
       status: 'completed',
       outcome: 'waiting-review',
       reason:
-        localReviewRequested && !localReviewSatisfiedFlag
+        readyHeadMismatch
+          ? 'PR was returned to draft because the current head changed after ready-validation clearance was recorded.'
+          : localReviewRequested && !localReviewSatisfiedFlag
           ? 'PR was returned to draft because local Docker/Desktop review clearance no longer matches the current head.'
           : 'PR was returned to draft because current-head draft-phase Copilot review clearance is missing or unresolved.',
       source: 'delivery-agent-broker',
@@ -2106,10 +2295,28 @@ async function enforceDraftOnlyReviewContract({
         reviewPhase: 'draft-review',
         helperCallsExecuted: uniqueStrings([...localReviewLoopHelperCalls, toDraft.helperCall]),
         filesTouched: localReviewLoopFilesTouched,
-        localReviewLoop: localReviewLoopReceipt
+        localReviewLoop: localReviewLoopReceipt,
+        readyValidationClearance: {
+          status: normalizeText(invalidatedClearance.receipt?.status) || null,
+          receiptPath: invalidatedClearance.receiptPath,
+          readyHeadSha: normalizeText(invalidatedClearance.receipt?.readyHeadSha) || storedReadyHeadSha,
+          currentHeadSha,
+          staleForCurrentHead: readyHeadMismatch,
+          reason: normalizeText(invalidatedClearance.receipt?.reason) || null
+        }
       }
     };
   }
+
+  const persistedReadyClearance = await persistReadyValidationClearance({
+    repoRoot,
+    repository,
+    pullRequest,
+    localReviewLoop: localReviewLoopReceipt,
+    status: 'current',
+    reason: 'PR remains in ready-validation on the same cleared head.'
+  });
+  void persistedReadyClearance;
 
   return null;
 }


### PR DESCRIPTION
# Summary

Preserves ready-validation clearance on the original cleared head and returns the PR to draft as soon as the current head diverges.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1075
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1075
- Files, tools, workflows, or policies touched:
  - `tools/priority/delivery-agent.mjs`
  - `tools/priority/__tests__/runtime-supervisor.test.mjs`
  - `tools/priority/__tests__/delivery-agent-schema.test.mjs`
  - `docs/schemas/delivery-agent-runtime-state-v1.schema.json`
- Required checks, merge-queue behavior, or approval flows affected: ready-validation now records the cleared head explicitly and invalidates on post-ready head drift before merge/promotion continues.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/runtime-supervisor.test.mjs tools/priority/__tests__/delivery-agent-schema.test.mjs`
- Key artifacts, logs, or workflow runs:
  - focused delivery-agent runtime and schema coverage only
- Risk-based checks not run:
  - full repo validation was not rerun because the slice is isolated to delivery-agent ready-validation state and its focused regressions

## Risks and Follow-ups

- Residual risks: broader promotion flows still rely on their existing integration coverage; this slice adds the missing explicit stale-head receipt seam.
- Follow-up issues or deferred work: None in this slice.
- Deployment, approval, or rollback notes: Standard required-check and merge-queue flow.

## Reviewer Focus

- Please verify: invalidation preserves `readyHeadSha` from the original clearance and records the new `currentHeadSha` separately.
- Areas where the reasoning is subtle: ready/draft transitions now distinguish between the head that was cleared and the head that was later observed.
- Manual spot checks requested: None.

Closes #1075
