### PR TITLE
#1151 Project health required contexts from branch classes

### DIFF
--- a/tests/BranchExpectedContexts.Tests.ps1
+++ b/tests/BranchExpectedContexts.Tests.ps1
@@ -1,0 +1,36 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'BranchExpectedContexts' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Import-Module (Join-Path $repoRoot 'tools' 'BranchExpectedContexts.psm1') -Force -DisableNameChecking
+  }
+
+  It 'projects expected contexts from branchClassRequiredChecks when branches are absent' {
+    $policy = [pscustomobject]@{
+      branchClassBindings = [pscustomobject]@{
+        develop = 'upstream-integration'
+      }
+      branchClassRequiredChecks = [pscustomobject]@{
+        'upstream-integration' = @('lint', 'session-index')
+      }
+    }
+
+    $expected = @(Resolve-BranchExpectedContexts -Policy $policy -BranchName 'develop')
+    $expected | Should -Be @('lint', 'session-index')
+  }
+
+  It 'falls back to branches when no branch-class projection is available' {
+    $policy = [pscustomobject]@{
+      branches = [pscustomobject]@{
+        develop = @('lint', 'fixtures')
+      }
+    }
+
+    $expected = @(Resolve-BranchExpectedContexts -Policy $policy -BranchName 'develop')
+    $expected | Should -Be @('fixtures', 'lint')
+  }
+}

--- a/tests/Write-HealthSnapshot.Tests.ps1
+++ b/tests/Write-HealthSnapshot.Tests.ps1
@@ -127,4 +127,92 @@ Describe 'Write-HealthSnapshot.ps1' -Tag 'Unit' {
     $snapshot.parity.planeTransition | Should -BeNullOrEmpty
     @($snapshot.degradedNotes) | Should -Contain 'Parity report is missing required plane-transition metadata.'
   }
