### PR TITLE
#1084 Make fork planes explicit in branch policy

### DIFF
--- a/docs/BRANCH_ROLE_CONTRACT.md
+++ b/docs/BRANCH_ROLE_CONTRACT.md
@@ -1,8 +1,8 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Branch Role Contract
 
-This document defines the branch classes and allowed transitions that unattended delivery, sync helpers, and
-branch-protection documentation must share.
+This document defines the branch classes, repository planes, and allowed transitions that unattended delivery, sync
+helpers, hook orchestration, and branch-protection documentation must share.
 
 ## Purpose
 
@@ -11,6 +11,20 @@ Instead, branch behavior is driven by one machine-readable contract:
 
 - policy artifact: [tools/policy/branch-classes.json](../tools/policy/branch-classes.json)
 - schema: [docs/schemas/branch-classes-v1.schema.json](schemas/branch-classes-v1.schema.json)
+
+This contract now makes the three collaboration planes explicit:
+
+- `upstream` = daemon and promotion authority
+- `origin` = org-fork review plane
+- `personal` = personal authoring plane
+
+## Repository Planes
+
+| Plane | Repository | `develop` semantics | Lane prefix | Personas | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `upstream` | `LabVIEW-Community-CI-CD/compare-vi-cli-action` | canonical integration branch (`upstream-integration`) | `issue/` | `daemon` | Queue-managed integration and promotion surface |
+| `origin` | `LabVIEW-Community-CI-CD/compare-vi-cli-action-fork` | mirror-only fork `develop` (`fork-mirror-develop`) | `issue/origin-` | `copilot-cli` | Org-fork review plane before upstream promotion |
+| `personal` | `svelderrainruiz/compare-vi-cli-action` | mirror-only fork `develop` (`fork-mirror-develop`) | `issue/personal-` | `codex`, `codex-cli` | Personal authoring plane before review or upstream promotion |
 
 ## Branch Classes
 
@@ -25,7 +39,7 @@ Instead, branch behavior is driven by one machine-readable contract:
 | `feature` | upstream or fork | `feature/*` | Explicit rehearsal/experiment branches | PR source only |
 | `merge-queue` | upstream | `gh-readonly-queue/**` | GitHub-owned merge queue refs | Queue-owned; never human or agent writable |
 
-## Allowed Transitions
+## Class Transitions
 
 The `Via` column below mirrors the exact `allowedTransitions[*].via` tokens from
 [tools/policy/branch-classes.json](../tools/policy/branch-classes.json).
@@ -45,12 +59,29 @@ The `Via` column below mirrors the exact `allowedTransitions[*].via` tokens from
 | `upstream-integration` | `branch` | `feature` | `feature/*` |
 | `fork-mirror-develop` | `branch` | `lane` | `issue/*` |
 
+## Plane Transitions
+
+The explicit collaboration flow between forks now lives beside the generic branch classes.
+
+| From plane | Action | To plane | Via | Branch class |
+| --- | --- | --- | --- | --- |
+| `upstream` | `sync` | `origin` | `priority:develop:sync` | `fork-mirror-develop` |
+| `upstream` | `sync` | `personal` | `priority:develop:sync` | `fork-mirror-develop` |
+| `personal` | `review` | `origin` | `pull-request` | `lane` |
+| `personal` | `promote` | `upstream` | `pull-request` | `lane` |
+| `origin` | `promote` | `upstream` | `pull-request` | `lane` |
+
 ## Operational Implications
 
 - `upstream/develop` is the only integration surface for standing work.
-- `origin/develop` and other fork `develop` branches are mirrors, not independent integration branches.
+- `origin/develop` and `personal/develop` are mirrors, not independent integration branches.
+- The personal plane is optimized for authoring; the org fork is optimized for review-oriented collaboration.
 - Lane branches may exist in forks, but they still promote into upstream protected branches.
 - Merge queue refs are their own branch class, not a special case of `develop` or `main`.
+- The branch prefix itself should reveal the active plane:
+  - `issue/personal-*` for the personal authoring plane
+  - `issue/origin-*` for the org-fork review plane
+  - bare `issue/*` for upstream-native lanes
 
 ## Helper Consumption
 
@@ -58,6 +89,7 @@ The contract is consumed directly by:
 
 - `priority:develop:sync`, which validates the upstream `develop` -> fork `develop` mirror transition
 - `priority:merge-sync`, which classifies the target base branch before choosing queue-aware promotion behavior
+- `tools/priority/lib/branch-classification.mjs`, which now resolves both repository role and explicit repository plane
 
