### PR TITLE
#1153 Project session-index contract contexts from branch classes

### DIFF
--- a/tests/Test-SessionIndexV2Contract.Tests.ps1
+++ b/tests/Test-SessionIndexV2Contract.Tests.ps1
@@ -1,0 +1,178 @@
+Describe 'Test-SessionIndexV2Contract' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools/Test-SessionIndexV2Contract.ps1'
+
+    function Write-JsonFile {
+      param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][object]$Data
+      )
+
+      $Data | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath $Path -Encoding utf8
+    }
+
+    function New-SessionIndexFixture {
+      param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$ExpectedContexts,
+        [string[]]$ActualContexts = $ExpectedContexts
+      )
+
+      $resultsDir = Join-Path $TestDrive $Name
+      New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+      Write-JsonFile -Path (Join-Path $resultsDir 'session-index.json') -Data @{
+        schema = 'session-index/v1'
+      }
+
+      Write-JsonFile -Path (Join-Path $resultsDir 'session-index-v2.json') -Data @{
+        schema = 'session-index/v2'
+        schemaVersion = '1.0.0'
+        generatedAtUtc = '2026-03-14T00:00:00.000Z'
+        run = @{
+          workflow = 'Validate'
+        }
+        branchProtection = @{
+          status = 'ok'
+          reason = 'aligned'
+          expected = @($ExpectedContexts)
+          actual = @($ActualContexts)
+        }
+        artifacts = @(
+          @{
+            name = 'session-index-v2'
+            path = 'session-index-v2.json'
+          }
+        )
+      }
+
+      return $resultsDir
+    }
+
+    function Invoke-ContractTool {
+      param(
+        [Parameter(Mandatory)][string]$ResultsDir,
+        [Parameter(Mandatory)][string]$PolicyPath,
+        [string]$Branch = 'develop',
+        [switch]$Enforce
+      )
+
+      $psi = [System.Diagnostics.ProcessStartInfo]::new()
+      $psi.FileName = 'pwsh'
+      $args = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-File', $scriptPath,
+        '-ResultsDir', $ResultsDir,
+        '-PolicyPath', $PolicyPath,
+        '-Branch', $Branch,
+        '-Owner', 'example-owner',
+        '-Repository', 'example-repo'
+      )
+      if ($Enforce) {
+        $args += '-Enforce'
+      }
+      foreach ($arg in $args) {
+        $psi.ArgumentList.Add([string]$arg) | Out-Null
+      }
+      $psi.WorkingDirectory = $repoRoot
+      $psi.UseShellExecute = $false
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+
+      $ghTokenPrevious = $env:GH_TOKEN
+      $githubTokenPrevious = $env:GITHUB_TOKEN
+      try {
+        Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $stdout = $proc.StandardOutput.ReadToEnd()
+        $stderr = $proc.StandardError.ReadToEnd()
+        $proc.WaitForExit()
+      } finally {
+        if ($null -eq $ghTokenPrevious) {
+          Remove-Item Env:GH_TOKEN -ErrorAction SilentlyContinue
+        } else {
+          $env:GH_TOKEN = $ghTokenPrevious
+        }
+        if ($null -eq $githubTokenPrevious) {
+          Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+        } else {
+          $env:GITHUB_TOKEN = $githubTokenPrevious
+        }
+      }
+
+      return @{
+        ExitCode = $proc.ExitCode
+        StdOut = $stdout
+        StdErr = $stderr
+        Report = (Get-Content -LiteralPath (Join-Path $ResultsDir 'session-index-v2-contract.json') -Raw | ConvertFrom-Json -Depth 50)
+      }
+    }
+  }
+
+  It 'projects required contexts from branch classes when explicit branch lists are absent' {
+    $resultsDir = New-SessionIndexFixture -Name 'projected' -ExpectedContexts @('lint', 'session-index')
+    $policyPath = Join-Path $TestDrive 'branch-policy.projected.json'
+    Write-JsonFile -Path $policyPath -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branchClassBindings = @{
+        develop = 'upstream-integration'
+      }
+      branchClassRequiredChecks = @{
+        'upstream-integration' = @('lint', 'session-index')
+      }
+    }
+
+    $run = Invoke-ContractTool -ResultsDir $resultsDir -PolicyPath $policyPath
+
+    $run.ExitCode | Should -Be 0
+    $run.Report.status | Should -Be 'pass'
+    ($run.Report.branchProtection.requiredContexts | Sort-Object) | Should -Be @('lint', 'session-index')
+    $run.Report.branchProtection.missingContexts | Should -BeNullOrEmpty
+  }
+
+  It 'falls back to explicit branch lists when no branch-class binding exists' {
+    $resultsDir = New-SessionIndexFixture -Name 'fallback' -ExpectedContexts @('lint', 'session-index')
+    $policyPath = Join-Path $TestDrive 'branch-policy.fallback.json'
+    Write-JsonFile -Path $policyPath -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branches = @{
+        develop = @('lint', 'session-index')
+      }
+    }
+
+    $run = Invoke-ContractTool -ResultsDir $resultsDir -PolicyPath $policyPath
+
+    $run.ExitCode | Should -Be 0
+    $run.Report.status | Should -Be 'pass'
+    ($run.Report.branchProtection.requiredContexts | Sort-Object) | Should -Be @('lint', 'session-index')
+    $run.Report.branchProtection.missingContexts | Should -BeNullOrEmpty
+  }
+
+  It 'fails closed in enforce mode when neither branch-class projection nor fallback data exist' {
+    $resultsDir = New-SessionIndexFixture -Name 'missing' -ExpectedContexts @()
+    $policyPath = Join-Path $TestDrive 'branch-policy.missing.json'
+    Write-JsonFile -Path $policyPath -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branchClassBindings = @{
+        main = 'upstream-release'
+      }
+      branchClassRequiredChecks = @{
+        'upstream-release' = @('commit-integrity')
+      }
+    }
+
+    $run = Invoke-ContractTool -ResultsDir $resultsDir -PolicyPath $policyPath -Enforce
+
+    $run.ExitCode | Should -Be 1
+    $run.Report.status | Should -Be 'fail'
+    $run.Report.failures | Should -Contain "Unable to resolve required contexts from branch policy for branch 'develop'."
+  }
+}

