### PR TITLE
#1127 Record fork-plane transitions in session-index and handoff evidence

### DIFF
--- a/tests/AgentHandoff.Local.Tests.ps1
+++ b/tests/AgentHandoff.Local.Tests.ps1
@@ -23,5 +23,10 @@ Describe 'Local Agent Handoff' -Tag 'Unit' {
     Test-Path -LiteralPath (Join-Path $resultsRoot '_agent/handoff/entrypoint-status.json') | Should -BeTrue
     Test-Path -LiteralPath (Join-Path $resultsRoot '_agent/handoff/issue-summary.json') | Should -BeTrue
     Test-Path -LiteralPath (Join-Path $resultsRoot '_agent/handoff/issue-router.json') | Should -BeTrue
+    Test-Path -LiteralPath (Join-Path $resultsRoot '_agent/handoff/plane-transition.json') | Should -BeTrue
+
+    $planeTransition = Get-Content -LiteralPath (Join-Path $resultsRoot '_agent/handoff/plane-transition.json') -Raw | ConvertFrom-Json -ErrorAction Stop
+    $planeTransition.schema | Should -Be 'agent-handoff/plane-transition-v1'
+    $planeTransition.status | Should -Not -BeNullOrEmpty
   }
 }

--- a/tests/AgentHandoff.PlaneTransition.Tests.ps1
+++ b/tests/AgentHandoff.PlaneTransition.Tests.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Agent Handoff plane transition evidence' -Tag 'Unit' {
+  It 'mirrors develop-sync plane transition evidence into the handoff bundle and session capsule' {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $workspaceRoot = Join-Path $TestDrive 'repo'
+    $toolsDir = Join-Path $workspaceRoot 'tools'
+    $priorityDir = Join-Path $toolsDir 'priority'
+    $scriptPath = Join-Path $toolsDir 'Print-AgentHandoff.ps1'
+    $entrypointPath = Join-Path $toolsDir 'Test-AgentHandoffEntryPoint.ps1'
+    $watcherManagerPath = Join-Path $toolsDir 'Dev-WatcherManager.ps1'
+    $issueDir = Join-Path $workspaceRoot 'tests' 'results' '_agent' 'issue'
+    $cachePath = Join-Path $workspaceRoot '.agent_priority_cache.json'
+    $resultsRoot = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Force -Path $toolsDir, $priorityDir, $issueDir, $resultsRoot | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Print-AgentHandoff.ps1') -Destination $scriptPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Test-AgentHandoffEntryPoint.ps1') -Destination $entrypointPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Dev-WatcherManager.ps1') -Destination $watcherManagerPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'AGENT_HANDOFF.txt') -Destination (Join-Path $workspaceRoot 'AGENT_HANDOFF.txt') -Force
+
+    [pscustomobject][ordered]@{
+      schema = 'standing-priority/issue@v1'
+      number = 1127
+      title = 'Record fork-plane transitions in session-index and handoff evidence'
+      state = 'OPEN'
+      updatedAt = '2026-03-14T08:40:00Z'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1127'
+      labels = @('ci', 'enhancement')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      bodyDigest = 'body-digest-1127'
+      digest = 'digest-1127'
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir '1127.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      schema = 'agent/priority-router@v1'
+      issue = [pscustomobject][ordered]@{
+        number = 1127
+        title = 'Record fork-plane transitions in session-index and handoff evidence'
+      }
+      updatedAt = '2026-03-14T08:40:00Z'
+      actions = @()
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir 'router.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      number = 1127
+      title = 'Record fork-plane transitions in session-index and handoff evidence'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1127'
+      cachedAtUtc = '2026-03-14T08:40:00Z'
+      repository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      state = 'OPEN'
+      labels = @('standing-priority', 'ci')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      lastSeenUpdatedAt = '2026-03-14T08:40:00Z'
+      issueDigest = 'digest-1127'
+      bodyDigest = 'body-digest-1127'
+      lastFetchSource = 'fixture'
+      lastFetchError = $null
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $cachePath -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      schema = 'priority/develop-sync-report@v1'
+      generatedAt = '2026-03-14T08:40:00Z'
+      actions = @(
+        [pscustomobject][ordered]@{
+          remote = 'origin'
+          planeTransition = [pscustomobject][ordered]@{
+            from = 'upstream'
+            to = 'origin'
+            action = 'sync'
+            via = 'priority:develop:sync'
+            baseRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+            headRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+          }
+        }
+      )
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path $issueDir 'develop-sync-report.json') -Encoding utf8
+
+    Push-Location $workspaceRoot
+    try {
+      { & $scriptPath -ApplyToggles -ResultsRoot $resultsRoot } | Should -Not -Throw
+    } finally {
+      Pop-Location
+    }
+
+    $handoffPlanePath = Join-Path $resultsRoot '_agent' 'handoff' 'plane-transition.json'
+    Test-Path -LiteralPath $handoffPlanePath | Should -BeTrue
+    $handoffPlane = Get-Content -LiteralPath $handoffPlanePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $handoffPlane.status | Should -Be 'ok'
+    $handoffPlane.transitionCount | Should -Be 1
+    $handoffPlane.transitions[0].from | Should -Be 'upstream'
+    $handoffPlane.transitions[0].to | Should -Be 'origin'
+    $handoffPlane.transitions[0].remote | Should -Be 'origin'
+
+    $watcherPath = Join-Path $resultsRoot '_agent' 'handoff' 'watcher-telemetry.json'
+    $watcher = Get-Content -LiteralPath $watcherPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $watcher.planeTransitions.status | Should -Be 'ok'
+    $watcher.planeTransitions.transitionCount | Should -Be 1
+
+    $sessionPath = Get-ChildItem -LiteralPath (Join-Path $resultsRoot '_agent' 'sessions') -Filter '*.json' | Select-Object -First 1
+    $sessionPath | Should -Not -BeNullOrEmpty
+    $session = Get-Content -LiteralPath $sessionPath.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
+    $session.planeTransitions.status | Should -Be 'ok'
+    $session.planeTransitions.transitionCount | Should -Be 1
+  }
+}

