### PR TITLE
#1073 Record disabled GitHub Copilot review in policy evidence

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -356,16 +356,18 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - Machine-readable routing evidence is written to
   `tests/results/_agent/validate-scope-plan/validate-scope-plan.json` and summarized in the Validate step summary so
   reviewers can see why heavy lanes were bypassed.
-- On `develop`, Copilot review is expected on ready PRs. Use **Draft PR** state as the explicit escape hatch when you do
-  not want Copilot review to run yet. Ready `develop` PRs also need the `agent-review-policy` check to turn green after
-  either:
-  - the first Copilot review lands on the current head during the workflow's bounded polling window, or
-  - a follow-up push leaves zero actionable current-head Copilot threads after an earlier Copilot review on the PR.
+- GitHub-native automatic Copilot review is intentionally disabled for this repository. Draft review is acquired through
+  the local CLI/orchestrator path, and `ready_for_review` is reserved for final hosted validation on the current head.
+- `agent-review-policy` is the hosted concentrator for local review evidence and promotion validation. It should not be
+  used to acquire a second GitHub-side Copilot review after `ready_for_review`.
 - Run `node tools/npm/run-script.mjs priority:policy` (or `node tools/npm/run-script.mjs priority:policy:sync`) if you
   need to audit merge settings locally; the command also runs during `priority:handoff-tests` and fails when
   repo/branch policy drifts.
 - Capture live branch/ruleset evidence with `node tools/npm/run-script.mjs priority:policy:snapshot`; the snapshot is
   written to `tests/results/_agent/policy/policy-state-snapshot.json`.
+  Inspect `state.copilotReview` in that artifact to confirm rulesets do not contain `copilot_code_review` rules.
+  Repository-level "Automatic request Copilot review" remains a manual settings-page verification point because GitHub's
+  REST policy surfaces do not expose that toggle directly.
 - Run `node tools/npm/run-script.mjs priority:queue:supervisor -- --dry-run` to preview queue ordering and
   candidate gates, or add `--apply` for guarded autonomous enqueue mode.
   Use `--governor-state <path>` (default `tests/results/_agent/slo/ops-governor-state.json`) to

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -77,6 +77,10 @@ promotion behavior, not the branch-class source of truth.
 
 `node tools/npm/run-script.mjs priority:policy` queries these rulesets and fails if the live configuration drifts from
 `tools/priority/policy.json`; run it whenever you adjust protections.
+`node tools/npm/run-script.mjs priority:policy:snapshot` now also emits `state.copilotReview`, which must show
+`rulesetCopilotCodeReviewPresent = false` for the local CLI review contract. The repository-level
+"Automatic request Copilot review" setting is still a manual settings-page verification point because GitHub's REST
+ruleset/branch-protection APIs do not expose that toggle directly.
 
 ## Prescriptive Protection Settings
 

