### PR TITLE
#1169 Add public Linux diagnostics review summary rendering

### DIFF
--- a/docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md
+++ b/docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md
@@ -56,13 +56,21 @@ The deterministic review bundle must expose:
 - VI history summary JSON
 - VI history HTML report
 - an operator-facing summary path under `_agent`
+- a deterministic rendered review summary for operators
 
 The checked-in schema for this contract is:
 
 - `docs/schemas/public-linux-diagnostics-harness-contract-v1.schema.json`
+- `docs/schemas/public-linux-diagnostics-review-summary-v1.schema.json`
 
 The initial contract reuses the existing Docker/Desktop parity artifact layout so future harness entry points do not
 invent a second bundle structure before the first one is proven.
+
+The renderer surface for operator review is:
+
+- `tools/priority/public-linux-diagnostics-review-summary.mjs`
+- JSON: `tests/results/_agent/diagnostics/public-linux-diagnostics-review-summary.json`
+- Markdown: `tests/results/_agent/diagnostics/public-linux-diagnostics-review-summary.md`
 
 ## Human go/no-go checkpoint
 

--- a/docs/schemas/public-linux-diagnostics-review-summary-v1.schema.json
+++ b/docs/schemas/public-linux-diagnostics-review-summary-v1.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/public-linux-diagnostics-review-summary-v1.schema.json",
+  "title": "public-linux-diagnostics-review-summary@v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "target",
+    "dispatch",
+    "diagnostics",
+    "decision",
+    "review"
+  ],
+  "properties": {
+    "schema": {
+      "const": "public-linux-diagnostics-review-summary@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repositorySlug",
+        "reference",
+        "developRelationship"
+      ],
+      "properties": {
+        "repositorySlug": { "type": ["string", "null"] },
+        "reference": { "type": ["string", "null"] },
+        "developRelationship": { "type": ["string", "null"] }
+      }
+    },
+    "dispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "receiptPath",
+        "workflowPath",
+        "workflowRunId",
+        "workflowRunUrl",
+        "status"
+      ],
+      "properties": {
+        "receiptPath": { "type": "string" },
+        "workflowPath": { "type": ["string", "null"] },
+        "workflowRunId": { "type": ["string", "null"] },
+        "workflowRunUrl": { "type": ["string", "null"] },
+        "status": { "type": ["string", "null"] }
+      }
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reviewSummaryPath",
+        "reviewLoopReceiptPath",
+        "historySummaryPath",
+        "historyReportHtmlPath",
+        "operatorSummaryPath",
+        "overallStatus",
+        "failedCheck",
+        "message",
+        "recommendedReviewOrder"
+      ],
+      "properties": {
+        "reviewSummaryPath": { "type": "string" },
+        "reviewLoopReceiptPath": { "type": ["string", "null"] },
+        "historySummaryPath": { "type": ["string", "null"] },
+        "historyReportHtmlPath": { "type": ["string", "null"] },
+        "operatorSummaryPath": { "type": ["string", "null"] },
+        "overallStatus": { "type": ["string", "null"] },
+        "failedCheck": { "type": "string" },
+        "message": { "type": "string" },
+        "recommendedReviewOrder": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "value",
+        "recommendedAction",
+        "feedback",
+        "recordedBy",
+        "workflowPath",
+        "decisionPath"
+      ],
+      "properties": {
+        "state": {
+          "enum": ["pending", "recorded"]
+        },
+        "value": { "type": ["string", "null"] },
+        "recommendedAction": { "type": ["string", "null"] },
+        "feedback": { "type": ["string", "null"] },
+        "recordedBy": { "type": ["string", "null"] },
+        "workflowPath": { "type": ["string", "null"] },
+        "decisionPath": { "type": "string" }
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "readyForHumanDecision",
+        "humanDecisionRecorded",
+        "blocking",
+        "sessionComplete",
+        "outputJsonPath",
+        "outputMarkdownPath"
+      ],
+      "properties": {
+        "readyForHumanDecision": { "type": "boolean" },
+        "humanDecisionRecorded": { "type": "boolean" },
+        "blocking": { "type": "boolean" },
+        "sessionComplete": { "type": "boolean" },
+        "outputJsonPath": { "type": "string" },
+        "outputMarkdownPath": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-workflow-dispatch.json
+++ b/tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-workflow-dispatch.json
@@ -1,0 +1,36 @@
+{
+  "schema": "public-linux-diagnostics-harness-workflow-dispatch@v1",
+  "generatedAt": "2026-03-14T14:30:00.000Z",
+  "target": {
+    "repositorySlug": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+    "repositoryVisibility": "public",
+    "repositoryUrl": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action",
+    "reference": "issue/personal-1167-public-linux-harness-workflow",
+    "defaultBranch": "develop",
+    "developRelationship": "ahead"
+  },
+  "contract": {
+    "schemaPath": "docs/schemas/public-linux-diagnostics-harness-contract-v1.schema.json",
+    "docPath": "docs/PUBLIC_LINUX_DIAGNOSTICS_HARNESS_CONTRACT.md"
+  },
+  "execution": {
+    "mode": "plan-only",
+    "hostedWorkflowPath": ".github/workflows/public-linux-diagnostics-harness.yml",
+    "workflowRunId": "123456789",
+    "workflowRunUrl": "https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/123456789",
+    "localDelegateCommand": "pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite"
+  },
+  "artifacts": {
+    "reviewLoopReceiptPath": "tests/results/docker-tools-parity/review-loop-receipt.json",
+    "historySummaryPath": "tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-report/results/history-summary.json",
+    "historyReportHtmlPath": "tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-report/results/history-report.html",
+    "operatorSummaryPath": "tests/results/_agent/verification/docker-review-loop-summary.json",
+    "dispatchReceiptPath": "tests/results/_agent/diagnostics/public-linux-diagnostics-workflow-dispatch.json"
+  },
+  "humanGoNoGo": {
+    "required": true,
+    "workflowPath": ".github/workflows/human-go-no-go-feedback.yml",
+    "decisionPath": "tests/results/_agent/handoff/human-go-no-go-decision.json"
+  },
+  "status": "planned"
+}

--- a/tools/priority/__tests__/public-linux-diagnostics-harness-contract.test.mjs
+++ b/tools/priority/__tests__/public-linux-diagnostics-harness-contract.test.mjs
@@ -42,5 +42,7 @@ test('public Linux diagnostics harness contract doc points to the shared bundle 
   assert.match(doc, /human-go-no-go-feedback\.yml/);
   assert.match(doc, /human-go-no-go-decision-v1\.schema\.json/);
   assert.match(doc, /public-linux-diagnostics-harness-contract-v1\.schema\.json/);
+  assert.match(doc, /public-linux-diagnostics-review-summary-v1\.schema\.json/);
+  assert.match(doc, /public-linux-diagnostics-review-summary\.mjs/);
   assert.match(doc, /equal to or ahead of `develop`/i);
 });

