### PR TITLE
#1165 Add the local public-repo Linux diagnostics harness entry point

### DIFF
--- a/docs/schemas/public-linux-diagnostics-harness-local-v1.schema.json
+++ b/docs/schemas/public-linux-diagnostics-harness-local-v1.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/public-linux-diagnostics-harness-local-v1.schema.json",
+  "title": "public-linux-diagnostics-harness-local@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "target",
+    "contract",
+    "execution",
+    "artifacts",
+    "humanGoNoGo",
+    "status"
+  ],
+  "properties": {
+    "schema": {
+      "const": "public-linux-diagnostics-harness-local@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repositorySlug",
+        "repositoryVisibility",
+        "repositoryUrl",
+        "reference",
+        "defaultBranch",
+        "developRelationship"
+      ],
+      "properties": {
+        "repositorySlug": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "repositoryVisibility": {
+          "const": "public"
+        },
+        "repositoryUrl": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "reference": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "developRelationship": {
+          "type": "string",
+          "enum": [
+            "equal",
+            "ahead"
+          ]
+        }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaPath",
+        "docPath"
+      ],
+      "properties": {
+        "schemaPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "docPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "entryCommand",
+        "entryArgs",
+        "repoRoot"
+      ],
+      "properties": {
+        "mode": {
+          "const": "plan-only"
+        },
+        "entryCommand": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entryArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "repoRoot": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receiptPath",
+        "reviewLoopReceiptPath",
+        "historySummaryPath",
+        "historyReportHtmlPath",
+        "operatorSummaryPath"
+      ],
+      "properties": {
+        "receiptPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewLoopReceiptPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "historySummaryPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "historyReportHtmlPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operatorSummaryPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "humanGoNoGo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "workflowPath",
+        "decisionPath"
+      ],
+      "properties": {
+        "required": {
+          "const": true
+        },
+        "workflowPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decisionPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "status": {
+      "const": "planned"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "priority:onboard:downstream": "node tools/priority/downstream-onboarding.mjs",
     "priority:onboard:feedback": "node tools/priority/downstream-onboarding-feedback.mjs",
     "priority:onboard:success": "node tools/priority/downstream-onboarding-success.mjs",
+    "priority:diagnostics:public-linux": "node tools/priority/public-linux-diagnostics-harness.mjs",
     "priority:develop:sync": "node tools/priority/develop-sync.mjs",
     "priority:github:metadata:apply": "tsc -p tsconfig.cli.json && node dist/tools/cli/github-metadata.js",
     "priority:policy": "node tools/priority/check-policy.mjs",

--- a/tools/priority/__tests__/public-linux-diagnostics-harness.test.mjs
+++ b/tools/priority/__tests__/public-linux-diagnostics-harness.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  buildPublicLinuxDiagnosticsHarnessReceipt,
+  parseArgs,
+  runPublicLinuxDiagnosticsHarness
+} from '../public-linux-diagnostics-harness.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('parseArgs requires supported develop relationship values', () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        'node',
+        'tools/priority/public-linux-diagnostics-harness.mjs',
+        '--repository',
+        'owner/repo',
+        '--reference',
+        'develop',
+        '--develop-relationship',
+        'behind'
+      ]),
+    /equal, ahead/
+  );
+});
+
+test('runPublicLinuxDiagnosticsHarness writes a deterministic planned receipt for a public repository', async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'public-linux-diagnostics-'));
+  const reportPath = path.join(tempRoot, 'public-linux-diagnostics-harness-local.json');
+  const argv = [
+    'node',
+    'tools/priority/public-linux-diagnostics-harness.mjs',
+    '--repository',
+    'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    '--reference',
+    'issue/personal-1165-public-linux-harness-local-entry',
+    '--develop-relationship',
+    'ahead',
+    '--report',
+    reportPath
+  ];
+
+  const result = await runPublicLinuxDiagnosticsHarness({
+    argv,
+    repoRoot,
+    now: new Date('2026-03-14T14:20:00Z'),
+    execFileFn: async () => ({
+      stdout: JSON.stringify({
+        visibility: 'public',
+        default_branch: 'develop',
+        html_url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      })
+    })
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.payload.status, 'planned');
+  assert.equal(result.payload.target.repositoryVisibility, 'public');
+  assert.equal(result.payload.target.developRelationship, 'ahead');
+  assert.match(result.payload.execution.entryCommand, /Run-NonLVChecksInDocker\.ps1/);
+  assert.equal(result.payload.humanGoNoGo.required, true);
+  assert.ok(fs.existsSync(reportPath));
+
+  const schema = JSON.parse(
+    await readFile(
+      path.join(repoRoot, 'docs', 'schemas', 'public-linux-diagnostics-harness-local-v1.schema.json'),
+      'utf8'
+    )
+  );
+  const payload = JSON.parse(await readFile(reportPath, 'utf8'));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(payload), true, JSON.stringify(validate.errors, null, 2));
+});
+
+test('runPublicLinuxDiagnosticsHarness fails closed for non-public repositories', async () => {
+  const argv = [
+    'node',
+    'tools/priority/public-linux-diagnostics-harness.mjs',
+    '--repository',
+    'owner/private-repo',
+    '--reference',
+    'develop',
+    '--develop-relationship',
+    'equal'
+  ];
+
+  await assert.rejects(
+    () =>
+      runPublicLinuxDiagnosticsHarness({
+        argv,
+        repoRoot,
+        execFileFn: async () => ({
+          stdout: JSON.stringify({
+            visibility: 'private',
+            default_branch: 'develop',
+            html_url: 'https://github.com/owner/private-repo'
+          })
+        })
+      }),
+    /not public/
+  );
+});
+
+test('buildPublicLinuxDiagnosticsHarnessReceipt binds itself to the shared #1163 contract and human decision surface', () => {
+  const payload = buildPublicLinuxDiagnosticsHarnessReceipt({
+    options: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      reference: 'develop',
+      developRelationship: 'equal',
+      reportPath: 'tests/results/_agent/diagnostics/public-linux-diagnostics-harness-local.json',
+      contractSchemaPath: 'docs/schemas/public-linux-diagnostics-harness-contract-v1.schema.json',
+      contractDocPath: 'docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md'
+    },
+    repositoryInfo: {
+      visibility: 'public',
+      defaultBranch: 'develop',
+      htmlUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    generatedAt: '2026-03-14T14:20:00Z',
+    repoRoot
+  });
+
+  assert.equal(payload.contract.schemaPath, 'docs/schemas/public-linux-diagnostics-harness-contract-v1.schema.json');
+  assert.equal(payload.humanGoNoGo.workflowPath, '.github/workflows/human-go-no-go-feedback.yml');
+  assert.equal(payload.artifacts.reviewLoopReceiptPath, 'tests/results/docker-tools-parity/review-loop-receipt.json');
+});

