### PR TITLE
#1121 Enforce fork-plane transitions in sync and promotion helpers

### DIFF
--- a/tools/priority/__tests__/branch-classification.test.mjs
+++ b/tools/priority/__tests__/branch-classification.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   assertAllowedTransition,
+  assertPlaneTransition,
   branchPatternToRegExp,
   classifyBranch,
   findRepositoryPlaneEntry,
@@ -49,6 +50,28 @@ test('resolveLaneBranchPrefix follows repository plane metadata from the branch 
   assert.equal(resolveLaneBranchPrefix({ contract, plane: 'personal' }), 'issue/personal-');
   assert.equal(resolveLaneBranchPrefix({ contract, repository: 'svelderrainruiz/compare-vi-cli-action' }), 'issue/personal-');
   assert.equal(findRepositoryPlaneEntry(contract, 'origin')?.laneBranchPrefix, 'issue/origin-');
+});
+
+test('assertPlaneTransition accepts tracked fork-plane edges and rejects undefined ones', () => {
+  const reviewTransition = assertPlaneTransition({
+    fromPlane: 'personal',
+    toPlane: 'origin',
+    action: 'review',
+    contract
+  });
+  assert.equal(reviewTransition.via, 'pull-request');
+  assert.equal(reviewTransition.branchClass, 'lane');
+
+  assert.throws(
+    () =>
+      assertPlaneTransition({
+        fromPlane: 'origin',
+        toPlane: 'personal',
+        action: 'review',
+        contract
+      }),
+    /plane transition origin --review--> personal is not allowed/i
+  );
 });
 
 test('loadBranchClassContract rejects missing or invalid upstreamRepository slugs', () => {

--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -116,6 +116,9 @@ test('buildDevelopSyncBranchClassTrace classifies upstream develop to fork devel
   assert.equal(trace.target.id, 'fork-mirror-develop');
   assert.equal(trace.transition.action, 'sync');
   assert.equal(trace.transition.via, 'priority:develop:sync');
+  assert.equal(trace.planeTransitions.origin.to, 'origin');
+  assert.equal(trace.planeTransitions.personal.to, 'personal');
+  assert.equal(trace.planeTransitions.origin.via, 'priority:develop:sync');
 });
 
 test('Sync-OriginUpstreamDevelop forwards the requested parity report path to the parity reporter', () => {
@@ -276,6 +279,9 @@ test('runDevelopSync records protected sync mode details from the parity report'
   assert.equal(report.actions[0].protectedSync.pullRequest.number, 44);
   assert.equal(report.actions[0].branchClassTrace.source.id, 'upstream-integration');
   assert.equal(report.actions[0].branchClassTrace.target.id, 'fork-mirror-develop');
+  assert.equal(report.actions[0].planeTransition.from, 'upstream');
+  assert.equal(report.actions[0].planeTransition.to, 'origin');
+  assert.equal(report.actions[0].planeTransition.action, 'sync');
 });
 
 test('runDevelopSync records fork-sync mode details from the parity report', async (t) => {
@@ -337,6 +343,7 @@ test('runDevelopSync records fork-sync mode details from the parity report', asy
   assert.equal(report.actions[0].parityConverged, true);
   assert.equal(report.actions[0].protectedSync.syncMethod, 'fork-sync');
   assert.equal(report.actions[0].protectedSync.mergeUpstream.merge_type, 'fast-forward');
+  assert.equal(report.actions[0].planeTransition.to, 'origin');
 });
 
 test('runDevelopSync fails closed when the parity report is unreadable', async (t) => {

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -448,6 +448,47 @@ test('buildBranchClassTrace emits deterministic base-branch classification metad
   );
 });
 
+test('buildMergeSummaryPayload carries the resolved plane transition when promotion crosses planes', () => {
+  const payload = buildMergeSummaryPayload({
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    pr: 912,
+    mergeMethod: 'squash',
+    selectedMode: 'auto',
+    selectedReason: 'merge-queue-branch-develop',
+    finalMode: 'auto',
+    finalReason: 'merge-queue-branch-develop',
+    dryRun: false,
+    mergeQueueBranches: new Set(['develop']),
+    attempts: [{ mode: 'auto', args: ['pr', 'merge', '--auto'], exitCode: 0 }],
+    prInfo: {
+      state: 'OPEN',
+      mergeStateStatus: 'BLOCKED',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'develop',
+      isDraft: false,
+      headRepository: { name: 'compare-vi-cli-action' },
+      headRepositoryOwner: { login: 'svelderrainruiz' },
+      url: 'https://example.test/pr/912'
+    },
+    planeTransition: {
+      from: 'personal',
+      action: 'promote',
+      to: 'upstream',
+      via: 'pull-request',
+      branchClass: 'lane'
+    },
+    createdAt: '2026-03-14T00:00:00.000Z'
+  });
+
+  assert.deepEqual(payload.planeTransition, {
+    from: 'personal',
+    action: 'promote',
+    to: 'upstream',
+    via: 'pull-request',
+    branchClass: 'lane'
+  });
+});
+
 test('buildMergeSummaryPayload remains stable for direct mode contracts', () => {
   const payload = buildMergeSummaryPayload({
     repo: 'owner/repo',
@@ -999,7 +1040,7 @@ test('runMergeSync includes review clearance evidence when clean current-head ad
       '--pr',
       '127',
       '--repo',
-      'owner/repo',
+      'LabVIEW-Community-CI-CD/compare-vi-cli-action',
       '--summary-path',
       path.join(tempDir, 'summary.json')
     ],
@@ -1007,14 +1048,20 @@ test('runMergeSync includes review clearance evidence when clean current-head ad
     ensureGhCliFn: () => {},
     readPrInfoFn: () => ({
       number: 127,
-      state: 'OPEN',
-      isDraft: false,
-      mergeStateStatus: 'BLOCKED',
-      mergeable: 'MERGEABLE',
-      baseRefName: 'develop',
-      headRefOid: '1234567890123456789012345678901234567890',
-      url: 'https://example.test/pr/127'
-    }),
+        state: 'OPEN',
+        isDraft: false,
+        mergeStateStatus: 'BLOCKED',
+        mergeable: 'MERGEABLE',
+        baseRefName: 'develop',
+        headRepository: {
+          name: 'compare-vi-cli-action'
+        },
+        headRepositoryOwner: {
+          login: 'svelderrainruiz'
+        },
+        headRefOid: '1234567890123456789012345678901234567890',
+        url: 'https://example.test/pr/127'
+      }),
     evaluatePromotionReviewClearanceFn: async () => ({
       ok: true,
       report: {
@@ -1055,10 +1102,59 @@ test('runMergeSync includes review clearance evidence when clean current-head ad
 
   assert.equal(payload.reviewClearance.status, 'pass');
   assert.deepEqual(payload.reviewClearance.reasons, ['current-head-review-run-completed-clean']);
+  assert.equal(payload.planeTransition.from, 'personal');
+  assert.equal(payload.planeTransition.to, 'upstream');
+  assert.equal(payload.planeTransition.action, 'promote');
 
   const written = JSON.parse(await readFile(path.join(tempDir, 'summary.json'), 'utf8'));
   assert.equal(written.reviewClearance.status, 'pass');
   assert.deepEqual(written.reviewClearance.reasons, ['current-head-review-run-completed-clean']);
+  assert.equal(written.planeTransition.from, 'personal');
+});
+
+test('runMergeSync fails closed when the head repository plane is outside the tracked branch model', async () => {
+  await assert.rejects(
+    () =>
+      runMergeSync({
+        argv: ['node', 'tools/priority/merge-sync-pr.mjs', '--pr', '130', '--repo', 'LabVIEW-Community-CI-CD/compare-vi-cli-action'],
+        repoRoot,
+        ensureGhCliFn: () => {},
+        readPrInfoFn: () => ({
+          number: 130,
+          state: 'OPEN',
+          isDraft: false,
+          mergeStateStatus: 'BLOCKED',
+          mergeable: 'MERGEABLE',
+          baseRefName: 'develop',
+          headRepository: {
+            name: 'compare-vi-cli-action'
+          },
+          headRepositoryOwner: {
+            login: 'someone-else'
+          },
+          headRefOid: '1234567890123456789012345678901234567890',
+          url: 'https://example.test/pr/130'
+        }),
+        evaluatePromotionReviewClearanceFn: async () => ({
+          ok: true,
+          report: {
+            status: 'pass',
+            gateState: 'ready',
+            reasons: ['current-head-review-run-completed-clean']
+          }
+        }),
+        readPromotionStateFn: () => ({
+          state: 'OPEN',
+          mergeStateStatus: 'BLOCKED',
+          isInMergeQueue: false,
+          autoMergeRequest: null,
+          mergedAt: null
+        }),
+        runMergeAttemptFn: () => ({ status: 0, stdout: '', stderr: '' }),
+        sleepFn: async () => {}
+      }),
+    /plane transition fork --promote--> upstream is not allowed/i
+  );
 });
 
 test('runMergeSync does not query promotion state when the PR is already merged', async () => {

--- a/tools/priority/develop-sync.mjs
+++ b/tools/priority/develop-sync.mjs
@@ -11,6 +11,7 @@ import { resolveActiveForkRemoteName } from './lib/remote-utils.mjs';
 import {
   DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH,
   assertAllowedTransition,
+  assertPlaneTransition,
   classifyBranch,
   loadBranchClassContract
 } from './lib/branch-classification.mjs';
@@ -163,12 +164,27 @@ export function buildDevelopSyncBranchClassTrace(repoRoot) {
     action: 'sync',
     contract
   });
+  const planeTransitions = {
+    origin: assertPlaneTransition({
+      fromPlane: 'upstream',
+      toPlane: 'origin',
+      action: 'sync',
+      contract
+    }),
+    personal: assertPlaneTransition({
+      fromPlane: 'upstream',
+      toPlane: 'personal',
+      action: 'sync',
+      contract
+    })
+  };
 
   return {
     contractPath,
     source,
     target,
-    transition
+    transition,
+    planeTransitions
   };
 }
 
@@ -257,6 +273,7 @@ export function runDevelopSync({
       parityReportPath: path.relative(repoRoot, parityReportPath).replace(/\\/g, '/'),
       adminPaths,
       branchClassTrace,
+      planeTransition: branchClassTrace.planeTransitions[remote] ?? null,
       syncMode: parityReport?.syncResult?.mode ?? 'direct-push',
       syncReason: parityReport?.syncResult?.reason ?? 'direct-push',
       parityConverged:

--- a/tools/priority/lib/branch-classification.mjs
+++ b/tools/priority/lib/branch-classification.mjs
@@ -159,6 +159,49 @@ export function findRepositoryPlaneEntry(contract, planeOrRepository) {
   return null;
 }
 
+export function classifyPlaneTransition({
+  fromPlane,
+  toPlane,
+  action,
+  contract
+}) {
+  if (!contract || typeof contract !== 'object') {
+    throw new Error('Branch class contract is required.');
+  }
+  const normalizedFrom = normalizeRepositoryPlane(fromPlane);
+  const normalizedTo = normalizeRepositoryPlane(toPlane);
+  const normalizedAction = String(action ?? '').trim();
+  if (!normalizedAction) {
+    throw new Error('Plane transition action is required.');
+  }
+
+  return (contract.planeTransitions || []).find((entry) => (
+    normalizeRepositoryPlane(entry?.from) === normalizedFrom &&
+    normalizeRepositoryPlane(entry?.to) === normalizedTo &&
+    String(entry?.action ?? '').trim() === normalizedAction
+  )) ?? null;
+}
+
+export function assertPlaneTransition({
+  fromPlane,
+  toPlane,
+  action,
+  contract
+}) {
+  const transition = classifyPlaneTransition({
+    fromPlane,
+    toPlane,
+    action,
+    contract
+  });
+  if (!transition) {
+    throw new Error(
+      `Plane transition ${normalizeRepositoryPlane(fromPlane)} --${String(action ?? '').trim()}--> ${normalizeRepositoryPlane(toPlane)} is not allowed by the branch class contract.`
+    );
+  }
+  return transition;
+}
+
 export function resolveLaneBranchPrefix({
   contract,
   repository = null,

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -11,8 +11,10 @@ import { ensureGhCli, resolveUpstream } from './lib/remote-utils.mjs';
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import {
   DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH,
+  assertPlaneTransition,
   classifyBranch,
   loadBranchClassContract,
+  resolveRepositoryPlane,
   resolveRepositoryRole
 } from './lib/branch-classification.mjs';
 
@@ -248,6 +250,15 @@ export function buildBranchClassTrace({ targetRepositoryRole = null, baseBranchC
   };
 }
 
+function resolveHeadRepositorySlug(prInfo = {}, repo = '') {
+  const owner = resolveHeadRepositoryOwner(prInfo);
+  const repoName = normalizeText(prInfo?.headRepository?.name);
+  if (!owner || !repoName) {
+    return '';
+  }
+  return `${owner}/${repoName}`;
+}
+
 export function resolveHeadRepositoryOwner(prInfo = {}) {
   const owner = prInfo?.headRepositoryOwner;
   if (typeof owner === 'string') {
@@ -286,6 +297,7 @@ export function buildMergeSummaryPayload({
   branchClassTrace = null,
   reviewClearance = null,
   promotion = null,
+  planeTransition = null,
   createdAt = new Date().toISOString()
 }) {
   const normalizedBaseRefName = normalizeBaseRefName(prInfo?.baseRefName);
@@ -318,6 +330,7 @@ export function buildMergeSummaryPayload({
       upstreamHeadOwned: isUpstreamOwnedHead(prInfo, repo)
     },
     promotion,
+    planeTransition,
     prUrl: prInfo?.url ?? null
   };
 }
@@ -442,7 +455,7 @@ function readPrInfo({ repoRoot, repo, pr }) {
       '--repo',
       repo,
       '--json',
-      'number,state,isDraft,mergeStateStatus,mergeable,baseRefName,url,headRefName,headRefOid,headRepositoryOwner,isCrossRepository'
+      'number,state,isDraft,mergeStateStatus,mergeable,baseRefName,url,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository'
     ],
     {
       cwd: repoRoot,
@@ -741,11 +754,25 @@ export async function runMergeSync({
     pr: options.pr
   });
   const targetRepositoryRole = resolveRepositoryRole(resolvedRepo, branchClassContract);
+  const targetRepositoryPlane = resolveRepositoryPlane(resolvedRepo, branchClassContract);
+  const headRepositorySlug = resolveHeadRepositorySlug(prInfo, resolvedRepo);
+  const headRepositoryPlane = headRepositorySlug
+    ? resolveRepositoryPlane(headRepositorySlug, branchClassContract)
+    : null;
   const baseBranchClass = classifyBranch({
     branch: prInfo?.baseRefName,
     contract: branchClassContract,
     repositoryRole: targetRepositoryRole
   });
+  const planeTransition =
+    headRepositoryPlane && headRepositoryPlane !== targetRepositoryPlane
+      ? assertPlaneTransition({
+          fromPlane: headRepositoryPlane,
+          toPlane: targetRepositoryPlane,
+          action: 'promote',
+          contract: branchClassContract
+        })
+      : null;
   const selection = selectMergeMode(prInfo, {
     admin: options.admin,
     mergeQueueBranches,
@@ -899,7 +926,8 @@ export async function runMergeSync({
       baseBranchClass
     }),
     reviewClearance: reviewClearance?.report ?? null,
-    promotion
+    promotion,
+    planeTransition
   });
   await maybeWriteSummary(options.summaryPath, payload);
 


### PR DESCRIPTION
## Summary
- consume branch-plane transitions directly in sync and promotion helpers
- record the applied plane transition in develop-sync and merge-sync summaries
- fail closed when a promotion head comes from an untracked fork plane

## Testing
- node --test tools/priority/__tests__/branch-classification.test.mjs tools/priority/__tests__/develop-sync.test.mjs tools/priority/__tests__/merge-sync-pr.test.mjs

## Issue
- Refs #1121
