### PR TITLE
#1125 Record plane transitions in health snapshot and release parity evidence

### DIFF
--- a/tests/Write-HealthSnapshot.Tests.ps1
+++ b/tests/Write-HealthSnapshot.Tests.ps1
@@ -1,0 +1,130 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Write-HealthSnapshot.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'priority' 'Write-HealthSnapshot.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Write-HealthSnapshot.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'records explicit plane-transition evidence in the health snapshot' {
+    $resultsDir = Join-Path $TestDrive 'results'
+    $outputDir = Join-Path $TestDrive 'out'
+    $parityPath = Join-Path $outputDir 'origin-upstream-parity.json'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+      branchProtection = [ordered]@{
+        result = [ordered]@{
+          status = 'ok'
+        }
+      }
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Encoding utf8
+
+    $parity = [ordered]@{
+      schema = 'origin-upstream-parity@v1'
+      status = 'ok'
+      baseRef = 'upstream/develop'
+      headRef = 'origin/develop'
+      tipDiff = [ordered]@{
+        fileCount = 0
+      }
+      treeParity = [ordered]@{
+        equal = $true
+        status = 'equal'
+      }
+      recommendation = [ordered]@{
+        code = 'aligned'
+      }
+      planeTransition = [ordered]@{
+        from = 'upstream'
+        to = 'origin'
+        action = 'sync'
+        via = 'priority:develop:sync'
+        baseRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+        headRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'
+      }
+    }
+    ($parity | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $parityPath -Encoding utf8
+
+    Push-Location -LiteralPath $script:RepoRoot
+    try {
+      & $script:ToolPath `
+        -ResultsRoot $resultsDir `
+        -OutputDir $outputDir `
+        -ParityReportPath $parityPath `
+        -SkipParityRefresh | Out-Null
+    } finally {
+      Pop-Location
+    }
+
+    $snapshot = Get-Content -LiteralPath (Join-Path $outputDir 'health-snapshot.json') -Raw | ConvertFrom-Json -Depth 30
+    $snapshot.parity.verdict | Should -Be 'pass'
+    $snapshot.parity.planeTransition.from | Should -Be 'upstream'
+    $snapshot.parity.planeTransition.to | Should -Be 'origin'
+    $snapshot.parity.planeTransition.via | Should -Be 'priority:develop:sync'
+
+    $markdown = Get-Content -LiteralPath (Join-Path $outputDir 'health-snapshot.md') -Raw
+    $markdown | Should -Match 'Plane transition: upstream->origin via priority:develop:sync'
+  }
+
+  It 'fails closed in the snapshot when plane-transition evidence is missing' {
+    $resultsDir = Join-Path $TestDrive 'results-missing'
+    $outputDir = Join-Path $TestDrive 'out-missing'
+    $parityPath = Join-Path $outputDir 'origin-upstream-parity.json'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+      branchProtection = [ordered]@{
+        result = [ordered]@{
+          status = 'ok'
+        }
+      }
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Encoding utf8
+
+    $parity = [ordered]@{
+      schema = 'origin-upstream-parity@v1'
+      status = 'ok'
+      baseRef = 'upstream/develop'
+      headRef = 'origin/develop'
+      tipDiff = [ordered]@{
+        fileCount = 0
+      }
+      treeParity = [ordered]@{
+        equal = $true
+        status = 'equal'
+      }
+      recommendation = [ordered]@{
+        code = 'aligned'
+      }
+    }
+    ($parity | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $parityPath -Encoding utf8
+
+    Push-Location -LiteralPath $script:RepoRoot
+    try {
+      & $script:ToolPath `
+        -ResultsRoot $resultsDir `
+        -OutputDir $outputDir `
+        -ParityReportPath $parityPath `
+        -SkipParityRefresh | Out-Null
+    } finally {
+      Pop-Location
+    }
+
+    $snapshot = Get-Content -LiteralPath (Join-Path $outputDir 'health-snapshot.json') -Raw | ConvertFrom-Json -Depth 30
+    $snapshot.parity.verdict | Should -Be 'fail'
+    $snapshot.parity.planeTransition | Should -BeNullOrEmpty
+    @($snapshot.degradedNotes) | Should -Contain 'Parity report is missing required plane-transition metadata.'
+  }
+}

--- a/tools/priority/Write-HealthSnapshot.ps1
+++ b/tools/priority/Write-HealthSnapshot.ps1
@@ -8,7 +8,9 @@ param(
   [string]$Branch = 'develop',
   [string]$BaseRef = 'upstream/develop',
   [string]$HeadRef = 'origin/develop',
-  [int]$IncidentLimit = 5
+  [int]$IncidentLimit = 5,
+  [string]$ParityReportPath,
+  [switch]$SkipParityRefresh
 )
 
 Set-StrictMode -Version Latest