-Future work under epic `#1038` should migrate other branch-role assumptions onto the same contract instead of creating
+Future work under epic `#1086` should migrate other branch-role assumptions onto the same contract instead of creating
 parallel policy files.

--- a/docs/schemas/branch-classes-v1.schema.json
+++ b/docs/schemas/branch-classes-v1.schema.json
@@ -8,8 +8,10 @@
     "schema",
     "schemaVersion",
     "upstreamRepository",
+    "repositoryPlanes",
     "classes",
-    "allowedTransitions"
+    "allowedTransitions",
+    "planeTransitions"
   ],
   "properties": {
     "schema": {
@@ -21,6 +23,65 @@
     "upstreamRepository": {
       "type": "string",
       "pattern": "^[^/]+/[^/]+$"
+    },
+    "repositoryPlanes": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "repositories",
+          "developBranch",
+          "developClass",
+          "laneBranchPrefix",
+          "purpose",
+          "personas"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "upstream",
+              "origin",
+              "personal"
+            ]
+          },
+          "repositories": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^[^/]+/[^/]+$"
+            }
+          },
+          "developBranch": {
+            "type": "string",
+            "minLength": 1
+          },
+          "developClass": {
+            "type": "string",
+            "minLength": 1
+          },
+          "laneBranchPrefix": {
+            "type": "string",
+            "minLength": 1
+          },
+          "purpose": {
+            "type": "string",
+            "minLength": 1
+          },
+          "personas": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
     },
     "classes": {
       "type": "array",
@@ -104,6 +165,53 @@
             "minLength": 1
           },
           "via": {
+            "type": "string",
+            "minLength": 1
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "planeTransitions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "from",
+          "action",
+          "to",
+          "via"
+        ],
+        "properties": {
+          "from": {
+            "type": "string",
+            "enum": [
+              "upstream",
+              "origin",
+              "personal"
+            ]
+          },
+          "action": {
+            "type": "string",
+            "minLength": 1
+          },
+          "to": {
+            "type": "string",
+            "enum": [
+              "upstream",
+              "origin",
+              "personal"
+            ]
+          },
+          "via": {
+            "type": "string",
+            "minLength": 1
+          },
+          "branchClass": {
             "type": "string",
             "minLength": 1
           },

--- a/tools/policy/branch-classes.json
+++ b/tools/policy/branch-classes.json
@@ -2,6 +2,48 @@
   "schema": "branch-classes/v1",
   "schemaVersion": "1.0.0",
   "upstreamRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+  "repositoryPlanes": [
+    {
+      "id": "upstream",
+      "repositories": [
+        "LabVIEW-Community-CI-CD/compare-vi-cli-action"
+      ],
+      "developBranch": "develop",
+      "developClass": "upstream-integration",
+      "laneBranchPrefix": "issue/",
+      "purpose": "Canonical integration and promotion plane. Standing work lands here through queue-managed squash promotion.",
+      "personas": [
+        "daemon"
+      ]
+    },
+    {
+      "id": "origin",
+      "repositories": [
+        "LabVIEW-Community-CI-CD/compare-vi-cli-action-fork"
+      ],
+      "developBranch": "develop",
+      "developClass": "fork-mirror-develop",
+      "laneBranchPrefix": "issue/origin-",
+      "purpose": "Org-fork review plane. Develop mirrors upstream, while issue/origin-* lanes carry review-oriented collaboration before upstream promotion.",
+      "personas": [
+        "copilot-cli"
+      ]
+    },
+    {
+      "id": "personal",
+      "repositories": [
+        "svelderrainruiz/compare-vi-cli-action"
+      ],
+      "developBranch": "develop",
+      "developClass": "fork-mirror-develop",
+      "laneBranchPrefix": "issue/personal-",
+      "purpose": "Personal authoring plane. Develop mirrors upstream, while issue/personal-* lanes carry Codex-led implementation before upstream promotion.",
+      "personas": [
+        "codex",
+        "codex-cli"
+      ]
+    }
+  ],
   "classes": [
     {
       "id": "upstream-integration",
@@ -183,6 +225,46 @@
       "to": "lane",
       "via": "issue/*",
       "notes": "Fork lanes may branch from the mirror, but promotion still targets upstream integration."
+    }
+  ],
+  "planeTransitions": [
+    {
+      "from": "upstream",
+      "action": "sync",
+      "to": "origin",
+      "via": "priority:develop:sync",
+      "branchClass": "fork-mirror-develop"
+    },
+    {
+      "from": "upstream",
+      "action": "sync",
+      "to": "personal",
+      "via": "priority:develop:sync",
+      "branchClass": "fork-mirror-develop"
+    },
+    {
+      "from": "personal",
+      "action": "review",
+      "to": "origin",
+      "via": "pull-request",
+      "branchClass": "lane",
+      "notes": "Personal authoring lanes may flow through the org fork review plane before upstream promotion."
+    },
+    {
+      "from": "personal",
+      "action": "promote",
+      "to": "upstream",
+      "via": "pull-request",
+      "branchClass": "lane",
+      "notes": "Direct personal fork promotion remains allowed when the lane already carries the required local review evidence."
+    },
+    {
+      "from": "origin",
+      "action": "promote",
+      "to": "upstream",
+      "via": "pull-request",
+      "branchClass": "lane",
+      "notes": "Org-fork review lanes promote into upstream protected branches after ready-validation evidence is complete."
     }
   ]
 }

