### PR TITLE
#1159 Add session-index v2 burn-in receipt

### DIFF
--- a/docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md
+++ b/docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md
@@ -22,6 +22,7 @@ operator dashboards, or developer feedback loops.
 - Required runs for promotion: **10 consecutive successful upstream runs**.
 - Regression guard target: **5 consecutive upstream runs without consumer regressions**.
 - Promotion evidence source: `validate-session-index-v2-contract/session-index-v2-contract.json`.
+- Burn-in triage front door: `burnInReceipt` inside `session-index-v2-contract.json`.
 - Deprecation policy and v1 cutover checklist: `docs/SESSION_INDEX_V1_DEPRECATION.md`.
 
 ## Remaining non-critical consumers

--- a/docs/SESSION_INDEX_V2_PROMOTION.md
+++ b/docs/SESSION_INDEX_V2_PROMOTION.md
@@ -18,7 +18,8 @@ The check validates:
 ## Burn-in policy
 
 - Threshold: **10 consecutive successful upstream runs**.
-- The check writes `session-index-v2-contract.json` with burn-in counters and promotion readiness.
+- The check writes `session-index-v2-contract.json` with burn-in counters, promotion readiness, and a
+  machine-readable `burnInReceipt` node.
 - While burn-in is active, failures are **non-blocking** but include warnings and triage details in the step summary.
 
 ## Enforce toggle
@@ -42,8 +43,9 @@ The workflow uses repository variable:
 When `session-index-v2-contract` reports failures:
 
 1. Open the artifact `validate-session-index-v2-contract/session-index-v2-contract.json`.
-2. Use the `failures[]` list to identify whether the issue is schema, parity, or artifact completeness.
-3. For schema failures, validate and inspect `session-index-v2.json` payload generation.
-4. For parity failures, compare `branchProtection.expected` against
+2. Inspect `burnInReceipt.mismatchClass`, `burnInReceipt.mismatchFingerprint`, and `burnInReceipt.evidence` first.
+3. Use the `failures[]` list to identify whether the issue is schema, parity, or artifact completeness.
+4. For schema failures, validate and inspect `session-index-v2.json` payload generation.
+5. For parity failures, compare `branchProtection.expected` against
    `tools/policy/branch-required-checks.json` and live branch protection output.
-5. Re-run Validate and confirm burn-in counter progression resumes.
+6. Re-run Validate and confirm burn-in counter progression resumes.

