### PR TITLE
#1084 Tie local collaboration KPIs to branch planes

### DIFF
--- a/tools/local-collab/kpi/__tests__/rollup-local-collab-kpi.test.mjs
+++ b/tools/local-collab/kpi/__tests__/rollup-local-collab-kpi.test.mjs
@@ -16,6 +16,7 @@ async function createGitRepo() {
   spawnSync('git', ['init', '--initial-branch=develop'], { cwd: repoRoot, encoding: 'utf8' });
   await writeFile(path.join(repoRoot, 'README.md'), '# test\n', 'utf8');
   await mkdir(path.join(repoRoot, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(repoRoot, 'tools', 'policy'), { recursive: true });
   await writeFile(
     path.join(repoRoot, 'tools', 'priority', 'delivery-agent.policy.json'),
     JSON.stringify({
@@ -25,11 +26,112 @@ async function createGitRepo() {
           enabled: true,
           model: 'gpt-5.4'
         }
+      },
+      collaboration: {
+        authoringRemote: 'personal',
+        authoringPersona: 'codex',
+        reviewRemote: 'origin',
+        reviewPersona: 'copilot-cli'
       }
     }, null, 2),
     'utf8'
   );
-  spawnSync('git', ['add', 'README.md', 'tools/priority/delivery-agent.policy.json'], { cwd: repoRoot, encoding: 'utf8' });
+  await writeFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    JSON.stringify({
+      schema: 'branch-classes/v1',
+      schemaVersion: '1.0.0',
+      upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      repositoryPlanes: [
+        {
+          id: 'upstream',
+          repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action'],
+          developBranch: 'develop',
+          developClass: 'upstream-integration',
+          laneBranchPrefix: 'issue/',
+          purpose: 'Canonical integration plane.',
+          personas: ['daemon']
+        },
+        {
+          id: 'origin',
+          repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+          developBranch: 'develop',
+          developClass: 'fork-mirror-develop',
+          laneBranchPrefix: 'issue/origin-',
+          purpose: 'Org review plane.',
+          personas: ['copilot-cli']
+        },
+        {
+          id: 'personal',
+          repositories: ['svelderrainruiz/compare-vi-cli-action'],
+          developBranch: 'develop',
+          developClass: 'fork-mirror-develop',
+          laneBranchPrefix: 'issue/personal-',
+          purpose: 'Personal authoring plane.',
+          personas: ['codex', 'codex-cli']
+        }
+      ],
+      classes: [
+        {
+          id: 'upstream-integration',
+          repositoryRoles: ['upstream'],
+          branchPatterns: ['develop'],
+          purpose: 'Canonical integration branch.',
+          prSourceAllowed: false,
+          prTargetAllowed: true,
+          mergePolicy: 'merge-queue-squash'
+        },
+        {
+          id: 'fork-mirror-develop',
+          repositoryRoles: ['fork'],
+          branchPatterns: ['develop'],
+          purpose: 'Mirror copy of upstream develop.',
+          prSourceAllowed: false,
+          prTargetAllowed: false,
+          mergePolicy: 'mirror-only'
+        },
+        {
+          id: 'lane',
+          repositoryRoles: ['upstream', 'fork'],
+          branchPatterns: ['issue/*'],
+          purpose: 'Short-lived implementation branches.',
+          prSourceAllowed: true,
+          prTargetAllowed: false,
+          mergePolicy: 'n/a'
+        }
+      ],
+      allowedTransitions: [
+        {
+          from: 'lane',
+          action: 'promote',
+          to: 'upstream-integration',
+          via: 'pull-request'
+        }
+      ],
+      planeTransitions: [
+        {
+          from: 'upstream',
+          action: 'sync',
+          to: 'personal',
+          via: 'priority:develop:sync',
+          branchClass: 'fork-mirror-develop'
+        },
+        {
+          from: 'personal',
+          action: 'review',
+          to: 'origin',
+          via: 'pull-request',
+          branchClass: 'lane'
+        }
+      ]
+    }, null, 2),
+    'utf8'
+  );
+  spawnSync(
+    'git',
+    ['add', 'README.md', 'tools/priority/delivery-agent.policy.json', 'tools/policy/branch-classes.json'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
   spawnSync(
     'git',
     ['-c', 'user.name=Test User', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'],
@@ -120,7 +222,11 @@ test('rollupLocalCollaborationKpi aggregates receipt and provider effort across 
   assert.equal(summary.schema, LOCAL_COLLAB_KPI_SCHEMA);
   assert.equal(summary.receiptInventory.receiptCount, 3);
   assert.equal(summary.receiptInventory.uniqueHeadCount, 1);
+  assert.equal(summary.branchPlaneContract.contractPath, 'tools/policy/branch-classes.json');
+  assert.equal(summary.branchPlaneContract.planes.personal.laneBranchPrefix, 'issue/personal-');
+  assert.equal(summary.branchPlaneContract.planes.origin.developClass, 'fork-mirror-develop');
   assert.equal(summary.planes.personal.receiptEffort.receiptCount, 2);
+  assert.equal(summary.planes.personal.branchModel.laneBranchPrefix, 'issue/personal-');
   assert.equal(summary.planes.personal.receiptEffort.durationMs, 1800);
   assert.equal(summary.planes.personal.receiptEffort.findingCount, 1);
   assert.equal(summary.planes.personal.receiptEffort.executionPlanes['windows-host'], 2);
@@ -143,6 +249,7 @@ test('rollupLocalCollaborationKpi aggregates receipt and provider effort across 
   assert.equal(summary.providers.simulation.totals.receiptCount, 1);
   assert.equal(summary.providers['codex-cli'].executionPlane, 'wsl2');
   assert.equal(summary.providers['codex-cli'].providerRuntime, 'codex-cli');
+  assert.equal(summary.providers['codex-cli'].branchModel.laneBranchPrefix, 'issue/personal-');
   assert.equal(summary.providers['codex-cli'].placeholderOnly, true);
   assert.equal(summary.providers.ollama.placeholderOnly, true);
 });
@@ -198,4 +305,62 @@ test('rollup-local-collab-kpi CLI writes the summary artifact and prints a compa
 
   const persisted = JSON.parse(await readFile(path.join(repoRoot, outputPath), 'utf8'));
   assert.equal(persisted.schema, LOCAL_COLLAB_KPI_SCHEMA);
+});
+
+test('rollupLocalCollaborationKpi fails closed when the branch plane contract is missing a required plane', async () => {
+  const repoRoot = await createGitRepo();
+  await writeFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    JSON.stringify({
+      schema: 'branch-classes/v1',
+      schemaVersion: '1.0.0',
+      upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      repositoryPlanes: [
+        {
+          id: 'upstream',
+          repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action'],
+          developBranch: 'develop',
+          developClass: 'upstream-integration',
+          laneBranchPrefix: 'issue/',
+          purpose: 'Canonical integration plane.',
+          personas: ['daemon']
+        },
+        {
+          id: 'origin',
+          repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+          developBranch: 'develop',
+          developClass: 'fork-mirror-develop',
+          laneBranchPrefix: 'issue/origin-',
+          purpose: 'Org review plane.',
+          personas: ['copilot-cli']
+        }
+      ],
+      classes: [
+        {
+          id: 'upstream-integration',
+          repositoryRoles: ['upstream'],
+          branchPatterns: ['develop'],
+          purpose: 'Canonical integration branch.',
+          prSourceAllowed: false,
+          prTargetAllowed: true,
+          mergePolicy: 'merge-queue-squash'
+        }
+      ],
+      allowedTransitions: [
+        {
+          from: 'lane',
+          action: 'promote',
+          to: 'upstream-integration',
+          via: 'pull-request'
+        }
+      ],
+      planeTransitions: []
+    }, null, 2),
+    'utf8'
+  );
+
+  await assert.rejects(
+    () => rollupLocalCollaborationKpi({ repoRoot }),
+    /missing required repository plane 'personal'/
+  );
 });

--- a/tools/local-collab/kpi/rollup-local-collab-kpi.mjs
+++ b/tools/local-collab/kpi/rollup-local-collab-kpi.mjs
@@ -14,6 +14,10 @@ import {
   DEFAULT_LOCAL_COLLAB_LEDGER_ROOT,
   LOCAL_COLLAB_LEDGER_RECEIPT_SCHEMA
 } from '../ledger/local-review-ledger.mjs';
+import {
+  DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH,
+  loadBranchClassContract
+} from '../../priority/lib/branch-classification.mjs';
 
 export const LOCAL_COLLAB_KPI_SCHEMA = 'comparevi/local-collab-kpi-summary@v1';
 export const DEFAULT_LOCAL_COLLAB_KPI_ROOT = path.join('tests', 'results', '_agent', 'local-collab', 'kpi');
@@ -130,9 +134,64 @@ function finalizeMetrics(accumulator) {
   };
 }
 
-function createPlaneAccumulator(plane) {
+function normalizePlaneContractEntry(entry = {}) {
+  return {
+    plane: normalizeText(entry.id),
+    repositories: normalizeArray(entry.repositories),
+    developBranch: normalizeText(entry.developBranch),
+    developClass: normalizeText(entry.developClass),
+    laneBranchPrefix: normalizeText(entry.laneBranchPrefix),
+    purpose: normalizeText(entry.purpose),
+    personas: normalizeArray(entry.personas)
+  };
+}
+
+function normalizePlaneTransitionEntry(entry = {}) {
+  return {
+    from: normalizeText(entry.from),
+    action: normalizeText(entry.action),
+    to: normalizeText(entry.to),
+    via: normalizeText(entry.via),
+    branchClass: normalizeText(entry.branchClass),
+    notes: normalizeText(entry.notes)
+  };
+}
+
+function loadLocalCollaborationPlaneContract(
+  repoRoot,
+  {
+    loadBranchClassContractFn = loadBranchClassContract
+  } = {}
+) {
+  const contract = loadBranchClassContractFn(repoRoot);
+  const planes = Object.fromEntries(
+    SUPPORTED_LOCAL_COLLAB_PLANES.map((plane) => {
+      const entry = Array.isArray(contract.repositoryPlanes)
+        ? contract.repositoryPlanes.find((candidate) => normalizeText(candidate?.id) === plane)
+        : null;
+      if (!entry) {
+        throw new Error(`Branch class contract is missing required repository plane '${plane}'.`);
+      }
+      return [plane, normalizePlaneContractEntry(entry)];
+    })
+  );
+
+  return {
+    schema: normalizeText(contract.schema),
+    schemaVersion: normalizeText(contract.schemaVersion),
+    contractPath: DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH.replace(/\\/g, '/'),
+    upstreamRepository: normalizeText(contract.upstreamRepository),
+    planes,
+    planeTransitions: Array.isArray(contract.planeTransitions)
+      ? contract.planeTransitions.map((entry) => normalizePlaneTransitionEntry(entry))
+      : []
+  };
+}
+
+function createPlaneAccumulator(plane, branchModel = null) {
   return {
     plane,
+    branchModel,
     receiptEffort: createMetricsAccumulator(),
     providerEffort: createMetricsAccumulator(),
     personas: new Map()
@@ -167,6 +226,7 @@ function finalizePlaneAccumulator(planeAccumulator) {
 
   return {
     plane: planeAccumulator.plane,
+    branchModel: planeAccumulator.branchModel,
     receiptEffort: finalizeMetrics(planeAccumulator.receiptEffort),
     providerEffort: finalizeMetrics(planeAccumulator.providerEffort),
     personas
@@ -353,7 +413,8 @@ export async function loadLocalCollaborationLedgerReceipts({ repoRoot, ledgerRoo
 export async function rollupLocalCollaborationKpi({
   repoRoot = process.cwd(),
   ledgerRoot = DEFAULT_LOCAL_COLLAB_LEDGER_ROOT,
-  outputPath = DEFAULT_LOCAL_COLLAB_KPI_SUMMARY_PATH
+  outputPath = DEFAULT_LOCAL_COLLAB_KPI_SUMMARY_PATH,
+  loadBranchClassContractFn = loadBranchClassContract
 } = {}) {
   const resolvedRepoRoot = path.resolve(normalizeText(repoRoot) || process.cwd());
   const resolvedOutputPath = path.resolve(resolvedRepoRoot, normalizeText(outputPath) || DEFAULT_LOCAL_COLLAB_KPI_SUMMARY_PATH);
@@ -361,9 +422,17 @@ export async function rollupLocalCollaborationKpi({
     repoRoot: resolvedRepoRoot,
     ledgerRoot
   });
+  const branchPlaneContract = loadLocalCollaborationPlaneContract(resolvedRepoRoot, {
+    loadBranchClassContractFn
+  });
   const copilotPolicy = await loadCopilotCliReviewPolicy(resolvedRepoRoot);
   const providerAssignments = buildProviderAssignments(copilotPolicy.collaboration);
-  const planes = new Map(SUPPORTED_LOCAL_COLLAB_PLANES.map((plane) => [plane, createPlaneAccumulator(plane)]));
+  const planes = new Map(
+    SUPPORTED_LOCAL_COLLAB_PLANES.map((plane) => [
+      plane,
+      createPlaneAccumulator(plane, branchPlaneContract.planes[plane])
+    ])
+  );
   const combinedPlane = createPlaneAccumulator('local');
   const providerAccumulators = new Map(
     SUPPORTED_LOCAL_REVIEW_PROVIDERS.map((providerId) => [
@@ -446,6 +515,7 @@ export async function rollupLocalCollaborationKpi({
       providerFindingCount: 'even-split-per-phase-provider',
       providerModels: 'single-provider-receipts-only'
     },
+    branchPlaneContract,
     receiptInventory: {
       receiptCount: receipts.length,
       uniqueHeadCount: headShas.size,
@@ -469,6 +539,7 @@ export async function rollupLocalCollaborationKpi({
             executable: accumulator.executable,
             reserved: accumulator.reserved,
             plane: accumulator.plane,
+            branchModel: branchPlaneContract.planes[accumulator.plane] ?? null,
             persona: accumulator.persona,
             effortType: accumulator.effortType,
             executionPlane: accumulator.executionPlane,


### PR DESCRIPTION
## Summary
- bind local collaboration KPI summaries to the checked-in branch-plane contract
- surface branch-model metadata on each plane and provider summary
- fail closed when the branch-plane contract is missing a required collaboration plane

## Testing
- node --check tools/local-collab/kpi/rollup-local-collab-kpi.mjs
- node --test tools/local-collab/kpi/__tests__/rollup-local-collab-kpi.test.mjs tools/local-collab/ledger/__tests__/local-review-ledger.test.mjs
- node tools/npm/run-script.mjs lint:md:changed

## Issue
- Refs #1084
