### PR TITLE
#1143 Consume branch-role contract in intake and orchestration

### DIFF
--- a/tests/GitHubIntake.Tests.ps1
+++ b/tests/GitHubIntake.Tests.ps1
@@ -57,6 +57,28 @@ Describe 'GitHubIntake.psm1' {
       Should -Be 'issue/origin-875-modernize-the-github-intake-layer-for-future-agents'
   }
 
+  It 'resolves lane branch prefixes from the checked-in branch contract' {
+    Resolve-GitHubIntakeLaneBranchPrefix -ForkRemote 'origin' |
+      Should -Be 'issue/origin-'
+
+    Resolve-GitHubIntakeLaneBranchPrefix -ForkRemote 'personal' |
+      Should -Be 'issue/personal-'
+
+    Resolve-GitHubIntakeLaneBranchPrefix |
+      Should -Be 'issue/'
+  }
+
+  It 'derives the fork plane from an existing contract-qualified lane branch' {
+    Resolve-GitHubIntakeForkPlaneFromBranchName -BranchName 'issue/personal-875-modernize-github-intake-layer' |
+      Should -Be 'personal'
+
+    Resolve-GitHubIntakeForkPlaneFromBranchName -BranchName 'issue/origin-875-modernize-github-intake-layer' |
+      Should -Be 'origin'
+
+    Resolve-GitHubIntakeForkPlaneFromBranchName -BranchName 'issue/875-modernize-github-intake-layer' |
+      Should -Be 'upstream'
+  }
+
   It 'loads the checked-in intake catalog with issue and PR templates' {
     $catalog = Get-GitHubIntakeCatalog
 

--- a/tools/Branch-Orchestrator.ps1
+++ b/tools/Branch-Orchestrator.ps1
@@ -26,10 +26,16 @@ function Get-GitDefaultBranch {
 function Resolve-SelectedForkRemote {
   param(
     [string]$RequestedForkRemote,
-    [string]$RequestedHeadRemote
+    [string]$RequestedHeadRemote,
+    [string]$CurrentBranch
   )
 
-  $selectedForkRemote = if ([string]::IsNullOrWhiteSpace($RequestedForkRemote)) { 'origin' } else { $RequestedForkRemote.Trim().ToLowerInvariant() }
+  $selectedForkRemote = if ([string]::IsNullOrWhiteSpace($RequestedForkRemote)) {
+    $inferredForkRemote = Resolve-GitHubIntakeForkPlaneFromBranchName -BranchName $CurrentBranch
+    if ([string]::IsNullOrWhiteSpace($inferredForkRemote)) { 'origin' } else { $inferredForkRemote }
+  } else {
+    $RequestedForkRemote.Trim().ToLowerInvariant()
+  }
   $selectedHeadRemote = if ([string]::IsNullOrWhiteSpace($RequestedHeadRemote)) { $selectedForkRemote } else { $RequestedHeadRemote.Trim().ToLowerInvariant() }
   return [pscustomobject]@{
     ForkRemote = $selectedForkRemote
@@ -163,11 +169,11 @@ $title = if ($snap -and ($snap.PSObject.Properties.Name -contains 'title') -and 
 $defaultBase = Get-GitDefaultBranch
 if (-not $Base) { $Base = $defaultBase }
 Write-Host ("[orchestrator] Base: {0}" -f $Base)
-$forkSelection = Resolve-SelectedForkRemote -RequestedForkRemote $ForkRemote -RequestedHeadRemote $HeadRemote
+$currentBranch = (& git rev-parse --abbrev-ref HEAD).Trim()
+$forkSelection = Resolve-SelectedForkRemote -RequestedForkRemote $ForkRemote -RequestedHeadRemote $HeadRemote -CurrentBranch $currentBranch
 Write-Host ("[orchestrator] Fork remote: {0}" -f $forkSelection.ForkRemote)
 Write-Host ("[orchestrator] Head remote: {0}" -f $forkSelection.HeadRemote)
 
-$currentBranch = (& git rev-parse --abbrev-ref HEAD).Trim()
 $branchName = Resolve-IssueBranchName `
   -Number $Issue `
   -Title $title `

--- a/tools/GitHubIntake.psm1
+++ b/tools/GitHubIntake.psm1
@@ -14,6 +14,15 @@ function Get-GitHubIntakeCatalogPath {
   Join-Path (Get-GitHubIntakeRepoRoot) 'tools' 'priority' 'github-intake-catalog.json'
 }
 
+function Get-GitHubIntakeBranchClassContractPath {
+  $override = [Environment]::GetEnvironmentVariable('COMPAREVI_BRANCH_CLASS_CONTRACT_PATH')
+  if (-not [string]::IsNullOrWhiteSpace($override)) {
+    return $override
+  }
+
+  Join-Path (Get-GitHubIntakeRepoRoot) 'tools' 'policy' 'branch-classes.json'
+}
+
 function Read-GitHubIntakeJsonFile {
   param([string]$Path)
 
@@ -26,6 +35,121 @@ function Read-GitHubIntakeJsonFile {
   } catch {
     return $null
   }
+}
+
+function Get-GitHubIntakeBranchClassContract {
+  $contractPath = Get-GitHubIntakeBranchClassContractPath
+  if (-not (Test-Path -LiteralPath $contractPath -PathType Leaf)) {
+    throw "Branch class contract not found: $contractPath"
+  }
+
+  $contract = Get-Content -LiteralPath $contractPath -Raw | ConvertFrom-Json -ErrorAction Stop
+  if ([string]$contract.schema -ne 'branch-classes/v1') {
+    throw "Unsupported branch class contract schema '$($contract.schema)' in $contractPath"
+  }
+
+  return $contract
+}
+
+function Resolve-GitHubIntakeForkPlane {
+  param(
+    [string]$ForkRemote,
+    [pscustomobject]$Contract
+  )
+
+  $candidate = if ([string]::IsNullOrWhiteSpace($ForkRemote)) { '' } else { $ForkRemote.Trim().ToLowerInvariant() }
+  if (-not $candidate) {
+    return $null
+  }
+
+  if (-not $Contract) {
+    $Contract = Get-GitHubIntakeBranchClassContract
+  }
+
+  $plane = @($Contract.repositoryPlanes | Where-Object { [string]$_.id -eq $candidate } | Select-Object -First 1)
+  if ($plane.Count -gt 0) {
+    return $candidate
+  }
+
+  return $null
+}
+
+function Resolve-GitHubIntakeLaneBranchPrefix {
+  param(
+    [string]$ForkRemote,
+    [string]$BranchPrefix = 'issue',
+    [pscustomobject]$Contract
+  )
+
+  if (-not $Contract) {
+    $Contract = Get-GitHubIntakeBranchClassContract
+  }
+
+  $branchRoot = if ([string]::IsNullOrWhiteSpace($BranchPrefix)) { 'issue' } else { $BranchPrefix.Trim() }
+  $planeId = Resolve-GitHubIntakeForkPlane -ForkRemote $ForkRemote -Contract $Contract
+  if ($planeId) {
+    $plane = $Contract.repositoryPlanes | Where-Object { [string]$_.id -eq $planeId } | Select-Object -First 1
+    $laneBranchPrefix = if ($plane -and ($plane.PSObject.Properties.Name -contains 'laneBranchPrefix')) {
+      ([string]$plane.laneBranchPrefix).Trim()
+    } else {
+      ''
+    }
+    if ([string]::IsNullOrWhiteSpace($laneBranchPrefix)) {
+      throw "Branch class contract does not define a laneBranchPrefix for fork plane '$planeId'."
+    }
+    return $laneBranchPrefix
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($ForkRemote)) {
+    return ('{0}/{1}-' -f $branchRoot, $ForkRemote.Trim().ToLowerInvariant())
+  }
+
+  return ('{0}/' -f $branchRoot)
+}
+
+function Resolve-GitHubIntakeForkPlaneFromBranchName {
+  param(
+    [string]$BranchName,
+    [pscustomobject]$Contract
+  )
+
+  if ([string]::IsNullOrWhiteSpace($BranchName)) {
+    return $null
+  }
+
+  if (-not $Contract) {
+    $Contract = Get-GitHubIntakeBranchClassContract
+  }
+
+  $normalizedBranch = $BranchName.Trim().ToLowerInvariant()
+  $planes = @($Contract.repositoryPlanes | Sort-Object {
+      if ($_ -and ($_.PSObject.Properties.Name -contains 'laneBranchPrefix') -and -not [string]::IsNullOrWhiteSpace([string]$_.laneBranchPrefix)) {
+        -([string]$_.laneBranchPrefix).Trim().Length
+      } else {
+        0
+      }
+    })
+  foreach ($plane in $planes) {
+    $planeId = if ($plane -and ($plane.PSObject.Properties.Name -contains 'id')) { ([string]$plane.id).Trim().ToLowerInvariant() } else { '' }
+    if (-not $planeId) {
+      continue
+    }
+
+    $laneBranchPrefix = if ($plane -and ($plane.PSObject.Properties.Name -contains 'laneBranchPrefix')) {
+      ([string]$plane.laneBranchPrefix).Trim().ToLowerInvariant()
+    } else {
+      ''
+    }
+    if (-not $laneBranchPrefix) {
+      continue
+    }
+
+    if ($normalizedBranch.StartsWith($laneBranchPrefix)) {
+      return $planeId
+    }
+  }
+
+  return $null
 }
 
 function Get-GitHubIntakeRepositoryContext {
@@ -957,23 +1081,17 @@ function Resolve-IssueBranchName {
     [string]$ForkRemote
   )
 
+  $laneBranchPrefix = Resolve-GitHubIntakeLaneBranchPrefix -ForkRemote $ForkRemote -BranchPrefix $BranchPrefix
+
   if ($Number -gt 0 -and -not [string]::IsNullOrWhiteSpace($CurrentBranch)) {
-    $remotePattern = if ([string]::IsNullOrWhiteSpace($ForkRemote)) {
-      '(?:(?:[A-Za-z0-9._-]+)-)?'
-    } else {
-      '(?:{0}-)?' -f [regex]::Escape($ForkRemote)
-    }
-    $pattern = '^{0}/{1}{2}(?:-|$)' -f [regex]::Escape($BranchPrefix), $remotePattern, $Number
+    $pattern = '^{0}{1}(?:-|$)' -f [regex]::Escape($laneBranchPrefix), $Number
     if ($CurrentBranch -match $pattern) {
       return $CurrentBranch
     }
   }
 
   $slug = ConvertTo-IntakeSlug -Title $Title
-  if (-not [string]::IsNullOrWhiteSpace($ForkRemote)) {
-    return '{0}/{1}-{2}-{3}' -f $BranchPrefix, $ForkRemote.ToLowerInvariant(), $Number, $slug
-  }
-  return '{0}/{1}-{2}' -f $BranchPrefix, $Number, $slug
+  return '{0}{1}-{2}' -f $laneBranchPrefix, $Number, $slug
 }
 
 function Get-BranchHeadCommitSubject {
@@ -1028,6 +1146,8 @@ Export-ModuleMember -Function `
   ConvertTo-GitHubIntakeAtlasMarkdown, `
   Get-GitHubIntakeCatalog, `
   Get-GitHubIntakeCatalogPath, `
+  Get-GitHubIntakeBranchClassContract, `
+  Get-GitHubIntakeBranchClassContractPath, `
   Get-GitHubIntakeScenarios, `
   Get-SupportedGitHubIssueTemplates, `
   Get-SupportedGitHubPullRequestTemplates, `
@@ -1036,6 +1156,9 @@ Export-ModuleMember -Function `
   New-GitHubIntakeExecutionPlan, `
   Resolve-GitHubIntakeDraftContext, `
   Resolve-GitHubIntakeDraftOutputPath, `
+  Resolve-GitHubIntakeForkPlane, `
+  Resolve-GitHubIntakeForkPlaneFromBranchName, `
+  Resolve-GitHubIntakeLaneBranchPrefix, `
   Resolve-GitHubIssueSnapshot, `
   Resolve-GitHubIssueTemplate, `
   Resolve-GitHubPullRequestTemplate, `

--- a/tools/priority/__tests__/github-intake-contract.test.mjs
+++ b/tools/priority/__tests__/github-intake-contract.test.mjs
@@ -158,6 +158,7 @@ test('github intake docs and manifest reference the new helper layer', () => {
   assert.match(orchestrator, /'priority:pr'/);
   assert.match(orchestrator, /'--issue'/);
   assert.match(orchestrator, /Resolve-GitHubIssueSnapshot -Issue \$Issue/);
+  assert.match(orchestrator, /Resolve-GitHubIntakeForkPlaneFromBranchName/);
   assert.match(orchestrator, /'pr'\s+'view'\s+\$branchName\s+'--json'\s+'number'/);
   assert.match(orchestrator, /'pr'\s+'edit'\s+\$pr\.number\s+'--title'\s+\$prTitle\s+'--body-file'/);
   assert.match(orchestrator, /Standing-priority queue is empty/);
@@ -172,7 +173,10 @@ test('github intake docs and manifest reference the new helper layer', () => {
   assert.match(oneButtonValidate, /--issue 127/);
   assert.doesNotMatch(oneButtonValidate, /gh pr view --json number --head/);
   assert.match(intakeModule, /function Get-GitHubIntakeCatalog/);
+  assert.match(intakeModule, /function Get-GitHubIntakeBranchClassContract/);
   assert.match(intakeModule, /function Resolve-GitHubIntakeDraftContext/);
+  assert.match(intakeModule, /function Resolve-GitHubIntakeLaneBranchPrefix/);
+  assert.match(intakeModule, /function Resolve-GitHubIntakeForkPlaneFromBranchName/);
   assert.match(intakeModule, /function Resolve-GitHubIssueSnapshot/);
   assert.match(intakeModule, /function Resolve-GitHubIntakeRoute/);
   assert.match(intakeModule, /function New-GitHubIntakeExecutionPlan/);


### PR DESCRIPTION
# Summary

Implements `#1143` by making the PowerShell intake/orchestration path consume the checked-in fork-plane branch contract instead of deriving lane names from hardcoded remote-prefix rules.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1143
- Updated intake module:
  - `tools/GitHubIntake.psm1`
- Updated orchestrator:
  - `tools/Branch-Orchestrator.ps1`
- Updated focused coverage:
  - `tests/GitHubIntake.Tests.ps1`
  - `tools/priority/__tests__/github-intake-contract.test.mjs`

## What Changed

- `Resolve-IssueBranchName` now derives lane prefixes from `tools/policy/branch-classes.json`
- intake now exposes contract-backed helpers for lane prefix resolution and branch-plane inference
- `Branch-Orchestrator` now infers the current fork plane from an existing lane branch before falling back to legacy remote defaults
- bare `issue/*` branches are treated as the upstream lane prefix, while `issue/origin-*` and `issue/personal-*` stay explicit

## Validation Evidence

- `Invoke-Pester -Path tests/GitHubIntake.Tests.ps1,tests/Invoke-GitHubIntakeExecutionPlan.Tests.ps1 -CI`
- `node --test tools/priority/__tests__/github-intake-contract.test.mjs`

## Risks and Follow-ups

- Residual risks: unknown fork remote names still use the legacy generic fallback because they are outside the checked-in plane catalog
- Follow-up issues or deferred work: none in this slice
- Deployment, approval, or rollback notes: rollback is a direct revert of the intake/orchestrator contract migration

## Reviewer Focus

- verify lane branch names now come from the branch contract for `origin`, `personal`, and `upstream`
- verify existing upstream `issue/*` flows remain valid
- verify the orchestrator no longer silently rewrites an existing `issue/personal-*` or `issue/origin-*` branch onto the wrong plane

Closes #1143
