### PR TITLE
#1167 Add the hosted public Linux diagnostics dispatch surface

### DIFF
--- a/.github/workflows/public-linux-diagnostics-harness.yml
+++ b/.github/workflows/public-linux-diagnostics-harness.yml
@@ -1,0 +1,68 @@
+name: Public Linux Diagnostics Harness
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Target public owner/repo'
+        required: true
+        type: string
+      reference:
+        description: 'Target branch/ref derived from develop'
+        required: true
+        type: string
+      develop_relationship:
+        description: 'Relationship to develop'
+        required: true
+        type: choice
+        default: ahead
+        options:
+          - equal
+          - ahead
+
+permissions:
+  contents: read
+
+jobs:
+  public-linux-diagnostics-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: node tools/npm/cli.mjs ci --ignore-scripts
+
+      - name: Write public Linux diagnostics dispatch receipt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node tools/priority/public-linux-diagnostics-workflow-dispatch.mjs \
+            --repository "${{ inputs.repository }}" \
+            --reference "${{ inputs.reference }}" \
+            --develop-relationship "${{ inputs.develop_relationship }}" \
+            --decision-workflow-path ".github/workflows/human-go-no-go-feedback.yml" \
+            --report "tests/results/_agent/diagnostics/public-linux-diagnostics-workflow-dispatch.json" \
+            --step-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload public Linux diagnostics dispatch artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: public-linux-diagnostics-harness-dispatch
+          path: |
+            tests/results/_agent/diagnostics/public-linux-diagnostics-workflow-dispatch.json
+          if-no-files-found: error

--- a/docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md
+++ b/docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md
@@ -22,6 +22,8 @@ This contract is for a diagnostics harness that:
 
 - Local parity entry point:
   - `tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite`
+- Hosted manual workflow:
+  - `.github/workflows/public-linux-diagnostics-harness.yml`
 - Existing Docker/Desktop parity guidance:
   - [`knowledgebase/DOCKER_TOOLS_PARITY.md`](knowledgebase/DOCKER_TOOLS_PARITY.md)
 - Human decision workflow:
@@ -29,8 +31,8 @@ This contract is for a diagnostics harness that:
 - Human decision schema:
   - `docs/schemas/human-go-no-go-decision-v1.schema.json`
 
-This slice does not add the new local harness or the new manual workflow yet. It only defines the shared contract those
-future entry points must satisfy.
+The shared contract now anchors both the local entry-point work and the hosted manual workflow surface. The human
+go/no-go workflow remains a separate completion surface and must not be conflated with the hosted diagnostics workflow.
 
 ## Target contract
 

--- a/tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-harness-contract.json
+++ b/tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-harness-contract.json
@@ -9,7 +9,7 @@
   },
   "execution": {
     "localEntryPoint": "tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite",
-    "hostedWorkflowPath": ".github/workflows/human-go-no-go-feedback.yml",
+    "hostedWorkflowPath": ".github/workflows/public-linux-diagnostics-harness.yml",
     "containerLane": "docker-desktop-linux",
     "labviewRelease": "2026 Q1 Linux"
   },

