### PR TITLE
#1084 Use branch contract for lane naming

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -249,7 +249,11 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 
 - `develop` is the integration branch. All standing-priority work lands here via squash merges (linear history).
 - `main` reflects the latest release. Use release branches to promote changes from `develop` to `main`.
-- For standing-priority work, create `issue/<number>-<slug>` and merge back with squash once checks are green.
+- For standing-priority work, create the plane-appropriate lane branch and merge back with squash once checks are green:
+  - `issue/personal-<number>-<slug>` for the personal authoring plane
+  - `issue/origin-<number>-<slug>` for the org-fork review plane
+  - bare `issue/<number>-<slug>` only for upstream-native lanes
+  The canonical mapping lives in [BRANCH_ROLE_CONTRACT.md](BRANCH_ROLE_CONTRACT.md).
 - When the standing-priority issue changes mid-flight, realign the branch name and PR head with  
   `node tools/npm/run-script.mjs priority:branch:rename -- --issue <number>`. The helper derives the slug from the
   issue title, renames the local branch, pushes the new name to any remotes that carried the old branch, retargets the

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -14,11 +14,13 @@ promotion behavior, not the branch-class source of truth.
 
 ## Branch Expectations
 
-| Branch pattern            | Purpose                               | Creation helper                                                 | Merge target |
-|---------------------------|---------------------------------------|-----------------------------------------------------------------|--------------|
-| `issue/<number>-<slug>`   | Standing-priority implementation work | `git checkout -b issue/<...>` (router creates/syncs automatically) | `develop` (squash) |
-| `feature/<slug>`          | Parallel experiments / rehearsals     | `node tools/npm/run-script.mjs feature:branch:dry -- <slug>` (live helper coming soon) | `develop` (squash) |
-| `release/<version>`       | Release preparation                   | `node tools/npm/run-script.mjs release:branch -- <version>`                            | PR to `main` |
+| Branch pattern | Purpose | Creation helper | Merge target |
+|----------------|---------|-----------------|--------------|
+| `issue/personal-<number>-<slug>` | Standing work on the personal authoring plane | `git checkout -b issue/personal-<...>` | `develop` (squash) |
+| `issue/origin-<number>-<slug>` | Standing work on the org-fork review plane | `git checkout -b issue/origin-<...>` | `develop` (squash) |
+| `issue/<number>-<slug>` | Upstream-native standing lanes only | `git checkout -b issue/<...>` | `develop` (squash) |
+| `feature/<slug>` | Parallel experiments / rehearsals | `node tools/npm/run-script.mjs feature:branch:dry -- <slug>` (live helper coming soon) | `develop` (squash) |
+| `release/<version>` | Release preparation | `node tools/npm/run-script.mjs release:branch -- <version>` | PR to `main` |
 
 - Keep branches short-lived and delete them after merge (repository default).
 - Rebase feature and issue branches on `develop` until the queue is green; avoid merge commits entirely.

--- a/tools/priority/__tests__/branch-classification.test.mjs
+++ b/tools/priority/__tests__/branch-classification.test.mjs
@@ -8,9 +8,11 @@ import {
   assertAllowedTransition,
   branchPatternToRegExp,
   classifyBranch,
+  findRepositoryPlaneEntry,
   loadBranchClassContract,
   matchBranchPattern,
   normalizeBranchName,
+  resolveLaneBranchPrefix,
   resolveRepositoryPlane,
   resolveRepositoryRole
 } from '../lib/branch-classification.mjs';