--- a/tools/priority/__tests__/branch-classification.test.mjs
+++ b/tools/priority/__tests__/branch-classification.test.mjs
@@ -11,6 +11,7 @@ import {
   loadBranchClassContract,
   matchBranchPattern,
   normalizeBranchName,
+  resolveRepositoryPlane,
   resolveRepositoryRole
 } from '../lib/branch-classification.mjs';
 
@@ -31,6 +32,13 @@ test('branchPatternToRegExp and matchBranchPattern support wildcard branch class
 test('resolveRepositoryRole distinguishes upstream and fork repositories', () => {
   assert.equal(resolveRepositoryRole('LabVIEW-Community-CI-CD/compare-vi-cli-action', contract), 'upstream');
   assert.equal(resolveRepositoryRole('LabVIEW-Community-CI-CD/compare-vi-cli-action-fork', contract), 'fork');
+});
+
+test('resolveRepositoryPlane distinguishes upstream, origin, and personal planes', () => {
+  assert.equal(resolveRepositoryPlane('LabVIEW-Community-CI-CD/compare-vi-cli-action', contract), 'upstream');
+  assert.equal(resolveRepositoryPlane('LabVIEW-Community-CI-CD/compare-vi-cli-action-fork', contract), 'origin');
+  assert.equal(resolveRepositoryPlane('svelderrainruiz/compare-vi-cli-action', contract), 'personal');
+  assert.equal(resolveRepositoryPlane('someone-else/compare-vi-cli-action', contract), 'fork');
 });
 
 test('loadBranchClassContract rejects missing or invalid upstreamRepository slugs', () => {
@@ -61,30 +69,28 @@ test('loadBranchClassContract rejects missing or invalid upstreamRepository slug
 });
 
 test('classifyBranch resolves upstream integration, fork mirror, and lane branches', () => {
-  assert.equal(
-    classifyBranch({
-      branch: 'develop',
-      contract,
-      repositoryRole: 'upstream'
-    }).id,
-    'upstream-integration'
-  );
-  assert.equal(
-    classifyBranch({
-      branch: 'develop',
-      contract,
-      repositoryRole: 'fork'
-    }).id,
-    'fork-mirror-develop'
-  );
-  assert.equal(
-    classifyBranch({
-      branch: 'issue/origin-1041-branch-roles',
-      contract,
-      repositoryRole: 'fork'
-    }).id,
-    'lane'
-  );
+  const upstreamDevelop = classifyBranch({
+    branch: 'develop',
+    contract,
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+  });
+  const forkDevelop = classifyBranch({
+    branch: 'develop',
+    contract,
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'
+  });
+  const personalLane = classifyBranch({
+    branch: 'issue/personal-1084-fork-plane-branching-model',
+    contract,
+    repository: 'svelderrainruiz/compare-vi-cli-action'
+  });
+
+  assert.equal(upstreamDevelop.id, 'upstream-integration');
+  assert.equal(upstreamDevelop.repositoryPlane, 'upstream');
+  assert.equal(forkDevelop.id, 'fork-mirror-develop');
+  assert.equal(forkDevelop.repositoryPlane, 'origin');
+  assert.equal(personalLane.id, 'lane');
+  assert.equal(personalLane.repositoryPlane, 'personal');
 });
 
 test('classifyBranch resolves merge queue refs as their own class', () => {
@@ -116,5 +122,28 @@ test('assertAllowedTransition accepts upstream develop sync to fork mirror and r
         contract
       }),
     /not allowed by the branch class contract/i
+  );
+});
+
+test('branch class contract records explicit plane metadata and transitions for personal/origin/upstream collaboration', () => {
+  assert.deepEqual(
+    contract.repositoryPlanes.map((entry) => entry.id),
+    ['upstream', 'origin', 'personal']
+  );
+
+  const originPlane = contract.repositoryPlanes.find((entry) => entry.id === 'origin');
+  const personalPlane = contract.repositoryPlanes.find((entry) => entry.id === 'personal');
+  assert.equal(originPlane.laneBranchPrefix, 'issue/origin-');
+  assert.equal(personalPlane.laneBranchPrefix, 'issue/personal-');
+
+  assert.deepEqual(
+    contract.planeTransitions.map((entry) => `${entry.from}:${entry.action}:${entry.to}`),
+    [
+      'upstream:sync:origin',
+      'upstream:sync:personal',
+      'personal:review:origin',
+      'personal:promote:upstream',
+      'origin:promote:upstream'
+    ]
   );
 });

