### PR TITLE
#1073 Align hosted review policy to the local CLI contract

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,10 @@
 
 - Use GitHub Copilot CLI only in the local `draft-review` loop.
 - Run it through the repo-owned wrapper surfaces under `tools/local-collab/providers/`.
+- GitHub-native automatic Copilot review is disabled for this repository.
+- Do not request GitHub-side Copilot reviewers from repo workflows or from
+  `ready_for_review`; hosted policy should validate local review evidence, not
+  acquire new Copilot review.
 - Precedence:
   - `AGENTS.md` is the repo-wide policy authority.
   - This file narrows GitHub Copilot CLI behavior for the local review plane.

--- a/.github/workflows/agent-review-policy.yml
+++ b/.github/workflows/agent-review-policy.yml
@@ -2,9 +2,7 @@ name: Agent Review Policy
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted]
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled, converted_to_draft]
   merge_group:
 
 permissions:
@@ -33,36 +31,10 @@ jobs:
       if: github.event_name == 'pull_request_target'
       run: node tools/npm/run-script.mjs build
 
-    - name: Collect Copilot review signal
-      if: github.event_name == 'pull_request_target'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        node dist/tools/priority/copilot-review-signal.js \
-          --repo "${{ github.repository }}" \
-          --pr "${{ github.event.pull_request.number }}" \
-          --head-sha "${{ github.event.pull_request.head.sha }}" \
-          --out tests/results/_agent/reviews/copilot-review-signal.json \
-          --step-summary "$GITHUB_STEP_SUMMARY"
-
-    - name: Validate Copilot review signal schema
-      if: github.event_name == 'pull_request_target'
-      run: node tools/npm/run-script.mjs schema:copilot-review-signal:validate
-
-    - name: Upload Copilot review signal artifact
-      if: always() && github.event_name == 'pull_request_target'
-      uses: actions/upload-artifact@v6
-      with:
-        name: copilot-review-signal-${{ github.event.pull_request.number }}
-        path: tests/results/_agent/reviews/copilot-review-signal.json
-        if-no-files-found: error
-
     - name: Evaluate Copilot queue gate
       if: >
         always() && (
           github.event_name == 'pull_request_target' ||
-          github.event_name == 'pull_request_review' ||
           github.event_name == 'merge_group'
         )
       env:
@@ -95,10 +67,6 @@ jobs:
             "--base-ref" "${{ github.event.pull_request.base.ref }}"
             "--draft" "${{ github.event.pull_request.draft }}"
           )
-        fi
-
-        if [[ "${{ github.event_name }}" == "pull_request_target" && -f tests/results/_agent/reviews/copilot-review-signal.json ]]; then
-          args+=("--signal" "tests/results/_agent/reviews/copilot-review-signal.json")
         fi
 
         node "${args[@]}"

--- a/.github/workflows/pr-agent-review-routing.yml
+++ b/.github/workflows/pr-agent-review-routing.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled, converted_to_draft]
 
 permissions:
-  pull-requests: write
   contents: read
 
 jobs:
@@ -13,10 +12,8 @@ jobs:
     if: github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     steps:
-      - name: Route reviewer for agent-authored PRs
+      - name: Acknowledge local-only review routing for agent-authored PRs
         uses: actions/github-script@v8
-        env:
-          REQUIRED_AGENT_REVIEWER: ${{ vars.REQUIRED_AGENT_REVIEWER || 'Copilot' }}
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -31,41 +28,7 @@ jobs:
               core.info('PR is not marked as agent-authored; skipping reviewer routing.');
               return;
             }
-
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const pull_number = pr.number;
-            const requiredReviewer = (process.env.REQUIRED_AGENT_REVIEWER || 'Copilot').trim();
-
-            // Skip if the required reviewer is the PR author (can't request review from yourself)
-            if (pr.user && pr.user.login === requiredReviewer) {
-              core.info(`PR author is @${requiredReviewer}; cannot request self-review. Skipping.`);
-              return;
-            }
-
-            const currentReviewRequests = await github.rest.pulls.listRequestedReviewers({
-              owner,
-              repo,
-              pull_number
-            });
-            const alreadyRequested = (currentReviewRequests.data.users || []).some((u) => u.login === requiredReviewer);
-            if (alreadyRequested) {
-              core.info(`Reviewer @${requiredReviewer} is already requested.`);
-              return;
-            }
-
-            try {
-              await github.rest.pulls.requestReviewers({
-                owner,
-                repo,
-                pull_number,
-                reviewers: [requiredReviewer]
-              });
-              core.info(`Requested reviewer @${requiredReviewer} for PR #${pull_number}.`);
-            } catch (error) {
-              if ((error.status || 0) === 422) {
-                core.info(`Reviewer @${requiredReviewer} could not be re-requested (likely already reviewed/requested).`);
-                return;
-              }
-              throw error;
-            }
+            core.info(
+              'GitHub-side Copilot reviewer routing is disabled for this repository; ' +
+              'draft-review acquisition remains local-only through the repo-owned CLI/orchestrator surfaces.'
+            );

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ artifacts under `tests/results/_agent/`.
 - Repo-owned Copilot CLI instructions live in `.github/copilot-instructions.md`.
   Use the local Copilot CLI review plane only for draft-review acceleration and
   keep hosted validation authoritative for final promotion.
