### PR TITLE
#1129 Record fork-plane transitions in daemon runtime receipts

### DIFF
--- a/docs/schemas/delivery-agent-runtime-state-v1.schema.json
+++ b/docs/schemas/delivery-agent-runtime-state-v1.schema.json
@@ -117,6 +117,19 @@
         "retryable": { "type": "boolean" },
         "nextWakeCondition": { "type": ["string", "null"] },
         "reviewPhase": { "type": ["string", "null"] },
+        "planeTransition": {
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "properties": {
+            "from": { "type": ["string", "null"] },
+            "to": { "type": ["string", "null"] },
+            "action": { "type": ["string", "null"] },
+            "via": { "type": ["string", "null"] },
+            "branchClass": { "type": ["string", "null"] },
+            "sourceRepository": { "type": ["string", "null"] },
+            "targetRepository": { "type": ["string", "null"] }
+          }
+        },
         "readyValidationClearance": {
           "type": ["object", "null"],
           "additionalProperties": true,

--- a/docs/schemas/runtime-delivery-task-packet-v1.schema.json
+++ b/docs/schemas/runtime-delivery-task-packet-v1.schema.json
@@ -56,6 +56,19 @@
             "issueGraph": { "type": ["object", "null"], "additionalProperties": true },
             "pullRequest": { "type": ["object", "null"], "additionalProperties": true },
             "backlog": { "type": ["object", "null"], "additionalProperties": true },
+            "planeTransition": {
+              "type": ["object", "null"],
+              "additionalProperties": true,
+              "properties": {
+                "from": { "type": ["string", "null"] },
+                "to": { "type": ["string", "null"] },
+                "action": { "type": ["string", "null"] },
+                "via": { "type": ["string", "null"] },
+                "branchClass": { "type": ["string", "null"] },
+                "sourceRepository": { "type": ["string", "null"] },
+                "targetRepository": { "type": ["string", "null"] }
+              }
+            },
             "localReviewLoop": { "type": ["object", "null"], "additionalProperties": true },
             "mutationEnvelope": { "type": "object", "additionalProperties": true },
             "turnBudget": { "type": "object", "additionalProperties": true },

--- a/tools/priority/__tests__/branch-classification.test.mjs
+++ b/tools/priority/__tests__/branch-classification.test.mjs
@@ -13,6 +13,7 @@ import {
   loadBranchClassContract,
   matchBranchPattern,
   normalizeBranchName,
+  resolveBranchPlaneTransition,
   resolveLaneBranchPrefix,
   resolveRepositoryPlane,
   resolveRepositoryRole
@@ -72,6 +73,33 @@ test('assertPlaneTransition accepts tracked fork-plane edges and rejects undefin
       }),
     /plane transition origin --review--> personal is not allowed/i
   );