--- a/tools/priority/__tests__/public-linux-diagnostics-harness-contract.test.mjs
+++ b/tools/priority/__tests__/public-linux-diagnostics-harness-contract.test.mjs
@@ -37,6 +37,7 @@ test('public Linux diagnostics harness contract doc points to the shared bundle 
   const doc = await readFile(path.join(repoRoot, 'docs', 'PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md'), 'utf8');
 
   assert.match(doc, /Run-NonLVChecksInDocker\.ps1 -UseToolsImage -NILinuxReviewSuite/);
+  assert.match(doc, /public-linux-diagnostics-harness\.yml/);
   assert.match(doc, /DOCKER_TOOLS_PARITY\.md/);
   assert.match(doc, /human-go-no-go-feedback\.yml/);
   assert.match(doc, /human-go-no-go-decision-v1\.schema\.json/);

--- a/tools/priority/__tests__/public-linux-diagnostics-harness-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/public-linux-diagnostics-harness-workflow-contract.test.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('public Linux diagnostics harness workflow is workflow_dispatch-only and exposes the shared contract inputs', () => {
+  const workflow = readRepoFile('.github/workflows/public-linux-diagnostics-harness.yml');
+
+  assert.match(workflow, /^on:\s*\r?\n\s+workflow_dispatch:/m);
+  assert.doesNotMatch(workflow, /^\s*pull_request:/m);
+  assert.match(workflow, /repository:\s+\s*description:[\s\S]+required: true[\s\S]+type: string/m);
+  assert.match(workflow, /reference:\s+\s*description:[\s\S]+required: true[\s\S]+type: string/m);
+  assert.match(workflow, /develop_relationship:[\s\S]+type: choice[\s\S]+options:\s+\s+- equal\s+\s+- ahead/m);
+});
+
+test('public Linux diagnostics harness workflow writes and uploads deterministic dispatch artifacts', () => {
+  const workflow = readRepoFile('.github/workflows/public-linux-diagnostics-harness.yml');
+
+  assert.match(workflow, /tools\/priority\/public-linux-diagnostics-workflow-dispatch\.mjs/);
+  assert.match(workflow, /tests\/results\/_agent\/diagnostics\/public-linux-diagnostics-workflow-dispatch\.json/);
+  assert.match(workflow, /name: Upload public Linux diagnostics dispatch artifact\s+if: always\(\)\s+uses: actions\/upload-artifact@v6/ms);
+  assert.match(workflow, /name: public-linux-diagnostics-harness-dispatch/);
+  assert.match(workflow, /human-go-no-go-feedback\.yml/);
+});
+
+test('public Linux diagnostics harness workflow keeps permissions minimal', () => {
+  const workflow = readRepoFile('.github/workflows/public-linux-diagnostics-harness.yml');
+
+  assert.match(workflow, /permissions:\s+contents: read/ms);
+  assert.doesNotMatch(workflow, /permissions:\s+write-all/);
+  assert.doesNotMatch(workflow, /deployments:\s+write/);
+  assert.doesNotMatch(workflow, /pull-requests:\s+write/);
+});

--- a/tools/priority/__tests__/public-linux-diagnostics-workflow-dispatch.test.mjs
+++ b/tools/priority/__tests__/public-linux-diagnostics-workflow-dispatch.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildPublicLinuxDiagnosticsWorkflowDispatchReceipt,
+  parseArgs,
+  runPublicLinuxDiagnosticsWorkflowDispatch
+} from '../public-linux-diagnostics-workflow-dispatch.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('parseArgs rejects unsupported develop relationship values for hosted dispatch', () => {
+  assert.throws(
+    () => parseArgs([
+      'node',
+      'tools/priority/public-linux-diagnostics-workflow-dispatch.mjs',
+      '--repository',
+      'owner/repo',
+      '--reference',
+      'develop',
+      '--develop-relationship',
+      'behind'
+    ]),
+    /equal, ahead/
+  );
+});
+
+test('runPublicLinuxDiagnosticsWorkflowDispatch writes a deterministic plan-only hosted receipt', async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'public-linux-dispatch-'));
+  const reportPath = path.join(tempRoot, 'public-linux-diagnostics-workflow-dispatch.json');
+  const stepSummaryPath = path.join(tempRoot, 'step-summary.md');
+  const argv = [
+    'node',
+    'tools/priority/public-linux-diagnostics-workflow-dispatch.mjs',
+    '--repository',
+    'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    '--reference',
+    'issue/personal-1167-public-linux-harness-workflow',
+    '--develop-relationship',
+    'ahead',
+    '--report',
+    reportPath,
+    '--step-summary',
+    stepSummaryPath
+  ];
+
+  const result = await runPublicLinuxDiagnosticsWorkflowDispatch({
+    argv,
+    environment: {
+      GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      GITHUB_RUN_ID: '123456789',
+      GITHUB_SERVER_URL: 'https://github.com'
+    },
+    now: new Date('2026-03-14T14:30:00Z'),
+    execFileFn: async () => ({
+      stdout: JSON.stringify({
+        visibility: 'public',
+        default_branch: 'develop',
+        html_url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      })
+    })
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.payload.status, 'planned');
+  assert.equal(result.payload.execution.hostedWorkflowPath, '.github/workflows/public-linux-diagnostics-harness.yml');
+  assert.equal(result.payload.humanGoNoGo.workflowPath, '.github/workflows/human-go-no-go-feedback.yml');
+  assert.match(result.payload.execution.localDelegateCommand, /Run-NonLVChecksInDocker\.ps1/);
+
+  const payload = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(payload.execution.workflowRunId, '123456789');
+  assert.match(payload.execution.workflowRunUrl, /actions\/runs\/123456789$/);
+
+  const stepSummary = await readFile(stepSummaryPath, 'utf8');
+  assert.match(stepSummary, /Public Linux Diagnostics Harness Dispatch/);
+  assert.match(stepSummary, /human-go-no-go-feedback\.yml/);
+});
+
+test('runPublicLinuxDiagnosticsWorkflowDispatch fails closed for non-public repositories', async () => {
+  const argv = [
+    'node',
+    'tools/priority/public-linux-diagnostics-workflow-dispatch.mjs',
+    '--repository',
+    'owner/private-repo',
+    '--reference',
+    'develop',
+    '--develop-relationship',
+    'equal'
+  ];
+
+  await assert.rejects(
+    () =>
+      runPublicLinuxDiagnosticsWorkflowDispatch({
+        argv,
+        execFileFn: async () => ({
+          stdout: JSON.stringify({
+            visibility: 'private',
+            default_branch: 'develop',
+            html_url: 'https://github.com/owner/private-repo'
+          })
+        })
+      }),
+    /not public/
+  );
+});
+
+test('buildPublicLinuxDiagnosticsWorkflowDispatchReceipt keeps hosted workflow and human decision surfaces separate', () => {
+  const payload = buildPublicLinuxDiagnosticsWorkflowDispatchReceipt({
+    options: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      reference: 'develop',
+      developRelationship: 'equal',
+      reportPath: 'tests/results/_agent/diagnostics/public-linux-diagnostics-workflow-dispatch.json',
+      workflowPath: '.github/workflows/public-linux-diagnostics-harness.yml',
+      decisionWorkflowPath: '.github/workflows/human-go-no-go-feedback.yml',
+      contractSchemaPath: 'docs/schemas/public-linux-diagnostics-harness-contract-v1.schema.json',
+      contractDocPath: 'docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md'
+    },
+    repositoryInfo: {
+      visibility: 'public',
+      defaultBranch: 'develop',
+      htmlUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    generatedAt: '2026-03-14T14:30:00Z',
+    environment: {
+      GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      GITHUB_RUN_ID: '123456789',
+      GITHUB_SERVER_URL: 'https://github.com'
+    }
+  });
+
+  assert.equal(payload.execution.hostedWorkflowPath, '.github/workflows/public-linux-diagnostics-harness.yml');
+  assert.equal(payload.humanGoNoGo.workflowPath, '.github/workflows/human-go-no-go-feedback.yml');
+  assert.equal(payload.artifacts.reviewLoopReceiptPath, 'tests/results/docker-tools-parity/review-loop-receipt.json');
+});