+- GitHub-native automatic Copilot review is intentionally disabled here.
+  Hosted workflow policy must validate local review receipts and promotion
+  state, not request a second GitHub-side Copilot pass.
 - Instruction precedence for future agents:
   - `AGENTS.md` is the repo-wide policy and standing-priority authority.
   - `.github/copilot-instructions.md` narrows GitHub Copilot CLI behavior for

--- a/tools/priority/__tests__/agent-review-policy-contract.test.mjs
+++ b/tools/priority/__tests__/agent-review-policy-contract.test.mjs
@@ -7,14 +7,14 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const workflowPath = path.join(repoRoot, '.github', 'workflows', 'agent-review-policy.yml');
 
-test('agent-review-policy validates existing draft-phase review state from pull_request_target, pull_request_review, and merge_group', () => {
+test('agent-review-policy validates local-only review promotion state from pull_request_target and merge_group', () => {
   const workflow = readFileSync(workflowPath, 'utf8');
 
   assert.match(workflow, /merge_group:/);
   assert.doesNotMatch(workflow, /workflow_run:/);
   assert.doesNotMatch(workflow, /review_requested/);
   assert.doesNotMatch(workflow, /review_request_removed/);
-  assert.match(workflow, /pull_request_review:\s+types:\s+\[submitted\]/);
+  assert.doesNotMatch(workflow, /pull_request_review:/);
   assert.match(workflow, /permissions:\s+actions: read\s+pull-requests: read\s+contents: read/ms);
   assert.match(workflow, /uses: actions\/checkout@v5/);
   assert.match(workflow, /repository:\s+\$\{\{\s*github\.repository\s*\}\}/);
@@ -28,16 +28,14 @@ test('agent-review-policy validates existing draft-phase review state from pull_
   assert.match(workflow, /actions\/setup-node@v5/);
   assert.match(workflow, /name: Install Node dependencies\s+if: github\.event_name == 'pull_request_target'\s+run: npm ci --ignore-scripts/);
   assert.match(workflow, /name: Build TypeScript utilities\s+if: github\.event_name == 'pull_request_target'\s+run: node tools\/npm\/run-script\.mjs build/);
-  assert.match(workflow, /name: Collect Copilot review signal\s+if: github\.event_name == 'pull_request_target'/);
-  assert.match(workflow, /node dist\/tools\/priority\/copilot-review-signal\.js/);
-  assert.match(workflow, /name: Validate Copilot review signal schema\s+if: github\.event_name == 'pull_request_target'/);
-  assert.match(workflow, /tests\/results\/_agent\/reviews\/copilot-review-signal\.json/);
-  assert.match(workflow, /if: always\(\) && github\.event_name == 'pull_request_target'\s+uses: actions\/upload-artifact@v6/);
+  assert.doesNotMatch(workflow, /Collect Copilot review signal/);
+  assert.doesNotMatch(workflow, /copilot-review-signal\.js/);
+  assert.doesNotMatch(workflow, /copilot-review-signal\.json/);
   assert.doesNotMatch(workflow, /name: Resolve workflow-run PR context/);
   assert.doesNotMatch(workflow, /name: Load workflow-run pull request metadata/);
   assert.match(
     workflow,
-    /name: Evaluate Copilot queue gate\s+if: >[\s\S]*github\.event_name == 'pull_request_target'[\s\S]*github\.event_name == 'pull_request_review'[\s\S]*github\.event_name == 'merge_group'/,
+    /name: Evaluate Copilot queue gate\s+if: >[\s\S]*github\.event_name == 'pull_request_target'[\s\S]*github\.event_name == 'merge_group'/,
   );
   assert.match(workflow, /delivery-agent\.policy\.json/);
   assert.match(workflow, /"--copilot-review-strategy" "\$review_strategy"/);
@@ -50,7 +48,6 @@ test('agent-review-policy validates existing draft-phase review state from pull_
   assert.doesNotMatch(workflow, /elif \[\[ "\$\{\{ github\.event_name \}\}" == "workflow_run" \]\]; then/);
   assert.doesNotMatch(workflow, /"--review-run-id"/);
   assert.match(workflow, /else\s+args\+=\(\s+"--pr" "\$\{\{ github\.event\.pull_request\.number \}\}"/s);
-  assert.match(workflow, /if \[\[ "\$\{\{ github\.event_name \}\}" == "pull_request_target" && -f tests\/results\/_agent\/reviews\/copilot-review-signal\.json \]\]; then/);
   assert.match(workflow, /node "\$\{args\[@\]\}"/);
   assert.doesNotMatch(workflow, /name: Evaluate Copilot queue gate \(merge_group\)/);
   assert.match(workflow, /name: Upload Copilot queue gate artifact\s+if: always\(\)\s+uses: actions\/upload-artifact@v6/);

--- a/tools/priority/__tests__/pr-agent-review-routing-contract.test.mjs
+++ b/tools/priority/__tests__/pr-agent-review-routing-contract.test.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from 'node:fs';
 
 const repoRoot = process.cwd();
 
-test('pr-agent-review-routing only requests Copilot while the PR is still draft', () => {
+test('pr-agent-review-routing keeps draft-phase routing local-only for agent-authored PRs', () => {
   const workflow = readFileSync(
     path.join(repoRoot, '.github', 'workflows', 'pr-agent-review-routing.yml'),
     'utf8'
@@ -19,8 +19,11 @@ test('pr-agent-review-routing only requests Copilot while the PR is still draft'
   );
   assert.doesNotMatch(workflow, /ready_for_review/);
   assert.match(workflow, /jobs:\s+request-reviewer:\s+if: github\.event\.pull_request\.draft == true/ms);
-  assert.match(workflow, /REQUIRED_AGENT_REVIEWER:\s+\$\{\{\s*vars\.REQUIRED_AGENT_REVIEWER \|\| 'Copilot'\s*\}\}/);
   assert.doesNotMatch(workflow, /github\.repository_owner/);
-  assert.match(workflow, /const requiredReviewer = \(process\.env\.REQUIRED_AGENT_REVIEWER \|\| 'Copilot'\)\.trim\(\);/);
-  assert.match(workflow, /reviewers:\s+\[requiredReviewer\]/);
+  assert.doesNotMatch(workflow, /REQUIRED_AGENT_REVIEWER/);
+  assert.doesNotMatch(workflow, /requestReviewers/);
+  assert.match(
+    workflow,
+    /GitHub-side Copilot reviewer routing is disabled for this repository;[\s\S]*draft-review acquisition remains local-only/
+  );
 });


### PR DESCRIPTION
# Summary

Aligns hosted workflow policy with the repository's local-only CLI review contract.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1073
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1073
- Files, tools, workflows, or policies touched:
  - `.github/workflows/agent-review-policy.yml`
  - `.github/workflows/pr-agent-review-routing.yml`
  - `tools/priority/__tests__/agent-review-policy-contract.test.mjs`
  - `tools/priority/__tests__/pr-agent-review-routing-contract.test.mjs`
  - `.github/copilot-instructions.md`
  - `AGENTS.md`
- Required checks, merge-queue behavior, or approval flows affected: hosted policy stops requesting or waiting on GitHub-side Copilot review and validates the local-only review contract instead.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/agent-review-policy-contract.test.mjs tools/priority/__tests__/pr-agent-review-routing-contract.test.mjs tools/priority/__tests__/github-instructions-contract.test.mjs`
  - `node tools/npm/run-script.mjs lint:md:changed`
- Key artifacts, logs, or workflow runs:
  - focused workflow and instruction contract coverage only
- Risk-based checks not run:
  - `actionlint` was not available in this fresh worktree without widening the lane into the full pre-push matrix; hosted workflow lint remains the outer confirmation gate

## Risks and Follow-ups

- Residual risks: downstream helper surfaces that still inspect GitHub-native Copilot review artifacts remain for later cleanup if they are no longer used.
- Follow-up issues or deferred work: later slices can remove unused `copilot-review-signal` surfaces once promotion consumers no longer depend on them.
- Deployment, approval, or rollback notes: standard required-check and merge-queue flow.

## Reviewer Focus

- Please verify: hosted workflows no longer request GitHub-side Copilot review or react to `pull_request_review` events.
- Areas where the reasoning is subtle: this slice changes acquisition policy only; it does not widen merge authority beyond `agent-review-policy` and existing required checks.
- Manual spot checks requested: None.

Closes #1073
