### PR TITLE
#990 Add fork deployment environment sync helper

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -296,6 +296,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - Run `node tools/npm/run-script.mjs priority:deployment:gate-policy` to verify the protected promotion environments enforce
   required reviewers and admin-bypass policy; report path:
   `tests/results/_agent/deployments/environment-gate-policy.json`.
+- Run `node tools/npm/run-script.mjs priority:deployment:gate-sync -- --target origin --target personal` to dry-run fork
+  environment parity from the checked-in portability policy. Add `--apply` only when you intend to create or repair the
+  fork environments through the repo-native helper path.
 - `PR Auto-approve` and `PR Auto-approve Label` workflows were retired because branch policy requires `0` approvals.
 
 ### Release metadata

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "priority:contracts:bootstrap": "node tools/priority/bootstrap-contracts.mjs",
     "priority:deployment:assert": "node tools/priority/assert-validation-deployment-determinism.mjs",
     "priority:deployment:gate-policy": "node tools/priority/check-deployment-gates.mjs",
+    "priority:deployment:gate-sync": "node tools/priority/sync-deployment-environments.mjs",
     "priority:release:scorecard": "node tools/priority/release-scorecard.mjs",
     "priority:release:cadence": "node tools/priority/release-cadence-check.mjs",
     "priority:release:conductor": "node tools/priority/release-conductor.mjs",