--- a/tests/Import-HandoffState.Tests.ps1
+++ b/tests/Import-HandoffState.Tests.ps1
@@ -38,4 +38,39 @@ Describe 'Import-HandoffState' -Tag 'Unit' {
 
     Remove-Variable -Name DockerReviewLoopHandoffSummary -Scope Global -ErrorAction SilentlyContinue
   }
+
+  It 'surfaces plane transition evidence when present' {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools' 'priority' 'Import-HandoffState.ps1'
+    $handoffDir = Join-Path $TestDrive 'handoff'
+    New-Item -ItemType Directory -Force -Path $handoffDir | Out-Null
+
+    [ordered]@{
+      schema = 'agent-handoff/plane-transition-v1'
+      generatedAt = '2026-03-14T08:40:00Z'
+      status = 'ok'
+      reason = $null
+      transitionCount = 1
+      transitions = @(
+        [ordered]@{
+          from = 'upstream'
+          to = 'origin'
+          action = 'sync'
+          via = 'priority:develop:sync'
+          sourceType = 'develop-sync'
+          sourceLabel = 'develop-sync-report'
+        }
+      )
+      sources = @()
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $handoffDir 'plane-transition.json') -Encoding utf8
+
+    $output = & $scriptPath -HandoffDir $handoffDir *>&1 | Out-String
+
+    $output | Should -Match '\[handoff\] Plane transition evidence'
+    $output | Should -Match 'status\s+: ok'
+    $output | Should -Match 'upstream->origin'
+    $global:PlaneTransitionHandoffSummary.schema | Should -Be 'agent-handoff/plane-transition-v1'
+
+    Remove-Variable -Name PlaneTransitionHandoffSummary -Scope Global -ErrorAction SilentlyContinue
+  }
 }

--- a/tests/Update-SessionIndexParity.Tests.ps1
+++ b/tests/Update-SessionIndexParity.Tests.ps1
@@ -31,6 +31,14 @@ Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
       generatedAt = '2026-03-03T00:00:00Z'
       baseRef = 'upstream/develop'
       headRef = 'origin/develop'
+      planeTransition = [ordered]@{
+        from = 'upstream'
+        to = 'origin'
+        action = 'sync'
+        via = 'priority:develop:sync'
+        baseRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+        headRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      }
       tipDiff = [ordered]@{
         fileCount = 0
       }
@@ -72,11 +80,15 @@ Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
     $updated.runContext.parity.commitDivergence.baseOnly | Should -Be 33
     $updated.runContext.parity.commitDivergence.headOnly | Should -Be 126
     $updated.runContext.parity.reportPath | Should -Be $parityPath
