### PR TITLE
#1177 Harden docker fast-loop proof host-plane provenance

### DIFF
--- a/tests/Write-DockerFastLoopProof.Tests.ps1
+++ b/tests/Write-DockerFastLoopProof.Tests.ps1
@@ -20,6 +20,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $statusPath = Join-Path $work 'docker-runtime-fastloop-status.json'
     $readinessPath = Join-Path $work 'docker-runtime-fastloop-readiness.json'
     $proofPath = Join-Path $work 'docker-fast-loop-proof.json'
+    $hostPlaneReportPath = Join-Path $work 'labview-2026-host-plane-report.json'
 
     ([ordered]@{
       schema = 'docker-desktop-fast-loop@v1'
@@ -30,6 +31,36 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       schema = 'docker-desktop-fast-loop-status@v1'
       generatedAt = (Get-Date).ToUniversalTime().ToString('o')
     } | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $statusPath -Encoding utf8
+
+    ([ordered]@{
+      schema = 'labview-2026-host-plane-report@v1'
+      host = [ordered]@{
+        os = 'windows'
+        computerName = 'GHOST'
+      }
+      runner = [ordered]@{
+        hostIsRunner = $true
+        runnerName = 'GHOST'
+        githubActions = $false
+      }
+      docker = [ordered]@{
+        operatorLabels = @('linux-docker-fast-loop', 'windows-docker-fast-loop', 'dual-docker-fast-loop')
+      }
+      native = [ordered]@{
+        planes = [ordered]@{
+          x64 = [ordered]@{ status = 'ready' }
+          x32 = [ordered]@{ status = 'ready' }
+        }
+      }
+      executionPolicy = [ordered]@{
+        candidateParallelPairs = [ordered]@{
+          pairs = @(
+            [ordered]@{ left = 'docker-desktop/windows-container-2026'; right = 'native-labview-2026-64' },
+            [ordered]@{ left = 'native-labview-2026-64'; right = 'native-labview-2026-32' }
+          )
+        }
+      }
+    } | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $hostPlaneReportPath -Encoding utf8
 
     ([ordered]@{
       schema = 'vi-history/docker-fast-loop-readiness@v1'
@@ -57,7 +88,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       source = [ordered]@{
         summaryPath = $summaryPath
         statusPath = $statusPath
-        hostPlaneReportPath = (Join-Path $work 'labview-2026-host-plane-report.json')
+        hostPlaneReportPath = $hostPlaneReportPath
       }
       hostPlane = [ordered]@{
         schema = 'labview-2026-host-plane-report@v1'
@@ -134,6 +165,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.runtimeManagerParseDefectCount | Should -Be 0
     $proof.runtimeManager.transitionCount | Should -Be 2
     $proof.hostPlaneReportPath | Should -Match 'labview-2026-host-plane-report\.json'
+    $proof.hostPlaneProvenance.status | Should -Be 'ok'
     $proof.hostPlane.runner.hostIsRunner | Should -BeTrue
     $proof.hostPlane.runner.runnerName | Should -Be 'GHOST'
     $proof.hostPlanes.x64.status | Should -Be 'ready'
@@ -141,6 +173,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.hashes.readinessSha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.summarySha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.statusSha256 | Should -Not -BeNullOrEmpty
+    $proof.hashes.hostPlaneReportSha256 | Should -Not -BeNullOrEmpty
     $proof.lanes.windows.diffDetected | Should -BeTrue
     $proof.laneLifecycle.windows.stopClass | Should -Be 'completed'
     $proof.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
@@ -249,9 +282,47 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
 
     $proof = Get-Content -LiteralPath $proofPath -Raw | ConvertFrom-Json -Depth 16
+    $proof.verdict | Should -Be 'not-ready'
+    $proof.recommendation | Should -Be 'do-not-push'
     $proof.hashes.readinessSha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.summarySha256 | Should -Be $null
     $proof.hashes.statusSha256 | Should -Be $null
+    $proof.hashes.hostPlaneReportSha256 | Should -Be $null
+    $proof.hostPlaneProvenance.status | Should -Be 'missing'
+    $proof.hostPlaneProvenance.reason | Should -Be 'host-plane-provenance-missing'
+  }
+
+  It 'fails closed when host-plane report provenance is declared but unreadable' {
+    $work = Join-Path $TestDrive 'proof-missing-host-plane-report'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $readinessPath = Join-Path $work 'docker-runtime-fastloop-readiness.json'
+    $proofPath = Join-Path $work 'docker-fast-loop-proof.json'
+    $missingHostPlaneReport = Join-Path $work 'missing-host-plane-report.json'
+
+    ([ordered]@{
+      schema = 'vi-history/docker-fast-loop-readiness@v1'
+      generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      verdict = 'ready-to-push'
+      recommendation = 'push'
+      source = [ordered]@{
+        hostPlaneReportPath = $missingHostPlaneReport
+      }
+    } | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $readinessPath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ProofScript `
+      -ReadinessPath $readinessPath `
+      -OutputPath $proofPath `
+      -GitHubOutputPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $proof = Get-Content -LiteralPath $proofPath -Raw | ConvertFrom-Json -Depth 16
+    $proof.verdict | Should -Be 'not-ready'
+    $proof.recommendation | Should -Be 'do-not-push'
+    $proof.hostPlaneProvenance.status | Should -Be 'corrupt'
+    $proof.hostPlaneProvenance.reason | Should -Be 'host-plane-report-missing'
+    $proof.hostPlaneReportPath | Should -Match 'missing-host-plane-report\.json'
+    $proof.hashes.hostPlaneReportSha256 | Should -Be $null
   }
 
   It 'writes GitHub output path for proof artifact' {

--- a/tools/Write-DockerFastLoopProof.ps1
+++ b/tools/Write-DockerFastLoopProof.ps1
@@ -51,6 +51,53 @@ function Read-JsonOrNull {
   }
 }
 
+function Get-HostPlaneProvenanceAssessment {
+  param(
+    [AllowNull()][AllowEmptyString()][string]$ReportPath,
+    $HostPlane,
+    $HostPlanes,
+    $HostExecutionPolicy
+  )
+
+  $hasReportPath = -not [string]::IsNullOrWhiteSpace($ReportPath)
+  $reportExists = $hasReportPath -and (Test-Path -LiteralPath $ReportPath -PathType Leaf)
+  $hasInlineEvidence = ($null -ne $HostPlane) -or ($null -ne $HostPlanes) -or ($null -ne $HostExecutionPolicy)
+
+  if ($hasReportPath -and -not $reportExists) {
+    return [ordered]@{
+      status = 'corrupt'
+      reason = 'host-plane-report-missing'
+      reportExists = $false
+      inlineEvidencePresent = [bool]$hasInlineEvidence
+    }
+  }
+
+  if ($hasReportPath -and -not $hasInlineEvidence) {
+    return [ordered]@{
+      status = 'corrupt'
+      reason = 'host-plane-report-unreadable'
+      reportExists = [bool]$reportExists
+      inlineEvidencePresent = $false
+    }
+  }
+
+  if (-not $hasInlineEvidence) {
+    return [ordered]@{
+      status = 'missing'
+      reason = 'host-plane-provenance-missing'
+      reportExists = [bool]$reportExists
+      inlineEvidencePresent = $false
+    }
+  }
+
+  return [ordered]@{
+    status = 'ok'
+    reason = ''
+    reportExists = [bool]$reportExists
+    inlineEvidencePresent = $true
+  }
+}
+
 function Write-GitHubOutput {
   param(
     [Parameter(Mandatory = $true)][string]$Key,
@@ -200,7 +247,8 @@ $runtimeManagerParseDefectCount = if ($readiness.PSObject.Properties['runtimeMan
   0
 }
 $hostPlaneReportPath = if ($readiness.PSObject.Properties['source'] -and $readiness.source -and $readiness.source.PSObject.Properties['hostPlaneReportPath']) {
-  [string]$readiness.source.hostPlaneReportPath
+  $candidateHostPlaneReport = [string]$readiness.source.hostPlaneReportPath
+  if ([string]::IsNullOrWhiteSpace($candidateHostPlaneReport)) { '' } else { Resolve-AbsolutePath -Path $candidateHostPlaneReport }
 } else {
   ''
 }
@@ -225,13 +273,24 @@ $hostExecutionPolicy = if ($readiness.PSObject.Properties['hostExecutionPolicy']
 } else {
   $null
 }
+$hostPlaneProvenance = Get-HostPlaneProvenanceAssessment `
+  -ReportPath $hostPlaneReportPath `
+  -HostPlane $hostPlane `
+  -HostPlanes $hostPlanes `
+  -HostExecutionPolicy $hostExecutionPolicy
+$verdict = if ($readiness.PSObject.Properties['verdict']) { [string]$readiness.verdict } else { 'unknown' }
+$recommendation = if ($readiness.PSObject.Properties['recommendation']) { [string]$readiness.recommendation } else { 'unknown' }
+if ($hostPlaneProvenance.status -ne 'ok') {
+  $verdict = 'not-ready'
+  $recommendation = 'do-not-push'
+}
 
 $proof = [ordered]@{
   schema = 'vi-history/docker-fast-loop-proof@v1'
   generatedAt = (Get-Date).ToUniversalTime().ToString('o')
   loopLabel = Get-DockerFastLoopLabel -ContextObject $readiness
-  verdict = if ($readiness.PSObject.Properties['verdict']) { [string]$readiness.verdict } else { 'unknown' }
-  recommendation = if ($readiness.PSObject.Properties['recommendation']) { [string]$readiness.recommendation } else { 'unknown' }
+  verdict = $verdict
+  recommendation = $recommendation
   diffStepCount = [int]$diffStepCount
   diffEvidenceSteps = [int]$diffEvidenceSteps
   diffLaneCount = [int]$diffLaneCount
@@ -253,9 +312,11 @@ $proof = [ordered]@{
     readinessSha256 = Get-FileHashOrNull -Path $readinessResolved
     summarySha256 = Get-FileHashOrNull -Path $summaryResolved
     statusSha256 = Get-FileHashOrNull -Path $statusResolved
+    hostPlaneReportSha256 = Get-FileHashOrNull -Path $hostPlaneReportPath
   }
   laneLifecycle = if ($readiness.PSObject.Properties['laneLifecycle']) { $readiness.laneLifecycle } elseif ($summary -and $summary.PSObject.Properties['laneLifecycle']) { $summary.laneLifecycle } else { $null }
   lanes = if ($readiness.PSObject.Properties['lanes']) { $readiness.lanes } else { $null }
+  hostPlaneProvenance = $hostPlaneProvenance
   hostPlane = $hostPlane
   hostPlanes = $hostPlanes
   hostExecutionPolicy = $hostExecutionPolicy


### PR DESCRIPTION
## Summary
- fail closed when docker fast-loop proof artifacts are missing differentiated host-plane provenance
- carry host-plane report hashing and provenance assessment into the proof surface
- add focused regressions for missing and unreadable host-plane provenance

## Testing
- `Invoke-Pester -Path tests/Write-DockerFastLoopProof.Tests.ps1 -CI`

Closes #1177

## Agent Metadata
- Primary issue or standing-priority context: #1177
- Execution plane: personal
- Secondary parked lane while #1175 / #1176 remains the live standing-priority path