### PR TITLE
#1147 Make runtime lane synthesis consume the branch contract

### DIFF
--- a/tools/priority/__tests__/runtime-daemon.test.mjs
+++ b/tools/priority/__tests__/runtime-daemon.test.mjs
@@ -86,6 +86,65 @@ function makeExecDeps() {
   };
 }
 
+function makeRuntimeBranchContract() {
+  return {
+    schema: 'branch-classes/v1',
+    upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    repositoryPlanes: [
+      {
+        id: 'upstream',
+        repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action'],
+        laneBranchPrefix: 'issue/'
+      },
+      {
+        id: 'origin',
+        repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+        laneBranchPrefix: 'issue/origin-'
+      },
+      {
+        id: 'personal',
+        repositories: ['svelderrainruiz/compare-vi-cli-action'],
+        laneBranchPrefix: 'issue/personal-'
+      }
+    ],
+    classes: [
+      {
+        id: 'lane',
+        repositoryRoles: ['upstream', 'fork'],
+        branchPatterns: ['issue/*'],
+        purpose: 'lane',
+        prSourceAllowed: true,
+        prTargetAllowed: false,
+        mergePolicy: 'n/a'
+      }
+    ],
+    allowedTransitions: [
+      {
+        from: 'lane',
+        action: 'promote',
+        to: 'upstream-integration',
+        via: 'pull-request'
+      }
+    ],
+    planeTransitions: [
+      {
+        from: 'origin',
+        action: 'promote',
+        to: 'upstream',
+        via: 'pull-request',
+        branchClass: 'lane'
+      },
+      {
+        from: 'personal',
+        action: 'promote',
+        to: 'upstream',
+        via: 'pull-request',
+        branchClass: 'lane'
+      }
+    ]
+  };
+}
+
 test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-daemon-wrapper-root-'));
   const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'runtime-daemon-wrapper-'));