--- a/tools/policy/deployment-environment-parity.json
+++ b/tools/policy/deployment-environment-parity.json
@@ -1,0 +1,24 @@
+{
+  "schema": "priority/deployment-environment-parity@v1",
+  "sourceRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+  "targets": {
+    "origin": {
+      "repository": "LabVIEW-Community-CI-CD/compare-vi-cli-action-fork",
+      "overrides": {}
+    },
+    "personal": {
+      "repository": "svelderrainruiz/compare-vi-cli-action",
+      "overrides": {
+        "monthly-stability-release": {
+          "preventSelfReview": false,
+          "reviewers": [
+            {
+              "type": "User",
+              "login": "svelderrainruiz"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tools/priority/__tests__/deployment-environment-sync.test.mjs
+++ b/tools/priority/__tests__/deployment-environment-sync.test.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  POLICY_SCHEMA,
+  buildDesiredEnvironmentContract,
+  loadPortabilityPolicy,
+  parseArgs,
+  runDeploymentEnvironmentSync
+} from '../sync-deployment-environments.mjs';
+
+function makeEnvironment(payload = {}) {
+  return {
+    name: 'production',
+    can_admins_bypass: false,
+    protection_rules: [
+      {
+        type: 'required_reviewers',
+        prevent_self_review: false,
+        reviewers: [
+          {
+            type: 'User',
+            reviewer: {
+              login: 'svelderrainruiz',
+              id: 156447188
+            }
+          }
+        ]
+      }
+    ],
+    ...payload
+  };
+}
+
+test('parseArgs captures defaults and explicit target selectors', () => {
+  const defaults = parseArgs(['node', 'sync-deployment-environments.mjs']);
+  assert.equal(defaults.apply, false);
+  assert.deepEqual(defaults.targetSelectors, []);
+  assert.match(defaults.policyPath, /deployment-environment-parity\.json$/);
+
+  const parsed = parseArgs([
+    'node',
+    'sync-deployment-environments.mjs',
+    '--target',
+    'origin',
+    '--target',
+    'personal',
+    '--source-repo',
+    'owner/repo',
+    '--apply'
+  ]);
+  assert.deepEqual(parsed.targetSelectors, ['origin', 'personal']);
+  assert.equal(parsed.sourceRepository, 'owner/repo');
+  assert.equal(parsed.apply, true);
+});
+
+test('loadPortabilityPolicy normalizes targets and overrides', async () => {
+  const policy = await loadPortabilityPolicy('ignored.json', async () =>
+    JSON.stringify({
+      schema: POLICY_SCHEMA,
+      sourceRepository: 'owner/repo',
+      targets: {
+        origin: {
+          repository: 'owner/repo-fork',
+          overrides: {
+            production: {
+              reviewers: [{ type: 'User', login: 'maintainer' }]
+            }
+          }
+        }
+      }
+    })
+  );
+
+  assert.equal(policy.sourceRepository, 'owner/repo');
+  assert.equal(policy.targets.get('origin').repository, 'owner/repo-fork');
+  assert.deepEqual(policy.targets.get('origin').overrides.production.reviewers, [{ type: 'User', login: 'maintainer' }]);
+});
+
+test('buildDesiredEnvironmentContract preserves source defaults and applies target overrides', () => {
+  const sourceMonthly = makeEnvironment({
+    name: 'monthly-stability-release',
+    protection_rules: [
+      {
+        type: 'required_reviewers',
+        prevent_self_review: true,
+        reviewers: [
+          { type: 'User', reviewer: { login: 'francois-normandin', id: 1 } },
+          { type: 'User', reviewer: { login: 'crossrulz', id: 2 } }
+        ]
+      }
+    ]
+  });
+  const targetPolicy = {
+    overrides: {
+      'monthly-stability-release': {
+        preventSelfReview: false,
+        reviewers: [{ type: 'User', login: 'svelderrainruiz' }]
+      }
+    }
+  };
+
+  const desired = buildDesiredEnvironmentContract(sourceMonthly, targetPolicy);
+  assert.equal(desired.canAdminsBypass, false);
+  assert.equal(desired.preventSelfReview, false);
+  assert.deepEqual(desired.reviewers, [{ type: 'User', login: 'svelderrainruiz' }]);
+});
+
+test('runDeploymentEnvironmentSync dry-run reports target-specific noops from live-shaped policy', async () => {
+  const policy = {
+    schema: POLICY_SCHEMA,
+    sourceRepository: 'upstream/repo',
+    targets: new Map([
+      ['origin', { alias: 'origin', repository: 'org/repo', overrides: {} }],
+      [
+        'personal',
+        {
+          alias: 'personal',
+          repository: 'personal/repo',
+          overrides: {
+            'monthly-stability-release': {
+              preventSelfReview: false,
+              reviewers: [{ type: 'User', login: 'svelderrainruiz' }]
+            }
+          }
+        }
+      ]
+    ])
+  };
+
+  const sourceMonthly = makeEnvironment({
+    name: 'monthly-stability-release',
+    protection_rules: [
+      {
+        type: 'required_reviewers',
+        prevent_self_review: true,
+        reviewers: [
+          { type: 'User', reviewer: { login: 'francois-normandin', id: 11 } },
+          { type: 'User', reviewer: { login: 'crossrulz', id: 22 } }
+        ]
+      }
+    ]
+  });
+
+  const environments = new Map([
+    ['upstream/repo|production', makeEnvironment({ name: 'production' })],
+    ['upstream/repo|monthly-stability-release', sourceMonthly],
+    ['org/repo|production', makeEnvironment({ name: 'production' })],
+    ['org/repo|monthly-stability-release', sourceMonthly],
+    ['personal/repo|production', makeEnvironment({ name: 'production' })],
+    [
+      'personal/repo|monthly-stability-release',
+      makeEnvironment({
+        name: 'monthly-stability-release',
+        protection_rules: [
+          {
+            type: 'required_reviewers',
+            prevent_self_review: false,
+            reviewers: [{ type: 'User', reviewer: { login: 'svelderrainruiz', id: 156447188 } }]
+          }
+        ]
+      })
+    ]
+  ]);
+
+  const reportPaths = [];
+  const result = await runDeploymentEnvironmentSync({
+    args: {
+      policyPath: 'tools/policy/deployment-environment-parity.json',
+      reportPath: 'tests/results/_agent/deployments/environment-gate-sync.json',
+      targetSelectors: [],
+      sourceRepository: null,
+      apply: false,
+      help: false
+    },
+    token: 'token',
+    loadPolicyFn: async () => policy,
+    requestGitHubJsonFn: async (url) => {
+      const asString = String(url);
+      if (asString.includes('/users/')) {
+        return { id: 156447188 };
+      }
+      const match = asString.match(/repos\/([^/]+\/[^/]+)\/environments\/([^/?]+)/);
+      if (!match) {
+        throw new Error(`unexpected url ${url}`);
+      }
+      const key = `${match[1]}|${decodeURIComponent(match[2])}`;
+      if (!environments.has(key)) {
+        const error = new Error('missing');
+        error.statusCode = 404;
+        throw error;
+      }
+      return environments.get(key);
+    },
+    writeJsonFn: async (reportPath, report) => {
+      reportPaths.push({ reportPath, report });
+      return reportPath;
+    }
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.summary.status, 'pass');
+  assert.equal(result.report.summary.actionsRequired, 0);
+  const personalMonthly = result.report.targets
+    .find((entry) => entry.alias === 'personal')
+    .environments.find((entry) => entry.name === 'monthly-stability-release');
+  assert.equal(personalMonthly.action, 'noop');
+  assert.deepEqual(personalMonthly.desired.reviewers, [{ type: 'User', login: 'svelderrainruiz' }]);
+  assert.equal(personalMonthly.desired.preventSelfReview, false);
+  assert.equal(reportPaths.length, 1);
+});
+
+test('runDeploymentEnvironmentSync apply mode creates missing environments with resolved reviewer ids', async () => {
+  const policy = {
+    schema: POLICY_SCHEMA,
+    sourceRepository: 'upstream/repo',
+    targets: new Map([['origin', { alias: 'origin', repository: 'org/repo', overrides: {} }]])
+  };
+  const environments = new Map([
+    ['upstream/repo|production', makeEnvironment({ name: 'production' })],
+    [
+      'upstream/repo|monthly-stability-release',
+      makeEnvironment({
+        name: 'monthly-stability-release',
+        protection_rules: [
+          {
+            type: 'required_reviewers',
+            prevent_self_review: true,
+            reviewers: [{ type: 'User', reviewer: { login: 'francois-normandin', id: 11728548 } }]
+          }
+        ]
+      })
+    ]
+  ]);
+  const puts = [];
+
+  const result = await runDeploymentEnvironmentSync({
+    args: {
+      policyPath: 'tools/policy/deployment-environment-parity.json',
+      reportPath: 'tests/results/_agent/deployments/environment-gate-sync.json',
+      targetSelectors: ['origin'],
+      sourceRepository: null,
+      apply: true,
+      help: false
+    },
+    token: 'token',
+    loadPolicyFn: async () => policy,
+    requestGitHubJsonFn: async (url) => {
+      const asString = String(url);
+      if (asString.includes('/users/')) {
+        if (asString.endsWith('/francois-normandin')) {
+          return { id: 11728548 };
+        }
+        if (asString.endsWith('/svelderrainruiz')) {
+          return { id: 156447188 };
+        }
+        throw new Error(`unexpected reviewer lookup ${url}`);
+      }
+      const match = asString.match(/repos\/([^/]+\/[^/]+)\/environments\/([^/?]+)/);
+      if (!match) {
+        throw new Error(`unexpected url ${url}`);
+      }
+      const key = `${match[1]}|${decodeURIComponent(match[2])}`;
+      if (!environments.has(key)) {
+        const error = new Error('missing');
+        error.statusCode = 404;
+        throw error;
+      }
+      return environments.get(key);
+    },
+    putGitHubJsonFn: async (url, token, method, payload) => {
+      puts.push({ url: String(url), token, method, payload });
+      const match = String(url).match(/repos\/([^/]+\/[^/]+)\/environments\/([^/?]+)/);
+      const repository = match[1];
+      const name = decodeURIComponent(match[2]);
+      const reviewerLogin = name === 'production' ? 'svelderrainruiz' : 'francois-normandin';
+      const reviewerId = name === 'production' ? 156447188 : 11728548;
+      const created = makeEnvironment({
+        name,
+        can_admins_bypass: payload.can_admins_bypass,
+        protection_rules: [
+          {
+            type: 'required_reviewers',
+            prevent_self_review: payload.prevent_self_review,
+            reviewers: [{ type: 'User', reviewer: { login: reviewerLogin, id: reviewerId } }]
+          }
+        ]
+      });
+      environments.set(`${repository}|${name}`, created);
+      return created;
+    },
+    writeJsonFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(puts.length, 2);
+  assert.equal(puts[0].method, 'PUT');
+  assert.equal(puts[1].payload.can_admins_bypass, false);
+  assert.equal(puts[1].payload.prevent_self_review, true);
+  assert.deepEqual(puts[1].payload.reviewers, [{ type: 'User', id: 11728548 }]);
+});

--- a/tools/priority/check-deployment-gates.mjs
+++ b/tools/priority/check-deployment-gates.mjs
@@ -29,7 +29,7 @@ function printUsage() {
   console.log('  -h, --help             Show help and exit.');
 }
 
-function normalizeText(value) {
+export function normalizeText(value) {
   if (value == null) return null;
   const text = String(value).trim();
   return text ? text : null;
@@ -120,7 +120,7 @@ export function parseArgs(argv = process.argv) {
   return options;
 }
 
-async function resolveToken() {
+export async function resolveToken() {
   for (const candidate of [process.env.GH_TOKEN, process.env.GITHUB_TOKEN]) {
     const token = normalizeText(candidate);
     if (token) return token;
@@ -144,7 +144,7 @@ async function resolveToken() {
   return null;
 }
 
-async function requestGitHubJson(url, token) {
+export async function requestGitHubJson(url, token) {
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -165,7 +165,7 @@ async function requestGitHubJson(url, token) {
   return payload;
 }
 
-function normalizeReviewers(rule) {
+export function normalizeReviewers(rule) {
   const reviewers = Array.isArray(rule?.reviewers) ? rule.reviewers : [];
   return reviewers
     .map((entry) => {
@@ -215,7 +215,7 @@ export function evaluateEnvironmentGatePolicy(envPayload, options = {}) {
   };
 }
 
-async function writeJson(filePath, payload) {
+export async function writeJson(filePath, payload) {
   const resolved = path.resolve(filePath);
   await mkdir(path.dirname(resolved), { recursive: true });
   await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');

--- a/tools/priority/sync-deployment-environments.mjs
+++ b/tools/priority/sync-deployment-environments.mjs
@@ -1,0 +1,486 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_ENVIRONMENTS,
+  evaluateEnvironmentGatePolicy,
+  normalizeReviewers,
+  normalizeText,
+  requestGitHubJson,
+  resolveToken,
+  writeJson
+} from './check-deployment-gates.mjs';
+
+export const POLICY_SCHEMA = 'priority/deployment-environment-parity@v1';
+export const REPORT_SCHEMA = 'priority/deployment-environment-sync@v1';
+export const DEFAULT_POLICY_PATH = path.join('tools', 'policy', 'deployment-environment-parity.json');
+export const DEFAULT_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'deployments',
+  'environment-gate-sync.json'
+);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/sync-deployment-environments.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(`  --policy <path>       Portability policy path (default: ${DEFAULT_POLICY_PATH}).`);
+  console.log(`  --report <path>       Report output path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log('  --target <name>       Target alias or repository slug. Repeat for multiple targets.');
+  console.log('  --source-repo <slug>  Override source repository from policy.');
+  console.log('  --apply               Apply changes to target repositories.');
+  console.log('  -h, --help            Show help and exit.');
+}
+
+function normalizeReviewerSpec(entry) {
+  const type = normalizeText(entry?.type) ?? 'User';
+  if (type === 'User') {
+    const login = normalizeText(entry?.login);
+    if (!login) {
+      throw new Error('User reviewer entries require login.');
+    }
+    return { type, login };
+  }
+
+  if (type === 'Team') {
+    const organization = normalizeText(entry?.organization);
+    const teamSlug = normalizeText(entry?.teamSlug);
+    if (!organization || !teamSlug) {
+      throw new Error('Team reviewer entries require organization and teamSlug.');
+    }
+    return { type, organization, teamSlug };
+  }
+
+  throw new Error(`Unsupported reviewer type '${type}'.`);
+}
+
+function normalizeEnvironmentOverride(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return {};
+  }
+
+  const override = {};
+  if (Array.isArray(entry.reviewers)) {
+    override.reviewers = entry.reviewers.map((reviewer) => normalizeReviewerSpec(reviewer));
+  }
+  if (typeof entry.preventSelfReview === 'boolean') {
+    override.preventSelfReview = entry.preventSelfReview;
+  }
+  if (typeof entry.canAdminsBypass === 'boolean') {
+    override.canAdminsBypass = entry.canAdminsBypass;
+  }
+  return override;
+}
+
+function normalizeTargetPolicy(alias, entry) {
+  const repository = normalizeText(entry?.repository);
+  if (!repository || !repository.includes('/')) {
+    throw new Error(`Target '${alias}' is missing repository.`);
+  }
+
+  const overrides = {};
+  const rawOverrides = entry?.overrides ?? {};
+  for (const [environmentName, override] of Object.entries(rawOverrides)) {
+    overrides[String(environmentName)] = normalizeEnvironmentOverride(override);
+  }
+
+  return {
+    alias,
+    repository,
+    overrides
+  };
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    policyPath: DEFAULT_POLICY_PATH,
+    reportPath: DEFAULT_REPORT_PATH,
+    targetSelectors: [],
+    sourceRepository: null,
+    apply: false,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--apply') {
+      options.apply = true;
+      continue;
+    }
+    if (token === '--policy' || token === '--report' || token === '--target' || token === '--source-repo') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--policy') options.policyPath = next;
+      if (token === '--report') options.reportPath = next;
+      if (token === '--target') options.targetSelectors.push(next);
+      if (token === '--source-repo') options.sourceRepository = next;
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+export async function loadPortabilityPolicy(policyPath, readFileFn = readFile) {
+  const raw = JSON.parse(await readFileFn(policyPath, 'utf8'));
+  if (raw?.schema !== POLICY_SCHEMA) {
+    throw new Error(`Unsupported deployment environment policy schema '${raw?.schema ?? 'missing'}'.`);
+  }
+
+  const sourceRepository = normalizeText(raw.sourceRepository);
+  if (!sourceRepository || !sourceRepository.includes('/')) {
+    throw new Error('Deployment environment parity policy requires sourceRepository.');
+  }
+
+  const rawTargets = raw.targets ?? {};
+  const targetEntries = Object.entries(rawTargets);
+  if (targetEntries.length === 0) {
+    throw new Error('Deployment environment parity policy requires at least one target.');
+  }
+
+  const targets = new Map();
+  for (const [alias, value] of targetEntries) {
+    const target = normalizeTargetPolicy(alias, value);
+    targets.set(alias, target);
+  }
+
+  return {
+    schema: POLICY_SCHEMA,
+    sourceRepository,
+    targets
+  };
+}
+
+function selectTargets(policy, selectors) {
+  if (!selectors || selectors.length === 0) {
+    return [...policy.targets.values()];
+  }
+
+  const selected = [];
+  for (const selector of selectors) {
+    const normalized = normalizeText(selector);
+    if (!normalized) {
+      continue;
+    }
+    if (normalized === 'all') {
+      return [...policy.targets.values()];
+    }
+    const byAlias = policy.targets.get(normalized);
+    if (byAlias) {
+      selected.push(byAlias);
+      continue;
+    }
+    const byRepository = [...policy.targets.values()].find((target) => target.repository === normalized);
+    if (!byRepository) {
+      throw new Error(`Unknown deployment environment sync target '${normalized}'.`);
+    }
+    selected.push(byRepository);
+  }
+
+  const deduped = new Map(selected.map((target) => [target.alias, target]));
+  return [...deduped.values()];
+}
+
+function summarizeEnvironmentContract(envPayload) {
+  const requiredReviewersRule =
+    (Array.isArray(envPayload?.protection_rules) ? envPayload.protection_rules : []).find(
+      (entry) => String(entry?.type ?? '').toLowerCase() === 'required_reviewers'
+    ) ?? null;
+  return {
+    name: normalizeText(envPayload?.name) ?? null,
+    canAdminsBypass: Boolean(envPayload?.can_admins_bypass),
+    preventSelfReview: requiredReviewersRule?.prevent_self_review === true,
+    reviewers: normalizeReviewers(requiredReviewersRule).map((reviewer) => {
+      if (reviewer.type === 'Team') {
+        return {
+          type: 'Team',
+          organization: reviewer.login?.split('/')[0] ?? null,
+          teamSlug: reviewer.login?.split('/')[1] ?? null
+        };
+      }
+      return {
+        type: 'User',
+        login: reviewer.login
+      };
+    })
+  };
+}
+
+export function buildDesiredEnvironmentContract(sourceEnvironment, targetPolicy) {
+  const sourceContract = summarizeEnvironmentContract(sourceEnvironment);
+  const override = targetPolicy.overrides[sourceContract.name] ?? {};
+  return {
+    name: sourceContract.name,
+    canAdminsBypass:
+      typeof override.canAdminsBypass === 'boolean' ? override.canAdminsBypass : sourceContract.canAdminsBypass,
+    preventSelfReview:
+      typeof override.preventSelfReview === 'boolean' ? override.preventSelfReview : sourceContract.preventSelfReview,
+    reviewers: Array.isArray(override.reviewers) ? override.reviewers : sourceContract.reviewers
+  };
+}
+
+function reviewerKey(reviewer) {
+  if (reviewer.type === 'Team') {
+    return `Team:${reviewer.organization}/${reviewer.teamSlug}`;
+  }
+  return `User:${reviewer.login}`;
+}
+
+function contractsEqual(left, right) {
+  if (!left || !right) {
+    return false;
+  }
+  if (left.canAdminsBypass !== right.canAdminsBypass || left.preventSelfReview !== right.preventSelfReview) {
+    return false;
+  }
+  const leftKeys = left.reviewers.map((reviewer) => reviewerKey(reviewer)).sort();
+  const rightKeys = right.reviewers.map((reviewer) => reviewerKey(reviewer)).sort();
+  return JSON.stringify(leftKeys) === JSON.stringify(rightKeys);
+}
+
+async function requestGitHubJsonWithMethod(url, token, method = 'GET', payload = null) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'priority-deployment-environment-sync',
+      ...(payload ? { 'Content-Type': 'application/json' } : {})
+    },
+    body: payload ? JSON.stringify(payload) : undefined
+  });
+
+  const text = await response.text();
+  const json = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const error = new Error(`GitHub API ${method} ${url} failed (${response.status}).`);
+    error.statusCode = response.status;
+    error.payload = json;
+    throw error;
+  }
+  return json;
+}
+
+async function resolveReviewerIds(reviewers, token, requestGitHubJsonFn) {
+  const resolved = [];
+  for (const reviewer of reviewers) {
+    if (reviewer.type === 'User') {
+      const payload = await requestGitHubJsonFn(`https://api.github.com/users/${encodeURIComponent(reviewer.login)}`, token);
+      const id = Number(payload?.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        throw new Error(`Unable to resolve user reviewer '${reviewer.login}'.`);
+      }
+      resolved.push({ type: 'User', id, login: reviewer.login });
+      continue;
+    }
+
+    if (reviewer.type === 'Team') {
+      const payload = await requestGitHubJsonFn(
+        `https://api.github.com/orgs/${encodeURIComponent(reviewer.organization)}/teams/${encodeURIComponent(reviewer.teamSlug)}`,
+        token
+      );
+      const id = Number(payload?.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        throw new Error(`Unable to resolve team reviewer '${reviewer.organization}/${reviewer.teamSlug}'.`);
+      }
+      resolved.push({ type: 'Team', id, organization: reviewer.organization, teamSlug: reviewer.teamSlug });
+      continue;
+    }
+
+    throw new Error(`Unsupported reviewer type '${reviewer.type}'.`);
+  }
+  return resolved;
+}
+
+function buildEnvironmentPayload(contract, resolvedReviewers) {
+  return {
+    reviewers: resolvedReviewers.map((reviewer) => ({ type: reviewer.type, id: reviewer.id })),
+    prevent_self_review: contract.preventSelfReview,
+    can_admins_bypass: contract.canAdminsBypass
+  };
+}
+
+async function fetchEnvironment(repository, environmentName, token, requestGitHubJsonFn) {
+  const url = `https://api.github.com/repos/${repository}/environments/${encodeURIComponent(environmentName)}`;
+  try {
+    return {
+      exists: true,
+      payload: await requestGitHubJsonFn(url, token)
+    };
+  } catch (error) {
+    if (error?.statusCode === 404) {
+      return { exists: false, payload: null };
+    }
+    throw error;
+  }
+}
+
+export async function runDeploymentEnvironmentSync(options = {}) {
+  const args = options.args ?? parseArgs();
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const loadPolicyFn = options.loadPolicyFn ?? loadPortabilityPolicy;
+  const resolveTokenFn = options.resolveTokenFn ?? resolveToken;
+  const requestGitHubJsonFn = options.requestGitHubJsonFn ?? requestGitHubJson;
+  const putGitHubJsonFn = options.putGitHubJsonFn ?? requestGitHubJsonWithMethod;
+  const writeJsonFn = options.writeJsonFn ?? writeJson;
+
+  const policyPath = path.resolve(repoRoot, args.policyPath);
+  const policy = await loadPolicyFn(policyPath);
+  const sourceRepository = normalizeText(args.sourceRepository) ?? policy.sourceRepository;
+  const targets = selectTargets(policy, args.targetSelectors);
+  const token = normalizeText(options.token ?? (await resolveTokenFn()));
+  if (!token) {
+    throw new Error('GitHub token unavailable. Set GH_TOKEN/GITHUB_TOKEN or GH_TOKEN_FILE.');
+  }
+
+  const sourceEnvironments = new Map();
+  for (const environmentName of DEFAULT_ENVIRONMENTS) {
+    const source = await fetchEnvironment(sourceRepository, environmentName, token, requestGitHubJsonFn);
+    if (!source.exists) {
+      throw new Error(`Source environment '${environmentName}' does not exist in ${sourceRepository}.`);
+    }
+    sourceEnvironments.set(environmentName, source.payload);
+  }
+
+  const targetReports = [];
+  for (const target of targets) {
+    const environmentReports = [];
+    for (const environmentName of DEFAULT_ENVIRONMENTS) {
+      const sourcePayload = sourceEnvironments.get(environmentName);
+      const desiredContract = buildDesiredEnvironmentContract(sourcePayload, target);
+      const current = await fetchEnvironment(target.repository, environmentName, token, requestGitHubJsonFn);
+      const beforeContract = current.exists ? summarizeEnvironmentContract(current.payload) : null;
+      const resolvedReviewers = await resolveReviewerIds(desiredContract.reviewers, token, requestGitHubJsonFn);
+      const desiredPayload = buildEnvironmentPayload(desiredContract, resolvedReviewers);
+      const needsApply = !current.exists || !contractsEqual(beforeContract, desiredContract);
+
+      let action = 'noop';
+      let afterPayload = current.payload;
+      if (args.apply && needsApply) {
+        action = current.exists ? 'updated' : 'created';
+        const environmentUrl = `https://api.github.com/repos/${target.repository}/environments/${encodeURIComponent(environmentName)}`;
+        await putGitHubJsonFn(environmentUrl, token, 'PUT', desiredPayload);
+        const refreshed = await fetchEnvironment(target.repository, environmentName, token, requestGitHubJsonFn);
+        afterPayload = refreshed.payload;
+      } else if (needsApply) {
+        action = current.exists ? 'would-update' : 'would-create';
+      }
+
+      const afterContract = afterPayload ? summarizeEnvironmentContract(afterPayload) : desiredContract;
+      const evaluation = evaluateEnvironmentGatePolicy(
+        afterPayload ?? {
+          name: environmentName,
+          can_admins_bypass: desiredContract.canAdminsBypass,
+          protection_rules: [
+            {
+              type: 'required_reviewers',
+              prevent_self_review: desiredContract.preventSelfReview,
+              reviewers: desiredContract.reviewers.map((reviewer) =>
+                reviewer.type === 'Team'
+                  ? {
+                      type: 'Team',
+                      reviewer: {
+                        login: `${reviewer.organization}/${reviewer.teamSlug}`
+                      }
+                    }
+                  : {
+                      type: 'User',
+                      reviewer: {
+                        login: reviewer.login
+                      }
+                    }
+              )
+            }
+          ]
+        },
+        { failOnAdminBypass: true, failOnMissingReviewers: true }
+      );
+
+      environmentReports.push({
+        name: environmentName,
+        action,
+        status: contractsEqual(afterContract, desiredContract) ? 'pass' : 'fail',
+        existsBefore: current.exists,
+        desired: desiredContract,
+        before: beforeContract,
+        after: afterContract,
+        evaluation
+      });
+    }
+
+    const failingEnvironments = environmentReports.filter((entry) => entry.status !== 'pass').map((entry) => entry.name);
+    targetReports.push({
+      alias: target.alias,
+      repository: target.repository,
+      status: failingEnvironments.length > 0 ? 'fail' : 'pass',
+      failingEnvironments,
+      environments: environmentReports
+    });
+  }
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: new Date().toISOString(),
+    apply: args.apply,
+    sourceRepository,
+    policyPath: path.relative(repoRoot, policyPath),
+    targets: targetReports,
+    summary: {
+      status: targetReports.some((entry) => entry.status !== 'pass') ? 'fail' : 'pass',
+      targetCount: targetReports.length,
+      failingTargets: targetReports.filter((entry) => entry.status !== 'pass').map((entry) => entry.alias),
+      actionsRequired: targetReports.flatMap((entry) => entry.environments).filter((entry) => entry.action.startsWith('would-')).length
+    }
+  };
+
+  const reportPath = await writeJsonFn(args.reportPath, report);
+  return {
+    report,
+    reportPath,
+    exitCode: report.summary.status === 'pass' ? 0 : 1
+  };
+}
+
+export async function main(argv = process.argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    printUsage();
+    return 0;
+  }
+
+  const result = await runDeploymentEnvironmentSync({ args });
+  console.log(
+    `[deployment-gate-sync] report: ${result.reportPath} status=${result.report.summary.status} targets=${result.report.summary.targetCount} actionsRequired=${result.report.summary.actionsRequired}`
+  );
+  return result.exitCode;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((code) => {
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    })
+    .catch((error) => {
+      console.error(error?.stack ?? error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- add a repo-native deployment environment sync helper for throughput forks
- store fork portability rules in a checked-in policy, including the personal-fork reviewer override for `monthly-stability-release`
- prove the helper dry-runs cleanly against upstream, org, and personal environment state

## Testing
- node --test tools/priority/__tests__/deployment-gate-policy.test.mjs tools/priority/__tests__/deployment-environment-sync.test.mjs
- node tools/npm/run-script.mjs priority:deployment:gate-sync -- --target origin --target personal --report tests/results/_agent/deployments/environment-gate-sync.live.json
- node tools/npm/run-script.mjs lint:md:changed

## Issue
- Closes #990

## Agent Metadata
- Plane: origin
- Branch: issue/origin-990-fork-deployment-environment-parity
- Focus: protected deployment environment portability for org and personal forks