--- a/tools/priority/__tests__/policy-snapshot.test.mjs
+++ b/tools/priority/__tests__/policy-snapshot.test.mjs
@@ -5,7 +5,8 @@ import {
   parseArgs,
   parseRemoteUrl,
   resolveRepositorySlug,
-  collectPolicyState
+  collectPolicyState,
+  summarizeCopilotReviewState
 } from '../policy-snapshot.mjs';
 
 test('parseArgs applies defaults and accepts explicit repo/output', () => {
@@ -116,6 +117,38 @@ test('collectPolicyState records branch protection and stable-key ruleset detail
   assert.equal(state.branches['release/*'].skipped, true);
   assert.equal(state.rulesets.develop.id, 100);
   assert.equal(state.rulesets['100'].id, 100);
+  assert.equal(state.copilotReview.rulesetCopilotCodeReviewPresent, false);
+  assert.deepEqual(state.copilotReview.rulesetsWithCopilotCodeReview, []);
+  assert.equal(state.copilotReview.rulesets.develop.present, false);
+  assert.equal(state.copilotReview.automaticRequestSettingObservableViaApi, false);
   assert.ok(calls.some((entry) => entry.endsWith('/rulesets/100')));
   assert.ok(calls.some((entry) => entry.endsWith('/rulesets')));
+});
+
+test('summarizeCopilotReviewState flags observed copilot review rules and unresolved rulesets', () => {
+  const summary = summarizeCopilotReviewState({
+    develop: {
+      id: 100,
+      name: 'develop',
+      rules: [
+        {
+          type: 'copilot_code_review',
+          parameters: {
+            review_on_push: false,
+            review_draft_pull_requests: true
+          }
+        }
+      ]
+    },
+    release: {
+      error: 'ruleset-not-found'
+    }
+  });
+
+  assert.equal(summary.rulesetCopilotCodeReviewPresent, true);
+  assert.deepEqual(summary.rulesetsWithCopilotCodeReview, ['develop']);
+  assert.equal(summary.rulesets.develop.present, true);
+  assert.equal(summary.rulesets.develop.parameters.review_draft_pull_requests, true);
+  assert.equal(summary.rulesets.release.status, 'unresolved');
+  assert.equal(summary.expectedRepositoryAutomaticRequestSetting, 'disabled');
 });

--- a/tools/priority/policy-snapshot.mjs
+++ b/tools/priority/policy-snapshot.mjs
@@ -154,6 +154,59 @@ async function loadRulesets(apiBase, token, requestJsonFn) {
   return requestJsonFn(`${apiBase}/rulesets`, token);
 }
 
+function findRule(rules = [], type) {
+  if (!Array.isArray(rules)) {
+    return null;
+  }
+  return rules.find((rule) => rule?.type === type) ?? null;
+}
+
+export function summarizeCopilotReviewState(rulesets = {}) {
+  const perRuleset = {};
+  const rulesetsWithCopilotCodeReview = [];
+  for (const [key, ruleset] of Object.entries(rulesets)) {
+    if (!ruleset || typeof ruleset !== 'object') {
+      perRuleset[key] = {
+        present: false,
+        status: 'invalid'
+      };
+      continue;
+    }
+    if (typeof ruleset.error === 'string' && ruleset.error.trim()) {
+      perRuleset[key] = {
+        present: false,
+        status: 'unresolved',
+        error: ruleset.error
+      };
+      continue;
+    }
+    const copilotRule = findRule(ruleset.rules, 'copilot_code_review');
+    const present = Boolean(copilotRule);
+    if (present) {
+      rulesetsWithCopilotCodeReview.push(key);
+    }
+    perRuleset[key] = {
+      present,
+      status: 'observed',
+      id: ruleset.id ?? null,
+      name: ruleset.name ?? null,
+      parameters: copilotRule?.parameters ?? null
+    };
+  }
+  return {
+    expectedRepositoryAutomaticRequestSetting: 'disabled',
+    automaticRequestSettingObservableViaApi: false,
+    automaticRequestSettingEvidence: 'manual-settings-page',
+    notes: [
+      'Repository-level Automatic request Copilot review is not exposed by the REST endpoints used by policy-snapshot.',
+      'Ruleset state is observable and must not contain copilot_code_review rules for this contract.'
+    ],
+    rulesetCopilotCodeReviewPresent: rulesetsWithCopilotCodeReview.length > 0,
+    rulesetsWithCopilotCodeReview,
+    rulesets: perRuleset
+  };
+}
+
 export async function collectPolicyState({
   repo,
   token,
@@ -209,7 +262,8 @@ export async function collectPolicyState({
       updated_at: repoState.updated_at
     },
     branches,
-    rulesets
+    rulesets,
+    copilotReview: summarizeCopilotReviewState(rulesets)
   };
 }
 

--- a/tools/priority/policy.json
+++ b/tools/priority/policy.json
@@ -126,6 +126,7 @@
           "rebase"
         ]
       },
+      "copilot_code_review": false,
       "code_quality": {
         "severity": "warnings"
       }
@@ -166,7 +167,8 @@
           "squash",
           "rebase"
         ]
-      }
+      },
+      "copilot_code_review": false
     },
     "8614172": {
       "name": "release",
@@ -193,7 +195,8 @@
         "allowed_merge_methods": [
           "rebase"
         ]
-      }
+      },
+      "copilot_code_review": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- make absence of GitHub-native `copilot_code_review` rules part of the checked-in policy contract
- surface live Copilot review acquisition state in `priority:policy:snapshot`
- align developer guidance with the local CLI review / ready-validation model and document the remaining manual settings-page verification seam

## Testing
- `node --test tools/priority/__tests__/policy-snapshot.test.mjs tools/priority/__tests__/check-policy-apply.test.mjs`
- `node tools/npm/run-script.mjs priority:policy`
- `node tools/npm/run-script.mjs priority:policy:snapshot`
- `node tools/npm/run-script.mjs lint:md:changed`

## Evidence
- `tests/results/_agent/policy/policy-state-snapshot.json`
  - `state.copilotReview.rulesetCopilotCodeReviewPresent = false`
  - `state.copilotReview.expectedRepositoryAutomaticRequestSetting = "disabled"`
  - `state.copilotReview.automaticRequestSettingObservableViaApi = false`

Refs #1073