@@ -107,6 +166,7 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
     {
       platform: 'linux',
       resolveRepoRootFn: () => repoRoot,
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
       nowFactory: () => new Date(Date.UTC(2026, 2, 10, 17, 0, tick++)),
       sleepFn: async () => {
         throw new Error('sleep should not run when maxCycles=1');
@@ -178,6 +238,7 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
     {
       platform: 'linux',
       resolveRepoRootFn: () => repoRoot,
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
       resolveStandingPriorityForRepoFn: async () => ({
         found: null
       }),
@@ -713,6 +774,7 @@ test('comparevi worker bootstrap activates the lane branch before invoking boots
       checkoutPath
     },
     deps: {
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
       execFileFn: async (command, args, options) => {
         calls.push({ command, args, options });
         if (command !== 'git') {
@@ -778,6 +840,43 @@ test('comparevi worker bootstrap includes stderr in blocked bootstrap diagnostic
   assert.match(blocked.reason, /bootstrap stderr/);
 });
 
+test('comparevi worker bootstrap fails closed when the branch prefix conflicts with the fork plane contract', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-daemon-worker-ready-branch-conflict-'));
+  const { checkoutPath } = compareviRuntimeTest.resolveCompareviWorkerCheckoutPath({
+    repoRoot,
+    repository: 'example/repo',
+    laneId: 'personal-997'
+  });
+  await mkdir(path.join(checkoutPath, 'tools', 'priority'), { recursive: true });
+  await writeFile(path.join(checkoutPath, 'tools', 'priority', 'bootstrap.ps1'), '# mocked bootstrap', 'utf8');
+
+  const blocked = await compareviRuntimeTest.bootstrapCompareviWorkerCheckout({
+    schedulerDecision: {
+      activeLane: {
+        laneId: 'personal-997',
+        forkRemote: 'personal',
+        branch: 'issue/origin-997-branch-conflict'
+      },
+      stepOptions: {
+        branch: 'issue/origin-997-branch-conflict'
+      }
+    },
+    preparedWorker: {
+      generatedAt: '2026-03-10T18:00:00.000Z',
+      checkoutPath
+    },
+    deps: {
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
+      execFileFn: async () => {
+        throw new Error('git should not run when the branch prefix conflicts with the plane contract');
+      }
+    }
+  });
+
+  assert.equal(blocked.status, 'blocked');
+  assert.match(blocked.reason, /does not match lane branch prefix 'issue\/personal-'/i);
+});
+
 test('comparevi worker activation attaches a ready checkout onto the deterministic lane branch', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-daemon-worker-branch-'));
   const { checkoutPath } = compareviRuntimeTest.resolveCompareviWorkerCheckoutPath({
@@ -808,6 +907,7 @@ test('comparevi worker activation attaches a ready checkout onto the determinist
       checkoutPath
     },
     deps: {
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
       execFileFn: async (command, args, options) => {
         calls.push({ command, args, options });
         if (command !== 'git') {
@@ -829,6 +929,46 @@ test('comparevi worker activation attaches a ready checkout onto the determinist
   assert.equal(attached.trackingRef, 'personal/issue/personal-998-runtime-worker-branch-activation');
   assert.deepEqual(attached.fetchedRemotes, ['upstream', 'origin', 'personal']);
   assert.ok(calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout' && entry.args.includes('--force')));
+});
+
+test('comparevi worker activation fails closed when the branch prefix conflicts with the fork plane contract', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-daemon-worker-branch-conflict-'));
+  const { checkoutPath } = compareviRuntimeTest.resolveCompareviWorkerCheckoutPath({
+    repoRoot,
+    repository: 'example/repo',
+    laneId: 'origin-998'
+  });
+  await mkdir(checkoutPath, { recursive: true });
+  await writeFile(path.join(checkoutPath, '.git'), 'gitdir: mocked\n', 'utf8');
+
+  const blocked = await compareviRuntimeTest.activateCompareviWorkerLane({
+    schedulerDecision: {
+      activeLane: {
+        laneId: 'origin-998',
+        forkRemote: 'origin',
+        branch: 'issue/personal-998-runtime-worker-branch-activation'
+      },
+      stepOptions: {
+        branch: 'issue/personal-998-runtime-worker-branch-activation'
+      }
+    },
+    preparedWorker: {
+      checkoutPath
+    },
+    workerReady: {
+      readyAt: '2026-03-10T18:30:00.000Z',
+      checkoutPath
+    },
+    deps: {
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
+      execFileFn: async () => {
+        throw new Error('git should not run when the branch prefix conflicts with the plane contract');
+      }
+    }
+  });
+
+  assert.equal(blocked.status, 'blocked');
+  assert.match(blocked.reason, /does not match lane branch prefix 'issue\/origin-'/i);
 });
 
 test('comparevi worker activation blocks when the scheduler does not resolve a branch name', async () => {
@@ -868,6 +1008,7 @@ test('comparevi planner prefers live standing issue data for the target reposito
     },
     explicitStepOptions: {},
     deps: {
+      loadBranchClassContractFn: () => makeRuntimeBranchContract(),
       resolveStandingPriorityForRepoFn: async () => ({
         found: {
           number: 315,
@@ -904,6 +1045,10 @@ test('comparevi planner prefers live standing issue data for the target reposito
 test('comparevi execution closes the fork mirror and advances to the next development issue', async () => {
   const handoffCalls = [];
   const closeCalls = [];
+  const issueLabels = new Map([
+    [315, ['fork-standing-priority']],
+    [313, []]
+  ]);
   const execution = await compareviRuntimeTest.executeCompareviTurn({
     options: {
       repo: 'svelderrainruiz/compare-vi-cli-action'
@@ -954,6 +1099,27 @@ test('comparevi execution closes the fork mirror and advances to the next develo
       ],
       handoffGhRunner: (args) => {
         handoffCalls.push(args);
+        if (args[0] === 'issue' && args[1] === 'edit') {
+          const issueNumber = Number(args[2]);
+          const labels = new Set(issueLabels.get(issueNumber) ?? []);
+          const addIndex = args.indexOf('--add-label');
+          if (addIndex >= 0) {
+            labels.add(args[addIndex + 1]);
+          }
+          const removeIndex = args.indexOf('--remove-label');
+          if (removeIndex >= 0) {
+            labels.delete(args[removeIndex + 1]);
+          }
+          issueLabels.set(issueNumber, Array.from(labels));
+          return '';
+        }
+        if (args[0] === 'issue' && args[1] === 'view') {
+          const issueNumber = Number(args[2]);
+          return JSON.stringify({
+            number: issueNumber,
+            labels: (issueLabels.get(issueNumber) ?? []).map((name) => ({ name }))
+          });
+        }
         if (args[0] === 'issue' && args[1] === 'list' && args.includes('--label')) {
           if (args.includes('fork-standing-priority')) {
             return JSON.stringify([{ number: 315, labels: [{ name: 'fork-standing-priority' }] }]);
@@ -963,6 +1129,9 @@ test('comparevi execution closes the fork mirror and advances to the next develo
         return '';
       },
       handoffSyncFn: async () => {},
+      patchIssueLabelsFn: (_repoRoot, _repoSlug, issueNumber, labels) => {
+        issueLabels.set(Number(issueNumber), Array.from(labels));
+      },
       closeIssueFn: async (payload) => {
         closeCalls.push(payload);
       }
@@ -972,10 +1141,10 @@ test('comparevi execution closes the fork mirror and advances to the next develo
   assert.equal(execution.outcome, 'mirror-closed-advanced');
   assert.equal(execution.stopLoop, false);
   assert.equal(execution.details.nextStandingIssueNumber, 313);
-  assert.deepEqual(handoffCalls.slice(-2), [
-    ['issue', 'edit', '315', '--remove-label', 'fork-standing-priority'],
-    ['issue', 'edit', '313', '--add-label', 'fork-standing-priority']
-  ]);
+  assert.deepEqual(issueLabels.get(315), []);
+  assert.deepEqual(issueLabels.get(313), ['fork-standing-priority']);
+  assert.ok(handoffCalls.some((args) => args[0] === 'issue' && args[1] === 'view' && args[2] === '315'));
+  assert.ok(handoffCalls.some((args) => args[0] === 'issue' && args[1] === 'view' && args[2] === '313'));
   assert.equal(closeCalls[0].repository, 'svelderrainruiz/compare-vi-cli-action');
   assert.equal(closeCalls[0].issueNumber, 315);
 });
@@ -1012,6 +1181,10 @@ test('comparevi execution derives standing context from explicit lane metadata w
   const handoffCalls = [];
   const closeCalls = [];
   const fetchCalls = [];
+  const issueLabels = new Map([
+    [315, ['fork-standing-priority']],
+    [313, []]
+  ]);
   const execution = await compareviRuntimeTest.executeCompareviTurn({
     options: {
       repo: 'svelderrainruiz/compare-vi-cli-action',
@@ -1066,6 +1239,27 @@ test('comparevi execution derives standing context from explicit lane metadata w
       ],
       handoffGhRunner: (args) => {
         handoffCalls.push(args);
+        if (args[0] === 'issue' && args[1] === 'edit') {
+          const issueNumber = Number(args[2]);
+          const labels = new Set(issueLabels.get(issueNumber) ?? []);
+          const addIndex = args.indexOf('--add-label');
+          if (addIndex >= 0) {
+            labels.add(args[addIndex + 1]);
+          }
+          const removeIndex = args.indexOf('--remove-label');
+          if (removeIndex >= 0) {
+            labels.delete(args[removeIndex + 1]);
+          }
+          issueLabels.set(issueNumber, Array.from(labels));
+          return '';
+        }
+        if (args[0] === 'issue' && args[1] === 'view') {
+          const issueNumber = Number(args[2]);
+          return JSON.stringify({
+            number: issueNumber,
+            labels: (issueLabels.get(issueNumber) ?? []).map((name) => ({ name }))
+          });
+        }
         if (args[0] === 'issue' && args[1] === 'list' && args.includes('--label')) {
           if (args.includes('fork-standing-priority')) {
             return JSON.stringify([{ number: 315, labels: [{ name: 'fork-standing-priority' }] }]);
@@ -1075,6 +1269,9 @@ test('comparevi execution derives standing context from explicit lane metadata w
         return '';
       },
       handoffSyncFn: async () => {},
+      patchIssueLabelsFn: (_repoRoot, _repoSlug, issueNumber, labels) => {
+        issueLabels.set(Number(issueNumber), Array.from(labels));
+      },
       closeIssueFn: async (payload) => {
         closeCalls.push(payload);
       }
@@ -1084,10 +1281,10 @@ test('comparevi execution derives standing context from explicit lane metadata w
   assert.equal(execution.outcome, 'mirror-closed-advanced');
   assert.equal(execution.details.standingIssueNumber, 315);
   assert.ok(fetchCalls.length >= 1);
-  assert.deepEqual(handoffCalls.slice(-2), [
-    ['issue', 'edit', '315', '--remove-label', 'fork-standing-priority'],
-    ['issue', 'edit', '313', '--add-label', 'fork-standing-priority']
-  ]);
+  assert.deepEqual(issueLabels.get(315), []);
+  assert.deepEqual(issueLabels.get(313), ['fork-standing-priority']);
+  assert.ok(handoffCalls.some((args) => args[0] === 'issue' && args[1] === 'view' && args[2] === '315'));
+  assert.ok(handoffCalls.some((args) => args[0] === 'issue' && args[1] === 'view' && args[2] === '313'));
   assert.equal(closeCalls[0].issueNumber, 315);
 });
 

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -534,85 +534,88 @@ test('comparevi branch resolver matches the repo issue branch naming contract', 
   assert.equal(branch, 'issue/personal-998-attach-ready-worker-checkouts-onto-deterministic-lane-branches');
 });
 
-test('comparevi branch resolver uses lane prefixes from the branch contract when provided', () => {
-  const branch = compareviRuntimeTest.resolveCompareviIssueBranchName({
-    issueNumber: 998,
-    title: 'Attach ready worker checkouts onto deterministic lane branches',
-    forkRemote: 'personal',
-    branchClassContract: {
-      repositoryPlanes: [
-        {
-          id: 'personal',
-          laneBranchPrefix: 'lane/personal-'
+test('comparevi branch resolver fails closed when the branch contract does not define the requested plane', () => {
+  assert.throws(
+    () =>
+      compareviRuntimeTest.resolveCompareviIssueBranchName({
+        issueNumber: 998,
+        title: 'Attach ready worker checkouts onto deterministic lane branches',
+        forkRemote: 'personal',
+        branchClassContract: {
+          repositoryPlanes: [
+            {
+              id: 'origin',
+              laneBranchPrefix: 'issue/origin-'
+            }
+          ]
         }
-      ]
-    }
-  });
-
-  assert.equal(branch, 'lane/personal-998-attach-ready-worker-checkouts-onto-deterministic-lane-branches');
+      }),
+    /does not define repository plane 'personal'/i
+  );
 });
 
-test('canonical delivery decision uses lane prefixes from the branch contract for the selected implementation plane', async () => {
-  const decision = await buildCanonicalDeliveryDecision({
-    repoRoot,
-    upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-    targetRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-    issueSnapshot: {
-      number: 1084,
-      title: 'Define a fork-plane branching model for personal/org/upstream collaboration',
-      state: 'OPEN',
-      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-      pullRequests: []
-    },
-    issueGraph: {
-      standingIssue: {
+test('canonical delivery decision fails closed when the implementation plane is missing from the branch contract', async () => {
+  await assert.rejects(
+    buildCanonicalDeliveryDecision({
+      repoRoot,
+      upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      targetRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      issueSnapshot: {
         number: 1084,
         title: 'Define a fork-plane branching model for personal/org/upstream collaboration',
         state: 'OPEN',
         repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
         pullRequests: []
       },
-      subIssues: [],
-      pullRequests: []
-    },
-    policy: {
-      implementationRemote: 'personal'
-    },
-    deps: {
-      loadBranchClassContractFn: () => ({
-        schema: 'branch-classes/v1',
-        upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-        repositoryPlanes: [
-          {
-            id: 'personal',
-            repositories: ['svelderrainruiz/compare-vi-cli-action'],
-            laneBranchPrefix: 'lane/personal-'
-          }
-        ],
-        classes: [
-          {
-            id: 'lane',
-            repositoryRoles: ['fork'],
-            branchPatterns: ['issue/*'],
-            purpose: 'lane',
-            prSourceAllowed: true,
-            prTargetAllowed: false,
-            mergePolicy: 'n/a'
-          }
-        ],
-        allowedTransitions: [
-          {
-            from: 'lane',
-            action: 'promote',
-            to: 'upstream-integration',
-            via: 'pull-request'
-          }
-        ]
-      })
-    }
-  });
-
-  assert.equal(decision.stepOptions.branch, 'lane/personal-1084-define-a-fork-plane-branching-model-for-personal-org-upstream-collaboration');
+      issueGraph: {
+        standingIssue: {
+          number: 1084,
+          title: 'Define a fork-plane branching model for personal/org/upstream collaboration',
+          state: 'OPEN',
+          repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          pullRequests: []
+        },
+        subIssues: [],
+        pullRequests: []
+      },
+      policy: {
+        implementationRemote: 'personal'
+      },
+      deps: {
+        loadBranchClassContractFn: () => ({
+          schema: 'branch-classes/v1',
+          upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          repositoryPlanes: [
+            {
+              id: 'origin',
+              repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+              laneBranchPrefix: 'issue/origin-'
+            }
+          ],
+          classes: [
+            {
+              id: 'lane',
+              repositoryRoles: ['fork'],
+              branchPatterns: ['issue/*'],
+              purpose: 'lane',
+              prSourceAllowed: true,
+              prTargetAllowed: false,
+              mergePolicy: 'n/a'
+            }
+          ],
+          allowedTransitions: [
+            {
+              from: 'lane',
+              action: 'promote',
+              to: 'upstream-integration',
+              via: 'pull-request'
+            }
+          ]
+        })
+      }
+    }),
+    /does not define repository plane 'personal'/i
+  );
 });
 
 test('runRuntimeSupervisor step writes runtime state, lane, turn, event, and blocker artifacts', async () => {
@@ -826,6 +829,48 @@ test('canonical delivery scheduler ranks existing PR unblock before ready child 
       allowPolicyMutations: false,
       allowReleaseAdmin: false,
       stopWhenNoOpenEpics: true
+    },
+    deps: {
+      loadBranchClassContractFn: () => ({
+        schema: 'branch-classes/v1',
+        upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        repositoryPlanes: [
+          {
+            id: 'upstream',
+            repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action'],
+            laneBranchPrefix: 'issue/'
+          },
+          {
+            id: 'origin',
+            repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+            laneBranchPrefix: 'issue/origin-'
+          },
+          {
+            id: 'personal',
+            repositories: ['svelderrainruiz/compare-vi-cli-action'],
+            laneBranchPrefix: 'issue/personal-'
+          }
+        ],
+        classes: [
+          {
+            id: 'lane',
+            repositoryRoles: ['upstream', 'fork'],
+            branchPatterns: ['issue/*'],
+            purpose: 'lane',
+            prSourceAllowed: true,
+            prTargetAllowed: false,
+            mergePolicy: 'n/a'
+          }
+        ],
+        allowedTransitions: [
+          {
+            from: 'lane',
+            action: 'promote',
+            to: 'upstream-integration',
+            via: 'pull-request'
+          }
+        ]
+      })
     }
   });
 
@@ -2054,6 +2099,48 @@ test('canonical delivery scheduler falls back to backlog repair when an epic has
       allowPolicyMutations: false,
       allowReleaseAdmin: false,
       stopWhenNoOpenEpics: true
+    },
+    deps: {
+      loadBranchClassContractFn: () => ({
+        schema: 'branch-classes/v1',
+        upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        repositoryPlanes: [
+          {
+            id: 'upstream',
+            repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action'],
+            laneBranchPrefix: 'issue/'
+          },
+          {
+            id: 'origin',
+            repositories: ['LabVIEW-Community-CI-CD/compare-vi-cli-action-fork'],
+            laneBranchPrefix: 'issue/origin-'
+          },
+          {
+            id: 'personal',
+            repositories: ['svelderrainruiz/compare-vi-cli-action'],
+            laneBranchPrefix: 'issue/personal-'
+          }
+        ],
+        classes: [
+          {
+            id: 'lane',
+            repositoryRoles: ['upstream', 'fork'],
+            branchPatterns: ['issue/*'],
+            purpose: 'lane',
+            prSourceAllowed: true,
+            prTargetAllowed: false,
+            mergePolicy: 'n/a'
+          }
+        ],
+        allowedTransitions: [
+          {
+            from: 'lane',
+            action: 'promote',
+            to: 'upstream-integration',
+            via: 'pull-request'
+          }
+        ]
+      })
     }
   });
 

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -4,7 +4,8 @@ import { spawnSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { loadBranchClassContract, resolveBranchPlaneTransition, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
+import { loadBranchClassContract, resolveBranchPlaneTransition } from './lib/branch-classification.mjs';
+import { resolveRequiredLaneBranchPrefix } from './lib/runtime-lane-branch-contract.mjs';
 import {
   assessDockerDesktopReviewLoopReceipt,
   buildLocalReviewLoopCliArgs,
@@ -514,8 +515,7 @@ function resolveIssueBranchName({
   implementationRemote = 'origin',
   repoRoot = process.cwd(),
   branchClassContract = null,
-  loadBranchClassContractFn = loadBranchClassContract,
-  branchPrefix = 'issue'
+  loadBranchClassContractFn = loadBranchClassContract
 }) {
   const slug = normalizeText(title)
     .normalize('NFKD')
@@ -525,18 +525,13 @@ function resolveIssueBranchName({
     .replace(/-+/g, '-')
     .toLowerCase()
     .replace(/^-+|-+$/g, '') || 'work';
-  let lanePrefix = '';
-  try {
-    lanePrefix = resolveLaneBranchPrefix({
-      contract: branchClassContract ?? loadBranchClassContractFn(repoRoot),
-      plane: normalizeText(implementationRemote) || 'upstream',
-      fallbackPrefix: `${branchPrefix}/`
-    });
-  } catch {
-    const remotePrefix = normalizeText(implementationRemote) ? `${normalizeText(implementationRemote).toLowerCase()}-` : '';
-    lanePrefix = `${branchPrefix}/${remotePrefix}`;
-  }
-  return `${lanePrefix}${issueNumber}-${slug}`;
+  const { laneBranchPrefix } = resolveRequiredLaneBranchPrefix({
+    plane: normalizeText(implementationRemote) || 'upstream',
+    repoRoot,
+    branchClassContract,
+    loadBranchClassContractFn
+  });
+  return `${laneBranchPrefix}${issueNumber}-${slug}`;
 }
 
 function parseRepositorySlug(repository) {

--- a/tools/priority/lib/runtime-lane-branch-contract.mjs
+++ b/tools/priority/lib/runtime-lane-branch-contract.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { findRepositoryPlaneEntry, loadBranchClassContract } from './branch-classification.mjs';
+
+function normalizeText(value) {
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function normalizeLaneBranchPrefix(prefix) {
+  const normalized = normalizeText(prefix);
+  if (!normalized) {
+    return '';
+  }
+  return normalized.endsWith('/') || normalized.endsWith('-') ? normalized : `${normalized}/`;
+}
+
+export function resolveRequiredLaneBranchPrefix({
+  plane,
+  repoRoot = process.cwd(),
+  branchClassContract = null,
+  loadBranchClassContractFn = loadBranchClassContract
+}) {
+  const normalizedPlane = normalizeText(plane).toLowerCase();
+  if (!normalizedPlane) {
+    throw new Error('Repository plane is required to resolve a runtime lane branch prefix.');
+  }
+
+  const contract = branchClassContract ?? loadBranchClassContractFn(repoRoot);
+  const planeEntry = findRepositoryPlaneEntry(contract, normalizedPlane);
+  if (!planeEntry) {
+    throw new Error(`Branch class contract does not define repository plane '${normalizedPlane}' for runtime lane branches.`);
+  }
+
+  const laneBranchPrefix = normalizeLaneBranchPrefix(planeEntry.laneBranchPrefix);
+  if (!laneBranchPrefix) {
+    throw new Error(
+      `Branch class contract repository plane '${normalizedPlane}' does not define a laneBranchPrefix for runtime lane branches.`
+    );
+  }
+
+  return {
+    contract,
+    plane: normalizedPlane,
+    laneBranchPrefix
+  };
+}
+
+export function assertLaneBranchMatchesPlane({
+  branch,
+  plane,
+  repoRoot = process.cwd(),
+  branchClassContract = null,
+  loadBranchClassContractFn = loadBranchClassContract
+}) {
+  const normalizedBranch = normalizeText(branch);
+  if (!normalizedBranch) {
+    throw new Error('Runtime lane branch is required.');
+  }
+
+  const { contract, laneBranchPrefix, plane: normalizedPlane } = resolveRequiredLaneBranchPrefix({
+    plane,
+    repoRoot,
+    branchClassContract,
+    loadBranchClassContractFn
+  });
+
+  if (!normalizedBranch.toLowerCase().startsWith(laneBranchPrefix.toLowerCase())) {
+    throw new Error(
+      `Runtime lane branch '${normalizedBranch}' does not match lane branch prefix '${laneBranchPrefix}' for plane '${normalizedPlane}'.`
+    );
+  }
+
+  return {
+    contract,
+    branch: normalizedBranch,
+    plane: normalizedPlane,
+    laneBranchPrefix
+  };
+}

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -28,7 +28,8 @@ import {
   runRuntimeSupervisor as runCoreRuntimeSupervisor
 } from '../../packages/runtime-harness/index.mjs';
 import { acquireWriterLease, defaultOwner, releaseWriterLease } from './agent-writer-lease.mjs';
-import { loadBranchClassContract, resolveBranchPlaneTransition, resolveLaneBranchPrefix } from './lib/branch-classification.mjs';
+import { loadBranchClassContract, resolveBranchPlaneTransition } from './lib/branch-classification.mjs';
+import { resolveRequiredLaneBranchPrefix } from './lib/runtime-lane-branch-contract.mjs';
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import { handoffStandingPriority } from './standing-priority-handoff.mjs';
 import {
@@ -216,22 +217,16 @@ function resolveCompareviIssueBranchName({
   forkRemote,
   repoRoot = process.cwd(),
   branchClassContract = null,
-  loadBranchClassContractFn = loadBranchClassContract,
-  branchPrefix = 'issue'
+  loadBranchClassContractFn = loadBranchClassContract
 }) {
   const slug = resolveCompareviIssueSlug(title);
-  let lanePrefix = '';
-  try {
-    lanePrefix = resolveLaneBranchPrefix({
-      contract: branchClassContract ?? loadBranchClassContractFn(repoRoot),
-      plane: normalizeText(forkRemote) || 'upstream',
-      fallbackPrefix: `${branchPrefix}/`
-    });
-  } catch {
-    const remotePrefix = normalizeText(forkRemote) ? `${normalizeText(forkRemote).toLowerCase()}-` : '';
-    lanePrefix = `${branchPrefix}/${remotePrefix}`;
-  }
-  return `${lanePrefix}${issueNumber}-${slug}`;
+  const { laneBranchPrefix } = resolveRequiredLaneBranchPrefix({
+    plane: normalizeText(forkRemote) || 'upstream',
+    repoRoot,
+    branchClassContract,
+    loadBranchClassContractFn
+  });
+  return `${laneBranchPrefix}${issueNumber}-${slug}`;
 }
 
 async function readJsonIfPresent(filePath) {
@@ -280,8 +275,11 @@ function resolveForkRemoteForRepository(repository, upstreamRepository, implemen
 
 function buildSchedulerDecisionFromSnapshot({
   snapshot,
+  repoRoot = process.cwd(),
   upstreamRepository,
   implementationRemote,
+  branchClassContract = null,
+  loadBranchClassContractFn = loadBranchClassContract,
   source,
   artifactPaths
 }) {
@@ -324,7 +322,9 @@ function buildSchedulerDecisionFromSnapshot({
     issueNumber: selectedIssue,
     title: snapshot.title,
     forkRemote,
-    repoRoot
+    repoRoot,
+    branchClassContract,
+    loadBranchClassContractFn
   });
   const reason =
     Number.isInteger(snapshot.mirrorOf?.number) && snapshot.mirrorOf.number !== snapshot.number
@@ -405,8 +405,11 @@ async function planCompareviRuntimeStepFromLiveStanding({ repoRoot, targetReposi
     }
     return buildSchedulerDecisionFromSnapshot({
       snapshot: snapshotWithRepo,
+      repoRoot,
       upstreamRepository,
       implementationRemote: deliveryPolicy.implementationRemote,
+      branchClassContract: deps.branchClassContract ?? null,
+      loadBranchClassContractFn: deps.loadBranchClassContractFn ?? loadBranchClassContract,
       source: 'comparevi-standing-priority-live',
       artifactPaths: {
         standingLabel: standingLookup.found.label || null,
@@ -476,8 +479,11 @@ async function planCompareviRuntimeStep({ repoRoot, env, explicitStepOptions, op
   if (cacheSnapshot) {
     return buildSchedulerDecisionFromSnapshot({
       snapshot: cacheSnapshot,
+      repoRoot,
       upstreamRepository,
       implementationRemote: deliveryPolicy.implementationRemote,
+      branchClassContract: deps.branchClassContract ?? null,
+      loadBranchClassContractFn: deps.loadBranchClassContractFn ?? loadBranchClassContract,
       source: 'comparevi-standing-priority-cache',
       artifactPaths: {
         cachePath
@@ -502,8 +508,11 @@ async function planCompareviRuntimeStep({ repoRoot, env, explicitStepOptions, op
   const issueSnapshot = await readJsonIfPresent(issuePath);
   return buildSchedulerDecisionFromSnapshot({
     snapshot: issueSnapshot,
+    repoRoot,
     upstreamRepository,
     implementationRemote: deliveryPolicy.implementationRemote,
+    branchClassContract: deps.branchClassContract ?? null,
+    loadBranchClassContractFn: deps.loadBranchClassContractFn ?? loadBranchClassContract,
     source: 'comparevi-standing-priority-router',
     artifactPaths: {
       routerPath,
@@ -893,6 +902,7 @@ async function executeCompareviTurn({
       },
       logger: deps.handoffLogger ?? (() => {}),
       ghRunner: deps.handoffGhRunner,
+      patchIssueLabelsFn: deps.patchIssueLabelsFn,
       syncFn: deps.handoffSyncFn,
       leaseReleaseFn: deps.handoffLeaseReleaseFn,
       releaseLease: false

--- a/tools/priority/runtime-worker-checkout.mjs
+++ b/tools/priority/runtime-worker-checkout.mjs
@@ -4,6 +4,8 @@ import { access, mkdir, readFile, readdir, rm, unlink, writeFile } from 'node:fs
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { loadBranchClassContract } from './lib/branch-classification.mjs';
+import { assertLaneBranchMatchesPlane } from './lib/runtime-lane-branch-contract.mjs';
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_WORKER_REF = 'upstream/develop';
@@ -653,6 +655,25 @@ export async function bootstrapCompareviWorkerCheckout({
   if (branch) {
     const forkRemote = normalizeText(schedulerDecision?.activeLane?.forkRemote) || 'upstream';
     try {
+      assertLaneBranchMatchesPlane({
+        branch,
+        plane: forkRemote,
+        repoRoot: preparedWorker.checkoutPath,
+        loadBranchClassContractFn: deps.loadBranchClassContractFn ?? loadBranchClassContract
+      });
+    } catch (error) {
+      return {
+        laneId: schedulerDecision.activeLane.laneId,
+        checkoutPath: preparedWorker.checkoutPath,
+        status: 'blocked',
+        source: 'comparevi-bootstrap',
+        reason: normalizeText(error?.message) || String(error),
+        bootstrapCommand: [],
+        bootstrapExitCode: 1,
+        preparedAt: preparedWorker.generatedAt ?? null
+      };
+    }
+    try {
       const availableRemotes = (await tryReadGitStdout(execFileFn, ['remote'], { cwd: preparedWorker.checkoutPath }))
         .split(/\r?\n/)
         .map((entry) => normalizeText(entry))
@@ -757,6 +778,27 @@ export async function activateCompareviWorkerLane({
 
   const execFileFn = deps.execFileFn ?? execFileAsync;
   const forkRemote = normalizeText(activeLane?.forkRemote) || 'upstream';
+  try {
+    assertLaneBranchMatchesPlane({
+      branch,
+      plane: forkRemote,
+      repoRoot: checkoutPath,
+      loadBranchClassContractFn: deps.loadBranchClassContractFn ?? loadBranchClassContract
+    });
+  } catch (error) {
+    return {
+      laneId,
+      checkoutPath,
+      branch,
+      forkRemote,
+      status: 'blocked',
+      source: 'comparevi-branch',
+      reason: normalizeText(error?.message) || String(error),
+      baseRef: DEFAULT_WORKER_REF,
+      trackingRef: `${forkRemote}/${branch}`,
+      fetchedRemotes: []
+    };
+  }
   const availableRemotes = (await tryReadGitStdout(execFileFn, ['remote'], { cwd: checkoutPath }))
     .split(/\r?\n/)
     .map((entry) => normalizeText(entry))


### PR DESCRIPTION
## Summary
- make runtime lane synthesis fail closed against the checked-in fork-plane branch contract
- validate worker checkout branch attachment against the same required lane prefixes
- replace focused runtime tests that still depended on legacy lane-prefix fallback behavior

## Testing
- node --check tools/priority/lib/runtime-lane-branch-contract.mjs
- node --test tools/priority/__tests__/runtime-supervisor.test.mjs tools/priority/__tests__/runtime-daemon.test.mjs