--- a/tools/priority/__tests__/public-linux-diagnostics-review-summary.test.mjs
+++ b/tools/priority/__tests__/public-linux-diagnostics-review-summary.test.mjs
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  buildPublicLinuxDiagnosticsReviewSummary,
+  parseArgs,
+  runPublicLinuxDiagnosticsReviewSummary
+} from '../public-linux-diagnostics-review-summary.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+async function loadFixture(relativePath) {
+  return JSON.parse(await readFile(path.join(repoRoot, relativePath), 'utf8'));
+}
+
+async function loadSchema() {
+  return JSON.parse(
+    await readFile(path.join(repoRoot, 'docs', 'schemas', 'public-linux-diagnostics-review-summary-v1.schema.json'), 'utf8')
+  );
+}
+
+function makeAjv() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+test('parseArgs accepts explicit review-summary surface overrides', () => {
+  const options = parseArgs([
+    'node',
+    'tools/priority/public-linux-diagnostics-review-summary.mjs',
+    '--dispatch',
+    'dispatch.json',
+    '--review-summary',
+    'review.json',
+    '--decision',
+    'decision.json',
+    '--out-json',
+    'summary.json',
+    '--out-md',
+    'summary.md'
+  ]);
+
+  assert.equal(options.dispatchPath, 'dispatch.json');
+  assert.equal(options.reviewSummaryPath, 'review.json');
+  assert.equal(options.decisionPath, 'decision.json');
+  assert.equal(options.outputJsonPath, 'summary.json');
+  assert.equal(options.outputMarkdownPath, 'summary.md');
+});
+
+test('runPublicLinuxDiagnosticsReviewSummary writes deterministic JSON and Markdown when a decision exists', async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'public-linux-review-summary-'));
+  const dispatchPath = path.join(tempRoot, 'dispatch.json');
+  const reviewPath = path.join(tempRoot, 'review.json');
+  const decisionPath = path.join(tempRoot, 'decision.json');
+  const outputJsonPath = path.join(tempRoot, 'summary.json');
+  const outputMarkdownPath = path.join(tempRoot, 'summary.md');
+
+  await fs.promises.writeFile(
+    dispatchPath,
+    JSON.stringify(await loadFixture('tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-workflow-dispatch.json'))
+  );
+  await fs.promises.writeFile(
+    reviewPath,
+    JSON.stringify(await loadFixture('tools/priority/__fixtures__/handoff/docker-review-loop-summary.json'))
+  );
+  await fs.promises.writeFile(
+    decisionPath,
+    JSON.stringify(await loadFixture('tools/priority/__fixtures__/handoff/human-go-no-go-decision.json'))
+  );
+
+  const result = await runPublicLinuxDiagnosticsReviewSummary({
+    argv: [
+      'node',
+      'tools/priority/public-linux-diagnostics-review-summary.mjs',
+      '--dispatch',
+      dispatchPath,
+      '--review-summary',
+      reviewPath,
+      '--decision',
+      decisionPath,
+      '--out-json',
+      outputJsonPath,
+      '--out-md',
+      outputMarkdownPath
+    ],
+    now: new Date('2026-03-14T14:40:00Z')
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.payload.review.readyForHumanDecision, true);
+  assert.equal(result.payload.decision.state, 'recorded');
+  assert.equal(result.payload.review.sessionComplete, true);
+  assert.equal(result.payload.review.blocking, true);
+
+  const schema = await loadSchema();
+  const validate = makeAjv().compile(schema);
+  const payload = JSON.parse(await readFile(outputJsonPath, 'utf8'));
+  assert.equal(validate(payload), true, JSON.stringify(validate.errors, null, 2));
+
+  const markdown = await readFile(outputMarkdownPath, 'utf8');
+  assert.match(markdown, /Public Linux Diagnostics Review Summary/);
+  assert.match(markdown, /human decision recorded: `true`/);
+  assert.match(markdown, /decision: `nogo`/);
+});
+
+test('runPublicLinuxDiagnosticsReviewSummary keeps the human decision pending when no decision file exists', async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'public-linux-review-summary-pending-'));
+  const dispatchPath = path.join(tempRoot, 'dispatch.json');
+  const reviewPath = path.join(tempRoot, 'review.json');
+
+  await fs.promises.writeFile(
+    dispatchPath,
+    JSON.stringify(await loadFixture('tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-workflow-dispatch.json'))
+  );
+  await fs.promises.writeFile(
+    reviewPath,
+    JSON.stringify(await loadFixture('tools/priority/__fixtures__/handoff/docker-review-loop-summary.json'))
+  );
+
+  const result = await runPublicLinuxDiagnosticsReviewSummary({
+    argv: [
+      'node',
+      'tools/priority/public-linux-diagnostics-review-summary.mjs',
+      '--dispatch',
+      dispatchPath,
+      '--review-summary',
+      reviewPath
+    ],
+    now: new Date('2026-03-14T14:40:00Z')
+  });
+
+  assert.equal(result.payload.decision.state, 'pending');
+  assert.equal(result.payload.review.humanDecisionRecorded, false);
+  assert.equal(result.payload.review.sessionComplete, false);
+  assert.equal(result.payload.review.readyForHumanDecision, true);
+});
+
+test('runPublicLinuxDiagnosticsReviewSummary fails closed on corrupt required inputs', async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'public-linux-review-summary-bad-'));
+  const dispatchPath = path.join(tempRoot, 'dispatch.json');
+  const reviewPath = path.join(tempRoot, 'review.json');
+  await fs.promises.writeFile(dispatchPath, '{not-json');
+  await fs.promises.writeFile(reviewPath, '{}');
+
+  await assert.rejects(
+    () =>
+      runPublicLinuxDiagnosticsReviewSummary({
+        argv: [
+          'node',
+          'tools/priority/public-linux-diagnostics-review-summary.mjs',
+          '--dispatch',
+          dispatchPath,
+          '--review-summary',
+          reviewPath
+        ]
+      }),
+    /Dispatch receipt is not valid JSON/
+  );
+});
+
+test('buildPublicLinuxDiagnosticsReviewSummary preserves the shared artifact order for operator review', async () => {
+  const payload = buildPublicLinuxDiagnosticsReviewSummary({
+    dispatchReceipt: await loadFixture('tools/priority/__fixtures__/diagnostics/public-linux-diagnostics-workflow-dispatch.json'),
+    reviewSummary: await loadFixture('tools/priority/__fixtures__/handoff/docker-review-loop-summary.json'),
+    decision: null,
+    dispatchPath: 'tests/results/_agent/diagnostics/public-linux-diagnostics-workflow-dispatch.json',
+    reviewSummaryPath: 'tests/results/_agent/verification/docker-review-loop-summary.json',
+    decisionPath: 'tests/results/_agent/handoff/human-go-no-go-decision.json',
+    outputJsonPath: 'tests/results/_agent/diagnostics/public-linux-diagnostics-review-summary.json',
+    outputMarkdownPath: 'tests/results/_agent/diagnostics/public-linux-diagnostics-review-summary.md',
+    generatedAt: '2026-03-14T14:40:00Z'
+  });
+
+  assert.deepEqual(payload.diagnostics.recommendedReviewOrder, [
+    'tests/results/docker-tools-parity/review-loop-receipt.json',
+    'tests/results/_agent/verification/docker-review-loop-summary.json',
+    'tests/results/docker-tools-parity/requirements-verification/verification-summary.json',
+    'tests/results/docker-tools-parity/requirements-verification/trace-matrix.json',
+    'tests/results/docker-tools-parity/requirements-verification/trace-matrix.html'
+  ]);
+});