+    $updated.runContext.parity.planeTransition.from | Should -Be 'upstream'
+    $updated.runContext.parity.planeTransition.to | Should -Be 'origin'
+    $updated.runContext.parity.planeTransition.via | Should -Be 'priority:develop:sync'
 
     $summary = Get-Content -LiteralPath $summaryPath -Raw
     $summary | Should -Match 'Origin/Upstream Parity Telemetry'
     $summary | Should -Match 'Tree Parity \| equal'
     $summary | Should -Match 'History Parity \| diverged'
+    $summary | Should -Match 'Plane Transition \| upstream->origin \(priority:develop:sync\)'
     $summary | Should -Match 'Tip Diff File Count \| 0'
     $summary | Should -Match 'Commit Divergence \(base-only/head-only\) \| 33/126'
     $summary | Should -Match 'Recommendation \| history-diverged-tree-equal'
@@ -98,6 +110,37 @@ Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
     $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
     $updated.runContext.parity.status | Should -Be 'unavailable'
     $updated.runContext.parity.reason | Should -Be 'report-missing'
+  }
+
+  It 'fails closed when an ok parity report omits plane transition evidence' {
+    $resultsDir = Join-Path $TestDrive 'missing-plane-transition'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $sessionIndexPath = Join-Path $resultsDir 'session-index.json'
+    [ordered]@{
+      schema = 'session-index/v1'
+      status = 'ok'
+      runContext = [ordered]@{}
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $sessionIndexPath -Encoding utf8
+
+    $parityPath = Join-Path $resultsDir 'origin-upstream-parity.json'
+    [ordered]@{
+      schema = 'origin-upstream-parity@v1'
+      status = 'ok'
+      generatedAt = '2026-03-03T00:00:00Z'
+      baseRef = 'upstream/develop'
+      headRef = 'origin/develop'
+      tipDiff = [ordered]@{ fileCount = 0 }
+      treeParity = [ordered]@{ equal = $true; status = 'equal' }
+      historyParity = [ordered]@{ equal = $true; status = 'equal' }
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $parityPath -Encoding utf8
+
+    & $script:ToolPath -ResultsDir $resultsDir -ParityReportPath $parityPath | Out-Null
+
+    $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
+    $updated.runContext.parity.status | Should -Be 'fail'
+    $updated.runContext.parity.reason | Should -Match 'missing-plane-transition'
+    $updated.runContext.parity.planeTransition | Should -Be $null
   }
 
   It 'does not throw when session-index is missing and IgnoreMissingSessionIndex is enabled' {

--- a/tests/Watcher.TelemetrySchema.Tests.ps1
+++ b/tests/Watcher.TelemetrySchema.Tests.ps1
@@ -21,6 +21,9 @@ Describe 'Watcher Telemetry - Handoff Snapshot' {
     $json.heartbeatFresh | Should -BeOfType ([bool])
     $json.needsTrim | Should -BeOfType ([bool])
     $json.events | Should -Not -BeNullOrEmpty
+    $json.planeTransitions | Should -Not -BeNullOrEmpty
+    $json.planeTransitions.schema | Should -Be 'agent-handoff/plane-transition-v1'
+    $json.planeTransitions.status | Should -Not -BeNullOrEmpty
     $json.events.schema | Should -Be 'comparevi/runtime-event/v1'
     $json.events.path | Should -Not -BeNullOrEmpty
     $json.events.present | Should -BeOfType ([bool])

--- a/tools/Print-AgentHandoff.ps1
+++ b/tools/Print-AgentHandoff.ps1
@@ -478,9 +478,224 @@ function Get-NonEmptyStringValues {
   return $values
 }
 
+function Test-PlaneTransitionRecord {
+  param([object]$Transition)
+
+  if ($null -eq $Transition) { return $false }
+  foreach ($requiredKey in @('from', 'to', 'action', 'via')) {
+    $value = if ($Transition -is [System.Collections.IDictionary]) {
+      if ($Transition.Contains($requiredKey)) { $Transition[$requiredKey] } else { $null }
+    } elseif ($Transition.PSObject.Properties[$requiredKey]) {
+      $Transition.$requiredKey
+    } else {
+      $null
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$value)) {
+      return $false
+    }
+  }
+  return $true
+}
+
+function Get-HandoffPlaneTransitionSummary {
+  param(
+    [string]$RepoRoot,
+    [string]$ResultsRoot
+  )
+
+  $summary = [ordered]@{
+    schema = 'agent-handoff/plane-transition-v1'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    repoRoot = $RepoRoot
+    resultsRoot = $ResultsRoot
+    status = 'unavailable'
+    reason = 'no-source-receipts'
+    transitionCount = 0
+    transitions = @()
+    sources = @()
+  }
+
+  $candidateRoots = [System.Collections.Generic.List[string]]::new()
+  foreach ($root in @($ResultsRoot, (Join-Path $RepoRoot 'tests/results'))) {
+    if ([string]::IsNullOrWhiteSpace($root)) { continue }
+    $resolved = [System.IO.Path]::GetFullPath($root)
+    if (-not $candidateRoots.Contains($resolved)) {
+      $candidateRoots.Add($resolved) | Out-Null
+    }
+  }
+
+  $candidateSpecs = [System.Collections.Generic.List[hashtable]]::new()
+  foreach ($root in $candidateRoots) {
+    $candidateSpecs.Add(@{ path = Join-Path $root 'origin-upstream-parity.json'; sourceType = 'parity'; label = 'results-root-parity' }) | Out-Null
+    $candidateSpecs.Add(@{ path = Join-Path $root '_agent/issue/develop-sync-report.json'; sourceType = 'develop-sync'; label = 'develop-sync-report' }) | Out-Null
+    $candidateSpecs.Add(@{ path = Join-Path $root '_agent/issue/origin-upstream-parity.json'; sourceType = 'parity'; label = 'origin-upstream-parity' }) | Out-Null
+    $candidateSpecs.Add(@{ path = Join-Path $root '_agent/issue/personal-upstream-parity.json'; sourceType = 'parity'; label = 'personal-upstream-parity' }) | Out-Null
+    $candidateSpecs.Add(@{ path = Join-Path $root '_agent/issue/origin-protected-develop-sync.json'; sourceType = 'protected-sync'; label = 'origin-protected-sync' }) | Out-Null
+    $candidateSpecs.Add(@{ path = Join-Path $root '_agent/issue/personal-protected-develop-sync.json'; sourceType = 'protected-sync'; label = 'personal-protected-sync' }) | Out-Null
+  }
+
+  $seenPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $hadFailure = $false
+
+  foreach ($spec in $candidateSpecs) {
+    $candidatePath = [System.IO.Path]::GetFullPath([string]$spec.path)
+    if (-not $seenPaths.Add($candidatePath)) {
+      continue
+    }
+    if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
+      continue
+    }
+
+    $sourceRecord = [ordered]@{
+      path = $candidatePath
+      sourceType = $spec.sourceType
+      label = $spec.label
+      schema = $null
+      status = 'ok'
+      transitionCount = 0
+      error = $null
+    }
+
+    try {
+      $payload = Get-Content -LiteralPath $candidatePath -Raw | ConvertFrom-Json -Depth 40 -ErrorAction Stop
+    } catch {
+      $sourceRecord.status = 'invalid-json'
+      $sourceRecord.error = $_.Exception.Message
+      $summary.sources += $sourceRecord
+      $hadFailure = $true
+      continue
+    }
+
+    if ($payload.PSObject.Properties['schema']) {
+      $sourceRecord.schema = [string]$payload.schema
+    }
+
+    $transitionsForSource = @()
+    if ($spec.sourceType -eq 'develop-sync') {
+      $actions = if ($payload.PSObject.Properties['actions']) { @($payload.actions) } else { @() }
+      foreach ($entry in $actions) {
+        $transition = if ($entry.PSObject.Properties['planeTransition']) { $entry.planeTransition } else { $null }
+        if (-not (Test-PlaneTransitionRecord -Transition $transition)) {
+          continue
+        }
+        $transitionsForSource += [ordered]@{
+          from = [string]$transition.from
+          to = [string]$transition.to
+          action = [string]$transition.action
+          via = [string]$transition.via
+          baseRepository = if ($transition.PSObject.Properties['baseRepository']) { [string]$transition.baseRepository } else { $null }
+          headRepository = if ($transition.PSObject.Properties['headRepository']) { [string]$transition.headRepository } else { $null }
+          sourcePath = $candidatePath
+          sourceSchema = $sourceRecord.schema
+          sourceType = $spec.sourceType
+          sourceLabel = $spec.label
+          remote = if ($entry.PSObject.Properties['remote']) { [string]$entry.remote } else { $null }
+        }
+      }
+      if ($actions.Count -gt 0 -and $transitionsForSource.Count -eq 0) {
+        $sourceRecord.status = 'missing-plane-transition'
+        $sourceRecord.error = 'No valid planeTransition entries were found in develop-sync actions.'
+        $hadFailure = $true
+      }
+    } else {
+      $transition = if ($payload.PSObject.Properties['planeTransition']) { $payload.planeTransition } else { $null }
+      if (Test-PlaneTransitionRecord -Transition $transition) {
+        $transitionsForSource += [ordered]@{
+          from = [string]$transition.from
+          to = [string]$transition.to
+          action = [string]$transition.action
+          via = [string]$transition.via
+          baseRepository = if ($transition.PSObject.Properties['baseRepository']) { [string]$transition.baseRepository } else { $null }
+          headRepository = if ($transition.PSObject.Properties['headRepository']) { [string]$transition.headRepository } else { $null }
+          sourcePath = $candidatePath
+          sourceSchema = $sourceRecord.schema
+          sourceType = $spec.sourceType
+          sourceLabel = $spec.label
+          remote = $null
+        }
+      } else {
+        $sourceRecord.status = 'missing-plane-transition'
+        $sourceRecord.error = 'Source report exists but does not contain a complete planeTransition payload.'
+        $hadFailure = $true
+      }
+    }
+
+    $sourceRecord.transitionCount = $transitionsForSource.Count
+    if ($transitionsForSource.Count -gt 0) {
+      $summary.transitions += $transitionsForSource
+    }
+    $summary.sources += $sourceRecord
+  }
+
+  $summary.transitionCount = @($summary.transitions).Count
+  if (@($summary.sources).Count -eq 0) {
+    $summary.status = 'unavailable'
+    $summary.reason = 'no-source-receipts'
+  } elseif ($hadFailure) {
+    $summary.status = 'fail'
+    $summary.reason = 'invalid-plane-transition-evidence'
+  } elseif ($summary.transitionCount -gt 0) {
+    $summary.status = 'ok'
+    $summary.reason = $null
+  } else {
+    $summary.status = 'unavailable'
+    $summary.reason = 'no-valid-plane-transitions'
+  }
+
+  return $summary
+}
+
+function Write-HandoffPlaneTransitionSummary {
+  param(
+    [string]$RepoRoot,
+    [string]$ResultsRoot
+  )
+
+  $summary = Get-HandoffPlaneTransitionSummary -RepoRoot $RepoRoot -ResultsRoot $ResultsRoot
+  $handoffDir = Join-Path $ResultsRoot '_agent/handoff'
+  New-Item -ItemType Directory -Force -Path $handoffDir | Out-Null
+  $summaryPath = Join-Path $handoffDir 'plane-transition.json'
+  ($summary | ConvertTo-Json -Depth 8) | Out-File -FilePath $summaryPath -Encoding utf8
+
+  Write-Host ''
+  Write-Host '[Plane Transition Evidence]' -ForegroundColor Cyan
+  Write-Host ("  status   : {0}" -f (Format-NullableValue $summary.status))
+  Write-Host ("  count    : {0}" -f (Format-NullableValue $summary.transitionCount))
+  if ($summary.reason) {
+    Write-Host ("  reason   : {0}" -f (Format-NullableValue $summary.reason))
+  }
+  foreach ($transition in @($summary.transitions | Select-Object -First 5)) {
+    $remoteLabel = if ($transition.remote) { " remote=$($transition.remote)" } else { '' }
+    Write-Host ("  - {0}->{1} ({2}) via {3}{4}" -f $transition.from, $transition.to, $transition.action, $transition.via, $remoteLabel)
+  }
+
+  if ($env:GITHUB_STEP_SUMMARY) {
+    $lines = @(
+      '### Plane Transition Evidence',
+      '',
+      ('- Status: {0}' -f (Format-NullableValue $summary.status)),
+      ('- Count: {0}' -f (Format-NullableValue $summary.transitionCount))
+    )
+    if ($summary.reason) {
+      $lines += ('- Reason: {0}' -f (Format-NullableValue $summary.reason))
+    }
+    foreach ($transition in @($summary.transitions | Select-Object -First 5)) {
+      $transitionLabel = '{0}->{1} ({2}) via {3}' -f $transition.from, $transition.to, $transition.action, $transition.via
+      if ($transition.remote) {
+        $transitionLabel = '{0} [remote={1}]' -f $transitionLabel, $transition.remote
+      }
+      $lines += ('- {0}' -f $transitionLabel)
+    }
+    ($lines -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+  }
+
+  return $summary
+}
+
 function Write-AgentSessionCapsule {
   param(
-    [string]$ResultsRoot
+    [string]$ResultsRoot,
+    [psobject]$PlaneTransitionSummary = $null
   )
 
   $repoRoot = (Resolve-Path '.').Path
@@ -541,6 +756,7 @@ function Write-AgentSessionCapsule {
     @{ name = 'handoff.releaseSummary'; path = Join-Path $handoffDir 'release-summary.json' },
     @{ name = 'handoff.issueSummary'; path = Join-Path $handoffDir 'issue-summary.json' },
     @{ name = 'handoff.dockerReviewLoopSummary'; path = Join-Path $handoffDir 'docker-review-loop-summary.json' },
+    @{ name = 'handoff.planeTransition'; path = Join-Path $handoffDir 'plane-transition.json' },
     @{ name = 'handoff.router'; path = Join-Path $handoffDir 'issue-router.json' },
     @{ name = 'handoff.localStatus'; path = Join-Path $handoffDir 'local-status.txt' },
     @{ name = 'handoff.localDiff'; path = Join-Path $handoffDir 'local-diff.txt' },
@@ -605,6 +821,7 @@ function Write-AgentSessionCapsule {
   }
 
   if ($gitInfo) { $capsule.git = $gitInfo }
+  if ($PlaneTransitionSummary) { $capsule.planeTransitions = $PlaneTransitionSummary }
 
   if ($priorityContext) {
     $topActions = $null
@@ -751,7 +968,8 @@ function Write-HookSummaries {
 function Write-WatcherStatusSummary {
   param(
     [string]$ResultsRoot,
-    [switch]$RequestAutoTrim
+    [switch]$RequestAutoTrim,
+    [psobject]$PlaneTransitionSummary = $null
   )
 
   $repoRoot = (Resolve-Path '.').Path
@@ -935,6 +1153,7 @@ function Write-WatcherStatusSummary {
     outPath = if ($status.files -and $status.files.out) { $status.files.out.path } else { $null }
     errPath = if ($status.files -and $status.files.err) { $status.files.err.path } else { $null }
     events = if ($watcherEvents) { $watcherEvents } else { $null }
+    planeTransitions = if ($PlaneTransitionSummary) { $PlaneTransitionSummary } else { $null }
     autoTrim = if ($autoTrim) {
       [ordered]@{
         eligible = $autoTrim.eligible
@@ -988,6 +1207,12 @@ function Write-WatcherStatusSummary {
           }
         }
         $summaryLines += "- Events Last: $eventSummary"
+      }
+    }
+    if ($PlaneTransitionSummary) {
+      $summaryLines += "- Plane Transitions: $(Format-NullableValue $PlaneTransitionSummary.status) ($((Format-NullableValue $PlaneTransitionSummary.transitionCount)))"
+      if ($PlaneTransitionSummary.reason) {
+        $summaryLines += "- Plane Transition Reason: $(Format-NullableValue $PlaneTransitionSummary.reason)"
       }
     }
     if ($autoTrim) {
@@ -1303,7 +1528,8 @@ try {
   Write-Warning ("Failed to read test summary: {0}" -f $_.Exception.Message)
 }
 
-Write-WatcherStatusSummary -ResultsRoot $ResultsRoot -RequestAutoTrim:$AutoTrim
+$planeTransitionSummary = Write-HandoffPlaneTransitionSummary -RepoRoot $repoRoot -ResultsRoot $ResultsRoot
+Write-WatcherStatusSummary -ResultsRoot $ResultsRoot -RequestAutoTrim:$AutoTrim -PlaneTransitionSummary $planeTransitionSummary
 
 try {
   Write-RogueLVSummary -RepoRoot $repoRoot -ResultsRoot $ResultsRoot | Out-Null
@@ -1326,7 +1552,7 @@ if ($hookSummaries -and $hookSummaries.Count -gt 0) {
   ($hookSummaries | ConvertTo-Json -Depth 4) | Out-File -FilePath (Join-Path $handoffDir 'hook-summary.json') -Encoding utf8
 }
 
-Write-AgentSessionCapsule -ResultsRoot $ResultsRoot
+Write-AgentSessionCapsule -ResultsRoot $ResultsRoot -PlaneTransitionSummary $planeTransitionSummary
 
 if ($OpenDashboard) {
   $cli = Join-Path (Resolve-Path '.').Path 'tools/Dev-Dashboard.ps1'

--- a/tools/Update-SessionIndexParity.ps1
+++ b/tools/Update-SessionIndexParity.ps1
@@ -55,6 +55,7 @@ function New-UnavailableParityPayload {
       baseOnly = $null
       headOnly = $null
     }
+    planeTransition = $null
   }
 }
 
@@ -129,6 +130,40 @@ function Convert-ToParityTelemetry {
     $headOnly = Get-ChildValue -Object $commitDivergence -Name 'headOnly'
   }
 
+  $planeTransition = $null
+  $planeTransitionNode = Get-ChildValue -Object $ParityReport -Name 'planeTransition'
+  if ($null -ne $planeTransitionNode) {
+    $fromPlane = [string](Get-ChildValue -Object $planeTransitionNode -Name 'from')
+    $toPlane = [string](Get-ChildValue -Object $planeTransitionNode -Name 'to')
+    $action = [string](Get-ChildValue -Object $planeTransitionNode -Name 'action')
+    $via = [string](Get-ChildValue -Object $planeTransitionNode -Name 'via')
+    if (
+      -not [string]::IsNullOrWhiteSpace($fromPlane) -and
+      -not [string]::IsNullOrWhiteSpace($toPlane) -and
+      -not [string]::IsNullOrWhiteSpace($action) -and
+      -not [string]::IsNullOrWhiteSpace($via)
+    ) {
+      $planeTransition = [ordered]@{
+        from = $fromPlane
+        to = $toPlane
+        action = $action
+        via = $via
+        baseRepository = if ($null -ne (Get-ChildValue -Object $planeTransitionNode -Name 'baseRepository')) { [string](Get-ChildValue -Object $planeTransitionNode -Name 'baseRepository') } else { $null }
+        headRepository = if ($null -ne (Get-ChildValue -Object $planeTransitionNode -Name 'headRepository')) { [string](Get-ChildValue -Object $planeTransitionNode -Name 'headRepository') } else { $null }
+      }
+    }
+  }
+
+  if ($status -eq 'ok' -and $null -eq $planeTransition) {
+    $status = 'fail'
+    $existingReason = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'reason')) { [string](Get-ChildValue -Object $ParityReport -Name 'reason') } else { '' }
+    $missingReason = 'missing-plane-transition'
+    if (-not [string]::IsNullOrWhiteSpace($existingReason)) {
+      $missingReason = '{0}; {1}' -f $existingReason, $missingReason
+    }
+    $ParityReport | Add-Member -NotePropertyName 'reason' -NotePropertyValue $missingReason -Force
+  }
+
   return [ordered]@{
     schema      = if ($null -ne (Get-ChildValue -Object $ParityReport -Name 'schema')) { [string](Get-ChildValue -Object $ParityReport -Name 'schema') } else { 'origin-upstream-parity@v1' }
     status      = $status
@@ -156,6 +191,7 @@ function Convert-ToParityTelemetry {
       baseOnly = $baseOnly
       headOnly = $headOnly
     }
+    planeTransition = $planeTransition
   }
 }
 
@@ -170,6 +206,22 @@ function Write-ParityStepSummary {
   $treeParityStatus = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'treeParity') -Name 'status'
   $historyParityStatus = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'historyParity') -Name 'status'
   $recommendationCode = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'recommendation') -Name 'code'
+  $planeTransition = Get-ChildValue -Object $Parity -Name 'planeTransition'
+  $planeTransitionLabel = 'n/a'
+  if ($null -ne $planeTransition) {
+    $fromPlane = Get-ChildValue -Object $planeTransition -Name 'from'
+    $toPlane = Get-ChildValue -Object $planeTransition -Name 'to'
+    $via = Get-ChildValue -Object $planeTransition -Name 'via'
+    if (
+      -not [string]::IsNullOrWhiteSpace([string]$fromPlane) -and
+      -not [string]::IsNullOrWhiteSpace([string]$toPlane)
+    ) {
+      $planeTransitionLabel = '{0}->{1}' -f $fromPlane, $toPlane
+      if (-not [string]::IsNullOrWhiteSpace([string]$via)) {
+        $planeTransitionLabel = '{0} ({1})' -f $planeTransitionLabel, $via
+      }
+    }
+  }
 
   $statusValue = if ($Parity.status) { [string]$Parity.status } else { 'unavailable' }
   $reasonValue = if ($Parity.reason) { [string]$Parity.reason } else { '' }
@@ -187,6 +239,7 @@ function Write-ParityStepSummary {
     ('| Status | {0} |' -f $statusValue),
     ('| Tree Parity | {0} |' -f $treeParityValue),
     ('| History Parity | {0} |' -f $historyParityValue),
+    ('| Plane Transition | {0} |' -f $planeTransitionLabel),
     ('| Tip Diff File Count | {0} |' -f $tipDiffValue),
     ('| Commit Divergence (base-only/head-only) | {0} |' -f $divergenceValue),
     ('| Recommendation | {0} |' -f $recommendationValue)

--- a/tools/priority/Import-HandoffState.ps1
+++ b/tools/priority/Import-HandoffState.ps1
@@ -37,6 +37,7 @@ $issueSummary = Read-HandoffJson -Name 'issue-summary.json'
 $issueRouter  = Read-HandoffJson -Name 'issue-router.json'
 $hookSummary  = Read-HandoffJson -Name 'hook-summary.json'
 $watcherTelemetry = Read-HandoffJson -Name 'watcher-telemetry.json'
+$planeTransitionSummary = Read-HandoffJson -Name 'plane-transition.json'
 $releaseSummary = Read-HandoffJson -Name 'release-summary.json'
 $testSummary = Read-HandoffJson -Name 'test-summary.json'
 $dockerReviewLoopSummary = Read-HandoffJson -Name 'docker-review-loop-summary.json'
@@ -91,6 +92,21 @@ if ($watcherTelemetry) {
     }
   }
   Set-Variable -Name WatcherHandoffTelemetry -Scope Global -Value $watcherTelemetry -Force
+}
+
+if ($planeTransitionSummary) {
+  Write-Host '[handoff] Plane transition evidence' -ForegroundColor Cyan
+  Write-Host ("  status   : {0}" -f (Format-NullableValue $planeTransitionSummary.status))
+  Write-Host ("  count    : {0}" -f (Format-NullableValue $planeTransitionSummary.transitionCount))
+  if ($planeTransitionSummary.reason) {
+    Write-Host ("  reason   : {0}" -f (Format-NullableValue $planeTransitionSummary.reason))
+  }
+  foreach ($transition in @($planeTransitionSummary.transitions | Select-Object -First 5)) {
+    $remoteValue = if ($transition.PSObject.Properties['remote']) { $transition.remote } else { $null }
+    $remoteLabel = if ($remoteValue) { " remote=$remoteValue" } else { '' }
+    Write-Host ("  - {0}->{1} ({2}) via {3}{4}" -f (Format-NullableValue $transition.from), (Format-NullableValue $transition.to), (Format-NullableValue $transition.action), (Format-NullableValue $transition.via), $remoteLabel)
+  }
+  Set-Variable -Name PlaneTransitionHandoffSummary -Scope Global -Value $planeTransitionSummary -Force
 }
 
 if ($releaseSummary) {


### PR DESCRIPTION
## Summary
Carry explicit fork-plane transition evidence into session-index parity enrichment and agent handoff artifacts so future agents do not have to infer `personal` / `origin` / `upstream` movement from branch names or unrelated receipts.

## What changed
- session-index parity enrichment now mirrors `planeTransition` evidence and fails closed when an `ok` parity report omits it
- `Print-AgentHandoff.ps1` now emits `tests/results/_agent/handoff/plane-transition.json`
- watcher telemetry and session capsules now include the same branch-plane evidence
- `Import-HandoffState.ps1` now surfaces the handoff plane-transition summary directly

## Validation
- `Invoke-Pester -Path tests/Update-SessionIndexParity.Tests.ps1,tests/AgentHandoff.Local.Tests.ps1,tests/AgentHandoff.PlaneTransition.Tests.ps1,tests/Import-HandoffState.Tests.ps1,tests/Watcher.TelemetrySchema.Tests.ps1 -CI`

## Issue
- Closes #1127

## Agent Metadata
- issue: #1127
- branch: `issue/personal-1127-session-handoff-plane-evidence`
- head: `5856815b`
- head-remote: `personal`