+});
+
+test('resolveBranchPlaneTransition resolves allowed lane promotions and review hops', () => {
+  const promoteTransition = resolveBranchPlaneTransition({
+    branch: 'issue/origin-1129-runtime-plane-transition-receipts',
+    sourcePlane: 'origin',
+    targetRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    contract
+  });
+  assert.deepEqual(promoteTransition, {
+    from: 'origin',
+    to: 'upstream',
+    action: 'promote',
+    via: 'pull-request',
+    branchClass: 'lane',
+    sourceRepository: 'labview-community-ci-cd/compare-vi-cli-action-fork',
+    targetRepository: 'labview-community-ci-cd/compare-vi-cli-action'
+  });
+
+  const reviewTransition = resolveBranchPlaneTransition({
+    branch: 'issue/personal-1084-fork-plane-branching-model',
+    sourcePlane: 'personal',
+    targetRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork',
+    contract
+  });
+  assert.equal(reviewTransition.action, 'review');
+  assert.equal(reviewTransition.to, 'origin');
 });
 
 test('loadBranchClassContract rejects missing or invalid upstreamRepository slugs', () => {

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -146,6 +146,15 @@ test('runtime delivery task packet schema validates canonical delivery packets',
           title: 'Wire canonical delivery broker',
           url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1012'
         },
+        planeTransition: {
+          from: 'origin',
+          to: 'upstream',
+          action: 'promote',
+          via: 'pull-request',
+          branchClass: 'lane',
+          sourceRepository: 'labview-community-ci-cd/compare-vi-cli-action-fork',
+          targetRepository: 'labview-community-ci-cd/compare-vi-cli-action'
+        },
         localReviewLoop: {
           requested: true,
           source: 'standing-issue-body',
@@ -222,6 +231,7 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
   const schema = await loadSchema('docs/schemas/delivery-agent-runtime-state-v1.schema.json');
   const state = buildDeliveryAgentRuntimeRecord({
     now: new Date('2026-03-11T08:10:00.000Z'),
+    repoRoot,
     repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
     runtimeDir: path.join(repoRoot, 'tests/results/_agent/runtime'),
     policy: {
@@ -249,10 +259,12 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
       },
       artifacts: {
         selectedActionType: 'existing-pr-unblock',
-        laneLifecycle: 'ready-merge'
+        laneLifecycle: 'ready-merge',
+        canonicalRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
       }
     },
     taskPacket: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
       laneId: 'origin-1012',
       branch: {
         name: 'issue/origin-1012-wire-canonical-delivery-broker',
@@ -267,6 +279,15 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
       evidence: {
         delivery: {
           laneLifecycle: 'ready-merge',
+          planeTransition: {
+            from: 'origin',
+            to: 'upstream',
+            action: 'promote',
+            via: 'pull-request',
+            branchClass: 'lane',
+            sourceRepository: 'labview-community-ci-cd/compare-vi-cli-action-fork',
+            targetRepository: 'labview-community-ci-cd/compare-vi-cli-action'
+          },
           localReviewLoop: {
             requested: true,
             source: 'standing-issue-body',
@@ -393,6 +414,9 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
     state.artifacts.localReviewLoopReceiptPath,
     'tests/results/docker-tools-parity/review-loop-receipt.json'
   );
+  assert.equal(state.activeLane.planeTransition.from, 'origin');
+  assert.equal(state.activeLane.planeTransition.to, 'upstream');
+  assert.equal(state.artifacts.planeTransition.action, 'promote');
 });
 
 test('delivery memory schema validates suite-aware terminal PR history', async () => {
@@ -475,4 +499,55 @@ test('delivery agent runtime state schema accepts legacy policy payloads without
     }
   };
   assert.equal(validate(state), true, JSON.stringify(validate.errors, null, 2));
+});
+
+test('buildDeliveryAgentRuntimeRecord fails closed when a fork lane omits required planeTransition evidence', () => {
+  assert.throws(
+    () =>
+      buildDeliveryAgentRuntimeRecord({
+        now: new Date('2026-03-13T19:00:00.000Z'),
+        repoRoot,
+        repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        runtimeDir: path.join(repoRoot, 'tests/results/_agent/runtime'),
+        policy: {
+          schema: 'priority/delivery-agent-policy@v1',
+          implementationRemote: 'origin',
+          maxActiveCodingLanes: 1
+        },
+        schedulerDecision: {
+          activeLane: {
+            laneId: 'origin-1129',
+            issue: 1129,
+            forkRemote: 'origin',
+            branch: 'issue/origin-1129-runtime-plane-transition-receipts'
+          }
+        },
+        taskPacket: {
+          repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          laneId: 'origin-1129',
+          branch: {
+            name: 'issue/origin-1129-runtime-plane-transition-receipts',
+            forkRemote: 'origin'
+          },
+          evidence: {
+            delivery: {
+              laneLifecycle: 'coding',
+              mutationEnvelope: {
+                implementationRemote: 'origin'
+              }
+            }
+          }
+        },
+        executionReceipt: {
+          outcome: 'waiting-review',
+          details: {
+            laneLifecycle: 'waiting-review',
+            blockerClass: 'review'
+          }
+        },
+        statePath: path.join(repoRoot, 'tests/results/_agent/runtime/delivery-agent-state.json'),
+        lanePath: path.join(repoRoot, 'tests/results/_agent/runtime/delivery-agent-lanes/origin-1129.json')
+      }),
+    /missing planeTransition evidence/i
+  );
 });

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -185,6 +185,10 @@ test('buildCompareviTaskPacket carries a daemon-requested Docker/Desktop review 
   assert.equal(packet.evidence.delivery.localReviewLoop.requirementsVerification, true);
   assert.equal(packet.evidence.delivery.localReviewLoop.niLinuxReviewSuite, true);
   assert.equal(packet.evidence.delivery.localReviewLoop.singleViHistory, null);
+  assert.equal(packet.evidence.delivery.planeTransition.from, 'origin');
+  assert.equal(packet.evidence.delivery.planeTransition.to, 'upstream');
+  assert.equal(packet.evidence.delivery.planeTransition.action, 'promote');
+  assert.equal(packet.evidence.delivery.planeTransition.branchClass, 'lane');
 });
 
 test('buildCompareviTaskPacket honors local review-loop directives from the selected issue when the standing issue body lacks them', async () => {
@@ -349,13 +353,120 @@ test('buildCompareviTaskPacket honors deps.deliveryAgentPolicyPath overrides', a
       checkoutPath: '/tmp/worker'
     },
     deps: {
-      deliveryAgentPolicyPath: policyPath
+      deliveryAgentPolicyPath: policyPath,
+      loadBranchClassContractFn: () => ({
+        schema: 'branch-classes/v1',
+        upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        repositoryPlanes: [
+          {
+            id: 'origin',
+            repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+            laneBranchPrefix: 'issue/origin-'
+          }
+        ],
+        classes: [
+          {
+            id: 'lane',
+            repositoryRoles: ['fork'],
+            branchPatterns: ['issue/*'],
+            purpose: 'lane',
+            prSourceAllowed: true,
+            prTargetAllowed: false,
+            mergePolicy: 'n/a'
+          }
+        ],
+        allowedTransitions: [
+          {
+            from: 'lane',
+            action: 'promote',
+            to: 'upstream-integration',
+            via: 'pull-request'
+          }
+        ],
+        planeTransitions: [
+          {
+            from: 'origin',
+            action: 'promote',
+            to: 'upstream',
+            via: 'pull-request',
+            branchClass: 'lane'
+          }
+        ]
+      })
     }
   });
 
   assert.equal(packet.evidence.delivery.turnBudget.maxMinutes, 7);
   assert.equal(packet.evidence.delivery.turnBudget.maxToolCalls, 3);
   assert.equal(packet.evidence.delivery.localReviewLoop, null);
+  assert.equal(packet.evidence.delivery.planeTransition.from, 'origin');
+  assert.equal(packet.evidence.delivery.planeTransition.to, 'upstream');
+});
+
+test('buildCompareviTaskPacket fails closed when the branch class contract has no matching plane transition', async () => {
+  await assert.rejects(
+    compareviRuntimeTest.buildCompareviTaskPacket({
+      repoRoot,
+      schedulerDecision: {
+        activeLane: {
+          issue: 1129,
+          branch: 'issue/origin-1129-runtime-plane-transition-receipts',
+          forkRemote: 'origin'
+        },
+        artifacts: {
+          executionMode: 'canonical-delivery',
+          selectedActionType: 'advance-child-issue',
+          laneLifecycle: 'coding',
+          canonicalRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          selectedIssueSnapshot: {
+            number: 1129,
+            title: 'Record fork-plane transitions in daemon runtime receipts',
+            url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1129'
+          }
+        }
+      },
+      preparedWorker: { checkoutPath: '/tmp/worker' },
+      workerReady: { checkoutPath: '/tmp/worker' },
+      workerBranch: {
+        branch: 'issue/origin-1129-runtime-plane-transition-receipts',
+        checkoutPath: '/tmp/worker'
+      },
+      deps: {
+        loadBranchClassContractFn: () => ({
+          schema: 'branch-classes/v1',
+          upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          repositoryPlanes: [
+            {
+              id: 'origin',
+              repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+              laneBranchPrefix: 'issue/origin-'
+            }
+          ],
+          classes: [
+            {
+              id: 'lane',
+              repositoryRoles: ['fork'],
+              branchPatterns: ['issue/*'],
+              purpose: 'lane',
+              prSourceAllowed: true,
+              prTargetAllowed: false,
+              mergePolicy: 'n/a'
+            }
+          ],
+          allowedTransitions: [
+            {
+              from: 'lane',
+              action: 'promote',
+              to: 'upstream-integration',
+              via: 'pull-request'
+            }
+          ],
+          planeTransitions: []
+        })
+      }
+    }),
+    /not allowed by the branch class contract/i
+  );
 });
 
 test('buildLocalReviewLoopRequest treats policy booleans as the full requested check set once the marker is present', () => {
@@ -1983,6 +2094,15 @@ test('comparevi canonical execution delegates to the delivery broker instead of 
         delivery: {
           laneLifecycle: 'coding',
           selectedActionType: 'advance-child-issue',
+          planeTransition: {
+            from: 'origin',
+            to: 'upstream',
+            action: 'promote',
+            via: 'pull-request',
+            branchClass: 'lane',
+            sourceRepository: 'labview-community-ci-cd/compare-vi-cli-action-fork',
+            targetRepository: 'labview-community-ci-cd/compare-vi-cli-action'
+          },
           mutationEnvelope: {
             maxActiveCodingLanes: 1
           },
@@ -2015,6 +2135,45 @@ test('comparevi canonical execution delegates to the delivery broker instead of 
       runtimeDir: '/tmp/repo/tests/results/_agent/runtime'
     },
     deps: {
+      loadBranchClassContractFn: () => ({
+        schema: 'branch-classes/v1',
+        upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        repositoryPlanes: [
+          {
+            id: 'origin',
+            repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+            laneBranchPrefix: 'issue/origin-'
+          }
+        ],
+        classes: [
+          {
+            id: 'lane',
+            repositoryRoles: ['fork'],
+            branchPatterns: ['issue/*'],
+            purpose: 'lane',
+            prSourceAllowed: true,
+            prTargetAllowed: false,
+            mergePolicy: 'n/a'
+          }
+        ],
+        allowedTransitions: [
+          {
+            from: 'lane',
+            action: 'promote',
+            to: 'upstream-integration',
+            via: 'pull-request'
+          }
+        ],
+        planeTransitions: [
+          {
+            from: 'origin',
+            action: 'promote',
+            to: 'upstream',
+            via: 'pull-request',
+            branchClass: 'lane'
+          }
+        ]
+      }),
       invokeDeliveryTurnBrokerFn: async () => ({
         status: 'completed',
         outcome: 'coding-command-finished',
@@ -2069,7 +2228,16 @@ test('comparevi canonical execution consumes the broker receipt file when stdout
       evidence: {
         delivery: {
           laneLifecycle: 'ready-merge',
-          selectedActionType: 'merge-pr'
+          selectedActionType: 'merge-pr',
+          planeTransition: {
+            from: 'origin',
+            to: 'upstream',
+            action: 'promote',
+            via: 'pull-request',
+            branchClass: 'lane',
+            sourceRepository: 'labview-community-ci-cd/compare-vi-cli-action-fork',
+            targetRepository: 'labview-community-ci-cd/compare-vi-cli-action'
+          }
         }
       }
     },
@@ -2163,6 +2331,15 @@ test('comparevi canonical execution persists a broker-managed ready-for-review r
           },
           standingIssue: {
             number: 1010
+          },
+          planeTransition: {
+            from: 'origin',
+            to: 'upstream',
+            action: 'promote',
+            via: 'pull-request',
+            branchClass: 'lane',
+            sourceRepository: 'labview-community-ci-cd/compare-vi-cli-action-fork',
+            targetRepository: 'labview-community-ci-cd/compare-vi-cli-action'
           },
           pullRequest: {
             number: 1015,
@@ -2270,6 +2447,9 @@ test('comparevi canonical execution persists a broker-managed ready-for-review r
   assert.equal(persistedState.activeLane.reviewPhase, 'draft-review');
   assert.equal(persistedState.activeLane.pollIntervalSecondsHint, 10);
   assert.equal(persistedState.activeLane.reviewMonitor.workflowName, 'Copilot code review');
+  assert.equal(persistedState.activeLane.planeTransition.from, 'origin');
+  assert.equal(persistedState.activeLane.planeTransition.to, 'upstream');
+  assert.equal(persistedState.activeLane.planeTransition.action, 'promote');
   assert.equal(persistedState.localReviewLoop.status, 'passed');
   assert.equal(persistedState.localReviewLoop.receiptStatus, 'passed');
   assert.equal(persistedState.localReviewLoop.requirementsCoverage.requirementCovered, 9);

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { loadBranchClassContract, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
+import { loadBranchClassContract, resolveBranchPlaneTransition, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
 import {
   assessDockerDesktopReviewLoopReceipt,
   buildLocalReviewLoopCliArgs,
@@ -1730,8 +1730,107 @@ function buildReadyValidationClearanceRuntimeState({ taskPacket, executionReceip
   };
 }
 
+function normalizePlaneTransitionRecord(value) {
+  const record = normalizeOptionalObject(value);
+  if (!record) {
+    return null;
+  }
+  return {
+    from: normalizeText(record.from) || null,
+    to: normalizeText(record.to) || null,
+    action: normalizeText(record.action) || null,
+    via: normalizeText(record.via) || null,
+    branchClass: normalizeText(record.branchClass) || null,
+    sourceRepository: normalizeText(record.sourceRepository) || null,
+    targetRepository: normalizeText(record.targetRepository) || null
+  };
+}
+
+function planeTransitionRecordsMatch(expected, actual) {
+  if (!expected && !actual) {
+    return true;
+  }
+  if (!expected || !actual) {
+    return false;
+  }
+  return (
+    expected.from === actual.from &&
+    expected.to === actual.to &&
+    expected.action === actual.action &&
+    expected.via === actual.via &&
+    expected.branchClass === actual.branchClass &&
+    expected.sourceRepository === actual.sourceRepository &&
+    expected.targetRepository === actual.targetRepository
+  );
+}
+
+function resolveDeliveryPlaneTransition({
+  repoRoot = null,
+  repository,
+  policy,
+  schedulerDecision,
+  taskPacket
+}) {
+  const explicit = normalizePlaneTransitionRecord(
+    taskPacket?.evidence?.delivery?.planeTransition ??
+    schedulerDecision?.artifacts?.planeTransition
+  );
+  const branch =
+    normalizeText(taskPacket?.branch?.name) ||
+    normalizeText(schedulerDecision?.activeLane?.branch) ||
+    null;
+  const sourcePlane =
+    normalizeText(taskPacket?.branch?.forkRemote) ||
+    normalizeText(schedulerDecision?.activeLane?.forkRemote) ||
+    normalizeText(policy?.implementationRemote) ||
+    null;
+  const targetRepository =
+    normalizeText(taskPacket?.repository) ||
+    normalizeText(schedulerDecision?.artifacts?.canonicalRepository) ||
+    normalizeText(repository) ||
+    null;
+
+  if (!branch || !sourcePlane || !targetRepository || !repoRoot) {
+    return explicit;
+  }
+
+  let contract;
+  try {
+    contract = loadBranchClassContract(repoRoot);
+  } catch (error) {
+    if (explicit) {
+      return explicit;
+    }
+    throw error;
+  }
+  const expected = resolveBranchPlaneTransition({
+    branch,
+    sourcePlane,
+    targetRepository,
+    contract
+  });
+  if (!expected) {
+    if (explicit) {
+      throw new Error(`Unexpected planeTransition evidence for ${sourcePlane} lane '${branch}'.`);
+    }
+    return null;
+  }
+  if (!explicit) {
+    throw new Error(
+      `Missing planeTransition evidence for ${sourcePlane} lane '${branch}' targeting '${targetRepository}'.`
+    );
+  }
+  if (!planeTransitionRecordsMatch(expected, explicit)) {
+    throw new Error(
+      `planeTransition evidence for ${sourcePlane} lane '${branch}' does not match the branch class contract.`
+    );
+  }
+  return explicit;
+}
+
 export function buildDeliveryAgentRuntimeRecord({
   now = new Date(),
+  repoRoot = null,
   repository,
   runtimeDir,
   policy,
@@ -1779,6 +1878,13 @@ export function buildDeliveryAgentRuntimeRecord({
     null;
   const localReviewLoop = buildLocalReviewLoopRuntimeState({ taskPacket, executionReceipt });
   const readyValidationClearance = buildReadyValidationClearanceRuntimeState({ taskPacket, executionReceipt });
+  const planeTransition = resolveDeliveryPlaneTransition({
+    repoRoot,
+    repository,
+    policy,
+    schedulerDecision,
+    taskPacket
+  });
   return {
     schema: DELIVERY_AGENT_RUNTIME_STATE_SCHEMA,
     generatedAt: toIso(now),
@@ -1825,18 +1931,21 @@ export function buildDeliveryAgentRuntimeRecord({
       reviewPhase: normalizeText(executionReceipt?.details?.reviewPhase) || null,
       pollIntervalSecondsHint,
       reviewMonitor,
+      planeTransition,
       localReviewLoop,
       readyValidationClearance
     },
     artifacts: {
       statePath,
       lanePath,
-      localReviewLoopReceiptPath: normalizeText(localReviewLoop?.receiptPath) || null
+      localReviewLoopReceiptPath: normalizeText(localReviewLoop?.receiptPath) || null,
+      planeTransition
     }
   };
 }
 
 export async function persistDeliveryAgentRuntimeState({
+  repoRoot = null,
   runtimeDir,
   repository,
   policy,
@@ -1857,6 +1966,7 @@ export async function persistDeliveryAgentRuntimeState({
   const lanePath = path.join(lanesDir, `${sanitizeSegment(laneId)}.json`);
   const payload = buildDeliveryAgentRuntimeRecord({
     now,
+    repoRoot,
     repository,
     runtimeDir,
     policy,

--- a/tools/priority/lib/branch-classification.mjs
+++ b/tools/priority/lib/branch-classification.mjs
@@ -40,6 +40,10 @@ function normalizeRepositorySlug(value) {
   return String(value ?? '').trim().toLowerCase();
 }
 
+function normalizeText(value) {
+  return String(value ?? '').trim();
+}
+
 function escapeRegExp(value) {
   return String(value).replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
 }
@@ -200,6 +204,81 @@ export function assertPlaneTransition({
     );
   }
   return transition;
+}
+
+export function resolveBranchPlaneTransition({
+  branch,
+  sourcePlane,
+  targetRepository,
+  contract,
+  sourceRepository = null
+}) {
+  if (!contract || typeof contract !== 'object') {
+    throw new Error('Branch class contract is required.');
+  }
+
+  const normalizedSourcePlane = normalizeRepositoryPlane(sourcePlane);
+  const normalizedTargetRepository = normalizeRepositorySlug(targetRepository);
+  if (!normalizedTargetRepository) {
+    throw new Error('Target repository slug is required to resolve a branch plane transition.');
+  }
+
+  const targetPlane = resolveRepositoryPlane(normalizedTargetRepository, contract);
+  if (normalizedSourcePlane === targetPlane) {
+    return null;
+  }
+
+  const normalizedBranch = normalizeBranchName(branch);
+  if (!normalizedBranch) {
+    throw new Error(`Branch name is required to resolve plane transition ${normalizedSourcePlane}->${targetPlane}.`);
+  }
+
+  const resolvedSourceRepository =
+    normalizeRepositorySlug(sourceRepository) ||
+    normalizeRepositorySlug(
+      normalizedSourcePlane === 'upstream'
+        ? contract.upstreamRepository
+        : findRepositoryPlaneEntry(contract, normalizedSourcePlane)?.repositories?.[0]
+    ) ||
+    null;
+  const branchClassification = classifyBranch({
+    branch: normalizedBranch,
+    contract,
+    repositoryRole: normalizedSourcePlane === 'upstream' ? 'upstream' : 'fork',
+    repository: resolvedSourceRepository || normalizedTargetRepository
+  });
+  if (!branchClassification?.id) {
+    throw new Error(
+      `Unable to classify branch '${normalizedBranch}' for plane transition ${normalizedSourcePlane}->${targetPlane}.`
+    );
+  }
+
+  const matches = (contract.planeTransitions || []).filter((entry) => (
+    normalizeRepositoryPlane(entry?.from) === normalizedSourcePlane &&
+    normalizeRepositoryPlane(entry?.to) === targetPlane &&
+    normalizeText(entry?.branchClass) === branchClassification.id
+  ));
+  if (matches.length === 0) {
+    throw new Error(
+      `Plane transition ${normalizedSourcePlane}->${targetPlane} for branch class '${branchClassification.id}' is not allowed by the branch class contract.`
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous plane transition ${normalizedSourcePlane}->${targetPlane} for branch class '${branchClassification.id}'.`
+    );
+  }
+
+  const selected = matches[0];
+  return {
+    from: normalizedSourcePlane,
+    to: targetPlane,
+    action: normalizeText(selected.action),
+    via: normalizeText(selected.via),
+    branchClass: branchClassification.id,
+    sourceRepository: resolvedSourceRepository,
+    targetRepository: normalizedTargetRepository
+  };
 }
 
 export function resolveLaneBranchPrefix({

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -28,7 +28,7 @@ import {
   runRuntimeSupervisor as runCoreRuntimeSupervisor
 } from '../../packages/runtime-harness/index.mjs';
 import { acquireWriterLease, defaultOwner, releaseWriterLease } from './agent-writer-lease.mjs';
-import { loadBranchClassContract, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
+import { loadBranchClassContract, resolveBranchPlaneTransition, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import { handoffStandingPriority } from './standing-priority-handoff.mjs';
 import {
@@ -548,6 +548,18 @@ async function buildCompareviTaskPacket({ repoRoot, schedulerDecision, preparedW
   const branchName = normalizeText(workerBranch?.branch) || normalizeText(activeLane?.branch);
   const selectedActionType = normalizeText(artifacts.selectedActionType);
   const laneLifecycle = normalizeText(artifacts.laneLifecycle) || (activeLane?.prUrl ? 'waiting-ci' : 'coding');
+  const loadBranchClassContractFn = deps.loadBranchClassContractFn ?? loadBranchClassContract;
+  const canonicalRepository =
+    normalizeText(artifacts.canonicalRepository) ||
+    normalizeText(snapshot?.repository) ||
+    normalizeText(artifacts.standingRepository) ||
+    COMPAREVI_UPSTREAM_REPOSITORY;
+  const planeTransition = resolveBranchPlaneTransition({
+    branch: branchName,
+    sourcePlane: normalizeText(activeLane?.forkRemote) || normalizeText(deliveryPolicy.implementationRemote) || 'origin',
+    targetRepository: canonicalRepository,
+    contract: loadBranchClassContractFn(repoRoot)
+  });
   const objectiveSummary =
     selectedActionType === 'reshape-backlog'
       ? `Reshape epic #${issueNumber}${issueTitle ? `: ${issueTitle}` : ''} into an executable child slice`
@@ -628,6 +640,7 @@ async function buildCompareviTaskPacket({ repoRoot, schedulerDecision, preparedW
         issueGraph: artifacts.issueGraph ?? null,
         pullRequest: pullRequestArtifact,
         backlog: artifacts.backlogRepair ?? null,
+        planeTransition,
         localReviewLoop,
         mutationEnvelope: {
           backlogAuthority: 'issues',
@@ -725,6 +738,7 @@ async function persistCompareviDeliveryRuntime({
     policyPath: deps.deliveryAgentPolicyPath || DELIVERY_AGENT_POLICY_RELATIVE_PATH
   });
   return persistDeliveryAgentRuntimeState({
+    repoRoot,
     runtimeDir: runtimeArtifactPaths.runtimeDir,
     repository,
     policy: deliveryPolicy,


### PR DESCRIPTION
## Summary
- record explicit fork-plane transition evidence in runtime-supervisor task packets
- carry the same plane-transition evidence into persisted delivery-agent runtime state
- fail closed when a fork lane cannot prove the transition defined by `tools/policy/branch-classes.json`

## Testing
- `node --check tools/priority/lib/branch-classification.mjs`
- `node --check tools/priority/runtime-supervisor.mjs`
- `node --check tools/priority/delivery-agent.mjs`
- `node --test tools/priority/__tests__/branch-classification.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs tools/priority/__tests__/delivery-agent-schema.test.mjs`

Closes #1129