@@ -39,6 +41,14 @@ test('resolveRepositoryPlane distinguishes upstream, origin, and personal planes
   assert.equal(resolveRepositoryPlane('LabVIEW-Community-CI-CD/compare-vi-cli-action-fork', contract), 'origin');
   assert.equal(resolveRepositoryPlane('svelderrainruiz/compare-vi-cli-action', contract), 'personal');
   assert.equal(resolveRepositoryPlane('someone-else/compare-vi-cli-action', contract), 'fork');
+});
+
+test('resolveLaneBranchPrefix follows repository plane metadata from the branch contract', () => {
+  assert.equal(resolveLaneBranchPrefix({ contract, plane: 'upstream' }), 'issue/');
+  assert.equal(resolveLaneBranchPrefix({ contract, plane: 'origin' }), 'issue/origin-');
+  assert.equal(resolveLaneBranchPrefix({ contract, plane: 'personal' }), 'issue/personal-');
+  assert.equal(resolveLaneBranchPrefix({ contract, repository: 'svelderrainruiz/compare-vi-cli-action' }), 'issue/personal-');
+  assert.equal(findRepositoryPlaneEntry(contract, 'origin')?.laneBranchPrefix, 'issue/origin-');
 });
 
 test('loadBranchClassContract rejects missing or invalid upstreamRepository slugs', () => {

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -423,6 +423,87 @@ test('comparevi branch resolver matches the repo issue branch naming contract', 
   assert.equal(branch, 'issue/personal-998-attach-ready-worker-checkouts-onto-deterministic-lane-branches');
 });
 
+test('comparevi branch resolver uses lane prefixes from the branch contract when provided', () => {
+  const branch = compareviRuntimeTest.resolveCompareviIssueBranchName({
+    issueNumber: 998,
+    title: 'Attach ready worker checkouts onto deterministic lane branches',
+    forkRemote: 'personal',
+    branchClassContract: {
+      repositoryPlanes: [
+        {
+          id: 'personal',
+          laneBranchPrefix: 'lane/personal-'
+        }
+      ]
+    }
+  });
+
+  assert.equal(branch, 'lane/personal-998-attach-ready-worker-checkouts-onto-deterministic-lane-branches');
+});
+
+test('canonical delivery decision uses lane prefixes from the branch contract for the selected implementation plane', async () => {
+  const decision = await buildCanonicalDeliveryDecision({
+    repoRoot,
+    upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    targetRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    issueSnapshot: {
+      number: 1084,
+      title: 'Define a fork-plane branching model for personal/org/upstream collaboration',
+      state: 'OPEN',
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      pullRequests: []
+    },
+    issueGraph: {
+      standingIssue: {
+        number: 1084,
+        title: 'Define a fork-plane branching model for personal/org/upstream collaboration',
+        state: 'OPEN',
+        repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        pullRequests: []
+      },
+      subIssues: [],
+      pullRequests: []
+    },
+    policy: {
+      implementationRemote: 'personal'
+    },
+    deps: {
+      loadBranchClassContractFn: () => ({
+        schema: 'branch-classes/v1',
+        upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        repositoryPlanes: [
+          {
+            id: 'personal',
+            repositories: ['svelderrainruiz/compare-vi-cli-action'],
+            laneBranchPrefix: 'lane/personal-'
+          }
+        ],
+        classes: [
+          {
+            id: 'lane',
+            repositoryRoles: ['fork'],
+            branchPatterns: ['issue/*'],
+            purpose: 'lane',
+            prSourceAllowed: true,
+            prTargetAllowed: false,
+            mergePolicy: 'n/a'
+          }
+        ],
+        allowedTransitions: [
+          {
+            from: 'lane',
+            action: 'promote',
+            to: 'upstream-integration',
+            via: 'pull-request'
+          }
+        ]
+      })
+    }
+  });
+
+  assert.equal(decision.stepOptions.branch, 'lane/personal-1084-define-a-fork-plane-branching-model-for-personal-org-upstream-collaboration');
+});
+
 test('runRuntimeSupervisor step writes runtime state, lane, turn, event, and blocker artifacts', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-supervisor-'));
   const runtimeDir = 'tests/results/_agent/runtime';

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { loadBranchClassContract, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
 import {
   assessDockerDesktopReviewLoopReceipt,
   buildLocalReviewLoopCliArgs,
@@ -507,7 +508,15 @@ function selectBestIssueCandidate(candidates = []) {
   return normalized[0] ?? null;
 }
 
-function resolveIssueBranchName({ issueNumber, title, implementationRemote = 'origin', branchPrefix = 'issue' }) {
+function resolveIssueBranchName({
+  issueNumber,
+  title,
+  implementationRemote = 'origin',
+  repoRoot = process.cwd(),
+  branchClassContract = null,
+  loadBranchClassContractFn = loadBranchClassContract,
+  branchPrefix = 'issue'
+}) {
   const slug = normalizeText(title)
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '')
@@ -516,8 +525,18 @@ function resolveIssueBranchName({ issueNumber, title, implementationRemote = 'or
     .replace(/-+/g, '-')
     .toLowerCase()
     .replace(/^-+|-+$/g, '') || 'work';
-  const remotePrefix = normalizeText(implementationRemote) ? `${normalizeText(implementationRemote).toLowerCase()}-` : '';
-  return `${branchPrefix}/${remotePrefix}${issueNumber}-${slug}`;
+  let lanePrefix = '';
+  try {
+    lanePrefix = resolveLaneBranchPrefix({
+      contract: branchClassContract ?? loadBranchClassContractFn(repoRoot),
+      plane: normalizeText(implementationRemote) || 'upstream',
+      fallbackPrefix: `${branchPrefix}/`
+    });
+  } catch {
+    const remotePrefix = normalizeText(implementationRemote) ? `${normalizeText(implementationRemote).toLowerCase()}-` : '';
+    lanePrefix = `${branchPrefix}/${remotePrefix}`;
+  }
+  return `${lanePrefix}${issueNumber}-${slug}`;
 }
 
 function parseRepositorySlug(repository) {
@@ -803,7 +822,13 @@ function buildIssueGraphSummary(issueGraph) {
       : 0
   };
 }
-function selectCanonicalCandidate({ issueGraph, implementationRemote }) {
+function selectCanonicalCandidate({
+  issueGraph,
+  implementationRemote,
+  repoRoot = process.cwd(),
+  branchClassContract = null,
+  loadBranchClassContractFn = loadBranchClassContract
+}) {
   const standingIssue = issueGraph?.standingIssue ?? null;
   if (!standingIssue) {
     return null;
@@ -841,7 +866,10 @@ function selectCanonicalCandidate({ issueGraph, implementationRemote }) {
         resolveIssueBranchName({
           issueNumber: selected.issue.number,
           title: selected.issue.title,
-          implementationRemote
+          implementationRemote,
+          repoRoot,
+          branchClassContract,
+          loadBranchClassContractFn
         })
     };
   }
@@ -858,7 +886,10 @@ function selectCanonicalCandidate({ issueGraph, implementationRemote }) {
       branch: resolveIssueBranchName({
         issueNumber: selectedChild.number,
         title: selectedChild.title,
-        implementationRemote
+        implementationRemote,
+        repoRoot,
+        branchClassContract,
+        loadBranchClassContractFn
       })
     };
   }
@@ -880,7 +911,10 @@ function selectCanonicalCandidate({ issueGraph, implementationRemote }) {
       branch: resolveIssueBranchName({
         issueNumber: standingIssue.number,
         title: standingIssue.title,
-        implementationRemote
+        implementationRemote,
+        repoRoot,
+        branchClassContract,
+        loadBranchClassContractFn
       })
     };
   }
@@ -895,7 +929,10 @@ function selectCanonicalCandidate({ issueGraph, implementationRemote }) {
     branch: resolveIssueBranchName({
       issueNumber: standingIssue.number,
       title: standingIssue.title,
-      implementationRemote
+      implementationRemote,
+      repoRoot,
+      branchClassContract,
+      loadBranchClassContractFn
     })
   };
 }
@@ -1314,7 +1351,9 @@ export async function buildCanonicalDeliveryDecision({
   };
   const selected = selectCanonicalCandidate({
     issueGraph: graph,
-    implementationRemote
+    implementationRemote,
+    repoRoot,
+    loadBranchClassContractFn: deps.loadBranchClassContractFn
   });
   if (!selected?.selectedIssue) {
     return null;

--- a/tools/priority/lib/branch-classification.mjs
+++ b/tools/priority/lib/branch-classification.mjs
@@ -134,6 +134,48 @@ export function resolveRepositoryPlane(repository, contract) {
   return 'fork';
 }
 
+export function findRepositoryPlaneEntry(contract, planeOrRepository) {
+  if (!contract || typeof contract !== 'object') {
+    throw new Error('Branch class contract is required.');
+  }
+
+  const normalizedInput = String(planeOrRepository ?? '').trim().toLowerCase();
+  if (normalizedInput.includes('/')) {
+    const resolvedPlane = resolveRepositoryPlane(normalizedInput, contract);
+    if (!resolvedPlane || resolvedPlane === 'fork') {
+      return null;
+    }
+    return (Array.isArray(contract.repositoryPlanes) ? contract.repositoryPlanes : []).find(
+      (entry) => normalizeRepositoryPlane(entry?.id) === resolvedPlane
+    ) ?? null;
+  }
+
+  const normalizedPlane = normalizeRepositoryPlane(planeOrRepository);
+  if (normalizedPlane !== 'fork') {
+    return (Array.isArray(contract.repositoryPlanes) ? contract.repositoryPlanes : []).find(
+      (entry) => normalizeRepositoryPlane(entry?.id) === normalizedPlane
+    ) ?? null;
+  }
+  return null;
+}
+
+export function resolveLaneBranchPrefix({
+  contract,
+  repository = null,
+  plane = null,
+  fallbackPrefix = 'issue/'
+}) {
+  const planeEntry = findRepositoryPlaneEntry(contract, plane || repository);
+  const configured = String(planeEntry?.laneBranchPrefix ?? '').trim();
+  if (configured) {
+    return configured.endsWith('/') || configured.endsWith('-') ? configured : `${configured}/`;
+  }
+  const normalizedFallback = String(fallbackPrefix ?? '').trim() || 'issue/';
+  return normalizedFallback.endsWith('/') || normalizedFallback.endsWith('-')
+    ? normalizedFallback
+    : `${normalizedFallback}/`;
+}
+
 export function resolveRepositoryRole(repository, contract) {
   return resolveRepositoryPlane(repository, contract) === 'upstream' ? 'upstream' : 'fork';
 }

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -28,6 +28,7 @@ import {
   runRuntimeSupervisor as runCoreRuntimeSupervisor
 } from '../../packages/runtime-harness/index.mjs';
 import { acquireWriterLease, defaultOwner, releaseWriterLease } from './agent-writer-lease.mjs';
+import { loadBranchClassContract, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import { handoffStandingPriority } from './standing-priority-handoff.mjs';
 import {
@@ -209,10 +210,28 @@ function resolveCompareviIssueSlug(title) {
   return normalized.replace(/^-+|-+$/g, '') || 'work';
 }
 
-function resolveCompareviIssueBranchName({ issueNumber, title, forkRemote, branchPrefix = 'issue' }) {
+function resolveCompareviIssueBranchName({
+  issueNumber,
+  title,
+  forkRemote,
+  repoRoot = process.cwd(),
+  branchClassContract = null,
+  loadBranchClassContractFn = loadBranchClassContract,
+  branchPrefix = 'issue'
+}) {
   const slug = resolveCompareviIssueSlug(title);
-  const remotePrefix = normalizeText(forkRemote) ? `${normalizeText(forkRemote).toLowerCase()}-` : '';
-  return `${branchPrefix}/${remotePrefix}${issueNumber}-${slug}`;
+  let lanePrefix = '';
+  try {
+    lanePrefix = resolveLaneBranchPrefix({
+      contract: branchClassContract ?? loadBranchClassContractFn(repoRoot),
+      plane: normalizeText(forkRemote) || 'upstream',
+      fallbackPrefix: `${branchPrefix}/`
+    });
+  } catch {
+    const remotePrefix = normalizeText(forkRemote) ? `${normalizeText(forkRemote).toLowerCase()}-` : '';
+    lanePrefix = `${branchPrefix}/${remotePrefix}`;
+  }
+  return `${lanePrefix}${issueNumber}-${slug}`;
 }
 
 async function readJsonIfPresent(filePath) {
@@ -304,7 +323,8 @@ function buildSchedulerDecisionFromSnapshot({
   const branch = resolveCompareviIssueBranchName({
     issueNumber: selectedIssue,
     title: snapshot.title,
-    forkRemote
+    forkRemote,
+    repoRoot
   });
   const reason =
     Number.isInteger(snapshot.mirrorOf?.number) && snapshot.mirrorOf.number !== snapshot.number


### PR DESCRIPTION
## Summary
- make delivery-agent and runtime-supervisor derive lane prefixes from the branch-plane contract instead of hardcoded remote-prefix formatting
- add consumer proofs that branch naming follows injected `laneBranchPrefix` metadata
- update branch guidance docs to reflect `issue/personal-*`, `issue/origin-*`, and upstream-native `issue/*` lanes

## Validation
- `node --test tools/priority/__tests__/branch-classification.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

Refs #1084

## Agent Metadata
- Agent: Codex CLI
- Plane: personal
- Execution: local worktree
