### PR TITLE
#1155 Allow requirements contract branch-class-only policy

### DIFF
--- a/tests/RequirementsVerificationCheckContract.Tests.ps1
+++ b/tests/RequirementsVerificationCheckContract.Tests.ps1
@@ -90,4 +90,98 @@ jobs:
     $run.ExitCode | Should -Be 1
     ($run.StdOut + $run.StdErr) | Should -Match 'Workflow job name mismatch'
   }
+
+  It 'passes when branch-class-only policy data resolves the expected check' {
+    $tmpWorkflow = Join-Path $TestDrive 'verification.branch-class.yml'
+    $tmpBranchPolicy = Join-Path $TestDrive 'branch-required-checks.branch-class.json'
+    $tmpPriorityPolicy = Join-Path $TestDrive 'policy.branch-class.json'
+
+    @'
+name: Requirements Verification
+on:
+  workflow_dispatch:
+jobs:
+  verification:
+    name: requirements-verification
+    runs-on: ubuntu-latest
+'@ | Set-Content -LiteralPath $tmpWorkflow -Encoding utf8
+
+    Write-JsonFile -Path $tmpBranchPolicy -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branchClassBindings = @{
+        develop = 'upstream-integration'
+      }
+      branchClassRequiredChecks = @{
+        'upstream-integration' = @('Requirements Verification / requirements-verification')
+      }
+    }
+
+    Write-JsonFile -Path $tmpPriorityPolicy -Data @{
+      branches = @{
+        develop = @{
+          branch_class_id = 'upstream-integration'
+          required_status_checks = @('Requirements Verification / requirements-verification')
+        }
+      }
+      rulesets = @{
+        develop = @{
+          branch_class_id = 'upstream-integration'
+          includes = @('refs/heads/develop')
+          required_status_checks = @('Requirements Verification / requirements-verification')
+        }
+      }
+    }
+
+    $run = Invoke-ContractScript -WorkflowPath $tmpWorkflow -BranchPolicyPath $tmpBranchPolicy -PriorityPolicyPath $tmpPriorityPolicy
+    $run.ExitCode | Should -Be 0
+    ($run.StdOut + $run.StdErr) | Should -Match 'verification-check-contract'
+  }
+
+  It 'fails closed when neither branch-class projection nor fallback branch checks resolve the expected check' {
+    $tmpWorkflow = Join-Path $TestDrive 'verification.missing.yml'
+    $tmpBranchPolicy = Join-Path $TestDrive 'branch-required-checks.missing.json'
+    $tmpPriorityPolicy = Join-Path $TestDrive 'policy.missing.json'
+
+    @'
+name: Requirements Verification
+on:
+  workflow_dispatch:
+jobs:
+  verification:
+    name: requirements-verification
+    runs-on: ubuntu-latest
+'@ | Set-Content -LiteralPath $tmpWorkflow -Encoding utf8
+
+    Write-JsonFile -Path $tmpBranchPolicy -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branchClassBindings = @{
+        main = 'upstream-release'
+      }
+      branchClassRequiredChecks = @{
+        'upstream-release' = @('commit-integrity')
+      }
+    }
+
+    Write-JsonFile -Path $tmpPriorityPolicy -Data @{
+      branches = @{
+        develop = @{
+          branch_class_id = 'upstream-integration'
+          required_status_checks = @('Requirements Verification / requirements-verification')
+        }
+      }
+      rulesets = @{
+        develop = @{
+          branch_class_id = 'upstream-integration'
+          includes = @('refs/heads/develop')
+          required_status_checks = @('Requirements Verification / requirements-verification')
+        }
+      }
+    }
+
+    $run = Invoke-ContractScript -WorkflowPath $tmpWorkflow -BranchPolicyPath $tmpBranchPolicy -PriorityPolicyPath $tmpPriorityPolicy
+    $run.ExitCode | Should -Be 1
+    ($run.StdOut + $run.StdErr) | Should -Match "Missing required checks for branch 'develop'"
+  }
 }

--- a/tools/Assert-RequirementsVerificationCheckContract.ps1
+++ b/tools/Assert-RequirementsVerificationCheckContract.ps1
@@ -54,15 +54,11 @@ if (-not [regex]::IsMatch($workflowContent, $jobNamePattern)) {
 
 $branchPolicy = Read-JsonFile -Path $BranchRequiredChecksPath
 $branchHasExpectedCheck = $false
-if (-not $branchPolicy.branches) {
-  Add-ContractError "Missing branches node in $BranchRequiredChecksPath."
-} else {
-  $developChecks = @((Resolve-BranchRequiredCheckProjection -BranchPolicy $branchPolicy -BranchName $BranchName -BranchClassId $null).requiredChecks)
-  if ($developChecks.Count -eq 0) {
-    Add-ContractError "Missing required checks for branch '$BranchName' in $BranchRequiredChecksPath."
-  }
-  $branchHasExpectedCheck = $developChecks -contains $expectedCheckName
+$developChecks = @((Resolve-BranchRequiredCheckProjection -BranchPolicy $branchPolicy -BranchName $BranchName -BranchClassId $null).requiredChecks)
+if ($developChecks.Count -eq 0) {
+  Add-ContractError "Missing required checks for branch '$BranchName' in $BranchRequiredChecksPath."
 }
+$branchHasExpectedCheck = $developChecks -contains $expectedCheckName
 
 $priorityPolicy = Read-JsonFile -Path $PriorityPolicyPath
 $priorityBranchChecks = @(Resolve-PriorityPolicyBranchRequiredChecks -PriorityPolicy $priorityPolicy -BranchPolicy $branchPolicy -BranchName $BranchName)


### PR DESCRIPTION
# Summary

Allows the requirements-verification contract to accept branch-class-only policy files when they resolve the expected required check.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1155
- Files touched:
  - `tools/Assert-RequirementsVerificationCheckContract.ps1`
  - `tests/RequirementsVerificationCheckContract.Tests.ps1`
- Cross-repo or external-consumer impact: None expected beyond the requirements-verification contract.
- Required checks, merge-queue behavior, or approval flows affected: None; this keeps the existing contract fail-closed.

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/RequirementsVerificationCheckContract.Tests.ps1 -CI`
- Key artifacts, logs, or workflow runs:
  - Focused Pester suite passed locally (`4/4`).
- Risk-based checks not run:
  - No broader workflow or session-index suites were needed for this narrow contract adjustment.

## Risks and Follow-ups

- Residual risks: Low; the change only removes the legacy `branches` hard requirement and still fails closed when no required-check projection resolves.
- Follow-up issues or deferred work: None.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: branch-class-only policy files now satisfy the contract when they resolve the expected check.
- Areas where the reasoning is subtle: legacy `branches` fallback remains accepted, but the resolver is now authoritative.
- Manual spot checks requested: None.

Closes #1155