--- a/tools/priority/public-linux-diagnostics-harness.mjs
+++ b/tools/priority/public-linux-diagnostics-harness.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFile = promisify(execFileCallback);
+
+export const REPORT_SCHEMA = 'public-linux-diagnostics-harness-local@v1';
+export const DEFAULT_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'diagnostics',
+  'public-linux-diagnostics-harness-local.json'
+);
+export const DEFAULT_CONTRACT_PATH = path.join(
+  'docs',
+  'schemas',
+  'public-linux-diagnostics-harness-contract-v1.schema.json'
+);
+export const DEFAULT_CONTRACT_DOC_PATH = path.join('docs', 'PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md');
+export const DEFAULT_REVIEW_LOOP_RECEIPT_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'review-loop-receipt.json'
+);
+export const DEFAULT_OPERATOR_SUMMARY_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'verification',
+  'docker-review-loop-summary.json'
+);
+export const DEFAULT_HISTORY_SUMMARY_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'ni-linux-review-suite',
+  'vi-history-report',
+  'results',
+  'history-summary.json'
+);
+export const DEFAULT_HISTORY_REPORT_HTML_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'ni-linux-review-suite',
+  'vi-history-report',
+  'results',
+  'history-report.html'
+);
+export const DEFAULT_HUMAN_DECISION_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'human-go-no-go-decision.json'
+);
+export const DEFAULT_HUMAN_WORKFLOW_PATH = '.github/workflows/human-go-no-go-feedback.yml';
+
+function printUsage() {
+  console.log(
+    'Usage: node tools/priority/public-linux-diagnostics-harness.mjs --repository <owner/repo> --reference <ref> --develop-relationship <equal|ahead> [options]'
+  );
+  console.log('');
+  console.log('Plans the local public-repo Linux diagnostics harness entry point and writes a deterministic receipt.');
+  console.log('');
+  console.log('Options:');
+  console.log('  --repository <owner/repo>           Required public repository slug.');
+  console.log('  --reference <ref>                   Required target branch/ref derived from develop.');
+  console.log('  --develop-relationship <value>      Required: equal | ahead.');
+  console.log(`  --report <path>                     Receipt path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log('  --contract-schema <path>            Override shared contract schema path.');
+  console.log('  --contract-doc <path>               Override shared contract doc path.');
+  console.log('  --json                              Print the receipt JSON to stdout after writing it.');
+  console.log('  -h, --help                          Show help.');
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function toRepoPath(value) {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.replace(/\\/g, '/') : null;
+}
+
+function normalizeRepository(value) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+  const parts = normalized.split('/').map((part) => part.trim());
+  if (parts.length !== 2 || parts.some((part) => part.length === 0)) {
+    throw new Error(`--repository must use the form <owner>/<repo>; received '${value}'.`);
+  }
+  return `${parts[0]}/${parts[1]}`;
+}
+
+function normalizeDevelopRelationship(value) {
+  const normalized = normalizeText(value)?.toLowerCase();
+  if (normalized !== 'equal' && normalized !== 'ahead') {
+    throw new Error('--develop-relationship must be one of: equal, ahead.');
+  }
+  return normalized;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    help: false,
+    repository: null,
+    reference: null,
+    developRelationship: null,
+    reportPath: DEFAULT_REPORT_PATH,
+    contractSchemaPath: DEFAULT_CONTRACT_PATH,
+    contractDocPath: DEFAULT_CONTRACT_DOC_PATH,
+    json: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (
+      token === '--repository' ||
+      token === '--reference' ||
+      token === '--develop-relationship' ||
+      token === '--report' ||
+      token === '--contract-schema' ||
+      token === '--contract-doc'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--repository') options.repository = normalizeRepository(next);
+      if (token === '--reference') options.reference = normalizeText(next);
+      if (token === '--develop-relationship') options.developRelationship = normalizeDevelopRelationship(next);
+      if (token === '--report') options.reportPath = next;
+      if (token === '--contract-schema') options.contractSchemaPath = next;
+      if (token === '--contract-doc') options.contractDocPath = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!options.help) {
+    if (!options.repository) {
+      throw new Error('--repository is required.');
+    }
+    if (!options.reference) {
+      throw new Error('--reference is required.');
+    }
+    if (!options.developRelationship) {
+      throw new Error('--develop-relationship is required.');
+    }
+  }
+
+  return options;
+}
+
+async function inspectRepository(repository, execFileFn = execFile) {
+  const { stdout } = await execFileFn(
+    'gh',
+    ['api', `repos/${repository}`],
+    { encoding: 'utf8', windowsHide: true }
+  );
+  const payload = JSON.parse(stdout);
+  return {
+    visibility: normalizeText(payload.visibility) ?? 'unknown',
+    defaultBranch: normalizeText(payload.default_branch) ?? null,
+    htmlUrl: normalizeText(payload.html_url) ?? null
+  };
+}
+
+function writeJson(filePath, payload) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+export function buildPublicLinuxDiagnosticsHarnessReceipt({
+  options,
+  repositoryInfo,
+  generatedAt,
+  repoRoot = process.cwd()
+}) {
+  const contractSchemaPath = toRepoPath(options.contractSchemaPath);
+  const contractDocPath = toRepoPath(options.contractDocPath);
+  const reportPath = toRepoPath(options.reportPath);
+
+  return {
+    schema: REPORT_SCHEMA,
+    generatedAt,
+    target: {
+      repositorySlug: options.repository,
+      repositoryVisibility: repositoryInfo.visibility,
+      repositoryUrl: repositoryInfo.htmlUrl,
+      reference: options.reference,
+      defaultBranch: repositoryInfo.defaultBranch,
+      developRelationship: options.developRelationship
+    },
+    contract: {
+      schemaPath: contractSchemaPath,
+      docPath: contractDocPath
+    },
+    execution: {
+      mode: 'plan-only',
+      entryCommand: 'pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite',
+      entryArgs: [
+        '-UseToolsImage',
+        '-NILinuxReviewSuite',
+        '-DockerParityReviewReceiptPath',
+        toRepoPath(DEFAULT_REVIEW_LOOP_RECEIPT_PATH)
+      ],
+      repoRoot: repoRoot
+    },
+    artifacts: {
+      receiptPath: reportPath,
+      reviewLoopReceiptPath: toRepoPath(DEFAULT_REVIEW_LOOP_RECEIPT_PATH),
+      historySummaryPath: toRepoPath(DEFAULT_HISTORY_SUMMARY_PATH),
+      historyReportHtmlPath: toRepoPath(DEFAULT_HISTORY_REPORT_HTML_PATH),
+      operatorSummaryPath: toRepoPath(DEFAULT_OPERATOR_SUMMARY_PATH)
+    },
+    humanGoNoGo: {
+      required: true,
+      workflowPath: toRepoPath(DEFAULT_HUMAN_WORKFLOW_PATH),
+      decisionPath: toRepoPath(DEFAULT_HUMAN_DECISION_PATH)
+    },
+    status: 'planned'
+  };
+}
+
+export async function runPublicLinuxDiagnosticsHarness({
+  argv = process.argv,
+  execFileFn = execFile,
+  now = new Date(),
+  repoRoot = process.cwd(),
+  writeJsonFn = writeJson
+} = {}) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return {
+      exitCode: 0,
+      reportPath: null,
+      payload: null
+    };
+  }
+
+  const repositoryInfo = await inspectRepository(options.repository, execFileFn);
+  if (repositoryInfo.visibility !== 'public') {
+    throw new Error(
+      `Repository ${options.repository} is not public (visibility=${repositoryInfo.visibility ?? 'unknown'}).`
+    );
+  }
+
+  const payload = buildPublicLinuxDiagnosticsHarnessReceipt({
+    options,
+    repositoryInfo,
+    generatedAt: now.toISOString(),
+    repoRoot
+  });
+  const reportPath = writeJsonFn(options.reportPath, payload);
+  return {
+    exitCode: 0,
+    reportPath,
+    payload
+  };
+}
+
+export async function main(argv = process.argv) {
+  try {
+    const result = await runPublicLinuxDiagnosticsHarness({ argv });
+    if (result.payload) {
+      console.log(`[public-linux-diagnostics-harness] report: ${result.reportPath}`);
+      console.log(
+        `[public-linux-diagnostics-harness] repository=${result.payload.target.repositorySlug} reference=${result.payload.target.reference} relationship=${result.payload.target.developRelationship}`
+      );
+      if (parseArgs(argv).json) {
+        console.log(JSON.stringify(result.payload, null, 2));
+      }
+    }
+    return result.exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv).then((exitCode) => {
+    process.exit(exitCode);
+  });
+}


### PR DESCRIPTION
# Summary

Adds the local public-repo Linux diagnostics harness entry point for #1165.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Adds `tools/priority/public-linux-diagnostics-harness.mjs` as the plan-only local entry point for the shared public Linux diagnostics harness contract.
- Adds `docs/schemas/public-linux-diagnostics-harness-local-v1.schema.json` for the local receipt surface.
- Adds focused regression coverage in `tools/priority/__tests__/public-linux-diagnostics-harness.test.mjs`.
- Adds the repo command `priority:diagnostics:public-linux` in `package.json`.

## Validation Evidence

- `node --test tools/priority/__tests__/public-linux-diagnostics-harness.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

## Risks and Follow-ups

- This slice is plan-only by design; it does not execute the diagnostics loop yet.
- The receipt fails closed when the target repository is not public.
- The shared contract remains anchored to #1163 and the human go/no-go workflow surface.

## Reviewer Focus

- Verify the local receipt surface is deterministic across Windows and Linux path styles.
- Verify the public-repo guard is strict enough for future downstream use.
- Verify the command surface stays narrow and does not bypass the existing Docker diagnostics loop.

Closes #1165
