### PR TITLE
#976 Migrate maintained artifact downloads onto the helper

### DIFF
--- a/tools/OneButton-CI.ps1
+++ b/tools/OneButton-CI.ps1
@@ -127,7 +127,12 @@ function Download-RunArtifacts {
     [Parameter(Mandatory=$true)][string]$TargetDir
   )
   New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
-  gh run download $RunId -R $Repo -D $TargetDir | Out-Null
+  $reportPath = Join-Path $TargetDir '_run-artifact-download.json'
+  $runnerPath = Join-Path $PSScriptRoot 'npm' 'run-script.mjs'
+  & node $runnerPath 'priority:artifact:download' '--' '--repo' $Repo '--run-id' $RunId '--all' '--destination-root' $TargetDir '--report' $reportPath
+  if ($LASTEXITCODE -ne 0) {
+    throw "Artifact download helper failed for run $RunId."
+  }
 }
 
 function Write-LocalSummary {

--- a/tools/priority/__tests__/artifact-download-migration-contract.test.mjs
+++ b/tools/priority/__tests__/artifact-download-migration-contract.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('OneButton-CI uses the checked-in artifact download helper instead of raw gh run download', () => {
+  const scriptPath = path.join(repoRoot, 'tools', 'OneButton-CI.ps1');
+  const raw = fs.readFileSync(scriptPath, 'utf8');
+
+  assert.doesNotMatch(raw, /\bgh\s+run\s+download\b/i);
+  assert.match(raw, /priority:artifact:download/);
+  assert.match(raw, /--all/);
+});

--- a/tools/priority/__tests__/download-run-artifact.test.mjs
+++ b/tools/priority/__tests__/download-run-artifact.test.mjs
@@ -15,40 +15,39 @@ async function loadModule() {
   return modulePromise;
 }
 
-test('isDirectExecution matches the current module path without file URL reconstruction drift', async () => {
-  const { isDirectExecution } = await loadModule();
-
-  assert.equal(isDirectExecution(['node', modulePath], pathToFileURL(modulePath).href), true);
-  assert.equal(isDirectExecution(['node', path.join(repoRoot, 'tools', 'priority', 'other-file.mjs')], pathToFileURL(modulePath).href), false);
-});
-
-test('parseArgs trims artifact values and rejects whitespace-only artifact names', async () => {
+test('parseArgs accepts --all without requiring named artifacts', async () => {
   const { parseArgs } = await loadModule();
-
   const parsed = parseArgs([
     'node',
-    modulePath,
+    'download-run-artifact.mjs',
     '--repo',
     'LabVIEW-Community-CI-CD/compare-vi-cli-action',
     '--run-id',
-    '22879026878',
-    '--artifact',
-    '  named-artifact  ',
+    '12345',
+    '--all',
   ]);
-  assert.deepEqual(parsed.artifactNames, ['named-artifact']);
 
+  assert.equal(parsed.repo, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(parsed.runId, '12345');
+  assert.equal(parsed.downloadAll, true);
+  assert.deepEqual(parsed.artifactNames, []);
+});
+
+test('parseArgs rejects mixing --all with named artifacts', async () => {
+  const { parseArgs } = await loadModule();
   assert.throws(
     () =>
       parseArgs([
         'node',
-        modulePath,
+        'download-run-artifact.mjs',
         '--repo',
         'LabVIEW-Community-CI-CD/compare-vi-cli-action',
         '--run-id',
-        '22879026878',
+        '12345',
+        '--all',
         '--artifact',
-        '   ',
+        'artifact-a',
       ]),
-    /Artifact name is required for --artifact\./,
+    /Use either --all or one or more --artifact values, not both\./,
   );
 });

--- a/tools/priority/__tests__/run-artifact-download.test.mjs
+++ b/tools/priority/__tests__/run-artifact-download.test.mjs
@@ -136,6 +136,83 @@ test('downloadNamedArtifacts records missing artifact requests without invoking 
   assert.equal(processCallCount, 0);
 });
 
+test('downloadNamedArtifacts can download every discovered artifact when downloadAll is requested', async (t) => {
+  const { downloadNamedArtifacts } = await loadModule();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-artifact-download-all-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const seenDownloads = [];
+  const result = downloadNamedArtifacts({
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    runId: '22872590273',
+    artifactNames: [],
+    downloadAll: true,
+    destinationRoot: path.join(tmpDir, 'artifacts'),
+    reportPath: path.join(tmpDir, 'report.json'),
+    runGhJsonFn() {
+      return {
+        artifacts: [
+          {
+            id: 1,
+            name: 'artifact-a',
+            size_in_bytes: 10,
+            expired: false,
+          },
+          {
+            id: 2,
+            name: 'artifact-b',
+            size_in_bytes: 20,
+            expired: false,
+          },
+        ],
+      };
+    },
+    runProcessFn(_command, args) {
+      const destinationIndex = args.indexOf('-D');
+      const artifactIndex = args.indexOf('-n');
+      const destination = args[destinationIndex + 1];
+      const artifactName = args[artifactIndex + 1];
+      seenDownloads.push(artifactName);
+      writeFile(path.join(destination, `${artifactName}.txt`), 'ok\n');
+      return { status: 0, stdout: '', stderr: '', error: null };
+    },
+  });
+
+  assert.equal(result.report.status, 'pass');
+  assert.deepEqual(result.report.requestedArtifacts, ['artifact-a', 'artifact-b']);
+  assert.equal(result.report.summary.requestedArtifactCount, 2);
+  assert.equal(result.report.summary.downloadedCount, 2);
+  assert.deepEqual(seenDownloads, ['artifact-a', 'artifact-b']);
+});
+
+test('downloadNamedArtifacts fails closed when downloadAll is requested but the run exposes no artifacts', async (t) => {
+  const { downloadNamedArtifacts } = await loadModule();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-artifact-download-all-empty-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  let processCallCount = 0;
+  const result = downloadNamedArtifacts({
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    runId: '22872590273',
+    artifactNames: [],
+    downloadAll: true,
+    destinationRoot: path.join(tmpDir, 'artifacts'),
+    reportPath: path.join(tmpDir, 'report.json'),
+    runGhJsonFn() {
+      return { artifacts: [] };
+    },
+    runProcessFn() {
+      processCallCount += 1;
+      return { status: 0, stdout: '', stderr: '', error: null };
+    },
+  });
+
+  assert.equal(result.report.status, 'fail');
+  assert.equal(result.report.discovery.failureClass, 'artifact-not-found');
+  assert.equal(result.report.summary.requestedArtifactCount, 0);
+  assert.equal(processCallCount, 0);
+});
+
 test('downloadNamedArtifacts fails fast when all requested artifact names normalize to empty values', async (t) => {
   const { downloadNamedArtifacts } = await loadModule();
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-artifact-download-invalid-request-'));

--- a/tools/priority/__tests__/validation-approval-proof.test.mjs
+++ b/tools/priority/__tests__/validation-approval-proof.test.mjs
@@ -327,6 +327,9 @@ test('runValidationApprovalProof emits a passing report with conservative false-
   assert.equal(result.report?.samples[0].comparison, 'match-ready');
   assert.equal(result.report?.samples[1].comparison, 'false-blocked');
   assert.ok(result.report?.samples[1].reasons.includes('copilot-review-run-unobserved'));
+  const attestation = JSON.parse(fs.readFileSync(result.report?.samples[0].artifacts.attestationPath, 'utf8'));
+  assert.match(attestation.validationEvidence.commands[1].command, /priority:artifact:download/);
+  assert.doesNotMatch(attestation.validationEvidence.commands[1].command, /\bgh run download\b/);
   assert.ok(fs.existsSync(reportPath));
 });
 

--- a/tools/priority/download-run-artifact.mjs
+++ b/tools/priority/download-run-artifact.mjs
@@ -18,6 +18,7 @@ function printUsage() {
   console.log('  --repo <owner/repo>          Target repository (default: GITHUB_REPOSITORY).');
   console.log('  --run-id <id>               Workflow run id to download from.');
   console.log('  --artifact <name>           Artifact name to download (repeatable).');
+  console.log('  --all                       Download every non-expired artifact from the run.');
   console.log(`  --destination-root <path>   Destination root (default: ${DEFAULT_DESTINATION_ROOT}).`);
   console.log(`  --report <path>             Output report path (default: ${DEFAULT_REPORT_PATH}).`);
   console.log('  -h, --help                  Show help.');
@@ -38,6 +39,7 @@ export function parseArgs(argv = process.argv) {
     repo: normalizeText(process.env.GITHUB_REPOSITORY),
     runId: null,
     artifactNames: [],
+    downloadAll: false,
     destinationRoot: DEFAULT_DESTINATION_ROOT,
     reportPath: DEFAULT_REPORT_PATH,
   };
@@ -46,6 +48,10 @@ export function parseArgs(argv = process.argv) {
     const token = args[index];
     if (token === '-h' || token === '--help') {
       options.help = true;
+      continue;
+    }
+    if (token === '--all') {
+      options.downloadAll = true;
       continue;
     }
     const next = args[index + 1];
@@ -83,8 +89,11 @@ export function parseArgs(argv = process.argv) {
     if (!options.runId) {
       throw new Error('Run id is required. Pass --run-id <id>.');
     }
-    if (options.artifactNames.length === 0) {
-      throw new Error('At least one artifact is required. Pass --artifact <name>.');
+    if (options.downloadAll && options.artifactNames.length > 0) {
+      throw new Error('Use either --all or one or more --artifact values, not both.');
+    }
+    if (!options.downloadAll && options.artifactNames.length === 0) {
+      throw new Error('At least one artifact is required. Pass --artifact <name> or use --all.');
     }
   }
 
@@ -110,6 +119,7 @@ export async function main(argv = process.argv) {
     repository: options.repo,
     runId: options.runId,
     artifactNames: options.artifactNames,
+    downloadAll: options.downloadAll,
     destinationRoot: options.destinationRoot,
     reportPath: options.reportPath,
   });

--- a/tools/priority/lib/run-artifact-download.mjs
+++ b/tools/priority/lib/run-artifact-download.mjs
@@ -219,13 +219,14 @@ export function downloadNamedArtifacts({
   repository,
   runId,
   artifactNames,
+  downloadAll = false,
   destinationRoot = DEFAULT_DESTINATION_ROOT,
   reportPath = DEFAULT_REPORT_PATH,
   now = new Date(),
   runGhJsonFn = runGhJson,
   runProcessFn = runProcess,
 }) {
-  const requestedArtifacts = uniqueStrings(artifactNames);
+  let requestedArtifacts = uniqueStrings(artifactNames);
   const normalizedRepository = normalizeText(repository);
   const normalizedRunId = normalizeText(runId);
   const report = {
@@ -262,7 +263,7 @@ export function downloadNamedArtifacts({
   if (!normalizedRunId) {
     invalidRequestErrors.push('Run id is required.');
   }
-  if (requestedArtifacts.length === 0) {
+  if (!downloadAll && requestedArtifacts.length === 0) {
     invalidRequestErrors.push('At least one non-empty artifact name is required.');
   }
 
@@ -288,6 +289,21 @@ export function downloadNamedArtifacts({
     report.discovery.command = discovery.command;
     report.discovery.availableArtifacts = discovery.artifacts;
     report.summary.availableArtifactCount = discovery.artifacts.length;
+    if (downloadAll) {
+      requestedArtifacts = uniqueStrings(discovery.artifacts.map((artifact) => artifact?.name));
+      report.requestedArtifacts = requestedArtifacts;
+      report.summary.requestedArtifactCount = requestedArtifacts.length;
+      if (requestedArtifacts.length === 0) {
+        const message = `No artifacts were available for run ${normalizedRunId}.`;
+        report.status = 'fail';
+        report.discovery.status = 'fail';
+        report.discovery.failureClass = 'artifact-not-found';
+        report.discovery.errorMessage = message;
+        report.errors.push(message);
+        const resolvedReportPath = writeJsonFile(reportPath, report);
+        return { report, reportPath: resolvedReportPath };
+      }
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     report.status = 'fail';

--- a/tools/priority/validation-approval-proof.mjs
+++ b/tools/priority/validation-approval-proof.mjs
@@ -664,7 +664,7 @@ function buildReplayAttestation({
           artifactPath: null,
         },
         {
-          command: `gh run download ${run.id ?? 'unknown'} -n ${DEPLOYMENT_DETERMINISM_ARTIFACT_NAME}`,
+          command: `node tools/npm/run-script.mjs priority:artifact:download -- --repo ${repository} --run-id ${run.id ?? 'unknown'} --artifact ${DEPLOYMENT_DETERMINISM_ARTIFACT_NAME}`,
           status: determinismPassed ? 'passed' : 'failed',
           exitCode: null,
           details: `Deployment determinism result=${normalizeText(deploymentDeterminism?.result) ?? 'unknown'}.`,


### PR DESCRIPTION
# Summary

Moves the remaining maintained raw artifact-download path onto the checked-in helper. `OneButton-CI` now downloads whole run artifact sets through the helper, and validation approval proof guidance now points at the repo-owned helper command instead of raw `gh run download`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context:
  - Fixes #976
- Files, tools, workflows, or policies touched:
  - `tools/priority/lib/run-artifact-download.mjs`
  - `tools/priority/download-run-artifact.mjs`
  - `tools/OneButton-CI.ps1`
  - `tools/priority/validation-approval-proof.mjs`
  - focused artifact-download / proof contract tests
- Cross-repo or external-consumer impact:
  - none; maintained local/operator download surfaces now converge on the repo helper
- Required checks, merge-queue behavior, or approval flows affected:
  - none directly; this removes a remaining operator fallback to raw `gh run download`

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/download-run-artifact.test.mjs tools/priority/__tests__/run-artifact-download.test.mjs tools/priority/__tests__/validation-approval-proof.test.mjs tools/priority/__tests__/artifact-download-migration-contract.test.mjs`
  - PowerShell parse check for `tools/OneButton-CI.ps1`
- Key artifacts, logs, or workflow runs:
  - focused local test output only
- Risk-based checks not run:
  - broader workflow bundles were not rerun because this slice is limited to helper plumbing and maintained operator guidance

## Risks and Follow-ups

- Residual risks:
  - historical frozen examples outside maintained surfaces may still mention raw download commands
- Follow-up issues or deferred work:
  - epic #966 can keep narrowing any intentionally retained historical examples separately
- Deployment, approval, or rollback notes:
  - rollback is isolated to this helper migration slice

## Reviewer Focus

- Please verify:
  - `--all` artifact download mode stays fail-closed when a run exposes no artifacts
  - `OneButton-CI` keeps the same artifact layout expectations after moving to the helper
  - validation approval proof no longer teaches raw `gh run download` on maintained paths
- Areas where the reasoning is subtle:
  - helper behavior intentionally distinguishes named-artifact mode from all-artifacts mode without widening schema scope
- Manual spot checks requested:
  - none
