### PR TITLE
#1076 Consume stored ready-validation clearance in merge preflight

### DIFF
--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import {
   assertUpstreamOwnedHead,
@@ -12,6 +12,7 @@ import {
   buildPolicyTrace,
   classifyPromotionState,
   evaluatePromotionReviewClearance,
+  resolveReadyValidationClearancePath,
   isUpstreamOwnedHead,
   normalizeBaseRefName,
   runMergeSync,
@@ -819,7 +820,128 @@ test('evaluatePromotionReviewClearance summarizes a passing current-head no-comm
     actionableThreadCount: 0,
     hasCurrentHeadReview: false,
     latestReviewIsCurrentHead: false,
-    reviewRunCompletedClean: true
+    reviewRunCompletedClean: true,
+    source: 'copilot-review-gate',
+    receiptPath: null,
+    readyHeadSha: null,
+    currentHeadSha: '1234567890123456789012345678901234567890',
+    staleForCurrentHead: null
+  });
+});
+
+test('evaluatePromotionReviewClearance passes from stored ready-validation clearance on the current head without invoking the GitHub gate', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'merge-sync-pr-stored-clearance-'));
+  const receiptPath = resolveReadyValidationClearancePath({
+    repoRoot: tempDir,
+    repo: 'owner/repo',
+    pr: 126
+  });
+  await mkdir(path.dirname(receiptPath), { recursive: true });
+  await writeFile(
+    receiptPath,
+    `${JSON.stringify({
+      schema: 'priority/ready-validation-clearance@v1',
+      generatedAt: '2026-03-14T00:00:00.000Z',
+      repository: 'owner/repo',
+      pullRequestNumber: 126,
+      readyHeadSha: '1234567890123456789012345678901234567890',
+      currentHeadSha: '1234567890123456789012345678901234567890',
+      status: 'current',
+      reason: 'PR remains in ready-validation on the same cleared head.'
+    })}\n`,
+    'utf8'
+  );
+
+  let gateCalls = 0;
+  const result = await evaluatePromotionReviewClearance({
+    repoRoot: tempDir,
+    repo: 'owner/repo',
+    pr: 126,
+    prInfo: {
+      isDraft: false,
+      baseRefName: 'develop',
+      headRefOid: '1234567890123456789012345678901234567890'
+    },
+    runCopilotReviewGateFn: async () => {
+      gateCalls += 1;
+      throw new Error('gate should not be called when stored clearance is current');
+    }
+  });
+
+  assert.equal(gateCalls, 0);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.report, {
+    status: 'pass',
+    gateState: 'ready',
+    reasons: ['stored-ready-validation-clearance-current-head'],
+    actionableCommentCount: 0,
+    actionableThreadCount: 0,
+    hasCurrentHeadReview: false,
+    latestReviewIsCurrentHead: false,
+    reviewRunCompletedClean: false,
+    source: 'stored-ready-validation-clearance',
+    receiptPath,
+    readyHeadSha: '1234567890123456789012345678901234567890',
+    currentHeadSha: '1234567890123456789012345678901234567890',
+    staleForCurrentHead: false
+  });
+});
+
+test('evaluatePromotionReviewClearance fails closed when stored ready-validation clearance is stale for the current head', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'merge-sync-pr-stale-clearance-'));
+  const receiptPath = resolveReadyValidationClearancePath({
+    repoRoot: tempDir,
+    repo: 'owner/repo',
+    pr: 127
+  });
+  await mkdir(path.dirname(receiptPath), { recursive: true });
+  await writeFile(
+    receiptPath,
+    `${JSON.stringify({
+      schema: 'priority/ready-validation-clearance@v1',
+      generatedAt: '2026-03-14T00:00:00.000Z',
+      repository: 'owner/repo',
+      pullRequestNumber: 127,
+      readyHeadSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      currentHeadSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      status: 'current',
+      reason: 'PR remains in ready-validation on the same cleared head.'
+    })}\n`,
+    'utf8'
+  );
+
+  let gateCalls = 0;
+  const result = await evaluatePromotionReviewClearance({
+    repoRoot: tempDir,
+    repo: 'owner/repo',
+    pr: 127,
+    prInfo: {
+      isDraft: false,
+      baseRefName: 'develop',
+      headRefOid: 'cccccccccccccccccccccccccccccccccccccccc'
+    },
+    runCopilotReviewGateFn: async () => {
+      gateCalls += 1;
+      throw new Error('gate should not be called when stored clearance is stale');
+    }
+  });
+
+  assert.equal(gateCalls, 0);
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.report, {
+    status: 'fail',
+    gateState: 'blocked',
+    reasons: ['stored-ready-validation-clearance-stale-head'],
+    actionableCommentCount: 0,
+    actionableThreadCount: 0,
+    hasCurrentHeadReview: false,
+    latestReviewIsCurrentHead: false,
+    reviewRunCompletedClean: false,
+    source: 'stored-ready-validation-clearance',
+    receiptPath,
+    readyHeadSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    currentHeadSha: 'cccccccccccccccccccccccccccccccccccccccc',
+    staleForCurrentHead: true
   });
 });
 

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -47,6 +47,13 @@ const POLICY_BLOCK_PATTERNS = [
   /cannot be merged automatically/i
 ];
 
