### PR TITLE
#1034 Fail closed on stale standing-priority cleanup

### DIFF
--- a/tools/priority/__tests__/standing-priority-handoff.test.mjs
+++ b/tools/priority/__tests__/standing-priority-handoff.test.mjs
@@ -6,34 +6,22 @@ import { handoffStandingPriority } from '../standing-priority-handoff.mjs';
 
 test('handoffStandingPriority normalizes fork standing labels and syncs cache', async () => {
   const calls = [];
+  const patchCalls = [];
+  const issues = new Map([
+    [315, { number: 315, title: 'Legacy-labelled target', labels: [{ name: 'standing-priority' }], url: 'https://github.com/example/repo/issues/315' }],
+    [317, { number: 317, title: 'Current fork standing issue', labels: [{ name: 'fork-standing-priority' }], url: 'https://github.com/example/repo/issues/317' }]
+  ]);
   let leaseReleaseCount = 0;
   const ghRunner = (args) => {
     calls.push(args);
     if (args[0] === 'issue' && args[1] === 'list' && args.includes('--label') && args.includes('fork-standing-priority')) {
-      return JSON.stringify([
-        {
-          number: 317,
-          title: 'Current fork standing issue',
-          labels: [{ name: 'fork-standing-priority' }],
-          url: 'https://github.com/example/repo/issues/317'
-        }
-      ]);
+      return JSON.stringify([issues.get(317)]);
     }
     if (args[0] === 'issue' && args[1] === 'list' && args.includes('--label') && args.includes('standing-priority')) {
-      return JSON.stringify([
-        {
-          number: 315,
-          title: 'Legacy-labelled target',
-          labels: [{ name: 'standing-priority' }],
-          url: 'https://github.com/example/repo/issues/315'
-        },
-        {
-          number: 317,
-          title: 'Current fork standing issue',
-          labels: [{ name: 'fork-standing-priority' }],
-          url: 'https://github.com/example/repo/issues/317'
-        }
-      ]);
+      return JSON.stringify([issues.get(315), issues.get(317)]);
+    }
+    if (args[0] === 'issue' && args[1] === 'view') {
+      return JSON.stringify(issues.get(Number(args[2])));
     }
     return '';
   };
@@ -45,9 +33,15 @@ test('handoffStandingPriority normalizes fork standing labels and syncs cache', 
     leaseReleaseCount += 1;
     return { status: 'released' };
   };
+  const patchIssueLabelsFn = (_repoRoot, _repoSlug, issueNumber, labels) => {
+    patchCalls.push({ issueNumber, labels });
+    const issue = issues.get(issueNumber);
+    issue.labels = labels.map((label) => ({ name: label }));
+  };
 
   await handoffStandingPriority(315, {
     ghRunner,
+    patchIssueLabelsFn,
     syncFn,
     leaseReleaseFn,
     logger: () => {},
@@ -86,8 +80,12 @@ test('handoffStandingPriority normalizes fork standing labels and syncs cache', 
       '--label',
       'standing-priority'
     ],
-    ['issue', 'edit', '317', '--remove-label', 'fork-standing-priority'],
-    ['issue', 'edit', '315', '--remove-label', 'standing-priority', '--add-label', 'fork-standing-priority']
+    ['issue', 'view', '317', '--repo', 'fork-owner/compare-vi-cli-action', '--json', 'number,title,body,labels,createdAt,updatedAt,url,state'],
+    ['issue', 'view', '315', '--repo', 'fork-owner/compare-vi-cli-action', '--json', 'number,title,body,labels,createdAt,updatedAt,url,state']
+  ]);
+  assert.deepEqual(patchCalls, [
+    { issueNumber: 317, labels: [] },
+    { issueNumber: 315, labels: ['fork-standing-priority'] }
   ]);
   assert.equal(syncCount, 1);
   assert.equal(leaseReleaseCount, 1);
@@ -95,15 +93,18 @@ test('handoffStandingPriority normalizes fork standing labels and syncs cache', 
 
 test('handoffStandingPriority auto-selects the next actionable issue and skips cadence alerts', async () => {
   const calls = [];
+  const patchCalls = [];
+  const issues = new Map([
+    [315, { number: 315, title: '[P1] Real development issue', labels: [] }],
+    [317, { number: 317, title: 'Current standing issue', labels: [{ name: 'fork-standing-priority' }] }]
+  ]);
   let syncCount = 0;
   const ghRunner = (args) => {
     calls.push(args);
     if (args[0] === 'issue' && args[1] === 'list' && args.includes('--label')) {
       return JSON.stringify([
         {
-          number: 317,
-          title: 'Current standing issue',
-          labels: [{ name: 'fork-standing-priority' }],
+          ...issues.get(317),
           createdAt: '2026-03-10T00:00:00Z',
           updatedAt: '2026-03-10T00:00:00Z'
         }
@@ -128,21 +129,29 @@ test('handoffStandingPriority auto-selects the next actionable issue and skips c
           updatedAt: '2026-03-02T00:00:00Z'
         },
         {
-          number: 317,
+          ...issues.get(317),
           title: '[P0] Current standing issue',
           body: 'Already active',
-          labels: [{ name: 'fork-standing-priority' }],
           createdAt: '2026-03-03T00:00:00Z',
           updatedAt: '2026-03-03T00:00:00Z'
         }
       ]);
     }
+    if (args[0] === 'issue' && args[1] === 'view') {
+      return JSON.stringify(issues.get(Number(args[2])));
+    }
     return '';
+  };
+  const patchIssueLabelsFn = (_repoRoot, _repoSlug, issueNumber, labels) => {
+    patchCalls.push({ issueNumber, labels });
+    const issue = issues.get(issueNumber);
+    issue.labels = labels.map((label) => ({ name: label }));
   };
 
   await handoffStandingPriority(null, {
     auto: true,
     ghRunner,
+    patchIssueLabelsFn,
     syncFn: async () => {
       syncCount += 1;
     },
@@ -195,8 +204,12 @@ test('handoffStandingPriority auto-selects the next actionable issue and skips c
       '--json',
       'number,title,body,labels,createdAt,updatedAt,url'
     ],
-    ['issue', 'edit', '317', '--remove-label', 'fork-standing-priority'],
-    ['issue', 'edit', '315', '--add-label', 'fork-standing-priority']
+    ['issue', 'view', '317', '--repo', 'fork-owner/compare-vi-cli-action', '--json', 'number,title,body,labels,createdAt,updatedAt,url,state'],
+    ['issue', 'view', '315', '--repo', 'fork-owner/compare-vi-cli-action', '--json', 'number,title,body,labels,createdAt,updatedAt,url,state']
+  ]);
+  assert.deepEqual(patchCalls, [
+    { issueNumber: 317, labels: [] },
+    { issueNumber: 315, labels: ['fork-standing-priority'] }
   ]);
   assert.equal(syncCount, 1);
 });
@@ -270,5 +283,40 @@ test('handoffStandingPriority rejects non-positive explicit issue numbers', asyn
         }
       }),
     /positive integer/
+  );
+});
+
+test('handoffStandingPriority fails loudly when label verification remains stale after mutation', async () => {
+  await assert.rejects(
+    handoffStandingPriority(315, {
+      ghRunner: (args) => {
+        if (args[0] === 'issue' && args[1] === 'list') {
+          return JSON.stringify([
+            {
+              number: 317,
+              title: 'Current standing issue',
+              labels: [{ name: 'standing-priority' }]
+            }
+          ]);
+        }
+        if (args[0] === 'issue' && args[1] === 'view') {
+          return JSON.stringify({
+            number: 317,
+            title: 'Current standing issue',
+            labels: [{ name: 'standing-priority' }]
+          });
+        }
+        return '';
+      },
+      patchIssueLabelsFn: () => {},
+      syncFn: async () => {},
+      leaseReleaseFn: async () => ({ status: 'released' }),
+      logger: () => {},
+      env: {
+        GITHUB_REPOSITORY: 'owner/repo',
+        AGENT_PRIORITY_UPSTREAM_REPOSITORY: 'owner/repo'
+      }
+    }),
+    /label verification failed/i
   );
 });