--- a/tools/priority/public-linux-diagnostics-review-summary.mjs
+++ b/tools/priority/public-linux-diagnostics-review-summary.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const REPORT_SCHEMA = 'public-linux-diagnostics-review-summary@v1';
+export const DEFAULT_DISPATCH_RECEIPT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'diagnostics',
+  'public-linux-diagnostics-workflow-dispatch.json'
+);
+export const DEFAULT_REVIEW_SUMMARY_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'verification',
+  'docker-review-loop-summary.json'
+);
+export const DEFAULT_DECISION_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'human-go-no-go-decision.json'
+);
+export const DEFAULT_OUTPUT_JSON_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'diagnostics',
+  'public-linux-diagnostics-review-summary.json'
+);
+export const DEFAULT_OUTPUT_MARKDOWN_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'diagnostics',
+  'public-linux-diagnostics-review-summary.md'
+);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/public-linux-diagnostics-review-summary.mjs [options]');
+  console.log('');
+  console.log('Render a deterministic operator-facing summary for the public Linux diagnostics harness.');
+  console.log('');
+  console.log(`  --dispatch <path>         Hosted/local dispatch receipt (default: ${DEFAULT_DISPATCH_RECEIPT_PATH})`);
+  console.log(`  --review-summary <path>   Docker parity agent summary (default: ${DEFAULT_REVIEW_SUMMARY_PATH})`);
+  console.log(`  --decision <path>         Human go/no-go decision path (default: ${DEFAULT_DECISION_PATH})`);
+  console.log(`  --out-json <path>         Summary JSON path (default: ${DEFAULT_OUTPUT_JSON_PATH})`);
+  console.log(`  --out-md <path>           Summary Markdown path (default: ${DEFAULT_OUTPUT_MARKDOWN_PATH})`);
+  console.log('  --json                    Print the JSON summary to stdout after writing it.');
+  console.log('  -h, --help                Show help.');
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function toRepoPath(value) {
+  const normalized = normalizeText(value);
+  return normalized ? normalized.replace(/\\/g, '/') : null;
+}
+
+function writeJson(filePath, payload) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+function writeText(filePath, content) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, content, 'utf8');
+  return resolved;
+}
+
+function loadJsonRequired(filePath, label) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`${label} not found: ${filePath}`);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${filePath}`);
+  }
+}
+
+function loadJsonOptional(filePath, label) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(resolved)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${filePath}`);
+  }
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    help: false,
+    dispatchPath: DEFAULT_DISPATCH_RECEIPT_PATH,
+    reviewSummaryPath: DEFAULT_REVIEW_SUMMARY_PATH,
+    decisionPath: DEFAULT_DECISION_PATH,
+    outputJsonPath: DEFAULT_OUTPUT_JSON_PATH,
+    outputMarkdownPath: DEFAULT_OUTPUT_MARKDOWN_PATH,
+    json: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (
+      token === '--dispatch' ||
+      token === '--review-summary' ||
+      token === '--decision' ||
+      token === '--out-json' ||
+      token === '--out-md'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--dispatch') options.dispatchPath = next;
+      if (token === '--review-summary') options.reviewSummaryPath = next;
+      if (token === '--decision') options.decisionPath = next;
+      if (token === '--out-json') options.outputJsonPath = next;
+      if (token === '--out-md') options.outputMarkdownPath = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+function buildMarkdownSummary(summary) {
+  const lines = [
+    '# Public Linux Diagnostics Review Summary',
+    '',
+    `- repository: \`${summary.target.repositorySlug}\``,
+    `- reference: \`${summary.target.reference}\``,
+    `- develop relationship: \`${summary.target.developRelationship}\``,
+    `- diagnostics status: \`${summary.diagnostics.overallStatus}\``,
+    `- ready for human decision: \`${summary.review.readyForHumanDecision}\``,
+    `- human decision recorded: \`${summary.review.humanDecisionRecorded}\``,
+    `- session complete: \`${summary.review.sessionComplete}\``,
+    '',
+    '## Review Order',
+    ''
+  ];
+
+  for (const entry of summary.diagnostics.recommendedReviewOrder) {
+    lines.push(`- \`${entry}\``);
+  }
+
+  lines.push('', '## Human Decision', '');
+  if (summary.decision.state === 'pending') {
+    lines.push(`- pending at \`${summary.decision.decisionPath}\``);
+    lines.push(`- record disposition through \`${summary.decision.workflowPath}\``);
+  } else {
+    lines.push(`- decision: \`${summary.decision.value}\``);
+    lines.push(`- recommended action: \`${summary.decision.recommendedAction}\``);
+    lines.push(`- recorded by: \`${summary.decision.recordedBy}\``);
+    lines.push(`- feedback: ${summary.decision.feedback}`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function buildPublicLinuxDiagnosticsReviewSummary({
+  dispatchReceipt,
+  reviewSummary,
+  decision,
+  dispatchPath,
+  reviewSummaryPath,
+  decisionPath,
+  outputJsonPath,
+  outputMarkdownPath,
+  generatedAt
+}) {
+  const diagnosticsPassed = normalizeText(reviewSummary?.overall?.status) === 'passed';
+  const decisionValue = normalizeText(decision?.decision?.value);
+  const decisionRecorded = Boolean(decision && decisionValue);
+
+  return {
+    schema: REPORT_SCHEMA,
+    generatedAt,
+    target: {
+      repositorySlug: dispatchReceipt?.target?.repositorySlug ?? null,
+      reference: dispatchReceipt?.target?.reference ?? null,
+      developRelationship: dispatchReceipt?.target?.developRelationship ?? null
+    },
+    dispatch: {
+      receiptPath: toRepoPath(dispatchPath),
+      workflowPath: dispatchReceipt?.execution?.hostedWorkflowPath ?? null,
+      workflowRunId: dispatchReceipt?.execution?.workflowRunId ?? null,
+      workflowRunUrl: dispatchReceipt?.execution?.workflowRunUrl ?? null,
+      status: dispatchReceipt?.status ?? null
+    },
+    diagnostics: {
+      reviewSummaryPath: toRepoPath(reviewSummaryPath),
+      reviewLoopReceiptPath: reviewSummary?.reviewLoopReceiptPath ?? reviewSummary?.artifacts?.reviewLoopReceiptPath ?? null,
+      historySummaryPath: dispatchReceipt?.artifacts?.historySummaryPath ?? null,
+      historyReportHtmlPath: dispatchReceipt?.artifacts?.historyReportHtmlPath ?? null,
+      operatorSummaryPath: dispatchReceipt?.artifacts?.operatorSummaryPath ?? toRepoPath(reviewSummaryPath),
+      overallStatus: reviewSummary?.overall?.status ?? null,
+      failedCheck: reviewSummary?.overall?.failedCheck ?? '',
+      message: reviewSummary?.overall?.message ?? '',
+      recommendedReviewOrder: Array.isArray(reviewSummary?.recommendedReviewOrder)
+        ? [...reviewSummary.recommendedReviewOrder]
+        : []
+    },
+    decision: decisionRecorded
+      ? {
+          state: 'recorded',
+          value: decisionValue,
+          recommendedAction: decision?.nextIteration?.recommendedAction ?? null,
+          feedback: decision?.decision?.feedback ?? null,
+          recordedBy: decision?.decision?.recordedBy ?? null,
+          workflowPath: decision?.workflow?.path ?? dispatchReceipt?.humanGoNoGo?.workflowPath ?? null,
+          decisionPath: decision?.artifacts?.decisionPath ?? toRepoPath(decisionPath)
+        }
+      : {
+          state: 'pending',
+          value: null,
+          recommendedAction: null,
+          feedback: null,
+          recordedBy: null,
+          workflowPath: dispatchReceipt?.humanGoNoGo?.workflowPath ?? null,
+          decisionPath: toRepoPath(decisionPath)
+        },
+    review: {
+      readyForHumanDecision: diagnosticsPassed,
+      humanDecisionRecorded: decisionRecorded,
+      blocking: !diagnosticsPassed || decisionValue === 'nogo',
+      sessionComplete: decisionRecorded,
+      outputJsonPath: toRepoPath(outputJsonPath),
+      outputMarkdownPath: toRepoPath(outputMarkdownPath)
+    }
+  };
+}
+
+export async function runPublicLinuxDiagnosticsReviewSummary({
+  argv = process.argv,
+  now = new Date(),
+  loadJsonRequiredFn = loadJsonRequired,
+  loadJsonOptionalFn = loadJsonOptional,
+  writeJsonFn = writeJson,
+  writeTextFn = writeText
+} = {}) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return { exitCode: 0, payload: null, markdown: null, outputJsonPath: null, outputMarkdownPath: null };
+  }
+
+  const dispatchReceipt = loadJsonRequiredFn(options.dispatchPath, 'Dispatch receipt');
+  const reviewSummary = loadJsonRequiredFn(options.reviewSummaryPath, 'Review summary');
+  const decision = loadJsonOptionalFn(options.decisionPath, 'Human decision');
+  const payload = buildPublicLinuxDiagnosticsReviewSummary({
+    dispatchReceipt,
+    reviewSummary,
+    decision,
+    dispatchPath: options.dispatchPath,
+    reviewSummaryPath: options.reviewSummaryPath,
+    decisionPath: options.decisionPath,
+    outputJsonPath: options.outputJsonPath,
+    outputMarkdownPath: options.outputMarkdownPath,
+    generatedAt: now.toISOString()
+  });
+  const markdown = buildMarkdownSummary(payload);
+  const outputJsonPath = writeJsonFn(options.outputJsonPath, payload);
+  const outputMarkdownPath = writeTextFn(options.outputMarkdownPath, markdown);
+
+  return {
+    exitCode: 0,
+    payload,
+    markdown,
+    outputJsonPath,
+    outputMarkdownPath
+  };
+}
+
+export async function main(argv = process.argv) {
+  try {
+    const result = await runPublicLinuxDiagnosticsReviewSummary({ argv });
+    if (result.payload) {
+      console.log(`[public-linux-diagnostics-review-summary] json: ${result.outputJsonPath}`);
+      console.log(`[public-linux-diagnostics-review-summary] markdown: ${result.outputMarkdownPath}`);
+      console.log(
+        `[public-linux-diagnostics-review-summary] diagnostics=${result.payload.diagnostics.overallStatus} decision=${result.payload.decision.state}`
+      );
+      if (parseArgs(argv).json) {
+        console.log(JSON.stringify(result.payload, null, 2));
+      }
+    }
+    return result.exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv).then((exitCode) => {
+    process.exit(exitCode);
+  });
+}


### PR DESCRIPTION
# Summary

Adds the deterministic artifact/report rendering surface for the public Linux diagnostics harness under #1169.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- adds `tools/priority/public-linux-diagnostics-review-summary.mjs` to render one operator-facing review summary from the shared dispatch, review, and human-decision surfaces
- adds `docs/schemas/public-linux-diagnostics-review-summary-v1.schema.json`
- adds deterministic fixtures/regressions for the renderer
- updates the shared public Linux diagnostics contract doc to reference the renderer output surfaces

## Validation Evidence

- `node --check tools/priority/public-linux-diagnostics-review-summary.mjs`
- `node --test tools/priority/__tests__/public-linux-diagnostics-review-summary.test.mjs tools/priority/__tests__/public-linux-diagnostics-harness-contract.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`

## Risks and Follow-ups

- this slice is renderer-only; it does not change the execution path of the local or hosted harness lanes
- the human go/no-go workflow remains the final disposition surface
- the hosted/manual dispatch lane remains under #1167

## Reviewer Focus

- verify the renderer consumes the existing artifact layout instead of inventing a second summary contract
- verify pending-vs-recorded human decision states are rendered deterministically
- verify the markdown summary is sufficient for operator review without reading every raw artifact first

Closes #1169
