### PR TITLE
#1161 Standardize downstream onboarding report-first contract

### DIFF
--- a/.github/workflows/downstream-onboarding-feedback.yml
+++ b/.github/workflows/downstream-onboarding-feedback.yml
@@ -35,6 +35,7 @@ jobs:
   onboarding-feedback:
     runs-on: ubuntu-latest
     env:
+      GITHUB_TOKEN: ${{ github.token }}
       GH_TOKEN: ${{ github.token }}
       DOWNSTREAM_REPO: ${{ inputs.downstream_repo }}
       DOWNSTREAM_STARTED_AT: ${{ inputs.started_at }}
@@ -105,6 +106,33 @@ jobs:
             --schema docs/schemas/downstream-onboarding-feedback-v1.schema.json \
             --data tests/results/_agent/onboarding/downstream-onboarding-feedback.json
 
+      - name: Append onboarding feedback summary
+        if: ${{ always() && hashFiles('tests/results/_agent/onboarding/downstream-onboarding-feedback.json') != '' }}
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const reportPath = 'tests/results/_agent/onboarding/downstream-onboarding-feedback.json';
+          if (!fs.existsSync(reportPath)) {
+            console.log('downstream onboarding feedback report missing');
+            process.exit(0);
+          }
+          const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+          const lines = [
+            '## Downstream Onboarding Feedback',
+            `- execution status: \`${report.execution?.status ?? 'unknown'}\``,
+            `- downstream repository: \`${report.inputs?.downstreamRepository ?? 'unknown'}\``,
+            `- onboarding report present: \`${report.outputs?.onboardingReportExists ?? false}\``,
+            `- success report present: \`${report.outputs?.successReportExists ?? false}\``,
+            `- evaluate exit code: \`${report.execution?.evaluateExitCode ?? 'unknown'}\``,
+            `- success exit code: \`${report.execution?.successExitCode ?? 'unknown'}\``
+          ];
+          if (process.env.GITHUB_STEP_SUMMARY) {
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\\n')}\\n`);
+          }
+          console.log(lines.join('\\n'));
+          NODE
+
       - name: Upload onboarding artifacts
         if: ${{ always() && hashFiles('tests/results/_agent/onboarding/*.json') != '' }}
         uses: actions/upload-artifact@v6
@@ -118,4 +146,3 @@ jobs:
         run: |
           echo "Downstream onboarding feedback reported a failure."
           exit 1
-

--- a/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
+++ b/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
@@ -123,3 +123,8 @@ node tools/npm/run-script.mjs priority:onboard:feedback -- \
 
 The hosted workflow exports `GH_TOKEN`, attempts to leave behind a valid onboarding report even on infrastructure
 failures, validates all report schemas that were produced, and uploads the resulting JSON artifacts for auditability.
+It now follows the shared hosted-signal contract in [`HOSTED_SIGNAL_REPORT_FIRST_CONTRACT.md`](HOSTED_SIGNAL_REPORT_FIRST_CONTRACT.md):
+
+- exports both `GH_TOKEN` and `GITHUB_TOKEN`
+- appends a deterministic step summary from the feedback report when present
+- keeps schema validation and artifact upload existence-aware so missing-report cascades do not mask the primary failure

--- a/docs/HOSTED_SIGNAL_REPORT_FIRST_CONTRACT.md
+++ b/docs/HOSTED_SIGNAL_REPORT_FIRST_CONTRACT.md
@@ -1,0 +1,52 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Hosted Signal Report-First Contract
+
+This contract applies to hosted workflows whose primary job is to evaluate, summarize, or enforce repository state
+rather than build product artifacts.
+
+## When to use this pattern
+
+Use the `report-first` pattern when a hosted workflow exists to:
+
+- evaluate GitHub or repository policy state
+- summarize health, onboarding, hygiene, or governance signals
+- emit machine-readable evidence for future-agent triage
+
+Do not use this pattern for build/product workflows that cannot produce a meaningful report before runtime setup
+completes.
+
+## Required workflow behavior
+
+Hosted signal workflows that follow this contract must:
+
+1. export both `GH_TOKEN` and `GITHUB_TOKEN`
+2. write a machine-readable report or failure envelope whenever runtime setup can still explain the failure
+3. gate schema validation and artifact uploads on report existence so secondary missing-file cascades do not hide the
+   primary failure
+4. preserve one explicit enforcement step that fails the job on the actual signal failure condition
+5. append a deterministic step summary from the emitted report when present
+
+## Canonical examples
+
+- `.github/workflows/issue-milestone-hygiene.yml`
+- `.github/workflows/downstream-onboarding-feedback.yml`
+
+## Workflow shape
+
+The expected pattern is:
+
+1. export the token surface in workflow env
+2. run the evaluation harness with `continue-on-error` only when a later explicit enforcement step will own failure
+3. validate only the report files that exist
+4. upload only the artifacts that exist
+5. append a summary from the report
+6. fail once, in the final enforcement step, if the underlying signal is unhealthy
+
+## Future-agent guidance
+
+When adding a new hosted signal workflow:
+
+- start from one of the canonical examples above
+- keep report schemas workflow-specific when needed
+- keep the `report-first` envelope and existence-aware follow-on behavior consistent with this contract
+- prefer one clear failure over multiple secondary upload/schema failures

