### PR TITLE
#1053 Relax tools parity checkout major contract

### DIFF
--- a/tools/priority/__tests__/tools-parity-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/tools-parity-workflow-contract.test.mjs
@@ -13,7 +13,7 @@ function readRepoFile(relativePath) {
 
 test('tools parity workflow can dispatch the NI Linux review suite and upload its evidence', () => {
   const workflow = readRepoFile('.github/workflows/tools-parity.yml');
-  assert.match(workflow, /uses: actions\/checkout@v4[\s\S]*fetch-depth:\s*0/);
+  assert.match(workflow, /uses: actions\/checkout@v\d+[\s\S]*fetch-depth:\s*0/);
   assert.match(workflow, /runNiLinuxReviewSuite:/);
   assert.match(workflow, /runRequirementsVerification:/);
   assert.match(workflow, /historyTargetPath:/);


### PR DESCRIPTION
## Summary
- relax the tools parity checkout contract so it requires full-history checkout without pinning a stale `actions/checkout` major
- keep the `#1053` Docker/Desktop parity acceptance focused on the real contract surface
- prove the current Docker/Desktop receipt, runtime, and `_agent` verification bundle is green on current `develop`

## Testing
- `node tools/npm/run-script.mjs build`
- `node --test tools/priority/__tests__/delivery-agent-schema.test.mjs tools/priority/__tests__/docker-tools-parity-agent-verification-schema.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs tools/priority/__tests__/docker-desktop-review-loop.test.mjs tools/priority/__tests__/tools-parity-workflow-contract.test.mjs`