--- a/tools/Test-SessionIndexV2Contract.ps1
+++ b/tools/Test-SessionIndexV2Contract.ps1
@@ -14,6 +14,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Import-Module (Join-Path $PSScriptRoot 'BranchExpectedContexts.psm1') -Force -DisableNameChecking
+
 function Convert-GitRemoteUrlToSlug {
   param([string]$RemoteUrl)
 
@@ -214,8 +216,10 @@ if (Test-Path -LiteralPath $v2Path -PathType Leaf) {
 $expectedContexts = @()
 if (Test-Path -LiteralPath $PolicyPath -PathType Leaf) {
   try {
-    $policy = Get-Content -Raw -LiteralPath $PolicyPath | ConvertFrom-Json -Depth 50
-    $expectedContexts = @($policy.branches.$Branch)
+    $expectedContexts = @(Resolve-BranchExpectedContextsFromPath -Path $PolicyPath -BranchName $Branch)
+    if ($expectedContexts.Count -eq 0) {
+      Add-Failure -Failures ([ref]$failures) -Message ("Unable to resolve required contexts from branch policy for branch '{0}'." -f $Branch)
+    }
   } catch {
     Add-Failure -Failures ([ref]$failures) -Message "Unable to read required-check policy: $($_.Exception.Message)"
   }


### PR DESCRIPTION
# Summary

Projects session-index required contexts from the branch-class contract instead of relying only on explicit per-branch copies in `branch-required-checks.json`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1153
- Files, tools, workflows, or policies touched:
  - `tools/Test-SessionIndexV2Contract.ps1`
  - `tests/Test-SessionIndexV2Contract.Tests.ps1`
- Cross-repo or external-consumer impact: session-index v2 contract verification now shares the same branch-class projection seam as policy enforcement and health snapshots.
- Required checks, merge-queue behavior, or approval flows affected: none directly; this aligns another required-check consumer to the same contract source.

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/Test-SessionIndexV2Contract.Tests.ps1 -CI`
- Key artifacts, logs, or workflow runs:
  - local Pester run passed with 3/3 tests
- Risk-based checks not run:
  - broader hosted validation is deferred to the PR checks.

## Risks and Follow-ups

- Residual risks: other remaining required-check consumers may still need the same projection treatment.
- Follow-up issues or deferred work: none added in this slice.
- Deployment, approval, or rollback notes: standard PR merge-queue flow.

## Reviewer Focus

- Please verify: branch-class resolution is authoritative and legacy explicit branch lists remain a valid fallback.
- Areas where the reasoning is subtle: the contract now fails closed when neither branch-class projection nor explicit fallback can resolve required contexts.
- Manual spot checks requested: none.

Closes #1153