### PR TITLE
#1173 Surface Docker Desktop plane diagnostics in fast-loop readiness

### DIFF
--- a/tests/Show-DockerFastLoopDiagnostics.Tests.ps1
+++ b/tests/Show-DockerFastLoopDiagnostics.Tests.ps1
@@ -72,6 +72,33 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
       historyScenarioSet = 'smoke'
       diffEvidenceSteps = 2
       extractedReportCount = 2
+      dockerDesktopPlanes = [ordered]@{
+        schema = 'docker-fast-loop/docker-desktop-planes@v1'
+        laneScope = 'windows'
+        loopLabel = 'windows-docker-fast-loop'
+        requestedPlanes = @('docker-desktop/windows-container-2026')
+        exclusiveRequired = $false
+        exclusiveSatisfied = $true
+        mutuallyExclusivePairCount = 1
+        planes = [ordered]@{
+          windows = [ordered]@{
+            plane = 'docker-desktop/windows-container-2026'
+            enabled = $true
+            status = 'success'
+            context = 'desktop-windows'
+            expectedOsType = 'windows'
+            observedOsType = 'windows'
+          }
+          linux = [ordered]@{
+            plane = 'docker-desktop/linux-container-2026'
+            enabled = $false
+            status = 'skipped'
+            context = 'desktop-linux'
+            expectedOsType = 'linux'
+            observedOsType = ''
+          }
+        }
+      }
       source = [ordered]@{
         resultsRoot = $resultsRoot
         hostPlaneReportPath = $hostPlaneReportPath
@@ -108,6 +135,8 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
     $outputText | Should -Match '\[native-labview-2026-64\]\[host-plane\] status=ready'
     $outputText | Should -Match '\[host-plane-split\]\[runner\] hostIsRunner=True runnerName=GHOST githubActions=False'
     $outputText | Should -Match 'candidateParallelPairs=docker-desktop/windows-container-2026\+native-labview-2026-64,native-labview-2026-64\+native-labview-2026-32'
+    $outputText | Should -Match '\[windows-docker-fast-loop\]\[docker-plane\] requested=docker-desktop/windows-container-2026 exclusiveRequired=False exclusiveSatisfied=True pairCount=1'
+    $outputText | Should -Match 'lane=windows plane=docker-desktop/windows-container-2026 enabled=True status=success context=desktop-windows expectedOs=windows observedOs=windows'
     $outputText | Should -Match '\[windows-docker-fast-loop\]\[diagnostics\] scenarioSet=smoke differentiatedSteps=2 evidenceSteps=2 reports=2'
     $outputText | Should -Match 'lane=windows sequence=direct mode=attribute images=6'
     $outputText | Should -Match 'report=history-scenarios\\attribute\\container-export\\windows-compare-report.html'

--- a/tests/Write-DockerFastLoopReadiness.Tests.ps1
+++ b/tests/Write-DockerFastLoopReadiness.Tests.ps1
@@ -31,6 +31,20 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
         transitionCount = 3
         daemonUnavailableCount = 1
         parseDefectCount = 0
+        probes = [ordered]@{
+          windows = [ordered]@{
+            enabled = $true
+            status = 'success'
+            context = 'desktop-windows'
+            osType = 'windows'
+          }
+          linux = [ordered]@{
+            enabled = $true
+            status = 'success'
+            context = 'desktop-linux'
+            osType = 'linux'
+          }
+        }
       }
       hostPlane = [ordered]@{
         schema = 'labview-2026-host-plane-report@v1'
@@ -125,6 +139,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
       -StepSummaryPath '' *>&1
     $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
     ($output -join "`n") | Should -Match '\[dual-docker-fast-loop\]\[diagnostics\] scenarioSet=none differentiatedSteps=1 evidenceSteps=1 reports=1'
+    ($output -join "`n") | Should -Match '\[dual-docker-fast-loop\]\[docker-plane\] requested=docker-desktop/windows-container-2026,docker-desktop/linux-container-2026 exclusiveRequired=True exclusiveSatisfied=True pairCount=1'
+    ($output -join "`n") | Should -Match 'lane=windows plane=docker-desktop/windows-container-2026 enabled=True status=success context=desktop-windows expectedOs=windows observedOs=windows'
     ($output -join "`n") | Should -Match 'lane=windows sequence=direct mode=attribute images=2'
 
     $readiness = Get-Content -LiteralPath $jsonOut -Raw | ConvertFrom-Json -Depth 16
@@ -142,6 +158,14 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.runtimeManagerDaemonUnavailableCount | Should -Be 1
     $readiness.runtimeManagerParseDefectCount | Should -Be 0
     $readiness.runtimeManager.transitionCount | Should -Be 3
+    $readiness.dockerDesktopPlanes.schema | Should -Be 'docker-fast-loop/docker-desktop-planes@v1'
+    $readiness.dockerDesktopPlanes.requestedPlanes.Count | Should -Be 2
+    @($readiness.dockerDesktopPlanes.requestedPlanes) | Should -Contain 'docker-desktop/windows-container-2026'
+    @($readiness.dockerDesktopPlanes.requestedPlanes) | Should -Contain 'docker-desktop/linux-container-2026'
+    $readiness.dockerDesktopPlanes.exclusiveRequired | Should -BeTrue
+    $readiness.dockerDesktopPlanes.exclusiveSatisfied | Should -BeTrue
+    $readiness.dockerDesktopPlanes.planes.windows.context | Should -Be 'desktop-windows'
+    $readiness.dockerDesktopPlanes.planes.linux.context | Should -Be 'desktop-linux'
     $readiness.hostPlane.runner.hostIsRunner | Should -BeTrue
     $readiness.hostPlane.runner.runnerName | Should -Be 'GHOST'
     $readiness.hostPlane.host.os | Should -Be 'windows'
@@ -157,6 +181,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $markdown | Should -Match '\| Host Is Runner \| `True` \|'
     $markdown | Should -Match '\| Runner Name \| `GHOST` \|'
     $markdown | Should -Match '\| Mutually Exclusive Pairs \| `docker-desktop/linux-container-2026<->docker-desktop/windows-container-2026` \|'
+    $markdown | Should -Match '\| Requested Docker Planes \| `docker-desktop/windows-container-2026, docker-desktop/linux-container-2026` \|'
+    $markdown | Should -Match '\| Docker Exclusivity Satisfied \| `True` \|'
   }
 
   It 'marks tool failure runs not-ready' {
@@ -220,6 +246,79 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.containerExportFailureCount | Should -Be 1
     $readiness.runtimeFailureCount | Should -Be 0
     $readiness.lanes.windows.failureClass | Should -Be 'cli/tool'
+  }
+
+  It 'records a single-lane linux Docker plane projection when only the linux lane is requested' {
+    $resultsRoot = Join-Path $TestDrive 'linux-plane'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    $summaryPath = Join-Path $resultsRoot 'docker-runtime-fastloop-20260301030303.json'
+    $statusPath = Join-Path $resultsRoot 'docker-runtime-fastloop-status.json'
+    $jsonOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.json'
+    $mdOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.md'
+
+    $summary = [ordered]@{
+      schema = 'docker-desktop-fast-loop@v1'
+      generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      laneScope = 'linux'
+      status = 'success'
+      hardStopTriggered = $false
+      runtimeManager = [ordered]@{
+        schema = 'docker-fast-loop/runtime-manager@v1'
+        transitionCount = 1
+        daemonUnavailableCount = 0
+        parseDefectCount = 0
+        probes = [ordered]@{
+          windows = [ordered]@{
+            enabled = $false
+            status = 'skipped'
+            context = 'desktop-windows'
+            osType = ''
+          }
+          linux = [ordered]@{
+            enabled = $true
+            status = 'success'
+            context = 'desktop-linux'
+            osType = 'linux'
+          }
+        }
+      }
+      steps = @(
+        [ordered]@{
+          name = 'linux-runtime-preflight'
+          status = 'success'
+          durationMs = 900
+          exitCode = 0
+          resultClass = 'success-no-diff'
+          gateOutcome = 'pass'
+          failureClass = 'none'
+          isDiff = $false
+        }
+      )
+    }
+    $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+    ([ordered]@{
+        schema = 'docker-desktop-fast-loop-status@v1'
+        generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      } | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $statusPath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ReadinessScript `
+      -ResultsRoot $resultsRoot `
+      -SummaryPath $summaryPath `
+      -StatusPath $statusPath `
+      -OutputJsonPath $jsonOut `
+      -OutputMarkdownPath $mdOut `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '' *>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+    ($output -join "`n") | Should -Match '\[linux-docker-fast-loop\]\[docker-plane\] requested=docker-desktop/linux-container-2026 exclusiveRequired=False exclusiveSatisfied=True pairCount=0'
+
+    $readiness = Get-Content -LiteralPath $jsonOut -Raw | ConvertFrom-Json -Depth 16
+    $readiness.loopLabel | Should -Be 'linux-docker-fast-loop'
+    @($readiness.dockerDesktopPlanes.requestedPlanes) | Should -Be @('docker-desktop/linux-container-2026')
+    $readiness.dockerDesktopPlanes.exclusiveRequired | Should -BeFalse
+    $readiness.dockerDesktopPlanes.exclusiveSatisfied | Should -BeTrue
+    $readiness.dockerDesktopPlanes.planes.linux.context | Should -Be 'desktop-linux'
+    $readiness.dockerDesktopPlanes.planes.windows.enabled | Should -BeFalse
   }
 
   It 'marks runtime hard-stop runs not-ready with runtime failure counts' {

--- a/tools/DockerFastLoopDiagnostics.psm1
+++ b/tools/DockerFastLoopDiagnostics.psm1
@@ -299,6 +299,182 @@ function Get-DockerFastLoopLogPrefix {
   return ('[{0}]' -f (Get-DockerFastLoopLabel -ContextObject $ContextObject -Diagnostics $Diagnostics))
 }
 
+function Get-DockerDesktopPlaneId {
+  param([Parameter(Mandatory)][string]$Lane)
+
+  switch ($Lane.Trim().ToLowerInvariant()) {
+    'windows' { return 'docker-desktop/windows-container-2026' }
+    'linux' { return 'docker-desktop/linux-container-2026' }
+    default { return '' }
+  }
+}
+
+function Get-DockerFastLoopDockerDesktopPlaneProjection {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][AllowNull()]$ContextObject,
+    [AllowNull()]$HostExecutionPolicy = $null
+  )
+
+  $explicit = Get-PropertyValue -InputObject $ContextObject -Name 'dockerDesktopPlanes'
+  if ($explicit) {
+    return $explicit
+  }
+
+  $runtimeManager = Get-PropertyValue -InputObject $ContextObject -Name 'runtimeManager'
+  if (-not $runtimeManager) {
+    return $null
+  }
+
+  $laneScope = Convert-ToTrimmedString (Get-PropertyValue -InputObject $ContextObject -Name 'laneScope')
+  if ([string]::IsNullOrWhiteSpace($laneScope)) {
+    $runObject = Get-PropertyValue -InputObject $ContextObject -Name 'run'
+    $laneScope = Convert-ToTrimmedString (Get-PropertyValue -InputObject $runObject -Name 'laneScope')
+  }
+  if ([string]::IsNullOrWhiteSpace($laneScope)) {
+    $laneScope = 'both'
+  }
+
+  $runtimeProbes = Get-PropertyValue -InputObject $runtimeManager -Name 'probes'
+  $requestedPlanes = New-Object System.Collections.Generic.List[string]
+  $planeRecords = [ordered]@{}
+  foreach ($laneName in @('windows', 'linux')) {
+    $planeId = Get-DockerDesktopPlaneId -Lane $laneName
+    $expectedOsType = if ($laneName -eq 'windows') { 'windows' } else { 'linux' }
+    $probe = Get-PropertyValue -InputObject $runtimeProbes -Name $laneName
+    $enabled = Convert-ToBoolean (Get-PropertyValue -InputObject $probe -Name 'enabled')
+    if (-not $enabled) {
+      switch ($laneScope) {
+        'windows' { $enabled = ($laneName -eq 'windows') }
+        'linux' { $enabled = ($laneName -eq 'linux') }
+        'both' { $enabled = $true }
+      }
+    }
+
+    $status = Convert-ToTrimmedString (Get-PropertyValue -InputObject $probe -Name 'status')
+    if ([string]::IsNullOrWhiteSpace($status)) {
+      $status = if ($enabled) { 'pending' } else { 'skipped' }
+    }
+    $contextName = Convert-ToTrimmedString (Get-PropertyValue -InputObject $probe -Name 'context')
+    $observedOsType = Convert-ToTrimmedString (Get-PropertyValue -InputObject $probe -Name 'osType')
+    $osTypeMatches = [string]::Equals($observedOsType, $expectedOsType, [System.StringComparison]::OrdinalIgnoreCase)
+    $engineReady = ($status -eq 'success') -and $osTypeMatches
+
+    if ($enabled) {
+      $requestedPlanes.Add($planeId) | Out-Null
+    }
+
+    $planeRecords[$laneName] = [ordered]@{
+      plane = $planeId
+      lane = $laneName
+      enabled = [bool]$enabled
+      status = $status
+      context = $contextName
+      expectedOsType = $expectedOsType
+      observedOsType = $observedOsType
+      osTypeMatches = [bool]$osTypeMatches
+      engineReady = [bool]$engineReady
+    }
+  }
+
+  $exclusivePairs = @(
+    @(Get-PropertyValue -InputObject (Get-PropertyValue -InputObject $HostExecutionPolicy -Name 'mutuallyExclusivePairs') -Name 'pairs' -Default @()) |
+      ForEach-Object {
+        [ordered]@{
+          left = Convert-ToTrimmedString (Get-PropertyValue -InputObject $_ -Name 'left')
+          right = Convert-ToTrimmedString (Get-PropertyValue -InputObject $_ -Name 'right')
+        }
+      }
+  )
+  $exclusiveRequired = ($requestedPlanes.Count -gt 1)
+  $exclusiveSatisfied = $false
+  if (-not $exclusiveRequired) {
+    $requestedRecord = @($planeRecords.GetEnumerator() | ForEach-Object { $_.Value } | Where-Object { [bool]$_.enabled } | Select-Object -First 1)
+    if ($requestedRecord.Count -eq 0) {
+      $exclusiveSatisfied = $true
+    } else {
+      $exclusiveSatisfied = [bool]$requestedRecord[0].engineReady
+    }
+  } else {
+    $windowsRecord = $planeRecords.windows
+    $linuxRecord = $planeRecords.linux
+    $contextsDistinct = -not [string]::Equals([string]$windowsRecord.context, [string]$linuxRecord.context, [System.StringComparison]::OrdinalIgnoreCase)
+    $exclusiveSatisfied = [bool](
+      $windowsRecord.enabled -and
+      $linuxRecord.enabled -and
+      $windowsRecord.engineReady -and
+      $linuxRecord.engineReady -and
+      $contextsDistinct
+    )
+  }
+
+  return [pscustomobject][ordered]@{
+    schema = 'docker-fast-loop/docker-desktop-planes@v1'
+    laneScope = $laneScope
+    loopLabel = Get-DockerFastLoopLabel -ContextObject $ContextObject
+    requestedPlanes = @($requestedPlanes.ToArray())
+    exclusiveRequired = [bool]$exclusiveRequired
+    exclusiveSatisfied = [bool]$exclusiveSatisfied
+    mutuallyExclusivePairCount = [int]@($exclusivePairs).Count
+    mutuallyExclusivePairs = [ordered]@{
+      pairs = @($exclusivePairs)
+    }
+    planes = [ordered]@{
+      windows = $planeRecords.windows
+      linux = $planeRecords.linux
+    }
+  }
+}
+
+function Write-DockerFastLoopDockerDesktopPlaneDiagnostics {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][AllowNull()]$ContextObject
+  )
+
+  $hostExecutionPolicy = Get-PropertyValue -InputObject $ContextObject -Name 'hostExecutionPolicy'
+  $dockerDesktopPlanes = Get-DockerFastLoopDockerDesktopPlaneProjection -ContextObject $ContextObject -HostExecutionPolicy $hostExecutionPolicy
+  if ($null -eq $dockerDesktopPlanes) {
+    return $null
+  }
+
+  $prefix = Get-DockerFastLoopLogPrefix -ContextObject $ContextObject
+  $requestedPlanes = @($dockerDesktopPlanes.requestedPlanes | ForEach-Object { [string]$_ }) -join ','
+  if ([string]::IsNullOrWhiteSpace($requestedPlanes)) {
+    $requestedPlanes = '-'
+  }
+
+  Write-Host (
+    "{0}[docker-plane] requested={1} exclusiveRequired={2} exclusiveSatisfied={3} pairCount={4}" -f
+    $prefix,
+    $requestedPlanes,
+    [bool]$dockerDesktopPlanes.exclusiveRequired,
+    [bool]$dockerDesktopPlanes.exclusiveSatisfied,
+    [int]$dockerDesktopPlanes.mutuallyExclusivePairCount
+  ) -ForegroundColor DarkCyan
+
+  foreach ($laneName in @('windows', 'linux')) {
+    $planeRecord = Get-PropertyValue -InputObject (Get-PropertyValue -InputObject $dockerDesktopPlanes -Name 'planes') -Name $laneName
+    if ($null -eq $planeRecord) {
+      continue
+    }
+
+    Write-Host (
+      "{0}[docker-plane] lane={1} plane={2} enabled={3} status={4} context={5} expectedOs={6} observedOs={7}" -f
+      $prefix,
+      $laneName,
+      [string]$planeRecord.plane,
+      [bool]$planeRecord.enabled,
+      [string]$planeRecord.status,
+      $(if ([string]::IsNullOrWhiteSpace([string]$planeRecord.context)) { '-' } else { [string]$planeRecord.context }),
+      [string]$planeRecord.expectedOsType,
+      $(if ([string]::IsNullOrWhiteSpace([string]$planeRecord.observedOsType)) { '-' } else { [string]$planeRecord.observedOsType })
+    ) -ForegroundColor DarkGray
+  }
+
+  return $dockerDesktopPlanes
+}
+
 function Get-DockerFastLoopDifferentiatedDiagnostics {
   [CmdletBinding()]
   param(
@@ -395,4 +571,4 @@ function Write-DockerFastLoopDifferentiatedDiagnostics {
   return $diagnostics
 }
 
-Export-ModuleMember -Function Get-DockerFastLoopDifferentiatedDiagnostics, Get-DockerFastLoopLabel, Get-DockerFastLoopLogPrefix, Write-DockerFastLoopDifferentiatedDiagnostics
+Export-ModuleMember -Function Get-DockerFastLoopDifferentiatedDiagnostics, Get-DockerFastLoopDockerDesktopPlaneProjection, Get-DockerFastLoopLabel, Get-DockerFastLoopLogPrefix, Write-DockerFastLoopDifferentiatedDiagnostics, Write-DockerFastLoopDockerDesktopPlaneDiagnostics

--- a/tools/Show-DockerFastLoopDiagnostics.ps1
+++ b/tools/Show-DockerFastLoopDiagnostics.ps1
@@ -68,6 +68,7 @@ if ($null -eq $hostPlane -and $readiness -and $readiness.PSObject.Properties['so
 if ($hostPlane) {
   Write-LabVIEW2026HostPlaneConsole -Report $hostPlane
 }
+Write-DockerFastLoopDockerDesktopPlaneDiagnostics -ContextObject $readiness | Out-Null
 $diagnostics = @(Write-DockerFastLoopDifferentiatedDiagnostics -Readiness $readiness -ResultsRoot $effectiveResultsRoot)
 if ($PassThru) {
   Write-Output $diagnostics

--- a/tools/Write-DockerFastLoopReadiness.ps1
+++ b/tools/Write-DockerFastLoopReadiness.ps1
@@ -553,6 +553,7 @@ $hostExecutionPolicy = if ($summary.PSObject.Properties['hostExecutionPolicy']) 
 } else {
   $null
 }
+$dockerDesktopPlanes = Get-DockerFastLoopDockerDesktopPlaneProjection -ContextObject $summary -HostExecutionPolicy $hostExecutionPolicy
 
 $readiness = [ordered]@{
   schema = 'vi-history/docker-fast-loop-readiness@v1'
@@ -626,6 +627,7 @@ $readiness = [ordered]@{
   hostPlane = $hostPlane
   hostPlanes = $hostPlanes
   hostExecutionPolicy = $hostExecutionPolicy
+  dockerDesktopPlanes = $dockerDesktopPlanes
   steps = @($steps)
 }
 
@@ -695,6 +697,26 @@ if ($hostExecutionPolicy -and $hostExecutionPolicy.PSObject.Properties['candidat
   $candidatePairs = Convert-PairSetToText -PairSet $hostExecutionPolicy.candidateParallelPairs
   if (-not [string]::IsNullOrWhiteSpace($candidatePairs)) {
     $mdLines.Add(('| Candidate Parallel Pairs | `{0}` |' -f $candidatePairs)) | Out-Null
+  }
+}
+if ($dockerDesktopPlanes) {
+  $requestedDockerPlanes = @($dockerDesktopPlanes.requestedPlanes | ForEach-Object { [string]$_ }) -join ', '
+  if (-not [string]::IsNullOrWhiteSpace($requestedDockerPlanes)) {
+    $mdLines.Add(('| Requested Docker Planes | `{0}` |' -f $requestedDockerPlanes)) | Out-Null
+  }
+  $mdLines.Add(('| Docker Exclusivity Required | `{0}` |' -f [bool]$dockerDesktopPlanes.exclusiveRequired)) | Out-Null
+  $mdLines.Add(('| Docker Exclusivity Satisfied | `{0}` |' -f [bool]$dockerDesktopPlanes.exclusiveSatisfied)) | Out-Null
+  foreach ($laneName in @('windows', 'linux')) {
+    $planeRecord = $dockerDesktopPlanes.planes.$laneName
+    if ($null -eq $planeRecord) {
+      continue
+    }
+    $mdLines.Add(('| Docker Plane ({0}) | `{1}` / `{2}` / `{3}` / `{4}` |' -f `
+        $laneName, `
+        [string]$planeRecord.status, `
+        $(if ([string]::IsNullOrWhiteSpace([string]$planeRecord.context)) { '-' } else { [string]$planeRecord.context }), `
+        [string]$planeRecord.expectedOsType, `
+        $(if ([string]::IsNullOrWhiteSpace([string]$planeRecord.observedOsType)) { '-' } else { [string]$planeRecord.observedOsType }))) | Out-Null
   }
 }
 $mdLines.Add(('| Timeout Failure Count | `{0}` |' -f $readiness.run.timeoutFailureCount)) | Out-Null
@@ -789,6 +811,9 @@ Write-Host ("{0}[readiness] markdown={1}" -f $loopPrefix, $mdOutResolved)
 if ($PrintDifferentiatedDiagnostics) {
   if ($hostPlane) {
     Write-LabVIEW2026HostPlaneConsole -Report $hostPlane
+  }
+  if ($dockerDesktopPlanes) {
+    Write-DockerFastLoopDockerDesktopPlaneDiagnostics -ContextObject $readiness | Out-Null
   }
   Write-DockerFastLoopDifferentiatedDiagnostics -Readiness $readiness -ResultsRoot $resultsRootResolved | Out-Null
 }


### PR DESCRIPTION
## Summary
- project Docker Desktop plane and exclusivity evidence from the runtime-manager surface into the fast-loop readiness envelope
- print the differentiated Docker plane diagnostics in both readiness generation and replay output
- add focused regression coverage for `both`, `windows`, and `linux` lane scopes

## Testing
- `Invoke-Pester -Path tests/Write-DockerFastLoopReadiness.Tests.ps1,tests/Show-DockerFastLoopDiagnostics.Tests.ps1 -CI`

Closes #1173

## Agent Metadata
- Issue: #1173
- Execution plane: personal
- Secondary lane while #1171 / #1172 is the live standing-priority path