@@ -139,6 +141,14 @@ function Convert-ParityVerdict {
   param($Parity)
   if (-not $Parity -or $Parity.status -ne 'ok') {
     return 'degraded'
+  }
+  $planeTransition = if ($Parity.PSObject.Properties.Name -contains 'planeTransition') { $Parity.planeTransition } else { $null }
+  if (-not $planeTransition -or
+      [string]::IsNullOrWhiteSpace([string]$planeTransition.from) -or
+      [string]::IsNullOrWhiteSpace([string]$planeTransition.to) -or
+      [string]::IsNullOrWhiteSpace([string]$planeTransition.action) -or
+      [string]::IsNullOrWhiteSpace([string]$planeTransition.via)) {
+    return 'fail'
   }
   if ($Parity.tipDiff -and $Parity.tipDiff.fileCount -eq 0 -and $Parity.treeParity -and $Parity.treeParity.equal) {
     return 'pass'
@@ -333,6 +343,11 @@ function Write-MarkdownSummary {
   $lines += "- Upstream develop SHA: $($Snapshot.shas.upstreamDevelop)"
   $lines += "- Fork develop SHA: $($Snapshot.shas.forkDevelop)"
   $lines += "- Parity verdict: **$($Snapshot.parity.verdict)** (source: $($Snapshot.parity.source))"
+  if ($Snapshot.parity.planeTransition) {
+    $lines += "- Plane transition: $($Snapshot.parity.planeTransition.from)->$($Snapshot.parity.planeTransition.to) via $($Snapshot.parity.planeTransition.via)"
+  } else {
+    $lines += "- Plane transition: unavailable"
+  }
   $lines += "- Required-context verdict: **$($Snapshot.requiredContexts.verdict)** (source: $($Snapshot.requiredContexts.source))"
   $lines += ''
   $lines += '## Latest Incidents'
@@ -385,9 +400,17 @@ $forkSha = Invoke-GitText -Arguments @('rev-parse', '--verify', $HeadRef)
 if (-not $upstreamSha) { $upstreamSha = 'unavailable'; $degradedNotes += "Unable to resolve $BaseRef." }
 if (-not $forkSha) { $forkSha = 'unavailable'; $degradedNotes += "Unable to resolve $HeadRef." }
 
-$parityOutputPath = Join-Path $OutputDir 'origin-upstream-parity.json'
+$parityOutputPath = if ([string]::IsNullOrWhiteSpace($ParityReportPath)) {
+  Join-Path $OutputDir 'origin-upstream-parity.json'
+} elseif ([System.IO.Path]::IsPathRooted($ParityReportPath)) {
+  $ParityReportPath
+} else {
+  Join-Path (Get-Location).Path $ParityReportPath
+}
 try {
-  & node tools/priority/report-origin-upstream-parity.mjs --base-ref $BaseRef --head-ref $HeadRef --output-path $parityOutputPath | Out-Null
+  if (-not $SkipParityRefresh) {
+    & node tools/priority/report-origin-upstream-parity.mjs --base-ref $BaseRef --head-ref $HeadRef --output-path $parityOutputPath | Out-Null
+  }
 } catch {
   $degradedNotes += 'Parity report command failed; using degraded verdict.'
 }
@@ -401,6 +424,30 @@ if (Test-Path -LiteralPath $parityOutputPath -PathType Leaf) {
   }
 } else {
   $degradedNotes += 'Parity report not produced.'
+}
+
+$parityPlaneTransition = $null
+if ($parity -and $parity.status -eq 'ok') {
+  $candidatePlaneTransition = if ($parity.PSObject.Properties.Name -contains 'planeTransition') { $parity.planeTransition } else { $null }
+  $isValidPlaneTransition = (
+    $candidatePlaneTransition -and
+    -not [string]::IsNullOrWhiteSpace([string]$candidatePlaneTransition.from) -and
+    -not [string]::IsNullOrWhiteSpace([string]$candidatePlaneTransition.to) -and
+    -not [string]::IsNullOrWhiteSpace([string]$candidatePlaneTransition.action) -and
+    -not [string]::IsNullOrWhiteSpace([string]$candidatePlaneTransition.via)
+  )
+  if ($isValidPlaneTransition) {
+    $parityPlaneTransition = [ordered]@{
+      from = [string]$candidatePlaneTransition.from
+      to = [string]$candidatePlaneTransition.to
+      action = [string]$candidatePlaneTransition.action
+      via = [string]$candidatePlaneTransition.via
+      baseRepository = if ($candidatePlaneTransition.PSObject.Properties.Name -contains 'baseRepository') { [string]$candidatePlaneTransition.baseRepository } else { $null }
+      headRepository = if ($candidatePlaneTransition.PSObject.Properties.Name -contains 'headRepository') { [string]$candidatePlaneTransition.headRepository } else { $null }
+    }
+  } else {
+    $degradedNotes += 'Parity report is missing required plane-transition metadata.'
+  }
 }
 
 $sessionPreferred = Get-PreferredSessionIndex -ResultsDir $ResultsRoot
@@ -443,6 +490,7 @@ $snapshot = [ordered]@{
     status = if ($parity) { $parity.status } else { 'unavailable' }
     tipDiffFileCount = if ($parity -and $parity.tipDiff) { $parity.tipDiff.fileCount } else { $null }
     recommendationCode = if ($parity -and $parity.recommendation) { $parity.recommendation.code } else { $null }
+    planeTransition = $parityPlaneTransition
   }
   requiredContexts = [ordered]@{
     verdict = $requiredContexts.verdict

--- a/tools/priority/__tests__/release-priority-parity.test.mjs
+++ b/tools/priority/__tests__/release-priority-parity.test.mjs
@@ -101,6 +101,7 @@ test('collectOriginUpstreamParityEvidence enforces tipDiff file count target', (
           baseRef: 'upstream/develop',
           headRef: 'origin/develop',
           tipDiff: { fileCount: 2 },
+          planeTransition: { from: 'upstream', to: 'origin', action: 'sync', via: 'priority:develop:sync' },
           treeParity: { status: 'different', equal: false },
           historyParity: { status: 'diverged', equal: false, baseOnly: 1, headOnly: 1 }
         })
@@ -123,6 +124,7 @@ test('collectStandingPriorityParityGate returns combined sync and parity evidenc
       baseRef: 'upstream/develop',
       headRef: 'origin/develop',
       tipDiff: { fileCount: 0 },
+      planeTransition: { from: 'upstream', to: 'origin', action: 'sync', via: 'priority:develop:sync' },
       treeParity: { status: 'equal', equal: true },
       historyParity: { status: 'diverged', equal: false, baseOnly: 3, headOnly: 4 },
       recommendation: { code: 'history-diverged-tree-equal', summary: 'Tree is aligned.' }
@@ -133,4 +135,24 @@ test('collectStandingPriorityParityGate returns combined sync and parity evidenc
   assert.equal(evidence.standingPriority.issue, 285);
   assert.equal(evidence.parity.tipDiff.fileCount, 0);
   assert.equal(evidence.parity.tipDiff.target, 0);
+  assert.equal(evidence.parity.planeTransition.from, 'upstream');
+  assert.equal(evidence.parity.planeTransition.to, 'origin');
+});
+
+test('collectOriginUpstreamParityEvidence fails closed when plane transition metadata is missing', () => {
+  assert.throws(
+    () =>
+      collectOriginUpstreamParityEvidence({
+        tipDiffTarget: 0,
+        collectParityFn: () => ({
+          status: 'ok',
+          baseRef: 'upstream/develop',
+          headRef: 'origin/develop',
+          tipDiff: { fileCount: 0 },
+          treeParity: { status: 'equal', equal: true },
+          historyParity: { status: 'equal', equal: true, baseOnly: 0, headOnly: 0 }
+        })
+      }),
+    /plane-transition metadata/i
+  );
 });

--- a/tools/priority/lib/release-priority-parity.mjs
+++ b/tools/priority/lib/release-priority-parity.mjs
@@ -47,6 +47,23 @@ function parsePriorityIssueNumber(cache) {
   return number;
 }
 
+function requirePlaneTransition(parity, { baseRef, headRef }) {
+  const planeTransition = parity?.planeTransition;
+  if (!planeTransition || !planeTransition.from || !planeTransition.to || !planeTransition.action || !planeTransition.via) {
+    throw new Error(
+      `Origin/upstream parity evidence is missing plane-transition metadata (${baseRef} vs ${headRef}).`
+    );
+  }
+  return {
+    from: planeTransition.from,
+    to: planeTransition.to,
+    action: planeTransition.action,
+    via: planeTransition.via,
+    baseRepository: planeTransition.baseRepository ?? null,
+    headRepository: planeTransition.headRepository ?? null
+  };
+}
+
 export async function collectStandingPrioritySyncEvidence(
   repoRoot,
   {
@@ -145,6 +162,8 @@ export function collectOriginUpstreamParityEvidence(
     throw new Error(`Unable to evaluate origin/upstream parity (${baseRef} vs ${headRef}).`);
   }
 
+  const planeTransition = requirePlaneTransition(parity, { baseRef, headRef });
+
   const observedCount = Number(parity?.tipDiff?.fileCount ?? NaN);
   if (!Number.isInteger(observedCount) || observedCount !== target) {
     throw new Error(
@@ -160,6 +179,7 @@ export function collectOriginUpstreamParityEvidence(
       fileCount: observedCount,
       target
     },
+    planeTransition,
     treeParity: {
       status: parity?.treeParity?.status ?? null,
       equal: Boolean(parity?.treeParity?.equal)


### PR DESCRIPTION
## Summary
- record explicit fork-plane transition evidence in health snapshot outputs
- require the same evidence in release parity gating before promotion
- keep operator-facing health and release parity surfaces fail-closed when plane-transition metadata is missing

## Testing
- node --test tools/priority/__tests__/release-priority-parity.test.mjs
- Invoke-Pester -Path tests/Write-HealthSnapshot.Tests.ps1 -CI

Refs #1125
