### PR TITLE
#1123 Record plane transitions in protected sync and parity receipts

### DIFF
--- a/tools/priority/Sync-OriginUpstreamDevelop.ps1
+++ b/tools/priority/Sync-OriginUpstreamDevelop.ps1
@@ -491,6 +491,15 @@ try {
   }
 
   $parityReport = Get-Content -LiteralPath $parityReportPath -Raw | ConvertFrom-Json -AsHashtable
+  $planeTransition = $parityReport['planeTransition']
+  if (-not $planeTransition) {
+    throw ("Parity report missing planeTransition metadata: {0}" -f $parityReportPath)
+  }
+  foreach ($requiredKey in @('from', 'to', 'action', 'via')) {
+    if ([string]::IsNullOrWhiteSpace([string]$planeTransition[$requiredKey])) {
+      throw ("Parity report planeTransition metadata is incomplete ({0} missing) in {1}" -f $requiredKey, $parityReportPath)
+    }
+  }
   $parityReport['adminPaths'] = $adminPaths
   if ($pushTransport) {
     $parityReport['pushTransport'] = $pushTransport
@@ -500,11 +509,15 @@ try {
     mode = $syncMode
     reason = $syncReason
     parityConverged = ($tipDiffCount -eq 0)
+    planeTransition = $planeTransition
   }
   if ($protectedSyncReportPath) {
     $syncResult['reportPath'] = $protectedSyncReportPath
   }
   if ($protectedSync) {
+    if (-not $protectedSync['planeTransition']) {
+      throw ("Protected sync report missing planeTransition metadata: {0}" -f $protectedSyncReportPath)
+    }
     $syncResult['protectedSync'] = $protectedSync
   }
   $parityReport['syncResult'] = $syncResult

--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -234,11 +234,23 @@ test('runDevelopSync records protected sync mode details from the parity report'
       schema: 'origin-upstream-parity@v1',
       status: 'ok',
       tipDiff: { fileCount: 3 },
+      planeTransition: {
+        from: 'upstream',
+        to: 'origin',
+        action: 'sync',
+        via: 'priority:develop:sync'
+      },
       syncResult: {
         mode: 'protected-pr',
         reason: 'protected-branch-gh013',
         parityConverged: false,
         protectedSync: {
+          planeTransition: {
+            from: 'upstream',
+            to: 'origin',
+            action: 'sync',
+            via: 'priority:develop:sync'
+          },
           pullRequest: {
             number: 44,
             url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action-fork/pull/44'
@@ -299,11 +311,23 @@ test('runDevelopSync records fork-sync mode details from the parity report', asy
       schema: 'origin-upstream-parity@v1',
       status: 'ok',
       tipDiff: { fileCount: 0 },
+      planeTransition: {
+        from: 'upstream',
+        to: 'origin',
+        action: 'sync',
+        via: 'priority:develop:sync'
+      },
       syncResult: {
         mode: 'fork-sync',
         reason: 'protected-branch-gh013',
         parityConverged: true,
         protectedSync: {
+          planeTransition: {
+            from: 'upstream',
+            to: 'origin',
+            action: 'sync',
+            via: 'priority:develop:sync'
+          },
           syncMethod: 'fork-sync',
           mergeUpstream: {
             message: 'Branch synced',
@@ -344,6 +368,62 @@ test('runDevelopSync records fork-sync mode details from the parity report', asy
   assert.equal(report.actions[0].protectedSync.syncMethod, 'fork-sync');
   assert.equal(report.actions[0].protectedSync.mergeUpstream.merge_type, 'fast-forward');
   assert.equal(report.actions[0].planeTransition.to, 'origin');
+});
+
+test('runDevelopSync fails closed when the parity report omits plane transition evidence', async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'develop-sync-missing-plane-transition-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+  initTempGitRepo(tempRoot);
+
+  const parityReportPath = path.join(tempRoot, 'tests', 'results', '_agent', 'issue', 'origin-upstream-parity.json');
+  await mkdir(path.dirname(parityReportPath), { recursive: true });
+  await writeFile(
+    parityReportPath,
+    JSON.stringify({
+      schema: 'origin-upstream-parity@v1',
+      status: 'ok',
+      tipDiff: { fileCount: 0 },
+      syncResult: {
+        mode: 'direct-push',
+        reason: 'direct-push',
+        parityConverged: true
+      }
+    }, null, 2),
+    'utf8'
+  );
+
+  const reportPath = path.join(tempRoot, 'develop-sync-report.json');
+  await assert.rejects(
+    async () =>
+      runDevelopSync({
+        repoRoot: tempRoot,
+        options: {
+          forkRemote: 'origin',
+          reportPath
+        },
+        spawnSyncFn: (command, args, options = {}) => {
+          if (command === 'git') {
+            return spawnSync(command, args, {
+              ...options,
+              cwd: tempRoot,
+              encoding: 'utf8',
+              stdio: ['ignore', 'pipe', 'pipe']
+            });
+          }
+          if (command === 'pwsh') {
+            return { status: 0, stdout: '', stderr: '' };
+          }
+          throw new Error(`Unexpected command ${command}`);
+        }
+      }),
+    /missing required planeTransition metadata/i
+  );
+
+  const report = readJson(reportPath);
+  assert.equal(report.status, 'failed');
+  assert.match(report.actions[0].error, /planeTransition metadata/i);
 });
 
 test('runDevelopSync fails closed when the parity report is unreadable', async (t) => {
@@ -423,6 +503,8 @@ test('Sync-OriginUpstreamDevelop succeeds from a linked worktree and writes admi
   run('git', ['checkout', '--detach'], { cwd: controlRepo });
 
   await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'),
     path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1')
@@ -430,6 +512,14 @@ test('Sync-OriginUpstreamDevelop succeeds from a linked worktree and writes admi
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
     path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
   );
 
   run('git', ['clone', upstreamBare, updaterRepo], { cwd: sandboxRoot });
@@ -511,6 +601,8 @@ test('Sync-OriginUpstreamDevelop refreshes the local tracking ref after SSH fall
   run('git', ['checkout', '--detach'], { cwd: controlRepo });
 
   await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'),
     path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1')
@@ -518,6 +610,14 @@ test('Sync-OriginUpstreamDevelop refreshes the local tracking ref after SSH fall
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
     path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
   );
 
   await writeFile(
@@ -604,6 +704,8 @@ test('Sync-OriginUpstreamDevelop targeted refresh detects a newer remote head in
   run('git', ['checkout', '--detach'], { cwd: controlRepo });
 
   await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'),
     path.join(worktreeRepo, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1')
@@ -611,6 +713,14 @@ test('Sync-OriginUpstreamDevelop targeted refresh detects a newer remote head in
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
     path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
   );
 
   run('git', ['clone', upstreamBare, updaterRepo], { cwd: sandboxRoot });
@@ -709,6 +819,8 @@ test('Sync-OriginUpstreamDevelop treats GH013 as a protected sync PR handoff ins
   run('git', ['checkout', '--detach'], { cwd: controlRepo });
 
   await mkdir(path.join(worktreeRepo, 'tools', 'priority'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'priority', 'lib'), { recursive: true });
+  await mkdir(path.join(worktreeRepo, 'tools', 'policy'), { recursive: true });
   const source = readFileSyncImmediate(path.join(repoRoot, 'tools', 'priority', 'Sync-OriginUpstreamDevelop.ps1'), 'utf8');
   const protectedSource = source.replace(
     "$attemptPushTransport = Invoke-PushWithTransportFallback -Remote $HeadRemote -BranchName $Branch",
@@ -718,6 +830,14 @@ test('Sync-OriginUpstreamDevelop treats GH013 as a protected sync PR handoff ins
   await copyFile(
     path.join(repoRoot, 'tools', 'priority', 'report-origin-upstream-parity.mjs'),
     path.join(worktreeRepo, 'tools', 'priority', 'report-origin-upstream-parity.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'priority', 'lib', 'branch-classification.mjs'),
+    path.join(worktreeRepo, 'tools', 'priority', 'lib', 'branch-classification.mjs')
+  );
+  await copyFile(
+    path.join(repoRoot, 'tools', 'policy', 'branch-classes.json'),
+    path.join(worktreeRepo, 'tools', 'policy', 'branch-classes.json')
   );
   await writeFile(
     path.join(worktreeRepo, 'tools', 'priority', 'protected-develop-sync-pr.mjs'),
@@ -738,6 +858,12 @@ writeFileSync(reportPath, JSON.stringify({
   branch: 'develop',
   syncBranch,
   reason: 'protected-branch-gh013',
+  planeTransition: {
+    from: 'upstream',
+    to: 'origin',
+    action: 'sync',
+    via: 'priority:develop:sync'
+  },
   pullRequest: {
     number: 55,
     url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action-fork/pull/55',
@@ -777,9 +903,12 @@ writeFileSync(reportPath, JSON.stringify({
   );
 
   const parityReport = JSON.parse(await readFile(parityReportPath, 'utf8'));
+  assert.equal(parityReport.planeTransition.from, 'upstream');
+  assert.equal(parityReport.planeTransition.to, 'origin');
   assert.equal(parityReport.syncResult.mode, 'protected-pr');
   assert.equal(parityReport.syncResult.reason, 'protected-branch-gh013');
   assert.equal(parityReport.syncResult.parityConverged, false);
+  assert.equal(parityReport.syncResult.planeTransition.to, 'origin');
   assert.equal(parityReport.syncResult.protectedSync.pullRequest.number, 55);
   assert.equal(parityReport.tipDiff.fileCount > 0, true);
 });

--- a/tools/priority/__tests__/protected-develop-sync-pr.test.mjs
+++ b/tools/priority/__tests__/protected-develop-sync-pr.test.mjs
@@ -14,6 +14,43 @@ import {
   runProtectedDevelopSync
 } from '../protected-develop-sync-pr.mjs';
 
+const branchClassContract = {
+  schema: 'branch-classes/v1',
+  upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+  repositoryPlanes: [
+    {
+      id: 'upstream',
+      repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action']
+    },
+    {
+      id: 'origin',
+      repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork']
+    },
+    {
+      id: 'personal',
+      repositories: ['svelderrainruiz/compare-vi-cli-action']
+    }
+  ],
+  planeTransitions: [
+    {
+      from: 'upstream',
+      action: 'sync',
+      to: 'origin',
+      via: 'priority:develop:sync',
+      branchClass: 'fork-mirror-develop'
+    },
+    {
+      from: 'upstream',
+      action: 'sync',
+      to: 'personal',
+      via: 'priority:develop:sync',
+      branchClass: 'fork-mirror-develop'
+    }
+  ],
+  classes: [{ id: 'noop', repositoryRoles: ['upstream'], branchPatterns: ['develop'] }],
+  allowedTransitions: [{ from: 'noop', to: 'noop', action: 'sync' }]
+};
+
 test('parseArgs accepts protected sync options', () => {
   const options = parseArgs([
     'node',
@@ -99,6 +136,12 @@ test('buildProtectedSyncSummaryPayload captures PR and merge request details', (
     localHead: 'abc123',
     upstream: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' },
     targetRepository: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action-fork' },
+    planeTransition: {
+      from: 'upstream',
+      to: 'origin',
+      action: 'sync',
+      via: 'priority:develop:sync'
+    },
     pullRequest: { number: 42, url: 'https://example.test/pull/42' },
     readyState: { status: 'marked-ready' },
     mergeRequest: { status: 'requested' },
@@ -108,6 +151,8 @@ test('buildProtectedSyncSummaryPayload captures PR and merge request details', (
 
   assert.equal(payload.schema, 'priority/protected-develop-sync@v1');
   assert.equal(payload.targetRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork');
+  assert.equal(payload.planeTransition.from, 'upstream');
+  assert.equal(payload.planeTransition.to, 'origin');
   assert.equal(payload.syncMethod, 'protected-pr');
   assert.equal(payload.mergeUpstreamError, 'sync unavailable');
   assert.equal(payload.pullRequest.number, 42);
@@ -124,6 +169,12 @@ test('buildProtectedSyncSummaryPayload captures merge-upstream sync details', ()
     reason: 'protected-branch-gh013',
     upstream: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' },
     targetRepository: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action-fork' },
+    planeTransition: {
+      from: 'upstream',
+      to: 'origin',
+      action: 'sync',
+      via: 'priority:develop:sync'
+    },
     syncMethod: 'fork-sync',
     allowForkSyncing: true,
     mergeUpstream: { message: 'Branch synced', merge_type: 'fast-forward' }
@@ -187,6 +238,7 @@ test('runProtectedDevelopSync reuses an existing draft PR, marks it ready, and r
       reportPath
     },
     ensureGhCliFn: () => {},
+    loadBranchClassContractFn: () => branchClassContract,
     resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
     ensureForkRemoteFn: () => ({
       owner: 'LabVIEW-Community-CI-CD',
@@ -226,6 +278,8 @@ test('runProtectedDevelopSync reuses an existing draft PR, marks it ready, and r
 
   assert.equal(updated.length, 1);
   assert.equal(report.pullRequest.number, 42);
+  assert.equal(report.planeTransition.from, 'upstream');
+  assert.equal(report.planeTransition.to, 'origin');
   assert.equal(report.pullRequest.reusedExisting, true);
   assert.match(report.mergeUpstreamError, /Unexpected gh json args/);
   assert.equal(report.readyState.status, 'marked-ready');
@@ -266,6 +320,7 @@ test('runProtectedDevelopSync creates a new PR when no existing sync PR is open'
       reportPath
     },
     ensureGhCliFn: () => {},
+    loadBranchClassContractFn: () => branchClassContract,
     resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
     ensureForkRemoteFn: () => ({
       owner: 'svelderrainruiz',
@@ -310,6 +365,8 @@ test('runProtectedDevelopSync creates a new PR when no existing sync PR is open'
   assert.equal(created.length, 1);
   assert.equal(created[0].branch, 'sync/personal-develop');
   assert.equal(report.pullRequest.number, 77);
+  assert.equal(report.planeTransition.from, 'upstream');
+  assert.equal(report.planeTransition.to, 'personal');
   assert.equal(report.pullRequest.reusedExisting, false);
   assert.match(report.mergeUpstreamError, /Unexpected gh json args/);
 });
@@ -337,6 +394,7 @@ test('runProtectedDevelopSync prefers merge-upstream when the GitHub sync API is
       reportPath
     },
     ensureGhCliFn: () => {},
+    loadBranchClassContractFn: () => branchClassContract,
     resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
     ensureForkRemoteFn: () => ({
       owner: 'LabVIEW-Community-CI-CD',
@@ -362,6 +420,7 @@ test('runProtectedDevelopSync prefers merge-upstream when the GitHub sync API is
   });
 
   assert.equal(created.length, 0);
+  assert.equal(report.planeTransition.to, 'origin');
   assert.equal(report.syncMethod, 'fork-sync');
   assert.equal(report.allowForkSyncing, false);
   assert.equal(report.mergeUpstream.merge_type, 'fast-forward');
@@ -392,6 +451,7 @@ test('runProtectedDevelopSync tolerates branch protection lookup failures', asyn
       reportPath
     },
     ensureGhCliFn: () => {},
+    loadBranchClassContractFn: () => branchClassContract,
     resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
     ensureForkRemoteFn: () => ({
       owner: 'LabVIEW-Community-CI-CD',
@@ -412,5 +472,6 @@ test('runProtectedDevelopSync tolerates branch protection lookup failures', asyn
   });
 
   assert.equal(report.syncMethod, 'fork-sync');
+  assert.equal(report.planeTransition.to, 'origin');
   assert.equal(report.allowForkSyncing, false);
 });

--- a/tools/priority/__tests__/report-origin-upstream-parity.test.mjs
+++ b/tools/priority/__tests__/report-origin-upstream-parity.test.mjs
@@ -83,6 +83,12 @@ test('collectParity returns ok payload when git commands succeed', () => {
   assert.equal(report.recommendation.code, 'history-diverged-tree-equal');
   assert.equal(report.remoteManagement.baseRemote, 'upstream');
   assert.equal(report.remoteManagement.headRemote, 'origin');
+  assert.equal(report.remoteManagement.remotes.upstream.plane, 'upstream');
+  assert.equal(report.remoteManagement.remotes.origin.plane, 'origin');
+  assert.equal(report.planeTransition.from, 'upstream');
+  assert.equal(report.planeTransition.to, 'origin');
+  assert.equal(report.planeTransition.action, 'sync');
+  assert.equal(report.planeTransition.via, 'priority:develop:sync');
   assert.equal(calls.length >= 6, true);
 });
 
@@ -117,6 +123,38 @@ test('collectParity returns unavailable payload when refs are missing (non-stric
   assert.match(report.reason, /git rev-parse --verify/);
 });
 
+test('collectParity fails closed when plane transition evidence cannot be resolved', () => {
+  const fakeRunner = (_cmd, args) => {
+    if (args[0] === 'rev-parse' && args[1] === '--verify') {
+      return { status: 0, stdout: `${args[2]}-commit\n`, stderr: '' };
+    }
+    if (args[0] === 'rev-parse' && String(args[1]).endsWith('^{tree}')) {
+      return { status: 0, stdout: 'tree-shared\n', stderr: '' };
+    }
+    if (args[0] === 'rev-list') {
+      return { status: 0, stdout: '0\t0\n', stderr: '' };
+    }
+    if (args[0] === 'diff') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      return { status: 0, stdout: 'C:/tmp/local-bare.git\n', stderr: '' };
+    }
+    return { status: 1, stdout: '', stderr: 'unexpected command' };
+  };
+
+  const report = collectParity(
+    {
+      baseRef: 'mirror/develop',
+      headRef: 'review/develop'
+    },
+    fakeRunner
+  );
+
+  assert.equal(report.status, 'unavailable');
+  assert.match(report.reason, /plane transition|repository slug|repository plane/i);
+});
+
 test('collectParity throws in strict mode when git fails', () => {
   const fakeRunner = () => ({ status: 1, stdout: '', stderr: 'boom' });
   assert.throws(
@@ -142,6 +180,7 @@ test('renderSummaryMarkdown includes parity metrics for ok status', () => {
     historyParity: { status: 'diverged', equal: false },
     tipDiff: { fileCount: 3, sample: ['a.txt'], sampleLimit: 20 },
     commitDivergence: { baseOnly: 1, headOnly: 4 },
+    planeTransition: { from: 'upstream', to: 'origin', via: 'priority:develop:sync' },
     recommendation: {
       code: 'history-diverged-tree-equal',
       summary: 'Tree is aligned but history diverges.',
@@ -153,5 +192,6 @@ test('renderSummaryMarkdown includes parity metrics for ok status', () => {
   assert.match(markdown, /Tip Diff File Count \| 3/);
   assert.match(markdown, /Commit Divergence \(base-only\/head-only\) \| 1\/4/);
   assert.match(markdown, /Recommendation \| history-diverged-tree-equal/);
+  assert.match(markdown, /Plane Transition \| upstream->origin \(priority:develop:sync\)/);
   assert.match(markdown, /`a.txt`/);
 });

--- a/tools/priority/develop-sync.mjs
+++ b/tools/priority/develop-sync.mjs
@@ -210,6 +210,30 @@ function readJsonFile(filePath) {
   }
 }
 
+function requirePlaneTransitionEvidence({ remote, parityReport, branchClassTrace, parityReportPath }) {
+  const planeTransition = parityReport?.planeTransition;
+  if (!planeTransition || !planeTransition.from || !planeTransition.to || !planeTransition.action || !planeTransition.via) {
+    throw new Error(`Parity report '${parityReportPath}' is missing required planeTransition metadata for ${remote}.`);
+  }
+
+  const expected = branchClassTrace?.planeTransitions?.[remote] ?? null;
+  if (!expected) {
+    throw new Error(`No expected plane transition recorded for remote '${remote}'.`);
+  }
+  if (
+    planeTransition.from !== expected.from ||
+    planeTransition.to !== expected.to ||
+    planeTransition.action !== expected.action ||
+    planeTransition.via !== expected.via
+  ) {
+    throw new Error(
+      `Parity report '${parityReportPath}' recorded planeTransition ${planeTransition.from}->${planeTransition.to} (${planeTransition.via}) but expected ${expected.from}->${expected.to} (${expected.via}).`
+    );
+  }
+
+  return planeTransition;
+}
+
 export function runDevelopSync({
   repoRoot = getRepoRoot(),
   options = parseArgs(),
@@ -267,13 +291,39 @@ export function runDevelopSync({
       });
       throw error;
     }
+    let planeTransition;
+    try {
+      planeTransition = requirePlaneTransitionEvidence({
+        remote,
+        parityReport,
+        branchClassTrace,
+        parityReportPath
+      });
+    } catch (error) {
+      actions.push({
+        remote,
+        status: 'failed',
+        parityReportPath: path.relative(repoRoot, parityReportPath).replace(/\\/g, '/'),
+        adminPaths,
+        branchClassTrace,
+        error: error.message
+      });
+      writeDevelopSyncReport({
+        repoRoot,
+        reportPath,
+        remotes,
+        actions,
+        status: 'failed'
+      });
+      throw error;
+    }
     actions.push({
       remote,
       status: 'ok',
       parityReportPath: path.relative(repoRoot, parityReportPath).replace(/\\/g, '/'),
       adminPaths,
       branchClassTrace,
-      planeTransition: branchClassTrace.planeTransitions[remote] ?? null,
+      planeTransition,
       syncMode: parityReport?.syncResult?.mode ?? 'direct-push',
       syncReason: parityReport?.syncResult?.reason ?? 'direct-push',
       parityConverged:

--- a/tools/priority/protected-develop-sync-pr.mjs
+++ b/tools/priority/protected-develop-sync-pr.mjs
@@ -7,6 +7,11 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import {
+  assertPlaneTransition,
+  loadBranchClassContract,
+  resolveRepositoryPlane
+} from './lib/branch-classification.mjs';
+import {
   ensureForkRemote,
   ensureGhCli,
   resolveUpstream,
@@ -151,6 +156,7 @@ export function buildProtectedSyncSummaryPayload({
   localHead,
   upstream,
   targetRepository,
+  planeTransition,
   pullRequest,
   readyState,
   mergeRequest,
@@ -171,6 +177,7 @@ export function buildProtectedSyncSummaryPayload({
     localHead: localHead ?? null,
     upstreamRepository: upstream ? `${upstream.owner}/${upstream.repo}` : null,
     targetRepository: targetRepository ? `${targetRepository.owner}/${targetRepository.repo}` : null,
+    planeTransition: planeTransition ?? null,
     syncMethod,
     allowForkSyncing,
     mergeUpstream,
@@ -346,6 +353,31 @@ function writeReport(reportPath, payload) {
   writeFileSync(reportPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
+function resolveProtectedSyncPlaneTransition({
+  repoRoot,
+  upstream,
+  targetRepository,
+  loadBranchClassContractFn = loadBranchClassContract
+}) {
+  const contract = loadBranchClassContractFn(repoRoot);
+  const upstreamRepository = upstream ? `${upstream.owner}/${upstream.repo}` : null;
+  const forkRepository = targetRepository ? `${targetRepository.owner}/${targetRepository.repo}` : null;
+  const fromPlane = resolveRepositoryPlane(upstreamRepository, contract);
+  const toPlane = resolveRepositoryPlane(forkRepository, contract);
+  const transition = assertPlaneTransition({
+    fromPlane,
+    toPlane,
+    action: 'sync',
+    contract
+  });
+
+  return {
+    ...transition,
+    baseRepository: upstreamRepository,
+    headRepository: forkRepository
+  };
+}
+
 export function runProtectedDevelopSync({
   repoRoot = getRepoRoot(),
   options = parseArgs(),
@@ -355,7 +387,8 @@ export function runProtectedDevelopSync({
   runGhPrCreateFn = runGhPrCreate,
   runGhJsonFn = runGhJson,
   updateExistingPullRequestFn = updateExistingPullRequest,
-  spawnSyncFn = spawnSync
+  spawnSyncFn = spawnSync,
+  loadBranchClassContractFn = loadBranchClassContract
 } = {}) {
   if (options.help) {
     printUsage();
@@ -374,6 +407,12 @@ export function runProtectedDevelopSync({
   const upstream = resolveUpstreamFn(repoRoot);
   const targetRepository = ensureForkRemoteFn(repoRoot, upstream, options.targetRemote, { spawnSyncFn });
   const targetRepoSlug = `${targetRepository.owner}/${targetRepository.repo}`;
+  const planeTransition = resolveProtectedSyncPlaneTransition({
+    repoRoot,
+    upstream,
+    targetRepository,
+    loadBranchClassContractFn
+  });
   let protection = null;
   try {
     protection = loadBranchProtection(repoRoot, targetRepoSlug, options.branch, {
@@ -400,6 +439,7 @@ export function runProtectedDevelopSync({
       localHead: options.localHead,
       upstream,
       targetRepository,
+      planeTransition,
       syncMethod: 'fork-sync',
       allowForkSyncing,
       mergeUpstream,
@@ -494,6 +534,7 @@ export function runProtectedDevelopSync({
     localHead: options.localHead,
     upstream,
     targetRepository,
+    planeTransition,
     syncMethod: 'protected-pr',
     allowForkSyncing,
     mergeUpstreamError,

--- a/tools/priority/report-origin-upstream-parity.mjs
+++ b/tools/priority/report-origin-upstream-parity.mjs
@@ -4,6 +4,12 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  assertPlaneTransition,
+  findRepositoryPlaneEntry,
+  loadBranchClassContract,
+  resolveRepositoryPlane
+} from './lib/branch-classification.mjs';
 
 function sh(cmd, args, opts = {}) {
   return spawnSync(cmd, args, { encoding: 'utf8', shell: false, ...opts });
@@ -156,6 +162,14 @@ function runGitOptional(args, runner = sh) {
   return trimText(result.stdout);
 }
 
+function tryGetRepoRoot(runner = sh) {
+  const result = ensureCommand(runner('git', ['rev-parse', '--show-toplevel']), 'git');
+  if (result.status !== 0) {
+    return null;
+  }
+  return trimText(result.stdout);
+}
+
 function collectRemoteDetails(remoteName, runner = sh) {
   if (!remoteName) {
     return {
@@ -173,6 +187,92 @@ function collectRemoteDetails(remoteName, runner = sh) {
     present: Boolean(fetchUrl || pushUrl),
     fetchUrl: fetchUrl || null,
     pushUrl: pushUrl || null
+  };
+}
+
+function parseRepositorySlug(url) {
+  if (!url) return null;
+  const sshMatch = String(url).match(/:(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const httpsMatch = String(url).match(/github\.com\/(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/i);
+  const repoPath = sshMatch?.groups?.repoPath ?? httpsMatch?.groups?.repoPath;
+  if (!repoPath) {
+    return null;
+  }
+  const [owner, repo] = repoPath.split('/');
+  if (!owner || !repo) {
+    return null;
+  }
+  return `${owner}/${repo}`;
+}
+
+function resolvePlaneIdentity({ remoteName, remoteDetails, contract }) {
+  const normalizedRemote = trimText(remoteName).toLowerCase();
+  if (normalizedRemote === 'upstream') {
+    return {
+      remote: remoteName,
+      plane: 'upstream',
+      repository: contract.upstreamRepository
+    };
+  }
+
+  if (normalizedRemote === 'origin' || normalizedRemote === 'personal') {
+    const planeEntry = findRepositoryPlaneEntry(contract, normalizedRemote);
+    const repository = planeEntry?.repositories?.[0] ?? null;
+    if (!repository) {
+      throw new Error(`Branch class contract does not define a repository for remote '${remoteName}'.`);
+    }
+    return {
+      remote: remoteName,
+      plane: normalizedRemote,
+      repository
+    };
+  }
+
+  const repository =
+    parseRepositorySlug(remoteDetails?.fetchUrl) ??
+    parseRepositorySlug(remoteDetails?.pushUrl);
+  if (!repository) {
+    throw new Error(`Unable to resolve repository slug for remote '${remoteName}'.`);
+  }
+  const plane = resolveRepositoryPlane(repository, contract);
+  if (plane === 'fork') {
+    throw new Error(`Unable to resolve repository plane for remote '${remoteName}' (${repository}).`);
+  }
+  return {
+    remote: remoteName,
+    plane,
+    repository
+  };
+}
+
+function resolveParityPlaneTransition({ baseRef, headRef, contract, runner = sh }) {
+  const baseRemote = parseRemoteFromRef(baseRef);
+  const headRemote = parseRemoteFromRef(headRef);
+  if (!baseRemote || !headRemote) {
+    throw new Error(`Parity refs must point at named remotes. Received '${baseRef}' and '${headRef}'.`);
+  }
+
+  const baseRemoteDetails = collectRemoteDetails(baseRemote, runner);
+  const headRemoteDetails = collectRemoteDetails(headRemote, runner);
+  const base = resolvePlaneIdentity({ remoteName: baseRemote, remoteDetails: baseRemoteDetails, contract });
+  const head = resolvePlaneIdentity({ remoteName: headRemote, remoteDetails: headRemoteDetails, contract });
+  const transition = assertPlaneTransition({
+    fromPlane: base.plane,
+    toPlane: head.plane,
+    action: 'sync',
+    contract
+  });
+
+  return {
+    baseRemote,
+    headRemote,
+    baseRemoteDetails,
+    headRemoteDetails,
+    planeTransition: {
+      ...transition,
+      baseRepository: base.repository,
+      headRepository: head.repository
+    }
   };
 }
 
@@ -240,8 +340,10 @@ export function collectParity(options = {}, runner = sh) {
   const sampleLimit = toPositiveInt(options.sampleLimit, 20);
   const strict = Boolean(options.strict);
   const now = new Date().toISOString();
+  const repoRoot = options.repoRoot || tryGetRepoRoot(runner) || process.cwd();
 
   try {
+    const contract = options.branchClassContract || loadBranchClassContract(repoRoot);
     const baseCommit = trimText(runGit(['rev-parse', '--verify', baseRef], runner));
     const headCommit = trimText(runGit(['rev-parse', '--verify', headRef], runner));
     const baseTree = trimText(runGit(['rev-parse', `${baseRef}^{tree}`], runner));
@@ -253,8 +355,6 @@ export function collectParity(options = {}, runner = sh) {
     const sample = sampleLimit > 0 ? files.slice(0, sampleLimit) : [];
     const treeEqual = baseTree === headTree;
     const historyEqual = counts.baseOnly === 0 && counts.headOnly === 0;
-    const baseRemote = parseRemoteFromRef(baseRef);
-    const headRemote = parseRemoteFromRef(headRef);
     const recommendation = buildParityRecommendation({
       baseRef,
       headRef,
@@ -263,11 +363,33 @@ export function collectParity(options = {}, runner = sh) {
       headOnly: counts.headOnly,
       tipDiffCount: files.length
     });
-    const baseRemoteDetails = collectRemoteDetails(baseRemote, runner);
-    const headRemoteDetails = collectRemoteDetails(headRemote, runner);
+    const {
+      baseRemote,
+      headRemote,
+      baseRemoteDetails,
+      headRemoteDetails,
+      planeTransition
+    } = resolveParityPlaneTransition({
+      baseRef,
+      headRef,
+      contract,
+      runner
+    });
     const remotes = {};
-    if (baseRemoteDetails.name) remotes[baseRemoteDetails.name] = baseRemoteDetails;
-    if (headRemoteDetails.name) remotes[headRemoteDetails.name] = headRemoteDetails;
+    if (baseRemoteDetails.name) {
+      remotes[baseRemoteDetails.name] = {
+        ...baseRemoteDetails,
+        plane: planeTransition.from,
+        repository: planeTransition.baseRepository
+      };
+    }
+    if (headRemoteDetails.name) {
+      remotes[headRemoteDetails.name] = {
+        ...headRemoteDetails,
+        plane: planeTransition.to,
+        repository: planeTransition.headRepository
+      };
+    }
 
     return {
       schema: 'origin-upstream-parity@v1',
@@ -300,6 +422,7 @@ export function collectParity(options = {}, runner = sh) {
         headOnly: counts.headOnly
       },
       recommendation,
+      planeTransition,
       remoteManagement: {
         baseRemote,
         headRemote,
@@ -366,7 +489,8 @@ export function renderSummaryMarkdown(report) {
     `| History Parity | ${report.historyParity?.status || 'unknown'} |`,
     `| Tip Diff File Count | ${report.tipDiff.fileCount} |`,
     `| Commit Divergence (base-only/head-only) | ${report.commitDivergence.baseOnly}/${report.commitDivergence.headOnly} |`,
-    `| Recommendation | ${report.recommendation?.code || 'n/a'} |`
+    `| Recommendation | ${report.recommendation?.code || 'n/a'} |`,
+    `| Plane Transition | ${report.planeTransition ? `${report.planeTransition.from}->${report.planeTransition.to} (${report.planeTransition.via})` : 'n/a'} |`
   ];
 
   if (Array.isArray(report.tipDiff.sample) && report.tipDiff.sample.length > 0) {
@@ -449,6 +573,21 @@ async function main() {
     options.githubOutputPath,
     'parity_recommendation_code',
     report.status === 'ok' ? report.recommendation?.code : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_transition_from',
+    report.status === 'ok' ? report.planeTransition?.from : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_transition_to',
+    report.status === 'ok' ? report.planeTransition?.to : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_transition_via',
+    report.status === 'ok' ? report.planeTransition?.via : ''
   );
   appendGitHubOutput(options.githubOutputPath, 'parity_report_path', outputPath);
 


### PR DESCRIPTION
## Summary
- record explicit fork-plane transition evidence in origin/upstream parity receipts
- record the same transition evidence in protected develop sync receipts
- fail closed when sync/parity helpers cannot prove the required plane transition

## Testing
- node --check tools/priority/report-origin-upstream-parity.mjs
- node --check tools/priority/protected-develop-sync-pr.mjs
- node --check tools/priority/develop-sync.mjs
- node --test tools/priority/__tests__/report-origin-upstream-parity.test.mjs tools/priority/__tests__/protected-develop-sync-pr.test.mjs tools/priority/__tests__/develop-sync.test.mjs

Refs #1123