--- a/tests/Test-SessionIndexV2Contract.Tests.ps1
+++ b/tests/Test-SessionIndexV2Contract.Tests.ps1
@@ -134,6 +134,13 @@ Describe 'Test-SessionIndexV2Contract' {
     $run.Report.status | Should -Be 'pass'
     ($run.Report.branchProtection.requiredContexts | Sort-Object) | Should -Be @('lint', 'session-index')
     $run.Report.branchProtection.missingContexts | Should -BeNullOrEmpty
+    $run.Report.burnInReceipt.schema | Should -Be 'session-index-v2-burn-in-receipt@v1'
+    $run.Report.burnInReceipt.mode | Should -Be 'burn-in'
+    $run.Report.burnInReceipt.status | Should -Be 'clean'
+    $run.Report.burnInReceipt.mismatchClass | Should -Be 'none'
+    $run.Report.burnInReceipt.recurrence.classification | Should -Be 'clean'
+    $run.Report.burnInReceipt.evidence.reportPath | Should -Match 'session-index-v2-contract\.json$'
+    $run.Report.burnInReceipt.evidence.policyPath | Should -Be $policyPath
   }
 
   It 'falls back to explicit branch lists when no branch-class binding exists' {
@@ -156,7 +163,7 @@ Describe 'Test-SessionIndexV2Contract' {
   }
 
   It 'fails closed in enforce mode when neither branch-class projection nor fallback data exist' {
-    $resultsDir = New-SessionIndexFixture -Name 'missing' -ExpectedContexts @()
+    $resultsDir = New-SessionIndexFixture -Name 'missing' -ExpectedContexts @('lint')
     $policyPath = Join-Path $TestDrive 'branch-policy.missing.json'
     Write-JsonFile -Path $policyPath -Data @{
       schema = 'branch-required-checks/v1'
@@ -174,5 +181,11 @@ Describe 'Test-SessionIndexV2Contract' {
     $run.ExitCode | Should -Be 1
     $run.Report.status | Should -Be 'fail'
     $run.Report.failures | Should -Contain "Unable to resolve required contexts from branch policy for branch 'develop'."
+    $run.Report.burnInReceipt.mode | Should -Be 'enforce'
+    $run.Report.burnInReceipt.status | Should -Be 'mismatch'
+    $run.Report.burnInReceipt.mismatchClass | Should -Be 'branch-policy-projection'
+    $run.Report.burnInReceipt.recurrence.classification | Should -Be 'unknown'
+    $run.Report.burnInReceipt.mismatchFingerprint.Length | Should -Be 64
+    $run.Report.burnInReceipt.evidence.sessionIndexV2Path | Should -Match 'session-index-v2\.json$'
   }
 }

--- a/tools/Test-SessionIndexV2Contract.ps1
+++ b/tools/Test-SessionIndexV2Contract.ps1
@@ -175,6 +175,86 @@ function Get-ConsecutiveSuccessCount {
   }
 }
 
+function Get-BurnInMismatchClass {
+  param([string[]]$Failures)
+
+  $normalizedFailures = @($Failures | ForEach-Object { [string]$_ })
+  if ($normalizedFailures.Count -eq 0) {
+    return 'none'
+  }
+
+  $classes = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::Ordinal)
+  foreach ($failure in $normalizedFailures) {
+    if ($failure -match '^Missing v[12] artifact:') {
+      [void]$classes.Add('missing-artifact')
+      continue
+    }
+    if ($failure -match '^Schema validation failed') {
+      [void]$classes.Add('schema-validation')
+      continue
+    }
+    if ($failure -match '^Unable to resolve required contexts from branch policy') {
+      [void]$classes.Add('branch-policy-projection')
+      continue
+    }
+    if ($failure -match '^branchProtection\.(expected|actual)') {
+      [void]$classes.Add('branch-protection-shape')
+      continue
+    }
+    if ($failure -match '^branchProtection\.expected missing required contexts:') {
+      [void]$classes.Add('missing-required-contexts')
+      continue
+    }
+    if ($failure -match '^artifacts block is empty') {
+      [void]$classes.Add('artifact-catalog')
+      continue
+    }
+    [void]$classes.Add('unknown')
+  }
+
+  $classList = @($classes)
+  if ($classList.Count -eq 1) {
+    return [string]$classList[0]
+  }
+  return 'multiple'
+}
+
+function Get-BurnInMismatchFingerprint {
+  param(
+    [string]$MismatchClass,
+    [string[]]$Failures
+  )
+
+  $hasher = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $payload = [string]::Join("`n", @([string]$MismatchClass) + @($Failures | Sort-Object))
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($payload)
+    $hash = $hasher.ComputeHash($bytes)
+  } finally {
+    $hasher.Dispose()
+  }
+
+  return (($hash | ForEach-Object { $_.ToString('x2') }) -join '')
+}
+
+function Get-BurnInRecurrenceClassification {
+  param(
+    [string[]]$Failures,
+    [pscustomobject]$BurnIn
+  )
+
+  if (@($Failures).Count -eq 0) {
+    return 'clean'
+  }
+  if ($null -eq $BurnIn -or [string]$BurnIn.status -ne 'ok') {
+    return 'unknown'
+  }
+  if ([int]$BurnIn.consecutiveSuccess -gt 0) {
+    return 'new-after-success-streak'
+  }
+  return 'recurring-or-persistent'
+}
+
 if (-not (Test-Path -LiteralPath $ResultsDir -PathType Container)) {
   throw "ResultsDir does not exist: $ResultsDir"
 }