--- a/tools/priority/standing-priority-handoff.mjs
+++ b/tools/priority/standing-priority-handoff.mjs
@@ -133,6 +133,53 @@ function buildIssueEditArgs(issueNumber, { removeLabels = [], addLabels = [] } =
   return args;
 }
 
+function buildIssueViewArgs(repoSlug, issueNumber) {
+  return [
+    'issue',
+    'view',
+    String(issueNumber),
+    '--repo',
+    repoSlug,
+    '--json',
+    'number,title,body,labels,createdAt,updatedAt,url,state'
+  ];
+}
+
+function applyIssueLabelsViaApi(repoRoot, repoSlug, issueNumber, labels) {
+  const result = spawnSync(
+    'gh',
+    ['api', `repos/${repoSlug}/issues/${issueNumber}`, '-X', 'PATCH', '--input', '-'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: JSON.stringify({ labels: Array.from(labels || []) }),
+      stdio: ['pipe', 'pipe', 'pipe']
+    }
+  );
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim() || result.stdout?.trim() || 'unknown error';
+    throw new Error(`gh api repos/${repoSlug}/issues/${issueNumber} failed (${result.status}): ${stderr}`);
+  }
+  return (result.stdout || '').trim();
+}
+
+function normalizeLabelSet(labels) {
+  return Array.from(new Set(normalizeIssueLabels(labels).map((label) => label.toLowerCase()))).sort();
+}
+
+function verifyIssueLabels(ghRunner, repoSlug, issueNumber, expectedLabels) {
+  const issue = parseIssueList(
+    `[${ghRunner(buildIssueViewArgs(repoSlug, issueNumber), { quiet: true })}]`
+  )[0] ?? null;
+  const actual = normalizeLabelSet(issue?.labels);
+  const expected = normalizeLabelSet(expectedLabels);
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Issue #${issueNumber} label verification failed. Expected [${expected.join(', ')}], observed [${actual.join(', ')}].`
+    );
+  }
+}
+
 function resolveTargetIssue(nextIssue, auto, openIssues, excludedIssueNumbers) {
   const target = String(nextIssue ?? '').trim();
   if (target) {
@@ -172,7 +219,7 @@ function resolveTargetIssue(nextIssue, auto, openIssues, excludedIssueNumbers) {
  * Rotate the standing-priority label to a new issue.
  *
  * @param {number|string|null} nextIssue
- * @param {{ dryRun?: boolean, auto?: boolean, repoSlug?: string|null, repoRoot?: string, env?: NodeJS.ProcessEnv, ghRunner?: Function, syncFn?: Function, logger?: Function, leaseReleaseFn?: Function, releaseLease?: boolean, leaseScope?: string }} [options]
+ * @param {{ dryRun?: boolean, auto?: boolean, repoSlug?: string|null, repoRoot?: string, env?: NodeJS.ProcessEnv, ghRunner?: Function, syncFn?: Function, logger?: Function, leaseReleaseFn?: Function, releaseLease?: boolean, leaseScope?: string, patchIssueLabelsFn?: Function }} [options]
  */
 export async function handoffStandingPriority(
   nextIssue,
@@ -186,6 +233,7 @@ export async function handoffStandingPriority(
     syncFn = syncStandingPriority,
     logger = console.log,
     leaseReleaseFn = releaseWriterLease,
+    patchIssueLabelsFn = applyIssueLabelsViaApi,
     releaseLease = true,
     leaseScope = 'workspace'
   } = {}
@@ -215,6 +263,7 @@ export async function handoffStandingPriority(
     ? standingPriorityLabels.filter((label) => label !== primaryLabel && targetIssue.labels.includes(label))
     : [];
   const targetNeedsPrimaryLabel = !targetIssue || !targetIssue.labels.includes(primaryLabel);
+  const currentIssueMap = new Map(currentIssues.map((issue) => [issue.number, issue]));
 
   if (dryRun) {
     logger(
@@ -251,17 +300,21 @@ export async function handoffStandingPriority(
     logger(
       `[standing-handoff] Removing ${issue.removeLabels.join(', ')} from issue #${issue.number}...`
     );
-    ghRunner(buildIssueEditArgs(issue.number, { removeLabels: issue.removeLabels }));
+    const currentLabels = normalizeIssueLabels(currentIssueMap.get(issue.number)?.labels);
+    const desiredLabels = currentLabels.filter((label) => !issue.removeLabels.includes(label));
+    patchIssueLabelsFn(workingRepoRoot, resolvedRepoSlug, issue.number, desiredLabels);
+    verifyIssueLabels(ghRunner, resolvedRepoSlug, issue.number, desiredLabels);
   }
 
   if (targetRemoveLabels.length > 0 || targetNeedsPrimaryLabel) {
     logger(`[standing-handoff] Normalizing standing labels on issue #${targetIssueNumber}...`);
-    ghRunner(
-      buildIssueEditArgs(targetIssueNumber, {
-        removeLabels: targetRemoveLabels,
-        addLabels: targetNeedsPrimaryLabel ? [primaryLabel] : []
-      })
-    );
+    const currentLabels = normalizeIssueLabels(targetIssue?.labels);
+    const desiredLabels = currentLabels
+      .filter((label) => !targetRemoveLabels.includes(label))
+      .concat(targetNeedsPrimaryLabel ? [primaryLabel] : [])
+      .filter(Boolean);
+    patchIssueLabelsFn(workingRepoRoot, resolvedRepoSlug, targetIssueNumber, desiredLabels);
+    verifyIssueLabels(ghRunner, resolvedRepoSlug, targetIssueNumber, desiredLabels);
   } else {
     logger(`[standing-handoff] Issue #${targetIssueNumber} already labelled – ensuring cache is updated.`);
   }


### PR DESCRIPTION
## Summary
- switch standing-priority handoff label mutations to a deterministic REST patch path
- verify the resulting labels after each mutation before the cache/router sync runs
- add regression coverage for stale-label readback after a nominally successful mutation

## Testing
- `node --check tools/priority/standing-priority-handoff.mjs`
- `node --test tools/priority/__tests__/standing-priority-handoff.test.mjs tools/priority/__tests__/standing-priority-resolution.test.mjs`

Refs #1034
