### PR TITLE
#1016 Keep monitor-only monthly scorecards non-blocking

### DIFF
--- a/.github/workflows/monthly-stability-release.yml
+++ b/.github/workflows/monthly-stability-release.yml
@@ -287,6 +287,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          scorecard_fail_mode='--no-fail-on-blockers'
+          if [ '${{ needs.evaluate-window.outputs.publish_requested }}' = 'true' ]; then
+            scorecard_fail_mode='--fail-on-blockers'
+          fi
           node tools/priority/release-scorecard.mjs \
             --repo "${{ github.repository }}" \
             --stream monthly-stability-release \
@@ -295,7 +299,8 @@ jobs:
             --ledger tests/results/promotion-contract/monthly-ledger.json \
             --slo tests/results/_agent/slo/monthly-slo-metrics.json \
             --rollback tests/results/_agent/release/monthly-rollback-drill-health.json \
-            --output tests/results/_agent/release/monthly-release-scorecard.json
+            --output tests/results/_agent/release/monthly-release-scorecard.json \
+            "$scorecard_fail_mode"
 
       - name: Validate release scorecard schema
         if: always()
@@ -315,4 +320,3 @@ jobs:
             tests/results/_agent/release/monthly-rollback-drill-health.json
             tests/results/_agent/release/monthly-release-scorecard.json
           if-no-files-found: error
-

--- a/tools/priority/__tests__/shared-package-migration-contract.test.mjs
+++ b/tools/priority/__tests__/shared-package-migration-contract.test.mjs
@@ -45,3 +45,11 @@ test('monthly stability workflow derives CompareVi.Shared version from Directory
   assert.match(workflow, /publish_shared=true requires shared_version \(or Directory\.Build\.props CompareViSharedPackageVersion\/Version\)\./);
   assert.doesNotMatch(workflow, /fs\.readFileSync\('src\/CompareVi\.Shared\/CompareVi\.Shared\.csproj', 'utf8'\)/);
 });
+
+test('monthly stability workflow keeps monitor-only scorecards non-blocking', () => {
+  const workflow = read('.github/workflows/monthly-stability-release.yml');
+  assert.match(workflow, /scorecard_fail_mode='--no-fail-on-blockers'/);
+  assert.match(workflow, /needs\.evaluate-window\.outputs\.publish_requested/);
+  assert.match(workflow, /scorecard_fail_mode='--fail-on-blockers'/);
+  assert.match(workflow, /"\$scorecard_fail_mode"/);
+});


### PR DESCRIPTION
## Summary
- keep monitor-only monthly stability scorecard runs non-blocking so existing SLO breaches do not fail the observer workflow
- preserve fail-closed release blocker behavior when a publish dispatch is actually requested
- add a workflow contract regression for the new scorecard fail-mode switch

## Testing
- node --test tools/priority/__tests__/shared-package-migration-contract.test.mjs
- node --test tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs

## Issue
- Closes #1016

## Agent Metadata
- Plane: personal
- Branch: issue/personal-1016-release-cli-artifact-contract
- Focus: monthly stability SLO self-amplification loop