@@ -261,6 +341,9 @@ if ([string]::IsNullOrWhiteSpace($token)) {
 
 $burnIn = Get-ConsecutiveSuccessCount -Headers (Get-ApiHeaders -Token $token) -Owner $Owner -Repository $Repository -WorkflowFileName $WorkflowFileName -Branch $Branch -JobName 'session-index-v2-contract'
 $promotionReady = ($burnIn.status -eq 'ok' -and $burnIn.consecutiveSuccess -ge $BurnInThreshold)
+$mismatchClass = Get-BurnInMismatchClass -Failures $failures
+$mismatchFingerprint = Get-BurnInMismatchFingerprint -MismatchClass $mismatchClass -Failures $failures
+$recurrenceClassification = Get-BurnInRecurrenceClassification -Failures $failures -BurnIn $burnIn
 
 if ($burnIn.status -eq 'unavailable') {
   $notes += ("Burn-in status unavailable ({0})." -f $burnIn.reason)
@@ -286,6 +369,26 @@ $report = [ordered]@{
     consecutiveSuccess = $burnIn.consecutiveSuccess
     inspectedRuns = $burnIn.inspectedRuns
     promotionReady = $promotionReady
+  }
+  burnInReceipt = [ordered]@{
+    schema = 'session-index-v2-burn-in-receipt@v1'
+    mode = if ($Enforce) { 'enforce' } else { 'burn-in' }
+    status = if ($failures.Count -eq 0) { 'clean' } else { 'mismatch' }
+    mismatchClass = $mismatchClass
+    mismatchFingerprint = $mismatchFingerprint
+    mismatchSummary = @($failures)
+    recurrence = [ordered]@{
+      classification = $recurrenceClassification
+      burnInStatus = $burnIn.status
+      consecutiveSuccess = $burnIn.consecutiveSuccess
+    }
+    evidence = [ordered]@{
+      reportPath = $reportPath
+      resultsDir = $ResultsDir
+      sessionIndexV1Path = $v1Path
+      sessionIndexV2Path = $v2Path
+      policyPath = $PolicyPath
+    }
   }
 }
 


### PR DESCRIPTION
# Summary

Turns `session-index-v2-contract.json` into an explicit burn-in receipt surface by adding mismatch classification, fingerprinting, recurrence classification, and evidence paths.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1159
- Files touched:
  - `tools/Test-SessionIndexV2Contract.ps1`
  - `tests/Test-SessionIndexV2Contract.Tests.ps1`
  - `docs/SESSION_INDEX_V2_PROMOTION.md`
  - `docs/SESSION_INDEX_V2_CONSUMER_MATRIX.md`
- Cross-repo or external-consumer impact: None expected beyond the session-index-v2 burn-in report surface.
- Required checks, merge-queue behavior, or approval flows affected: None; this stays within the existing burn-in, non-blocking contract.

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/Test-SessionIndexV2Contract.Tests.ps1 -CI`
  - `node tools/npm/run-script.mjs lint:md:changed`
- Key artifacts, logs, or workflow runs:
  - Focused Pester suite passed locally (`3/3`).
- Risk-based checks not run:
  - No broader Validate workflow replay was needed for this receipt-only slice.

## Risks and Follow-ups

- Residual risks: This slice defines the burn-in receipt shape but does not yet change promotion policy or required-check status.
- Follow-up issues or deferred work: Remaining epic #956 slices still need promotion/rollback criteria and workflow-level visibility hardening.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: `session-index-v2-contract.json` now carries a deterministic `burnInReceipt` node with mismatch class, fingerprint, recurrence, and evidence paths.
- Areas where the reasoning is subtle: recurrence is intentionally classified from the helper's perspective, using available burn-in counters and token availability.
- Manual spot checks requested: None.

Closes #1159