--- a/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
+++ b/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
@@ -20,11 +20,14 @@ test('downstream onboarding policy defines required checklist seams', () => {
 
 test('workflow executes onboarding + success scripts with schema validation', () => {
   const workflow = read('.github/workflows/downstream-onboarding-feedback.yml');
+  assert.match(workflow, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
   assert.match(workflow, /GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
   assert.match(workflow, /downstream-onboarding-feedback\.mjs/);
   assert.match(workflow, /downstream-onboarding-report-v1\.schema\.json/);
   assert.match(workflow, /downstream-onboarding-success-v1\.schema\.json/);
   assert.match(workflow, /downstream-onboarding-feedback-v1\.schema\.json/);
+  assert.match(workflow, /Append onboarding feedback summary/);
+  assert.match(workflow, /execution status/);
   assert.match(workflow, /hashFiles\('tests\/results\/_agent\/onboarding\/downstream-onboarding\.json'\)/);
   assert.match(workflow, /hashFiles\('tests\/results\/_agent\/onboarding\/\*\.json'\)/);
 });
@@ -39,4 +42,5 @@ test('runbook and package scripts expose downstream onboarding commands', () => 
   assert.match(runbook, /priority:onboard:downstream/);
   assert.match(runbook, /priority:onboard:feedback/);
   assert.match(runbook, /priority:onboard:success/);
+  assert.match(runbook, /HOSTED_SIGNAL_REPORT_FIRST_CONTRACT\.md/);
 });

--- a/tools/priority/__tests__/hosted-report-first-contract.test.mjs
+++ b/tools/priority/__tests__/hosted-report-first-contract.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(process.cwd());
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('hosted report-first contract documents the canonical signal-workflow rules', () => {
+  const doc = read('docs/HOSTED_SIGNAL_REPORT_FIRST_CONTRACT.md');
+  assert.match(doc, /GH_TOKEN/);
+  assert.match(doc, /GITHUB_TOKEN/);
+  assert.match(doc, /report-first/i);
+  assert.match(doc, /existence-aware/i);
+  assert.match(doc, /issue-milestone-hygiene\.yml/);
+  assert.match(doc, /downstream-onboarding-feedback\.yml/);
+});
+
+test('issue milestone hygiene and downstream onboarding implement the hosted report-first contract', () => {
+  const milestoneWorkflow = read('.github/workflows/issue-milestone-hygiene.yml');
+  const downstreamWorkflow = read('.github/workflows/downstream-onboarding-feedback.yml');
+
+  assert.match(milestoneWorkflow, /GITHUB_TOKEN:\s+\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN \|\| github\.token\s*\}\}/);
+  assert.match(milestoneWorkflow, /GH_TOKEN:\s+\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN \|\| github\.token\s*\}\}/);
+  assert.match(milestoneWorkflow, /Append summary/);
+  assert.match(milestoneWorkflow, /if-no-files-found:\s+error/);
+
+  assert.match(downstreamWorkflow, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
+  assert.match(downstreamWorkflow, /GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
+  assert.match(downstreamWorkflow, /Append onboarding feedback summary/);
+  assert.match(
+    downstreamWorkflow,
+    /if:\s+\$\{\{\s*always\(\)\s*&&\s*hashFiles\('tests\/results\/_agent\/onboarding\/\*\.json'\)\s*!=\s*''\s*\}\}/
+  );
+  assert.match(downstreamWorkflow, /if-no-files-found:\s+error/);
+});


### PR DESCRIPTION
## Summary
- align `downstream-onboarding-feedback.yml` with the hosted report-first signal contract
- export both `GH_TOKEN` and `GITHUB_TOKEN`
- append a deterministic onboarding feedback summary from the emitted JSON envelope
- add the checked-in shared hosted-signal contract doc and lock it with contract tests

## Testing
- `node --test tools/priority/__tests__/downstream-onboarding-contract.test.mjs tools/priority/__tests__/hosted-report-first-contract.test.mjs tools/priority/__tests__/issue-milestone-hygiene-workflow-contract.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`
- `& 'C:\dev\compare-vi-cli-action\compare-vi-cli-action\bin\actionlint.exe' .github\workflows\downstream-onboarding-feedback.yml`

## Issue
- Closes #1161

## Agent Metadata
- Issue: #1161
- Branch: `issue/personal-1161-report-first-downstream-onboarding`
- Commit: `bb8fb7301c2313eef9e52903b59df363c879f1c3`
