### PR TITLE
#1145 Make priority:pr consume branch-plane contract

### DIFF
--- a/tools/priority/__tests__/branch-classification.test.mjs
+++ b/tools/priority/__tests__/branch-classification.test.mjs
@@ -13,6 +13,7 @@ import {
   loadBranchClassContract,
   matchBranchPattern,
   normalizeBranchName,
+  resolveRepositoryPlaneFromBranchName,
   resolveBranchPlaneTransition,
   resolveLaneBranchPrefix,
   resolveRepositoryPlane,
@@ -51,6 +52,13 @@ test('resolveLaneBranchPrefix follows repository plane metadata from the branch 
   assert.equal(resolveLaneBranchPrefix({ contract, plane: 'personal' }), 'issue/personal-');
   assert.equal(resolveLaneBranchPrefix({ contract, repository: 'svelderrainruiz/compare-vi-cli-action' }), 'issue/personal-');
   assert.equal(findRepositoryPlaneEntry(contract, 'origin')?.laneBranchPrefix, 'issue/origin-');
+});
+
+test('resolveRepositoryPlaneFromBranchName prefers the most specific lane prefix from the branch contract', () => {
+  assert.equal(resolveRepositoryPlaneFromBranchName('issue/1143-branch-intake-contract', contract), 'upstream');
+  assert.equal(resolveRepositoryPlaneFromBranchName('issue/origin-1084-review-plane', contract), 'origin');
+  assert.equal(resolveRepositoryPlaneFromBranchName('issue/personal-1084-authoring-plane', contract), 'personal');
+  assert.equal(resolveRepositoryPlaneFromBranchName('feature/experimental-branch', contract), null);
 });
 
 test('assertPlaneTransition accepts tracked fork-plane edges and rejects undefined ones', () => {

--- a/tools/priority/__tests__/create-pr.test.mjs
+++ b/tools/priority/__tests__/create-pr.test.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync as nodeReadFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   parseArgs,
   parseRouterIssueNumber,
@@ -20,6 +21,10 @@ import {
   createPriorityPr,
   writePriorityPrReport
 } from '../create-pr.mjs';
+import { loadBranchClassContract } from '../lib/branch-classification.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const TEST_BRANCH_CONTRACT = loadBranchClassContract(repoRoot);
 
 function readDefaultPrTemplate(filePath, encoding) {
   return nodeReadFileSync(filePath, encoding);
@@ -282,7 +287,8 @@ test('createPriorityPr refuses to open a priority PR when the standing queue is 
         runGhPrCreateFn: () => {
           throw new Error('should not create PR');
         },
-        resolveStandingIssueNumberFn: () => ({ issueNumber: null, source: 'router', noStandingReason: 'queue-empty' })
+        resolveStandingIssueNumberFn: () => ({ issueNumber: null, source: 'router', noStandingReason: 'queue-empty' }),
+        loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
       }),
     /Standing-priority queue is empty/i
   );
@@ -386,7 +392,8 @@ test('createPriorityPr builds PR metadata from resolved standing issue', () => {
       prPayload = payload;
       return { strategy: 'gh-pr-create' };
     },
-    resolveStandingIssueNumberFn: () => ({ issueNumber: 680, source: 'router' })
+    resolveStandingIssueNumberFn: () => ({ issueNumber: 680, source: 'router' }),
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
   });
 
   assert.equal(pushedBranch, 'origin:issue/680-sync-standing-priority');
@@ -398,6 +405,8 @@ test('createPriorityPr builds PR metadata from resolved standing issue', () => {
   assert.doesNotMatch(prPayload.body, /\(fill in summary\)/);
   assert.equal(result.issueNumber, 680);
   assert.equal(result.issueSource, 'router');
+  assert.equal(result.branchModel.branchPlane, 'upstream');
+  assert.equal(result.branchModel.selectedHeadRemote, 'origin');
   assert.equal(result.strategy, 'gh-pr-create');
 });
 
