### PR TITLE
#1074 Re-run daemon local review on fresh draft heads

### DIFF
--- a/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
+++ b/tools/local-collab/orchestrator/__tests__/run-phase.test.mjs
@@ -86,7 +86,6 @@ test('runLocalCollaborationPhase writes deterministic daemon orchestrator receip
   const result = await runLocalCollaborationPhase({
     phase: 'daemon',
     repoRoot,
-    providers: ['copilot-cli'],
     delegateArgs: ['--receipt-path', 'tests/results/docker-tools-parity/review-loop-receipt.json'],
     delegateFns: {
       daemon: async () => ({
@@ -103,8 +102,8 @@ test('runLocalCollaborationPhase writes deterministic daemon orchestrator receip
   assert.equal(result.receipt.forkPlane, 'upstream');
   assert.equal(result.receipt.persona, 'daemon');
   assert.equal(result.receipt.executionPlane, 'docker');
-  assert.equal(result.receipt.selectionSource, 'explicit');
-  assert.deepEqual(result.receipt.providers, ['copilot-cli']);
+  assert.equal(result.receipt.selectionSource, 'default-empty');
+  assert.deepEqual(result.receipt.providers, []);
   assert.match(result.receipt.delegate.command.join(' '), /tools\/priority\/docker-desktop-review-loop\.mjs/);
   assert.equal(result.receipt.ledger.receiptId, `daemon:${result.receipt.headSha}`);
 
@@ -117,7 +116,100 @@ test('runLocalCollaborationPhase writes deterministic daemon orchestrator receip
   assert.equal(ledgerReceipt.phase, 'daemon');
   assert.equal(ledgerReceipt.headSha, result.receipt.headSha);
   assert.equal(ledgerReceipt.executionPlane, 'docker');
-  assert.equal(ledgerReceipt.providerId, 'copilot-cli');
+  assert.equal(ledgerReceipt.providerId, 'none');
+});
+
+test('runLocalCollaborationPhase runs daemon agent review after Docker parity passes', async () => {
+  const repoRoot = await createGitRepo();
+  const result = await runLocalCollaborationPhase({
+    phase: 'daemon',
+    repoRoot,
+    providers: ['simulation'],
+    delegateArgs: ['--receipt-path', 'tests/results/docker-tools-parity/review-loop-receipt.json'],
+    delegateFns: {
+      daemon: async () => ({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          status: 'passed',
+          source: 'docker-desktop-review-loop',
+          reason: 'Docker/Desktop review loop passed.',
+          receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+          currentHeadSha: 'head-sha',
+          receiptHeadSha: 'head-sha',
+          receiptFreshForHead: true,
+          requestedCoverageSatisfied: true,
+          requestedCoverageReason: 'coverage ok',
+          requestedCoverageMissingChecks: [],
+          receipt: {
+            overall: {
+              status: 'passed',
+              message: ''
+            }
+          }
+        }),
+        stderr: ''
+      })
+    },
+    invokeAgentReviewPolicyFn: () => ({
+      exitCode: 0,
+      receipt: {
+        overall: {
+          status: 'passed',
+          actionableFindingCount: 0,
+          message: 'Daemon local agent review providers passed.'
+        },
+        providerSelection: {
+          selectionSource: 'explicit-request'
+        },
+        requestedProviders: ['simulation']
+      }
+    })
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.receipt.delegate.agentReview.receiptStatus, 'passed');
+  assert.deepEqual(result.receipt.delegate.agentReview.requestedProviders, ['simulation']);
+  const daemonStdout = JSON.parse(result.stdout);
+  assert.equal(daemonStdout.source, 'local-collab-daemon-review');
+  assert.equal(daemonStdout.status, 'passed');
+  assert.equal(daemonStdout.agentReview.receiptStatus, 'passed');
+  assert.deepEqual(daemonStdout.agentReview.requestedProviders, ['simulation']);
+});
+
+test('runLocalCollaborationPhase skips daemon agent review when Docker parity fails', async () => {
+  const repoRoot = await createGitRepo();
+  let invokedAgentReview = false;
+  const result = await runLocalCollaborationPhase({
+    phase: 'daemon',
+    repoRoot,
+    providers: ['simulation'],
+    delegateFns: {
+      daemon: async () => ({
+        exitCode: 1,
+        stdout: JSON.stringify({
+          status: 'failed',
+          source: 'docker-desktop-review-loop',
+          reason: 'Docker/Desktop review loop failed.'
+        }),
+        stderr: 'docker failed'
+      })
+    },
+    invokeAgentReviewPolicyFn: () => {
+      invokedAgentReview = true;
+      return {
+        exitCode: 0,
+        receipt: {
+          overall: {
+            status: 'passed'
+          }
+        }
+      };
+    }
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(invokedAgentReview, false);
+  assert.equal(result.receipt.delegate.agentReview, null);
 });
 
 test('runLocalCollaborationPhase records codex authoring receipts for post-commit', async () => {

--- a/tools/local-collab/orchestrator/run-phase.mjs
+++ b/tools/local-collab/orchestrator/run-phase.mjs
@@ -482,6 +482,115 @@ function invokeDaemonDelegate(repoRoot, delegateArgs) {
   return normalizeCommandResult(result);
 }
 
+function invokeDaemonAgentReview(
+  repoRoot,
+  {
+    env = process.env,
+    providerSelection = { selectionSource: 'default-empty', providers: [] },
+    invokeAgentReviewPolicyFn
+  } = {}
+) {
+  const configuredReceiptPath = AGENT_REVIEW_POLICY_PROFILE_RECEIPT_PATHS.daemon;
+  const normalizedReceiptPath = configuredReceiptPath.replace(/\\/g, '/');
+  const args = [
+    ...AGENT_REVIEW_POLICY_COMMAND.slice(1),
+    '--repo-root',
+    repoRoot,
+    '--profile',
+    'daemon',
+    '--receipt-path',
+    configuredReceiptPath
+  ];
+  for (const providerId of providerSelection.providers) {
+    args.push('--review-provider', providerId);
+  }
+
+  let parsedReceipt = null;
+  const commandResult = typeof invokeAgentReviewPolicyFn === 'function'
+    ? (() => {
+        const injected = invokeAgentReviewPolicyFn({
+          repoRoot,
+          phase: 'daemon',
+          env,
+          providerSelection,
+          receiptPath: configuredReceiptPath
+        }) ?? {};
+        parsedReceipt = injected.receipt ?? null;
+        const status = Number.isInteger(injected.exitCode)
+          ? injected.exitCode
+          : normalizeText(parsedReceipt?.overall?.status) === 'failed'
+            ? 1
+            : 0;
+        return {
+          status,
+          stdout: normalizeText(injected.stdout) || (parsedReceipt ? JSON.stringify(parsedReceipt, null, 2) : ''),
+          stderr: normalizeText(injected.stderr)
+        };
+      })()
+    : normalizeCommandResult(
+        spawnSync(AGENT_REVIEW_POLICY_COMMAND[0], args, {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...env
+          },
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      );
+  parsedReceipt ??= tryParseJson(commandResult.stdout);
+
+  return {
+    exitCode: commandResult.status,
+    receiptPath: normalizedReceiptPath,
+    receiptStatus: normalizeText(parsedReceipt?.overall?.status) || null,
+    selectionSource:
+      normalizeText(parsedReceipt?.providerSelection?.selectionSource) || providerSelection.selectionSource,
+    requestedProviders: Array.isArray(parsedReceipt?.requestedProviders)
+      ? parsedReceipt.requestedProviders.filter(Boolean)
+      : [],
+    actionableFindingCount: Number.isInteger(parsedReceipt?.overall?.actionableFindingCount)
+      ? parsedReceipt.overall.actionableFindingCount
+      : 0,
+    reason:
+      normalizeText(parsedReceipt?.overall?.message) ||
+      normalizeText(commandResult.stderr) ||
+      normalizeText(commandResult.stdout) ||
+      'Daemon local agent review providers did not return a machine-readable status.',
+    receipt: parsedReceipt
+  };
+}
+
+function buildDaemonCombinedStdout(delegateReport, agentReview) {
+  if (!delegateReport || typeof delegateReport !== 'object') {
+    return '';
+  }
+
+  const combined = {
+    ...delegateReport,
+    source: 'local-collab-daemon-review',
+    reason:
+      normalizeText(agentReview?.receiptStatus).toLowerCase() === 'failed'
+        ? normalizeText(agentReview.reason) || 'Daemon local agent review providers failed after Docker/Desktop review passed.'
+        : 'Docker/Desktop review loop passed and daemon local agent review providers passed.',
+    agentReview: agentReview
+      ? {
+          receiptPath: normalizeText(agentReview.receiptPath) || null,
+          receiptStatus: normalizeText(agentReview.receiptStatus) || null,
+          selectionSource: normalizeText(agentReview.selectionSource) || null,
+          requestedProviders: normalizeStringList(agentReview.requestedProviders),
+          actionableFindingCount: Number.isInteger(agentReview.actionableFindingCount)
+            ? agentReview.actionableFindingCount
+            : 0
+        }
+      : null
+  };
+
+  if (normalizeText(agentReview?.receiptStatus).toLowerCase() === 'failed') {
+    combined.status = 'failed';
+  }
+  return JSON.stringify(combined, null, 2);
+}
+
 function invokePostCommitDelegate(repoRoot, env = process.env) {
   const runner = new HookRunner('post-commit', { repoRoot, env });
   info('[post-commit] Recording local collaboration authoring receipt');
@@ -517,7 +626,29 @@ export async function runLocalCollaborationPhase(options = {}) {
 
   const started = Date.now();
   let result;
-  if (typeof delegateFns[phase] === 'function') {
+  if (phase === 'daemon') {
+    result = typeof delegateFns.daemon === 'function'
+      ? await delegateFns.daemon({ repoRoot, phase, env, delegateArgs: options.delegateArgs ?? [] })
+      : invokeDaemonDelegate(repoRoot, options.delegateArgs ?? []);
+    const delegateReport = tryParseJson(result.stdout);
+    const delegatePassed =
+      result.exitCode === 0 &&
+      delegateReport &&
+      typeof delegateReport === 'object' &&
+      normalizeText(delegateReport.status).toLowerCase() === 'passed';
+    if (delegatePassed && providerSelection.providers.length > 0) {
+      result.agentReview = invokeDaemonAgentReview(repoRoot, {
+        env,
+        providerSelection,
+        invokeAgentReviewPolicyFn: options.invokeAgentReviewPolicyFn
+      });
+      result.stdout = buildDaemonCombinedStdout(delegateReport, result.agentReview);
+      if (normalizeText(result.agentReview.receiptStatus).toLowerCase() === 'failed' || result.agentReview.exitCode !== 0) {
+        result.exitCode = 1;
+        result.stderr = normalizeText(result.agentReview.reason) || result.stderr;
+      }
+    }
+  } else if (typeof delegateFns[phase] === 'function') {
     result = await delegateFns[phase]({ repoRoot, phase, env, delegateArgs: options.delegateArgs ?? [] });
   } else if (phase === 'pre-commit') {
     result = invokePreCommitDelegate(repoRoot, {
@@ -531,8 +662,6 @@ export async function runLocalCollaborationPhase(options = {}) {
       providerSelection,
       invokeAgentReviewPolicyFn: options.invokeAgentReviewPolicyFn
     });
-  } else if (phase === 'daemon') {
-    result = invokeDaemonDelegate(repoRoot, options.delegateArgs ?? []);
   } else if (phase === 'post-commit') {
     result = invokePostCommitDelegate(repoRoot, env);
   } else {

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -3006,6 +3006,143 @@ test('delivery broker restores ready only after clean current-head draft review 
   assert.match(brokerResult.reason, /marked the pr ready for review/i);
 });
 
+test('delivery broker passes configured daemon review providers to the local collaboration wrapper on a fresh draft head', async () => {
+  const tempRepo = await mkdtemp(path.join(os.tmpdir(), 'delivery-broker-daemon-rereview-'));
+  runGit(tempRepo, ['init']);
+  runGit(tempRepo, ['config', 'user.name', 'Agent Runner']);
+  runGit(tempRepo, ['config', 'user.email', 'agent@example.com']);
+  await writeFile(path.join(tempRepo, 'README.md'), '# temp\n', 'utf8');
+  runGit(tempRepo, ['add', 'README.md']);
+  runGit(tempRepo, ['commit', '-m', 'init']);
+  const headSha = runGit(tempRepo, ['rev-parse', 'HEAD']);
+
+  const helperCalls = [];
+  const brokerResult = await runDeliveryTurnBroker({
+    repoRoot: tempRepo,
+    taskPacket: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      status: 'waiting-review',
+      objective: {
+        summary: 'Advance issue #1074'
+      },
+      evidence: {
+        delivery: {
+          laneLifecycle: 'waiting-review',
+          pullRequest: {
+            number: 1074,
+            url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1074',
+            isDraft: true,
+            copilotReviewSignal: {
+              hasCurrentHeadReview: true,
+              actionableCommentCount: 0,
+              actionableThreadCount: 0
+            },
+            copilotReviewWorkflow: {
+              status: 'COMPLETED',
+              conclusion: 'SUCCESS'
+            }
+          },
+          localReviewLoop: {
+            requested: true,
+            source: 'standing-issue-body',
+            receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+            markdownlint: true,
+            requirementsVerification: true,
+            niLinuxReviewSuite: false,
+            singleViHistory: null
+          },
+          mutationEnvelope: {
+            copilotReviewStrategy: 'draft-only-explicit',
+            maxActiveCodingLanes: 1
+          },
+          turnBudget: {
+            maxMinutes: 20,
+            maxToolCalls: 12
+          }
+        }
+      }
+    },
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({
+        schema: 'priority/delivery-agent-policy@v1',
+        backlogAuthority: 'issues',
+        implementationRemote: 'origin',
+        copilotReviewStrategy: 'draft-only-explicit',
+        autoSlice: true,
+        autoMerge: true,
+        maxActiveCodingLanes: 1,
+        allowPolicyMutations: false,
+        allowReleaseAdmin: false,
+        stopWhenNoOpenEpics: true,
+        localReviewLoop: {
+          enabled: true,
+          reviewProviders: ['copilot-cli'],
+          receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+          command: ['node', 'tools/local-collab/orchestrator/run-phase.mjs', '--phase', 'daemon']
+        },
+        codingTurnCommand: ['node', 'mock-broker']
+      }),
+      runCommandFn: async (command, args) => {
+        helperCalls.push([command, ...args].join(' '));
+        if (command === 'node') {
+          return {
+            status: 0,
+            stdout: JSON.stringify({
+              status: 'passed',
+              source: 'local-collab-daemon-review',
+              reason: 'Docker/Desktop review loop passed and daemon local agent review providers passed.',
+              receiptPath: 'tests/results/docker-tools-parity/review-loop-receipt.json',
+              currentHeadSha: headSha,
+              receiptHeadSha: headSha,
+              receiptFreshForHead: true,
+              requestedCoverageSatisfied: true,
+              requestedCoverageReason: 'requested coverage satisfied',
+              requestedCoverageMissingChecks: [],
+              receipt: {
+                git: {
+                  headSha,
+                  dirtyTracked: false
+                },
+                overall: {
+                  status: 'passed',
+                  failedCheck: '',
+                  message: '',
+                  exitCode: 0
+                }
+              },
+              agentReview: {
+                receiptPath: 'tests/results/docker-tools-parity/agent-review-policy/receipt.json',
+                receiptStatus: 'passed',
+                selectionSource: 'explicit-request',
+                requestedProviders: ['copilot-cli'],
+                actionableFindingCount: 0
+              }
+            }),
+            stderr: ''
+          };
+        }
+        assert.equal(command, 'gh');
+        assert.deepEqual(args, ['pr', 'ready', '1074', '--repo', 'LabVIEW-Community-CI-CD/compare-vi-cli-action']);
+        return {
+          status: 0,
+          stdout: 'converted to ready\n',
+          stderr: ''
+        };
+      }
+    }
+  });
+
+  assert.equal(brokerResult.status, 'completed');
+  assert.equal(brokerResult.outcome, 'waiting-ci');
+  assert.equal(helperCalls.length, 2);
+  assert.match(
+    helperCalls[0],
+    /^node tools\/local-collab\/orchestrator\/run-phase\.mjs --phase daemon --providers copilot-cli --repo-root /
+  );
+  assert.equal(brokerResult.details.localReviewLoop.status, 'passed');
+  assert.equal(brokerResult.details.localReviewLoop.currentHeadSha, headSha);
+});
+
 test('delivery broker keeps a draft PR waiting-review when local receipt freshness or coverage cannot be proven', async () => {
   const helperCalls = [];
   const brokerResult = await runDeliveryTurnBroker({

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -331,6 +331,12 @@ function normalizeStringList(value) {
   return Array.isArray(value) ? value.map((entry) => normalizeText(entry)).filter(Boolean) : [];
 }
 
+function commandUsesLocalCollabOrchestrator(command = []) {
+  return Array.isArray(command)
+    ? command.some((entry) => normalizeText(entry).replace(/\\/g, '/').includes('tools/local-collab/orchestrator/run-phase.mjs'))
+    : false;
+}
+
 function normalizeCopilotReviewStrategy(value) {
   const normalized = normalizeText(value);
   if (!normalized) {
@@ -2368,8 +2374,13 @@ async function maybeRunLocalReviewLoop({
       ? normalizeCommandList(localReviewLoopPolicy.command)
       : [...DEFAULT_LOCAL_REVIEW_LOOP_COMMAND];
   const wrapperArgs = buildLocalReviewLoopCliArgs({ repoRoot, request });
+  const daemonReviewProviders = normalizeStringList(localReviewLoopPolicy.reviewProviders);
   const command = wrapperCommand[0];
-  const args = [...wrapperCommand.slice(1), ...wrapperArgs];
+  const args = [...wrapperCommand.slice(1)];
+  if (commandUsesLocalCollabOrchestrator(wrapperCommand) && daemonReviewProviders.length > 0) {
+    args.push('--providers', daemonReviewProviders.join(','));
+  }
+  args.push(...wrapperArgs);
   const commandText = [command, ...args].join(' ');
   let resolvedReceiptPathInfo;
   try {


### PR DESCRIPTION
## Summary
- run daemon-scoped local review providers after a fresh Docker/Desktop review loop pass
- pass configured daemon review providers through the delivery-agent local review wrapper
- cover the new daemon re-review path at both orchestrator and delivery-broker layers

## Validation
- `node --test tools/local-collab/orchestrator/__tests__/run-phase.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs`

Refs #1074

## Agent Metadata
- Agent: Codex CLI
- Plane: personal
- Execution: local worktree