--- a/tools/priority/lib/branch-classification.mjs
+++ b/tools/priority/lib/branch-classification.mjs
@@ -25,6 +25,17 @@ export function normalizeRepositoryRole(value) {
   return normalized;
 }
 
+export function normalizeRepositoryPlane(value) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized) {
+    return '';
+  }
+  if (!['upstream', 'origin', 'personal', 'fork'].includes(normalized)) {
+    throw new Error(`Unsupported repository plane '${value}'. Expected upstream, origin, personal, or fork.`);
+  }
+  return normalized;
+}
+
 function normalizeRepositorySlug(value) {
   return String(value ?? '').trim().toLowerCase();
 }
@@ -93,16 +104,38 @@ export function loadBranchClassContract(
       `Branch class contract in ${contractPath} has invalid upstreamRepository '${contract.upstreamRepository}'. Expected an owner/repo slug.`
     );
   }
+  if (!Array.isArray(contract.repositoryPlanes) || contract.repositoryPlanes.length === 0) {
+    throw new Error(`Branch class contract in ${contractPath} does not define any repositoryPlanes.`);
+  }
   return contract;
 }
 
-export function resolveRepositoryRole(repository, contract) {
-  const upstreamRepository = normalizeRepositorySlug(contract?.upstreamRepository);
+export function resolveRepositoryPlane(repository, contract) {
   const normalizedRepository = normalizeRepositorySlug(repository);
   if (!normalizedRepository) {
-    throw new Error('Repository slug is required to resolve branch role.');
+    throw new Error('Repository slug is required to resolve branch plane.');
   }
-  return normalizedRepository === upstreamRepository ? 'upstream' : 'fork';
+
+  const upstreamRepository = normalizeRepositorySlug(contract?.upstreamRepository);
+  if (normalizedRepository === upstreamRepository) {
+    return 'upstream';
+  }
+
+  for (const plane of Array.isArray(contract?.repositoryPlanes) ? contract.repositoryPlanes : []) {
+    const planeId = normalizeRepositoryPlane(plane?.id);
+    const repositories = Array.isArray(plane?.repositories)
+      ? plane.repositories.map((entry) => normalizeRepositorySlug(entry)).filter(Boolean)
+      : [];
+    if (repositories.includes(normalizedRepository)) {
+      return planeId;
+    }
+  }
+
+  return 'fork';
+}
+
+export function resolveRepositoryRole(repository, contract) {
+  return resolveRepositoryPlane(repository, contract) === 'upstream' ? 'upstream' : 'fork';
 }
 
 export function classifyBranch({
@@ -121,6 +154,7 @@ export function classifyBranch({
   const role = repositoryRole
     ? normalizeRepositoryRole(repositoryRole)
     : resolveRepositoryRole(repository, contract);
+  const repositoryPlane = repository ? resolveRepositoryPlane(repository, contract) : role;
 
   const matches = [];
   for (const entry of contract.classes) {
@@ -155,6 +189,7 @@ export function classifyBranch({
   return {
     id: selected.classEntry.id,
     repositoryRole: role,
+    repositoryPlane,
     branch: normalizedBranch,
     matchedPattern: selected.pattern,
     purpose: selected.classEntry.purpose,


### PR DESCRIPTION
## Summary
- make the existing branch-class contract explicit about the `upstream`, `origin`, and `personal` collaboration planes
- expose repository-plane resolution through the branch-classification helper
- update the checked-in branch role contract to describe plane-specific `develop` semantics and lane prefixes

## Validation
- `node --test tools/priority/__tests__/branch-classification.test.mjs tools/priority/__tests__/develop-sync.test.mjs tools/priority/__tests__/merge-sync-pr.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

Refs #1084

## Agent Metadata
- Agent: Codex CLI
- Plane: personal
- Execution: local worktree