@@ -469,7 +478,8 @@ test('createPriorityPr honors explicit CLI overrides and body files', () => {
     },
     resolveStandingIssueNumberFn: () => {
       throw new Error('should not resolve standing priority when --issue is explicit');
-    }
+    },
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
   });
 
   assert.equal(prPayload.upstream.owner, 'example');
@@ -482,6 +492,7 @@ test('createPriorityPr honors explicit CLI overrides and body files', () => {
   assert.equal(result.strategy, 'graphql-same-owner-fork');
   assert.equal(result.issueNumber, 963);
   assert.equal(result.issueSource, 'cli');
+  assert.equal(result.branchModel.branchPlane, 'upstream');
 });
 
 test('createPriorityPr fails before PR creation when branch issue mismatches standing issue', () => {
@@ -518,7 +529,11 @@ test('createPriorityPr uses mirror metadata for PR closing references while matc
     getCurrentBranchFn: () => 'issue/personal-1-artifact-download-helper',
     ensureGhCliFn: () => {},
     resolveUpstreamFn: () => ({ owner: 'upstream-owner', repo: 'repo' }),
-    ensureForkRemoteFn: (_repoRoot, _upstream, remote) => ({ owner: 'fork-owner', repo: 'repo', remoteName: remote }),
+    ensureForkRemoteFn: (_repoRoot, _upstream, remote) => ({
+      owner: 'svelderrainruiz',
+      repo: 'compare-vi-cli-action',
+      remoteName: remote
+    }),
     pushBranchFn: () => {},
     runGhPrCreateFn: (payload) => {
       observedTitle = payload.title;
@@ -534,11 +549,63 @@ test('createPriorityPr uses mirror metadata for PR closing references while matc
         repository: 'upstream-owner/repo',
         url: 'https://github.com/upstream-owner/repo/issues/966'
       }
-    })
+    }),
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
   });
 
   assert.match(observedTitle, /#966/);
   assert.match(observedBody, /Closes #966/);
+});
+
+test('createPriorityPr selects the personal remote from the branch contract for personal lane branches', () => {
+  let observedRemote = null;
+  let observedBranchModel = null;
+  const result = createPriorityPr({
+    env: {},
+    options: {},
+    getRepoRootFn: () => '/tmp/repo',
+    getCurrentBranchFn: () => 'issue/personal-1145-pr-branch-contract',
+    ensureGhCliFn: () => {},
+    resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
+    ensureForkRemoteFn: (_repoRoot, _upstream, remote) => {
+      observedRemote = remote;
+      return { owner: 'svelderrainruiz', repo: 'compare-vi-cli-action', remoteName: remote };
+    },
+    pushBranchFn: () => ({}),
+    runGhPrCreateFn: () => ({ strategy: 'gh-pr-create' }),
+    resolveStandingIssueNumberFn: () => ({ issueNumber: 1145, source: 'router' }),
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
+  });
+
+  observedBranchModel = result.branchModel;
+  assert.equal(observedRemote, 'personal');
+  assert.equal(observedBranchModel.branchPlane, 'personal');
+  assert.equal(observedBranchModel.requiredHeadRemote, 'personal');
+  assert.equal(observedBranchModel.selectedHeadRemoteSource, 'branch-contract');
+});
+
+test('createPriorityPr fails closed when an explicit head remote conflicts with the branch contract', () => {
+  assert.throws(
+    () =>
+      createPriorityPr({
+        env: {},
+        options: {
+          headRemote: 'origin'
+        },
+        getRepoRootFn: () => '/tmp/repo',
+        getCurrentBranchFn: () => 'issue/personal-1145-pr-branch-contract',
+        ensureGhCliFn: () => {},
+        resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
+        ensureForkRemoteFn: () => {
+          throw new Error('should not resolve the conflicting fork remote');
+        },
+        pushBranchFn: () => ({}),
+        runGhPrCreateFn: () => ({ strategy: 'gh-pr-create' }),
+        resolveStandingIssueNumberFn: () => ({ issueNumber: 1145, source: 'router' }),
+        loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
+      }),
+    /resolves to the personal fork plane/i
+  );
 });
 
 test('writePriorityPrReport persists personal fork lane metadata for future resume', () => {
@@ -565,6 +632,27 @@ test('writePriorityPrReport persists personal fork lane metadata for future resu
         owner: 'svelderrainruiz',
         repo: 'compare-vi-cli-action'
       },
+      branchModel: {
+        contractPath: 'tools/policy/branch-classes.json',
+        contractDigest: 'abc123',
+        branchPlane: 'personal',
+        repositoryPlane: 'personal',
+        classificationRepository: 'svelderrainruiz/compare-vi-cli-action',
+        laneBranchPrefix: 'issue/personal-',
+        selectedHeadRemote: 'personal',
+        selectedHeadRemoteSource: 'branch-contract',
+        requiredHeadRemote: 'personal',
+        classification: {
+          id: 'lane',
+          repositoryRole: 'fork',
+          repositoryPlane: 'personal',
+          matchedPattern: 'issue/*',
+          prSourceAllowed: true,
+          prTargetAllowed: false,
+          mergePolicy: 'n/a',
+          purpose: 'Short-lived implementation branches tied to issues.'
+        }
+      },
       pushStatus: 'pushed',
       strategy: 'gh-pr-create',
       reusedExistingPullRequest: false,
@@ -587,6 +675,9 @@ test('writePriorityPrReport persists personal fork lane metadata for future resu
   assert.equal(report.issue.mirrorOf.number, 969);
   assert.equal(report.head.remote, 'personal');
   assert.equal(report.head.repository, 'svelderrainruiz/compare-vi-cli-action');
+  assert.equal(report.branchModel.contractPath, 'tools/policy/branch-classes.json');
+  assert.equal(report.branchModel.branchPlane, 'personal');
+  assert.equal(report.branchModel.selectedHeadRemoteSource, 'branch-contract');
   assert.equal(report.pullRequest.number, 1139);
   assert.match(nodeReadFileSync(reportPath, 'utf8'), /priority\/pr-create@v1/);
 });
@@ -631,7 +722,8 @@ test('createPriorityPr preserves an already-published human-drafted PR so a late
     }),
     resolveStandingIssueNumberFn: () => {
       throw new Error('should not resolve standing priority when --issue is explicit');
-    }
+    },
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
   });
 
   assert.equal(result.pushStatus, 'already-published');