--- a/tools/priority/public-linux-diagnostics-workflow-dispatch.mjs
+++ b/tools/priority/public-linux-diagnostics-workflow-dispatch.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFile = promisify(execFileCallback);
+
+export const REPORT_SCHEMA = 'public-linux-diagnostics-harness-workflow-dispatch@v1';
+export const DEFAULT_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'diagnostics',
+  'public-linux-diagnostics-workflow-dispatch.json'
+);
+export const DEFAULT_CONTRACT_SCHEMA_PATH = path.join(
+  'docs',
+  'schemas',
+  'public-linux-diagnostics-harness-contract-v1.schema.json'
+);
+export const DEFAULT_CONTRACT_DOC_PATH = path.join('docs', 'PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md');
+export const DEFAULT_WORKFLOW_PATH = '.github/workflows/public-linux-diagnostics-harness.yml';
+export const DEFAULT_DECISION_WORKFLOW_PATH = '.github/workflows/human-go-no-go-feedback.yml';
+export const DEFAULT_REVIEW_LOOP_RECEIPT_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'review-loop-receipt.json'
+);
+export const DEFAULT_HISTORY_SUMMARY_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'ni-linux-review-suite',
+  'vi-history-report',
+  'results',
+  'history-summary.json'
+);
+export const DEFAULT_HISTORY_REPORT_HTML_PATH = path.join(
+  'tests',
+  'results',
+  'docker-tools-parity',
+  'ni-linux-review-suite',
+  'vi-history-report',
+  'results',
+  'history-report.html'
+);
+export const DEFAULT_OPERATOR_SUMMARY_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'verification',
+  'docker-review-loop-summary.json'
+);
+export const DEFAULT_DECISION_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'human-go-no-go-decision.json'
+);
+
+function printUsage() {
+  console.log(
+    'Usage: node tools/priority/public-linux-diagnostics-workflow-dispatch.mjs --repository <owner/repo> --reference <ref> --develop-relationship <equal|ahead> [options]'
+  );
+  console.log('');
+  console.log('Writes a deterministic plan-only receipt for the hosted public Linux diagnostics harness workflow.');
+  console.log('');
+  console.log('Options:');
+  console.log('  --repository <owner/repo>           Required public repository slug.');
+  console.log('  --reference <ref>                   Required target branch/ref derived from develop.');
+  console.log('  --develop-relationship <value>      Required: equal | ahead.');
+  console.log(`  --report <path>                     Receipt path (default: ${DEFAULT_REPORT_PATH}).`);
+  console.log(`  --workflow-path <path>              Workflow path (default: ${DEFAULT_WORKFLOW_PATH}).`);
+  console.log(`  --decision-workflow-path <path>     Human decision workflow path (default: ${DEFAULT_DECISION_WORKFLOW_PATH}).`);
+  console.log(`  --contract-schema <path>            Shared contract schema path (default: ${DEFAULT_CONTRACT_SCHEMA_PATH}).`);
+  console.log(`  --contract-doc <path>               Shared contract doc path (default: ${DEFAULT_CONTRACT_DOC_PATH}).`);
+  console.log('  --step-summary <path>               Optional GitHub step summary path.');
+  console.log('  --json                              Print the receipt JSON after writing it.');
+  console.log('  -h, --help                          Show help.');
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function toRepoPath(value) {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.replace(/\\/g, '/') : null;
+}
+
+function normalizeRepository(value) {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+  const parts = normalized.split('/').map((part) => part.trim());
+  if (parts.length !== 2 || parts.some((part) => part.length === 0)) {
+    throw new Error(`--repository must use the form <owner>/<repo>; received '${value}'.`);
+  }
+  return `${parts[0]}/${parts[1]}`;
+}
+
+function normalizeDevelopRelationship(value) {
+  const normalized = normalizeText(value)?.toLowerCase();
+  if (normalized !== 'equal' && normalized !== 'ahead') {
+    throw new Error('--develop-relationship must be one of: equal, ahead.');
+  }
+  return normalized;
+}
+
+export function parseArgs(argv = process.argv, environment = process.env) {
+  const args = argv.slice(2);
+  const options = {
+    help: false,
+    repository: null,
+    reference: null,
+    developRelationship: null,
+    reportPath: DEFAULT_REPORT_PATH,
+    workflowPath: DEFAULT_WORKFLOW_PATH,
+    decisionWorkflowPath: DEFAULT_DECISION_WORKFLOW_PATH,
+    contractSchemaPath: DEFAULT_CONTRACT_SCHEMA_PATH,
+    contractDocPath: DEFAULT_CONTRACT_DOC_PATH,
+    stepSummaryPath: normalizeText(environment.GITHUB_STEP_SUMMARY),
+    json: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (
+      token === '--repository' ||
+      token === '--reference' ||
+      token === '--develop-relationship' ||
+      token === '--report' ||
+      token === '--workflow-path' ||
+      token === '--decision-workflow-path' ||
+      token === '--contract-schema' ||
+      token === '--contract-doc' ||
+      token === '--step-summary'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--repository') options.repository = normalizeRepository(next);
+      if (token === '--reference') options.reference = normalizeText(next);
+      if (token === '--develop-relationship') options.developRelationship = normalizeDevelopRelationship(next);
+      if (token === '--report') options.reportPath = next;
+      if (token === '--workflow-path') options.workflowPath = next;
+      if (token === '--decision-workflow-path') options.decisionWorkflowPath = next;
+      if (token === '--contract-schema') options.contractSchemaPath = next;
+      if (token === '--contract-doc') options.contractDocPath = next;
+      if (token === '--step-summary') options.stepSummaryPath = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!options.help) {
+    if (!options.repository) {
+      throw new Error('--repository is required.');
+    }
+    if (!options.reference) {
+      throw new Error('--reference is required.');
+    }
+    if (!options.developRelationship) {
+      throw new Error('--develop-relationship is required.');
+    }
+  }
+
+  return options;
+}
+
+async function inspectRepository(repository, execFileFn = execFile) {
+  const { stdout } = await execFileFn(
+    'gh',
+    ['api', `repos/${repository}`],
+    { encoding: 'utf8', windowsHide: true }
+  );
+  const payload = JSON.parse(stdout);
+  return {
+    visibility: normalizeText(payload.visibility) ?? 'unknown',
+    defaultBranch: normalizeText(payload.default_branch) ?? null,
+    htmlUrl: normalizeText(payload.html_url) ?? null
+  };
+}
+
+function writeJson(filePath, payload) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+function appendStepSummary(stepSummaryPath, payload) {
+  if (!stepSummaryPath) {
+    return;
+  }
+  const resolved = path.resolve(process.cwd(), stepSummaryPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  const lines = [
+    '### Public Linux Diagnostics Harness Dispatch',
+    '',
+    `- repository: \`${payload.target.repositorySlug}\``,
+    `- reference: \`${payload.target.reference}\``,
+    `- develop relationship: \`${payload.target.developRelationship}\``,
+    `- workflow: \`${payload.execution.hostedWorkflowPath}\``,
+    `- status: \`${payload.status}\``,
+    '',
+    `Record the final manual disposition through \`${payload.humanGoNoGo.workflowPath}\` once the diagnostics bundle has been reviewed.`
+  ];
+  fs.writeFileSync(resolved, `${lines.join('\n')}\n`, { encoding: 'utf8', flag: 'a' });
+}
+
+export function buildPublicLinuxDiagnosticsWorkflowDispatchReceipt({
+  options,
+  repositoryInfo,
+  generatedAt,
+  environment = process.env
+}) {
+  const runId = normalizeText(environment.GITHUB_RUN_ID);
+  const serverUrl = normalizeText(environment.GITHUB_SERVER_URL) ?? 'https://github.com';
+  const repositorySlug = normalizeText(environment.GITHUB_REPOSITORY);
+
+  return {
+    schema: REPORT_SCHEMA,
+    generatedAt,
+    target: {
+      repositorySlug: options.repository,
+      repositoryVisibility: repositoryInfo.visibility,
+      repositoryUrl: repositoryInfo.htmlUrl,
+      reference: options.reference,
+      defaultBranch: repositoryInfo.defaultBranch,
+      developRelationship: options.developRelationship
+    },
+    contract: {
+      schemaPath: toRepoPath(options.contractSchemaPath),
+      docPath: toRepoPath(options.contractDocPath)
+    },
+    execution: {
+      mode: 'plan-only',
+      hostedWorkflowPath: toRepoPath(options.workflowPath),
+      workflowRunId: runId,
+      workflowRunUrl: runId && repositorySlug ? `${serverUrl}/${repositorySlug}/actions/runs/${runId}` : null,
+      localDelegateCommand: 'pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite'
+    },
+    artifacts: {
+      reviewLoopReceiptPath: toRepoPath(DEFAULT_REVIEW_LOOP_RECEIPT_PATH),
+      historySummaryPath: toRepoPath(DEFAULT_HISTORY_SUMMARY_PATH),
+      historyReportHtmlPath: toRepoPath(DEFAULT_HISTORY_REPORT_HTML_PATH),
+      operatorSummaryPath: toRepoPath(DEFAULT_OPERATOR_SUMMARY_PATH),
+      dispatchReceiptPath: toRepoPath(options.reportPath)
+    },
+    humanGoNoGo: {
+      required: true,
+      workflowPath: toRepoPath(options.decisionWorkflowPath),
+      decisionPath: toRepoPath(DEFAULT_DECISION_PATH)
+    },
+    status: 'planned'
+  };
+}
+
+export async function runPublicLinuxDiagnosticsWorkflowDispatch({
+  argv = process.argv,
+  environment = process.env,
+  execFileFn = execFile,
+  now = new Date(),
+  writeJsonFn = writeJson,
+  appendStepSummaryFn = appendStepSummary
+} = {}) {
+  const options = parseArgs(argv, environment);
+  if (options.help) {
+    printUsage();
+    return {
+      exitCode: 0,
+      reportPath: null,
+      payload: null
+    };
+  }
+
+  const repositoryInfo = await inspectRepository(options.repository, execFileFn);
+  if (repositoryInfo.visibility !== 'public') {
+    throw new Error(
+      `Repository ${options.repository} is not public (visibility=${repositoryInfo.visibility ?? 'unknown'}).`
+    );
+  }
+
+  const payload = buildPublicLinuxDiagnosticsWorkflowDispatchReceipt({
+    options,
+    repositoryInfo,
+    generatedAt: now.toISOString(),
+    environment
+  });
+  const reportPath = writeJsonFn(options.reportPath, payload);
+  appendStepSummaryFn(options.stepSummaryPath, payload);
+
+  return {
+    exitCode: 0,
+    reportPath,
+    payload
+  };
+}
+
+export async function main(argv = process.argv) {
+  try {
+    const result = await runPublicLinuxDiagnosticsWorkflowDispatch({ argv });
+    if (result.payload) {
+      console.log(`[public-linux-diagnostics-workflow-dispatch] report: ${result.reportPath}`);
+      console.log(
+        `[public-linux-diagnostics-workflow-dispatch] repository=${result.payload.target.repositorySlug} reference=${result.payload.target.reference} relationship=${result.payload.target.developRelationship}`
+      );
+      if (parseArgs(argv).json) {
+        console.log(JSON.stringify(result.payload, null, 2));
+      }
+    }
+    return result.exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv).then((exitCode) => {
+    process.exit(exitCode);
+  });
+}


### PR DESCRIPTION
# Summary

Adds the hosted/manual dispatch surface for the shared public Linux diagnostics harness under #1167.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- adds `.github/workflows/public-linux-diagnostics-harness.yml` as the manual `workflow_dispatch` surface for the shared public Linux diagnostics harness
- adds `tools/priority/public-linux-diagnostics-workflow-dispatch.mjs` to write a deterministic hosted dispatch receipt
- updates the shared `#1163` contract fixture/doc so the hosted workflow and the human decision workflow are distinct surfaces
- adds focused regression coverage for the hosted dispatch script and workflow contract

## Validation Evidence

- `node --check tools/priority/public-linux-diagnostics-workflow-dispatch.mjs`
- `node --test tools/priority/__tests__/public-linux-diagnostics-workflow-dispatch.test.mjs tools/priority/__tests__/public-linux-diagnostics-harness-workflow-contract.test.mjs tools/priority/__tests__/public-linux-diagnostics-harness-contract.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`
- `bash -lc "./bin/actionlint .github/workflows/public-linux-diagnostics-harness.yml"`

## Risks and Follow-ups

- this slice is intentionally plan-only; it creates the hosted/manual dispatch contract surface before bolting on the full diagnostics execution path
- the human decision workflow remains separate and is still required for final session completion
- the local entry-point lane remains under #1165

## Reviewer Focus

- verify the new manual workflow keeps permissions narrow and does not duplicate the human decision surface
- verify the shared `#1163` contract now distinguishes hosted diagnostics dispatch from human disposition
- verify the dispatch receipt stays deterministic across hosted runs

Closes #1167