+function sanitizeSegment(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'runtime';
+}
+
 function printUsage() {
   for (const line of USAGE_LINES) {
     console.log(line);
@@ -158,6 +165,44 @@ export function normalizeBaseRefName(value) {
     return lowered.substring(refsPrefix.length);
   }
   return lowered;
+}
+
+export function resolveReadyValidationClearancePath({ repoRoot, repo, pr }) {
+  const repositorySegment = sanitizeSegment(repo || 'repo');
+  const pullRequestSegment = sanitizeSegment(`pr-${pr || 'unknown'}`);
+  return path.join(
+    repoRoot,
+    'tests',
+    'results',
+    '_agent',
+    'runtime',
+    'ready-validation-clearance',
+    `${repositorySegment}-${pullRequestSegment}.json`
+  );
+}
+
+export async function loadReadyValidationClearance({
+  repoRoot,
+  repo,
+  pr,
+  readFileFn = readFile
+}) {
+  const receiptPath = resolveReadyValidationClearancePath({ repoRoot, repo, pr });
+  try {
+    const payload = JSON.parse(await readFileFn(receiptPath, 'utf8'));
+    return {
+      receiptPath,
+      receipt: payload && typeof payload === 'object' ? payload : null
+    };
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return {
+        receiptPath,
+        receipt: null
+      };
+    }
+    throw new Error(`Unable to read ready-validation clearance at ${receiptPath}: ${error.message}`);
+  }
 }
 
 export function getMergeQueueBranches(policy) {
@@ -447,13 +492,90 @@ function readPromotionState({ repoRoot, repo, pr }) {
 }
 
 export async function evaluatePromotionReviewClearance({
+  repoRoot = getRepoRoot(),
   repo,
   pr,
   prInfo,
   runCopilotReviewGateFn = runCopilotReviewGate,
+  readReadyValidationClearanceFn = loadReadyValidationClearance,
   pollAttempts = PROMOTION_REVIEW_GATE_POLL_ATTEMPTS,
   pollDelayMs = PROMOTION_REVIEW_GATE_POLL_DELAY_MS
 }) {
+  const currentHeadSha = normalizeText(prInfo?.headRefOid);
+  const readyValidationClearance = await readReadyValidationClearanceFn({
+    repoRoot,
+    repo,
+    pr
+  });
+  const stored = readyValidationClearance?.receipt ?? null;
+  const storedStatus = normalizeLower(stored?.status);
+  const storedReadyHeadSha = normalizeText(stored?.readyHeadSha);
+  const storedCurrentHeadSha = normalizeText(stored?.currentHeadSha);
+
+  if (stored && storedReadyHeadSha && storedStatus === 'current' && currentHeadSha && storedReadyHeadSha === currentHeadSha) {
+    return {
+      ok: true,
+      report: {
+        status: 'pass',
+        gateState: 'ready',
+        reasons: ['stored-ready-validation-clearance-current-head'],
+        actionableCommentCount: 0,
+        actionableThreadCount: 0,
+        hasCurrentHeadReview: false,
+        latestReviewIsCurrentHead: false,
+        reviewRunCompletedClean: false,
+        source: 'stored-ready-validation-clearance',
+        receiptPath: readyValidationClearance.receiptPath,
+        readyHeadSha: storedReadyHeadSha,
+        currentHeadSha,
+        staleForCurrentHead: false
+      }
+    };
+  }
+
+  if (stored && storedReadyHeadSha && currentHeadSha && storedReadyHeadSha !== currentHeadSha) {
+    return {
+      ok: false,
+      report: {
+        status: 'fail',
+        gateState: 'blocked',
+        reasons: ['stored-ready-validation-clearance-stale-head'],
+        actionableCommentCount: 0,
+        actionableThreadCount: 0,
+        hasCurrentHeadReview: false,
+        latestReviewIsCurrentHead: false,
+        reviewRunCompletedClean: false,
+        source: 'stored-ready-validation-clearance',
+        receiptPath: readyValidationClearance.receiptPath,
+        readyHeadSha: storedReadyHeadSha,
+        currentHeadSha,
+        staleForCurrentHead: true
+      }
+    };
+  }
+
+  if (stored && storedStatus && storedStatus !== 'current') {
+    return {
+      ok: false,
+      report: {
+        status: 'fail',
+        gateState: 'blocked',
+        reasons: ['stored-ready-validation-clearance-invalidated'],
+        actionableCommentCount: 0,
+        actionableThreadCount: 0,
+        hasCurrentHeadReview: false,
+        latestReviewIsCurrentHead: false,
+        reviewRunCompletedClean: false,
+        source: 'stored-ready-validation-clearance',
+        receiptPath: readyValidationClearance.receiptPath,
+        readyHeadSha: storedReadyHeadSha || null,
+        currentHeadSha: currentHeadSha || storedCurrentHeadSha || null,
+        staleForCurrentHead:
+          storedReadyHeadSha && currentHeadSha ? storedReadyHeadSha !== currentHeadSha : null
+      }
+    };
+  }
+
   const result = await runCopilotReviewGateFn({
     argv: [
       'node',
@@ -465,7 +587,7 @@ export async function evaluatePromotionReviewClearance({
       '--pr',
       String(pr),
       '--head-sha',
-      normalizeText(prInfo?.headRefOid),
+      currentHeadSha,
       '--base-ref',
       normalizeBaseRefName(prInfo?.baseRefName),
       '--draft',
@@ -488,13 +610,18 @@ export async function evaluatePromotionReviewClearance({
       ? {
           status: report.status ?? null,
           gateState: report.gateState ?? null,
-          reasons: Array.isArray(report.reasons) ? [...report.reasons] : [],
-          actionableCommentCount: report.summary?.actionableCommentCount ?? 0,
-          actionableThreadCount: report.summary?.actionableThreadCount ?? 0,
-          hasCurrentHeadReview: report.signals?.hasCurrentHeadReview ?? false,
-          latestReviewIsCurrentHead: report.signals?.latestReviewIsCurrentHead ?? false,
-          reviewRunCompletedClean: report.signals?.reviewRunCompletedClean ?? false
-        }
+        reasons: Array.isArray(report.reasons) ? [...report.reasons] : [],
+        actionableCommentCount: report.summary?.actionableCommentCount ?? 0,
+        actionableThreadCount: report.summary?.actionableThreadCount ?? 0,
+        hasCurrentHeadReview: report.signals?.hasCurrentHeadReview ?? false,
+        latestReviewIsCurrentHead: report.signals?.latestReviewIsCurrentHead ?? false,
+        reviewRunCompletedClean: report.signals?.reviewRunCompletedClean ?? false,
+        source: 'copilot-review-gate',
+        receiptPath: null,
+        readyHeadSha: null,
+        currentHeadSha: currentHeadSha || null,
+        staleForCurrentHead: null
+      }
       : null
   };
 }
@@ -640,6 +767,7 @@ export async function runMergeSync({
           }
         }
       : await evaluatePromotionReviewClearanceFn({
+          repoRoot,
           repo: resolvedRepo,
           pr: options.pr,
           prInfo


### PR DESCRIPTION
# Summary

Makes merge/promotion preflight consume stored ready-validation clearance on the current head before falling back to GitHub review discovery.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1076
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1076
- Files, tools, workflows, or policies touched:
  - `tools/priority/merge-sync-pr.mjs`
  - `tools/priority/__tests__/merge-sync-pr.test.mjs`
- Required checks, merge-queue behavior, or approval flows affected: merge/promotion can admit a PR from stored current-head ready-validation clearance instead of waiting for another review-discovery pass, while stale or invalidated clearance still fails closed.

## Validation Evidence

- Commands run:
  - `node --check tools/priority/merge-sync-pr.mjs`
  - `node --test tools/priority/__tests__/merge-sync-pr.test.mjs tools/priority/__tests__/queue-supervisor.test.mjs`
- Key artifacts, logs, or workflow runs:
  - focused merge-sync and queue-supervisor coverage only
- Risk-based checks not run:
  - broader repo validation was not rerun because this slice is isolated to promotion preflight and summary semantics

## Risks and Follow-ups

- Residual risks: branches without stored ready-validation clearance still fall back to the prior gate path until later slices remove that dependency entirely.
- Follow-up issues or deferred work: later slices can promote the same stored-clearance contract deeper into queue-only paths beyond merge preflight.
- Deployment, approval, or rollback notes: standard required-check and merge-queue flow.

## Reviewer Focus

- Please verify: current-head stored ready-validation clearance passes promotion preflight without invoking the GitHub review gate.
- Areas where the reasoning is subtle: stale or invalidated stored clearance now blocks promotion before fallback to merge automation.
- Manual spot checks requested: None.

Closes #1076