+
+  It 'projects expected required contexts from branch classes when explicit branch lists are absent' {
+    $resultsDir = Join-Path $TestDrive 'results-projected'
+    $outputDir = Join-Path $TestDrive 'out-projected'
+    $parityPath = Join-Path $outputDir 'origin-upstream-parity.json'
+    $policyPath = Join-Path $TestDrive 'branch-required-checks.json'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Encoding utf8
+
+    $parity = [ordered]@{
+      schema = 'origin-upstream-parity@v1'
+      status = 'ok'
+      baseRef = 'upstream/develop'
+      headRef = 'origin/develop'
+      tipDiff = [ordered]@{
+        fileCount = 0
+      }
+      treeParity = [ordered]@{
+        equal = $true
+        status = 'equal'
+      }
+      recommendation = [ordered]@{
+        code = 'aligned'
+      }
+      planeTransition = [ordered]@{
+        from = 'upstream'
+        to = 'origin'
+        action = 'sync'
+        via = 'priority:develop:sync'
+      }
+    }
+    ($parity | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $parityPath -Encoding utf8
+
+    $policy = [ordered]@{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branchClassBindings = [ordered]@{
+        develop = 'upstream-integration'
+      }
+      branchClassRequiredChecks = [ordered]@{
+        'upstream-integration' = @('lint', 'session-index')
+      }
+    }
+    ($policy | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $policyPath -Encoding utf8
+
+    $ghTokenPrevious = $env:GH_TOKEN
+    $githubTokenPrevious = $env:GITHUB_TOKEN
+    try {
+      Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+      Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+
+      Push-Location -LiteralPath $script:RepoRoot
+      try {
+        & $script:ToolPath `
+          -ResultsRoot $resultsDir `
+          -OutputDir $outputDir `
+          -ParityReportPath $parityPath `
+          -Owner 'example-owner' `
+          -Repository 'example-repo' `
+          -BranchRequiredChecksPath $policyPath `
+          -SkipParityRefresh | Out-Null
+      } finally {
+        Pop-Location
+      }
+    } finally {
+      if ($null -eq $ghTokenPrevious) {
+        Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+      } else {
+        $env:GH_TOKEN = $ghTokenPrevious
+      }
+      if ($null -eq $githubTokenPrevious) {
+        Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+      } else {
+        $env:GITHUB_TOKEN = $githubTokenPrevious
+      }
+    }
+
+    $snapshot = Get-Content -LiteralPath (Join-Path $outputDir 'health-snapshot.json') -Raw | ConvertFrom-Json -Depth 30
+    $snapshot.requiredContexts.verdict | Should -Be 'degraded'
+    $snapshot.requiredContexts.source | Should -Be 'fallback'
+    $snapshot.requiredContexts.expectedCount | Should -Be 2
+    @($snapshot.requiredContexts.missing | Sort-Object) | Should -Be @('lint', 'session-index')
+  }
 }

--- a/tools/BranchExpectedContexts.psm1
+++ b/tools/BranchExpectedContexts.psm1
@@ -1,0 +1,104 @@
+Set-StrictMode -Version Latest
+
+function Read-BranchPolicyFile {
+  param([Parameter(Mandatory)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Branch required-check policy file not found: $Path"
+  }
+
+  return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 50)
+}
+
+function Resolve-PatternValue {
+  param(
+    [AllowNull()][psobject]$Mapping,
+    [Parameter(Mandatory)][string]$BranchName
+  )
+
+  if (-not $Mapping) {
+    return $null
+  }
+
+  foreach ($prop in $Mapping.PSObject.Properties) {
+    if ($prop.Name -eq $BranchName) {
+      return $prop.Value
+    }
+  }
+
+  $bestMatch = $null
+  $bestSpecificity = -1
+  foreach ($prop in $Mapping.PSObject.Properties) {
+    $pattern = $prop.Name
+    if ($pattern -eq 'default') {
+      continue
+    }
+    if ($pattern -notmatch '[\*\?]') {
+      continue
+    }
+    if ($BranchName -like $pattern) {
+      $specificity = ($pattern -replace '[\*\?]', '').Length
+      if ($specificity -gt $bestSpecificity) {
+        $bestSpecificity = $specificity
+        $bestMatch = $prop.Value
+      }
+    }
+  }
+
+  if ($null -ne $bestMatch) {
+    return $bestMatch
+  }
+
+  foreach ($prop in $Mapping.PSObject.Properties) {
+    if ($prop.Name -eq 'default') {
+      return $prop.Value
+    }
+  }
+
+  return $null
+}
+
+function Resolve-BranchExpectedContexts {
+  param(
+    [AllowNull()][psobject]$Policy,
+    [Parameter(Mandatory)][string]$BranchName
+  )
+
+  if (-not $Policy) {
+    return @()
+  }
+
+  $branchClassId = $null
+  if ($Policy.PSObject.Properties.Name -contains 'branchClassBindings') {
+    $resolvedBranchClass = Resolve-PatternValue -Mapping $Policy.branchClassBindings -BranchName $BranchName
+    if ($resolvedBranchClass) {
+      $branchClassId = [string]$resolvedBranchClass
+    }
+  }
+
+  $expectedRaw = @()
+  if ($branchClassId -and $Policy.PSObject.Properties.Name -contains 'branchClassRequiredChecks') {
+    $expectedRaw = @(Resolve-PatternValue -Mapping $Policy.branchClassRequiredChecks -BranchName $branchClassId)
+  }
+  if ($expectedRaw.Count -eq 0 -and $Policy.PSObject.Properties.Name -contains 'branches') {
+    $expectedRaw = @(Resolve-PatternValue -Mapping $Policy.branches -BranchName $BranchName)
+  }
+
+  return @($expectedRaw | Where-Object { $_ } | Sort-Object -Unique)
+}
+
+function Resolve-BranchExpectedContextsFromPath {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$BranchName
+  )
+
+  $policy = Read-BranchPolicyFile -Path $Path
+  return @(Resolve-BranchExpectedContexts -Policy $policy -BranchName $BranchName)
+}
+
+Export-ModuleMember -Function `
+  Read-BranchPolicyFile, `
+  Resolve-PatternValue, `
+  Resolve-BranchExpectedContexts, `
+  Resolve-BranchExpectedContextsFromPath

--- a/tools/priority/Write-HealthSnapshot.ps1
+++ b/tools/priority/Write-HealthSnapshot.ps1
@@ -3,6 +3,7 @@
 param(
   [string]$ResultsRoot = 'tests/results',
   [string]$OutputDir = 'tests/results/_agent/health-snapshot',
+  [string]$BranchRequiredChecksPath = 'tools/policy/branch-required-checks.json',
   [string]$Owner,
   [string]$Repository,
   [string]$Branch = 'develop',
@@ -15,6 +16,8 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path (Split-Path -Parent $PSCommandPath) '..' 'BranchExpectedContexts.psm1') -Force -DisableNameChecking
 
 function Get-Token {
   if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) { return $env:GH_TOKEN }
@@ -201,12 +204,16 @@ function Get-RequiredContextVerdict {
     }
   }
 
-  $policyPath = Join-Path (Join-Path (Get-Location).Path 'tools') 'policy/branch-required-checks.json'
   $expected = @()
+  $policyPath = if ([System.IO.Path]::IsPathRooted($BranchRequiredChecksPath)) {
+    $BranchRequiredChecksPath
+  } else {
+    Join-Path (Get-Location).Path $BranchRequiredChecksPath
+  }
+
   if (Test-Path -LiteralPath $policyPath -PathType Leaf) {
     try {
-      $policy = Get-Content -LiteralPath $policyPath -Raw | ConvertFrom-Json -Depth 30
-      $expected = @($policy.branches.$Branch)
+      $expected = @(Resolve-BranchExpectedContextsFromPath -Path $policyPath -BranchName $Branch)
     } catch {
       $expected = @()
     }


### PR DESCRIPTION
# Summary

Projects health-snapshot required contexts from the branch-class contract instead of assuming explicit per-branch copies in the policy file.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1151
- Files, tools, workflows, or policies touched:
  - `tools/BranchExpectedContexts.psm1`
  - `tools/priority/Write-HealthSnapshot.ps1`
  - `tests/BranchExpectedContexts.Tests.ps1`
  - `tests/Write-HealthSnapshot.Tests.ps1`
- Cross-repo or external-consumer impact: health snapshot projection now shares the same branch-class source of truth as policy enforcement.
- Required checks, merge-queue behavior, or approval flows affected: none directly; this is a contract-consumer alignment slice.

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/BranchExpectedContexts.Tests.ps1,tests/Write-HealthSnapshot.Tests.ps1 -CI`
- Key artifacts, logs, or workflow runs:
  - local Pester run passed with 5/5 tests
- Risk-based checks not run:
  - broader hosted validation is deferred to the PR checks.

## Risks and Follow-ups

- Residual risks: other branch-required-check consumers may still need the same projection pattern.
- Follow-up issues or deferred work: broader health/session-index consumers remain tracked separately under `#1038`.
- Deployment, approval, or rollback notes: standard PR merge-queue flow.

## Reviewer Focus

- Please verify: fallback behavior remains stable when explicit branch lists are absent.
- Areas where the reasoning is subtle: expected required contexts now resolve through branch classes before falling back to legacy explicit branch lists.
- Manual spot checks requested: none.

Closes #1151