### PR TITLE
#1175 Add the single-host LabVIEW 2026 plane runbook

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -215,6 +215,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - Native LabVIEW 2026 host split diagnostics:
   - `node tools/npm/run-script.mjs env:labview:2026:host-planes`
   - The Windows host is treated as the execution runner; the generated report records `runner.hostIsRunner=true`.
+  - Use `docs/SINGLE_HOST_LABVIEW_2026_PLANES.md` when you need the explicit four-plane operating model and the
+    authoritative replay/diagnostics entry points in one place.
 - Differentiated history readback:
   - `node tools/npm/run-script.mjs history:diagnostics:show -- --ResultsRoot tests/results/local-parity/windows`
   - The replay prints the host/runner plane split before the differentiated mode diagnostics.

--- a/docs/SINGLE_HOST_LABVIEW_2026_PLANES.md
+++ b/docs/SINGLE_HOST_LABVIEW_2026_PLANES.md
@@ -1,0 +1,100 @@
+# Single-Host LabVIEW 2026 Planes
+
+This runbook defines how to reason about one Windows host that can operate across four explicit LabVIEW 2026 execution
+planes. Use it when you need to diagnose fast-loop output, explain provenance to another operator, or decide which host
+surface should run next.
+
+## Plane model
+
+Treat these four planes as distinct:
+
+- `docker-desktop/windows-container-2026`
+- `docker-desktop/linux-container-2026`
+- `native-labview-2026-64`
+- `native-labview-2026-32`
+
+Do not collapse them into a generic “LabVIEW 2026 host” concept. The repo contracts and artifacts are written so future
+agents can tell which plane actually produced the evidence.
+
+## Mutual-exclusion rule
+
+The two Docker Desktop planes are mutually exclusive:
+
+- `docker-desktop/windows-container-2026`
+- `docker-desktop/linux-container-2026`
+
+That exclusivity must be visible in diagnostics output. If a run does not make it clear which Docker plane was selected,
+do not trust the result as replayable evidence.
+
+The native planes are also distinct:
+
+- `native-labview-2026-64`
+- `native-labview-2026-32`
+
+They may share supporting tooling paths, but they remain different host planes and must not be reported as one surface.
+
+## Authoritative entry points
+
+Use these commands as the checked-in operator surfaces:
+
+1. Host-plane report:
+   - `node tools/npm/run-script.mjs env:labview:2026:host-planes`
+2. Fast Docker Desktop lane loops:
+   - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope linux -StepTimeoutSeconds 600`
+   - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope windows -StepTimeoutSeconds 600`
+   - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope both -StepTimeoutSeconds 600`
+3. Differentiated diagnostics replay:
+   - `node tools/npm/run-script.mjs history:diagnostics:show -- --ResultsRoot tests/results/local-parity/windows`
+
+The replay helper is the fastest operator readback. It prints the host-plane report first and then the differentiated
+Docker fast-loop diagnostics for the selected results root.
+
+## Authoritative artifacts
+
+Use these artifacts as the machine-readable source of truth:
+
+1. Host-plane report:
+   - `tests/results/_agent/host-planes/labview-2026-host-plane-report.json`
+2. Fast-loop readiness envelope:
+   - `docker-runtime-fastloop-readiness.json`
+   - `docker-runtime-fastloop-readiness.md`
+3. Fast-loop proof bundle when produced:
+   - `docker-fast-loop-proof-*.json`
+
+When the local fast loop runs, prefer the readiness envelope for lane verdicts and the host-plane report for the native
+64-bit versus native 32-bit split. For Docker lane replay, use the readiness envelope together with
+`history:diagnostics:show`.
+
+## Reading the evidence
+
+Use the artifacts in this order:
+
+1. `labview-2026-host-plane-report.json`
+   - confirms the native `x64` and `x32` plane readiness
+   - shows the host/runner identity
+   - records the mutually exclusive Docker pair and the candidate parallel pairs
+2. `docker-runtime-fastloop-readiness.json`
+   - records the fast-loop verdict and lane outcomes
+   - carries the differentiated Docker Desktop plane projection
+   - records whether Docker exclusivity was required and whether it was satisfied
+3. `history:diagnostics:show`
+   - replays the same distinction in console form for the operator
+
+If any of those surfaces disagree on the selected plane or exclusivity state, stop and treat the run as not yet
+trustworthy.
+
+## Practical rules for future agents
+
+1. Use `-LaneScope linux` or `-LaneScope windows` when you want one Docker plane only.
+2. Use `-LaneScope both` only when the run is explicitly about the dual-lane contract.
+3. Do not infer the active Docker plane from filenames alone; rely on the readiness envelope and replay helper.
+4. Do not infer the active native plane from a generic LabVIEW path; use the host-plane report.
+5. When summarizing a run, name the exact plane identifier instead of saying “host” or “Docker” without qualification.
+
+## Related contracts
+
+- [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)
+- [labview-2026-host-plane-report-v1.schema.json](schemas/labview-2026-host-plane-report-v1.schema.json)
+- [Write-LabVIEW2026HostPlaneDiagnostics.ps1](../tools/Write-LabVIEW2026HostPlaneDiagnostics.ps1)
+- [Test-DockerDesktopFastLoop.ps1](../tools/Test-DockerDesktopFastLoop.ps1)
+- [Show-DockerFastLoopDiagnostics.ps1](../tools/Show-DockerFastLoopDiagnostics.ps1)

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -147,8 +147,9 @@
       "name": "Host Plane Diagnostics Contracts",
       "category": "supporting",
       "status": "reference",
-      "description": "Machine-readable report contract and helper entrypoints for the LabVIEW 2026 native host-plane split.",
+      "description": "Machine-readable report contract, helper entrypoints, and single-host runbook for the LabVIEW 2026 host-plane split.",
       "files": [
+        "docs/SINGLE_HOST_LABVIEW_2026_PLANES.md",
         "docs/schemas/labview-2026-host-plane-report-v1.schema.json",
         "tools/LabVIEW2026HostPlaneDiagnostics.psm1",
         "tools/Write-LabVIEW2026HostPlaneDiagnostics.ps1"

--- a/tools/priority/__tests__/labview-2026-host-plane-runbook.test.mjs
+++ b/tools/priority/__tests__/labview-2026-host-plane-runbook.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const runbookPath = path.join(repoRoot, 'docs', 'SINGLE_HOST_LABVIEW_2026_PLANES.md');
+const developerGuidePath = path.join(repoRoot, 'docs', 'DEVELOPER_GUIDE.md');
+const manifestPath = path.join(repoRoot, 'docs', 'documentation-manifest.json');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+test('single-host runbook records the four explicit LabVIEW 2026 planes and the Docker exclusivity rule', () => {
+  const runbook = readFile(runbookPath);
+
+  assert.match(runbook, /docker-desktop\/windows-container-2026/);
+  assert.match(runbook, /docker-desktop\/linux-container-2026/);
+  assert.match(runbook, /native-labview-2026-64/);
+  assert.match(runbook, /native-labview-2026-32/);
+  assert.match(runbook, /The two Docker Desktop planes are mutually exclusive/i);
+});
+
+test('single-host runbook points to the authoritative commands and artifacts', () => {
+  const runbook = readFile(runbookPath);
+
+  assert.match(runbook, /node tools\/npm\/run-script\.mjs env:labview:2026:host-planes/);
+  assert.match(runbook, /pwsh -NoLogo -NoProfile -File tools\/Test-DockerDesktopFastLoop\.ps1 -LaneScope linux -StepTimeoutSeconds 600/);
+  assert.match(runbook, /pwsh -NoLogo -NoProfile -File tools\/Test-DockerDesktopFastLoop\.ps1 -LaneScope windows -StepTimeoutSeconds 600/);
+  assert.match(runbook, /pwsh -NoLogo -NoProfile -File tools\/Test-DockerDesktopFastLoop\.ps1 -LaneScope both -StepTimeoutSeconds 600/);
+  assert.match(runbook, /node tools\/npm\/run-script\.mjs history:diagnostics:show -- --ResultsRoot tests\/results\/local-parity\/windows/);
+  assert.match(runbook, /labview-2026-host-plane-report\.json/);
+  assert.match(runbook, /docker-runtime-fastloop-readiness\.json/);
+});
+
+test('developer guide and documentation manifest point back to the single-host runbook', () => {
+  const developerGuide = readFile(developerGuidePath);
+  const manifest = JSON.parse(readFile(manifestPath));
+  const entries = Array.isArray(manifest) ? manifest : manifest.entries;
+
+  assert.match(developerGuide, /docs\/SINGLE_HOST_LABVIEW_2026_PLANES\.md/);
+
+  assert.ok(Array.isArray(entries), 'documentation manifest should expose an entries array');
+  const entry = entries.find((item) => item.name === 'Host Plane Diagnostics Contracts');
+  assert.ok(entry, 'documentation manifest should include the host-plane diagnostics entry');
+  assert.ok(entry.files.includes('docs/SINGLE_HOST_LABVIEW_2026_PLANES.md'));
+});


### PR DESCRIPTION
## Summary
- add a dedicated runbook for the single-host LabVIEW 2026 plane split
- anchor it to the checked-in host-plane, fast-loop, and replay entry points
- add a contract test so the runbook cannot drift from the four-plane model or the authoritative commands

## Testing
- `node --test tools/priority/__tests__/labview-2026-host-plane-runbook.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs docs:manifest:validate`

Closes #1175

## Agent Metadata
- Issue: #1175
- Execution plane: personal
- Secondary lane while #1173 / PR #1174 remains the live standing-priority path