--- a/tools/priority/create-pr.mjs
+++ b/tools/priority/create-pr.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import process from 'node:process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -13,10 +14,20 @@ import {
   resolveUpstream,
   ensureForkRemote,
   resolveActiveForkRemoteName,
+  normalizeForkRemoteName,
   pushBranch,
   runGhPrCreate,
-  parseRepositorySlug
+  parseRepositorySlug,
+  buildRepositorySlug
 } from './lib/remote-utils.mjs';
+import {
+  DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH,
+  classifyBranch,
+  findRepositoryPlaneEntry,
+  loadBranchClassContract,
+  resolveRepositoryPlane,
+  resolveRepositoryPlaneFromBranchName
+} from './lib/branch-classification.mjs';
 
 const ROUTER_RELATIVE_PATH = path.join('tests', 'results', '_agent', 'issue', 'router.json');
 const CACHE_RELATIVE_PATH = '.agent_priority_cache.json';
@@ -155,6 +166,14 @@ function toPositiveInteger(value) {
     return null;
   }
   return number;
+}
+
+function normalizeText(value) {
+  return String(value ?? '').trim();
+}
+
+function digestText(value) {
+  return createHash('sha256').update(String(value ?? ''), 'utf8').digest('hex');
 }
 
 export function parseRouterIssueNumber(router) {
@@ -533,6 +552,124 @@ export function resolveBody({ options, issueNumber, env = process.env, readFileS
   );
 }
 
+function loadPriorityPrBranchContract(
+  repoRoot,
+  {
+    readFileSyncFn = readFileSync,
+    loadBranchClassContractFn = loadBranchClassContract
+  } = {}
+) {
+  const contractPath = path.join(repoRoot, DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH);
+  const contract = loadBranchClassContractFn(repoRoot, {
+    relativePath: DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH,
+    readFileSyncFn
+  });
+
+  let rawText = null;
+  try {
+    rawText = readFileSyncFn(contractPath, 'utf8');
+  } catch {
+    rawText = JSON.stringify(contract);
+  }
+
+  return {
+    contract,
+    contractPath: DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH.replace(/\\/g, '/'),
+    contractDigest: digestText(rawText)
+  };
+}
+
+export function resolvePriorityPrBranchModel({
+  repoRoot,
+  branch,
+  upstream,
+  headRemote = null,
+  headRemoteSource = null,
+  headRepository = null,
+  readFileSyncFn = readFileSync,
+  loadBranchClassContractFn = loadBranchClassContract
+}) {
+  const { contract, contractPath, contractDigest } = loadPriorityPrBranchContract(repoRoot, {
+    readFileSyncFn,
+    loadBranchClassContractFn
+  });
+  const branchPlane = resolveRepositoryPlaneFromBranchName(branch, contract);
+  const branchPlaneEntry = branchPlane ? findRepositoryPlaneEntry(contract, branchPlane) : null;
+  const requiredHeadRemote =
+    branchPlane === 'origin' || branchPlane === 'personal'
+      ? branchPlane
+      : null;
+
+  if (requiredHeadRemote && headRemote && normalizeText(headRemote).toLowerCase() !== requiredHeadRemote) {
+    throw new Error(
+      `Branch '${branch}' resolves to the ${requiredHeadRemote} fork plane via ${contractPath}, but head remote '${headRemote}' was selected from ${headRemoteSource ?? 'unknown-source'}.`
+    );
+  }
+
+  const headRepositorySlug = buildRepositorySlug(headRepository);
+  const upstreamRepositorySlug = buildRepositorySlug(upstream);
+  const classificationRepository =
+    branchPlane === 'upstream'
+      ? upstreamRepositorySlug
+      : headRepositorySlug || upstreamRepositorySlug;
+  const classification = classificationRepository
+    ? classifyBranch({
+        branch,
+        contract,
+        repository: classificationRepository
+      })
+    : null;
+
+  if (normalizeText(branch).toLowerCase().startsWith('issue/') && !classification) {
+    throw new Error(
+      `Branch '${branch}' is not classified by ${contractPath}; update the branch contract or rename the lane before opening a PR.`
+    );
+  }
+
+  if (classification && classification.prSourceAllowed !== true) {
+    throw new Error(
+      `Branch '${branch}' resolves to class '${classification.id}', which is not allowed as a PR source by ${contractPath}.`
+    );
+  }
+
+  const resolvedRepositoryPlane = classification?.repositoryPlane
+    ? normalizeText(classification.repositoryPlane).toLowerCase()
+    : branchPlane;
+
+  if (requiredHeadRemote && headRepositorySlug) {
+    const headRepositoryPlane = resolveRepositoryPlane(headRepositorySlug, contract);
+    if (headRepositoryPlane !== requiredHeadRemote) {
+      throw new Error(
+        `Head repository '${headRepositorySlug}' resolves to plane '${headRepositoryPlane}', but branch '${branch}' requires '${requiredHeadRemote}' according to ${contractPath}.`
+      );
+    }
+  }
+
+  return {
+    contractPath,
+    contractDigest,
+    branchPlane: branchPlane ?? null,
+    classificationRepository: classificationRepository ?? null,
+    classification: classification
+      ? {
+          id: classification.id,
+          repositoryRole: classification.repositoryRole,
+          repositoryPlane: classification.repositoryPlane,
+          matchedPattern: classification.matchedPattern,
+          prSourceAllowed: classification.prSourceAllowed,
+          prTargetAllowed: classification.prTargetAllowed,
+          mergePolicy: classification.mergePolicy,
+          purpose: classification.purpose
+        }
+      : null,
+    laneBranchPrefix: normalizeText(branchPlaneEntry?.laneBranchPrefix) || null,
+    selectedHeadRemote: headRemote ? normalizeText(headRemote).toLowerCase() : null,
+    selectedHeadRemoteSource: headRemoteSource ?? null,
+    requiredHeadRemote,
+    repositoryPlane: resolvedRepositoryPlane ?? null
+  };
+}
+
 export function createPriorityPr({
   env = process.env,
   options = {},
@@ -544,7 +681,8 @@ export function createPriorityPr({
   ensureForkRemoteFn = ensureForkRemote,
   pushBranchFn = pushBranch,
   runGhPrCreateFn = runGhPrCreate,
-  resolveStandingIssueNumberFn = resolveStandingIssueNumberForPr
+  resolveStandingIssueNumberFn = resolveStandingIssueNumberForPr,
+  loadBranchClassContractFn = loadBranchClassContract
 } = {}) {
   const repoRoot = getRepoRootFn();
   const branch = ensurePrSourceBranch(options.branch || getCurrentBranchFn(repoRoot));
@@ -568,8 +706,58 @@ export function createPriorityPr({
   }
   assertBranchMatchesIssue(branch, localIssueNumber);
   const upstream = options.repository ? parseRepositorySlug(options.repository) : resolveUpstreamFn(repoRoot);
-  const headRemote = options.headRemote || env.PR_HEAD_REMOTE || resolveActiveForkRemoteName(env);
+  const initialBranchModel = resolvePriorityPrBranchModel({
+    repoRoot,
+    branch,
+    upstream,
+    headRemote: null,
+    headRemoteSource: null,
+    headRepository: null,
+    readFileSyncFn,
+    loadBranchClassContractFn
+  });
+  const inferredBranchPlane = initialBranchModel.branchPlane;
+  const explicitHeadRemote = normalizeText(options.headRemote);
+  const envHeadRemote = normalizeText(env.PR_HEAD_REMOTE);
+  const activeForkRemote = normalizeText(env.AGENT_PRIORITY_ACTIVE_FORK_REMOTE);
+  let headRemoteSource = 'default';
+  let headRemote = null;
+  if (explicitHeadRemote) {
+    headRemote = normalizeForkRemoteName(explicitHeadRemote);
+    headRemoteSource = 'cli';
+  } else if (envHeadRemote) {
+    headRemote = normalizeForkRemoteName(envHeadRemote);
+    headRemoteSource = 'env:PR_HEAD_REMOTE';
+  } else if (inferredBranchPlane === 'origin' || inferredBranchPlane === 'personal') {
+    headRemote = inferredBranchPlane;
+    headRemoteSource = 'branch-contract';
+  } else if (activeForkRemote) {
+    headRemote = normalizeForkRemoteName(activeForkRemote);
+    headRemoteSource = 'env:AGENT_PRIORITY_ACTIVE_FORK_REMOTE';
+  } else {
+    headRemote = resolveActiveForkRemoteName(env);
+  }
+  resolvePriorityPrBranchModel({
+    repoRoot,
+    branch,
+    upstream,
+    headRemote,
+    headRemoteSource,
+    headRepository: null,
+    readFileSyncFn,
+    loadBranchClassContractFn
+  });
   const headRepository = ensureForkRemoteFn(repoRoot, upstream, headRemote);
+  const branchModel = resolvePriorityPrBranchModel({
+    repoRoot,
+    branch,
+    upstream,
+    headRemote,
+    headRemoteSource,
+    headRepository,
+    readFileSyncFn,
+    loadBranchClassContractFn
+  });
 
   const pushResult = pushBranchFn(repoRoot, branch, headRemote);
   const base = options.base || env.PR_BASE || 'develop';
@@ -612,6 +800,7 @@ export function createPriorityPr({
     upstream,
     headRemote,
     headRepository,
+    branchModel,
     strategy: prResult?.strategy ?? null,
     pullRequest: prResult?.pullRequest ?? null,
     reusedExistingPullRequest: prResult?.reusedExisting === true
@@ -640,6 +829,20 @@ export function buildPriorityPrReport(result, generatedAt = new Date().toISOStri
           : null,
       branch: result.branch ?? null
     },
+    branchModel: result.branchModel
+      ? {
+          contractPath: result.branchModel.contractPath ?? null,
+          contractDigest: result.branchModel.contractDigest ?? null,
+          branchPlane: result.branchModel.branchPlane ?? null,
+          repositoryPlane: result.branchModel.repositoryPlane ?? null,
+          classificationRepository: result.branchModel.classificationRepository ?? null,
+          laneBranchPrefix: result.branchModel.laneBranchPrefix ?? null,
+          selectedHeadRemote: result.branchModel.selectedHeadRemote ?? null,
+          selectedHeadRemoteSource: result.branchModel.selectedHeadRemoteSource ?? null,
+          requiredHeadRemote: result.branchModel.requiredHeadRemote ?? null,
+          classification: result.branchModel.classification
+        }
+      : null,
     base: result.base ?? null,
     pushStatus: result.pushStatus ?? null,
     strategy: result.strategy ?? null,

--- a/tools/priority/lib/branch-classification.mjs
+++ b/tools/priority/lib/branch-classification.mjs
@@ -298,6 +298,35 @@ export function resolveLaneBranchPrefix({
     : `${normalizedFallback}/`;
 }
 
+export function resolveRepositoryPlaneFromBranchName(branch, contract) {
+  if (!contract || typeof contract !== 'object') {
+    throw new Error('Branch class contract is required.');
+  }
+
+  const normalizedBranch = normalizeBranchName(branch);
+  if (!normalizedBranch) {
+    return null;
+  }
+
+  const matches = (Array.isArray(contract.repositoryPlanes) ? contract.repositoryPlanes : [])
+    .map((entry) => ({
+      plane: normalizeRepositoryPlane(entry?.id),
+      prefix: normalizeBranchName(entry?.laneBranchPrefix)
+    }))
+    .filter((entry) => entry.prefix && normalizedBranch.startsWith(entry.prefix))
+    .sort((left, right) => right.prefix.length - left.prefix.length);
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  if (matches.length > 1 && matches[0].prefix.length === matches[1].prefix.length) {
+    throw new Error(`Ambiguous repository plane resolution for branch '${normalizedBranch}'.`);
+  }
+
+  return matches[0].plane;
+}
+
 export function resolveRepositoryRole(repository, contract) {
   return resolveRepositoryPlane(repository, contract) === 'upstream' ? 'upstream' : 'fork';
 }


### PR DESCRIPTION
# Summary

Implements `#1145` by making `priority:pr` consume the checked-in fork-plane branch contract instead of resolving branch-plane behavior from helper-local assumptions.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: #1145
- Updated PR helper:
  - `tools/priority/create-pr.mjs`
- Updated branch contract library:
  - `tools/priority/lib/branch-classification.mjs`
- Updated focused coverage:
  - `tools/priority/__tests__/create-pr.test.mjs`
  - `tools/priority/__tests__/branch-classification.test.mjs`

## What Changed

- `priority:pr` now reads `tools/policy/branch-classes.json` and records contract path/digest metadata in its report
- explicit `issue/personal-*` and `issue/origin-*` lanes now select the matching fork remote from the branch contract when no override is supplied
- conflicting `--head-remote` / branch-plane combinations now fail closed before remote resolution
- PR creation reports now carry branch-plane evidence for future-agent replayability

## Validation Evidence

- `node --check tools/priority/create-pr.mjs`
- `node --test tools/priority/__tests__/branch-classification.test.mjs tools/priority/__tests__/create-pr.test.mjs`

## Risks and Follow-ups

- Residual risks: broader runtime/daemon branch-plane adoption remains separate from this `priority:pr` slice
- Follow-up issues or deferred work: none in this slice
- Deployment, approval, or rollback notes: rollback is a direct revert of the PR helper + branch classification changes

## Reviewer Focus

- verify `issue/personal-*` lanes now imply the `personal` head remote through the checked-in contract
- verify conflicting explicit `--head-remote` selections fail before any remote mutation
- verify the PR creation report now records branch-plane metadata and contract digest evidence

Closes #1145
