### PR TITLE
#1181 Consume host-plane summary artifacts in docker fast-loop readiness

### DIFF
--- a/tests/Show-DockerFastLoopDiagnostics.Tests.ps1
+++ b/tests/Show-DockerFastLoopDiagnostics.Tests.ps1
@@ -18,6 +18,7 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
     New-Item -ItemType Directory -Path (Join-Path $historyRoot 'attribute\container-export') -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $historyRoot 'sequential\block-diagram\container-export') -Force | Out-Null
     $hostPlaneReportPath = Join-Path $resultsRoot 'labview-2026-host-plane-report.json'
+    $hostPlaneSummaryPath = Join-Path $resultsRoot 'labview-2026-host-plane-summary.md'
     ([ordered]@{
         schema = 'labview-2026-host-plane-report@v1'
         host = [ordered]@{
@@ -65,6 +66,7 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
           }
         }
       } | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $hostPlaneReportPath -Encoding utf8
+    '# LabVIEW 2026 Host Plane Summary' | Set-Content -LiteralPath $hostPlaneSummaryPath -Encoding utf8
 
     $readinessPath = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.json'
     $readiness = [ordered]@{
@@ -102,6 +104,11 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
       source = [ordered]@{
         resultsRoot = $resultsRoot
         hostPlaneReportPath = $hostPlaneReportPath
+        hostPlaneSummaryPath = $hostPlaneSummaryPath
+      }
+      hostPlaneSummary = [ordered]@{
+        status = 'ok'
+        path = $hostPlaneSummaryPath
       }
       steps = @(
         [ordered]@{
@@ -133,6 +140,7 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
 
     $outputText = $output -join "`n"
     $outputText | Should -Match '\[native-labview-2026-64\]\[host-plane\] status=ready'
+    $outputText | Should -Match '\[host-plane-split\]\[summary\] .*labview-2026-host-plane-summary.md'
     $outputText | Should -Match '\[host-plane-split\]\[runner\] hostIsRunner=True runnerName=GHOST githubActions=False'
     $outputText | Should -Match 'candidateParallelPairs=docker-desktop/windows-container-2026\+native-labview-2026-64,native-labview-2026-64\+native-labview-2026-32'
     $outputText | Should -Match '\[windows-docker-fast-loop\]\[docker-plane\] requested=docker-desktop/windows-container-2026 exclusiveRequired=False exclusiveSatisfied=True pairCount=1'
@@ -203,5 +211,34 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
     $output = & pwsh -NoLogo -NoProfile -File $script:ShowScript -ReadinessPath $readinessPath *>&1
     $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
     ($output -join "`n") | Should -Match '\[windows-docker-fast-loop\]\[diagnostics\] no differentiated history diagnostics detected'
+  }
+
+  It 'fails closed when a declared host-plane summary artifact is missing' {
+    $resultsRoot = Join-Path $TestDrive 'missing-summary'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    $readinessPath = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.json'
+    $missingSummaryPath = Join-Path $resultsRoot 'labview-2026-host-plane-summary.md'
+    ([ordered]@{
+        schema = 'vi-history/docker-fast-loop-readiness@v1'
+        source = [ordered]@{
+          resultsRoot = $resultsRoot
+          hostPlaneSummaryPath = $missingSummaryPath
+        }
+        hostPlaneSummary = [ordered]@{
+          status = 'missing'
+          path = $missingSummaryPath
+        }
+        steps = @(
+          [ordered]@{
+            name = 'windows-container-probe'
+            isDiff = $false
+            durationMs = 100
+          }
+        )
+      } | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $readinessPath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ShowScript -ReadinessPath $readinessPath *>&1
+    $LASTEXITCODE | Should -Not -Be 0
+    ($output -join "`n") | Should -Match 'Declared host-plane summary artifact not found'
   }
 }

--- a/tests/Write-DockerFastLoopReadiness.Tests.ps1
+++ b/tests/Write-DockerFastLoopReadiness.Tests.ps1
@@ -19,6 +19,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $statusPath = Join-Path $resultsRoot 'docker-runtime-fastloop-status.json'
     $jsonOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.json'
     $mdOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.md'
+    $hostPlaneReportPath = Join-Path $resultsRoot 'labview-2026-host-plane-report.json'
+    $hostPlaneSummaryPath = Join-Path $resultsRoot 'labview-2026-host-plane-summary.md'
 
     $summary = [ordered]@{
       schema = 'docker-desktop-fast-loop@v1'
@@ -46,6 +48,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
           }
         }
       }
+      hostPlaneReportPath = $hostPlaneReportPath
+      hostPlaneSummaryPath = $hostPlaneSummaryPath
       hostPlane = [ordered]@{
         schema = 'labview-2026-host-plane-report@v1'
         host = [ordered]@{
@@ -124,6 +128,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
       )
     }
     $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+    ($summary.hostPlane | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $hostPlaneReportPath -Encoding utf8
+    '# LabVIEW 2026 Host Plane Summary' | Set-Content -LiteralPath $hostPlaneSummaryPath -Encoding utf8
     ([ordered]@{
         schema = 'docker-desktop-fast-loop-status@v1'
         generatedAt = (Get-Date).ToUniversalTime().ToString('o')
@@ -167,6 +173,10 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.dockerDesktopPlanes.planes.windows.context | Should -Be 'desktop-windows'
     $readiness.dockerDesktopPlanes.planes.linux.context | Should -Be 'desktop-linux'
     $readiness.hostPlane.runner.hostIsRunner | Should -BeTrue
+    $readiness.hostPlaneSummary.status | Should -Be 'ok'
+    $readiness.hostPlaneSummary.path | Should -Be $hostPlaneSummaryPath
+    $readiness.hostPlaneSummary.declared | Should -BeTrue
+    $readiness.hostPlaneSummary.sha256 | Should -Not -BeNullOrEmpty
     $readiness.hostPlane.runner.runnerName | Should -Be 'GHOST'
     $readiness.hostPlane.host.os | Should -Be 'windows'
     $readiness.hostExecutionPolicy.candidateParallelPairs.pairs.Count | Should -Be 2
@@ -179,6 +189,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.laneLifecycle.windows.endStep | Should -Be 'windows-history-attribute'
     $markdown = Get-Content -LiteralPath $mdOut -Raw
     $markdown | Should -Match '\| Host Is Runner \| `True` \|'
+    $markdown | Should -Match '\| Host Plane Summary \| `.*labview-2026-host-plane-summary.md` \|'
+    $markdown | Should -Match '\| Host Plane Summary Status \| `ok` \|'
     $markdown | Should -Match '\| Runner Name \| `GHOST` \|'
     $markdown | Should -Match '\| Mutually Exclusive Pairs \| `docker-desktop/linux-container-2026<->docker-desktop/windows-container-2026` \|'
     $markdown | Should -Match '\| Requested Docker Planes \| `docker-desktop/windows-container-2026, docker-desktop/linux-container-2026` \|'
@@ -246,6 +258,77 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.containerExportFailureCount | Should -Be 1
     $readiness.runtimeFailureCount | Should -Be 0
     $readiness.lanes.windows.failureClass | Should -Be 'cli/tool'
+  }
+
+  It 'fails closed when a declared host-plane summary artifact is missing' {
+    $resultsRoot = Join-Path $TestDrive 'missing-host-plane-summary'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    $summaryPath = Join-Path $resultsRoot 'docker-runtime-fastloop-20260301021212.json'
+    $statusPath = Join-Path $resultsRoot 'docker-runtime-fastloop-status.json'
+    $jsonOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.json'
+    $mdOut = Join-Path $resultsRoot 'docker-runtime-fastloop-readiness.md'
+    $hostPlaneReportPath = Join-Path $resultsRoot 'labview-2026-host-plane-report.json'
+    $hostPlaneSummaryPath = Join-Path $resultsRoot 'labview-2026-host-plane-summary.md'
+
+    $summary = [ordered]@{
+      schema = 'docker-desktop-fast-loop@v1'
+      generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      status = 'success'
+      hostPlaneReportPath = $hostPlaneReportPath
+      hostPlaneSummaryPath = $hostPlaneSummaryPath
+      hostPlane = [ordered]@{
+        schema = 'labview-2026-host-plane-report@v1'
+        host = [ordered]@{ os = 'windows' }
+        runner = [ordered]@{ hostIsRunner = $true; runnerName = 'GHOST'; githubActions = $false }
+        native = [ordered]@{
+          parallelLabVIEWSupported = $false
+          planes = [ordered]@{
+            x64 = [ordered]@{ status = 'ready' }
+            x32 = [ordered]@{ status = 'missing' }
+          }
+        }
+        executionPolicy = [ordered]@{
+          candidateParallelPairs = [ordered]@{ pairs = @() }
+          mutuallyExclusivePairs = [ordered]@{ pairs = @() }
+        }
+      }
+      steps = @(
+        [ordered]@{
+          name = 'windows-container-probe'
+          status = 'success'
+          durationMs = 100
+          exitCode = 0
+          resultClass = 'success-no-diff'
+          gateOutcome = 'pass'
+          failureClass = 'none'
+          isDiff = $false
+        }
+      )
+    }
+    $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+    ($summary.hostPlane | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $hostPlaneReportPath -Encoding utf8
+    ([ordered]@{
+        schema = 'docker-desktop-fast-loop-status@v1'
+        generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      } | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $statusPath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ReadinessScript `
+      -ResultsRoot $resultsRoot `
+      -SummaryPath $summaryPath `
+      -StatusPath $statusPath `
+      -OutputJsonPath $jsonOut `
+      -OutputMarkdownPath $mdOut `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $readiness = Get-Content -LiteralPath $jsonOut -Raw | ConvertFrom-Json -Depth 16
+    $readiness.verdict | Should -Be 'not-ready'
+    $readiness.recommendation | Should -Be 'do-not-push'
+    $readiness.hostPlaneSummary.status | Should -Be 'missing'
+    $readiness.hostPlaneSummary.reason | Should -Be 'declared-summary-unreadable'
+    $readiness.hostPlaneSummary.declared | Should -BeTrue
+    $readiness.source.hostPlaneSummaryPath | Should -Be $hostPlaneSummaryPath
   }
 
   It 'records a single-lane linux Docker plane projection when only the linux lane is requested' {

--- a/tools/Show-DockerFastLoopDiagnostics.ps1
+++ b/tools/Show-DockerFastLoopDiagnostics.ps1
@@ -65,8 +65,24 @@ if ($null -eq $hostPlane -and $readiness -and $readiness.PSObject.Properties['so
   }
 }
 
+$hostPlaneSummaryPath = ''
+if ($readiness -and $readiness.PSObject.Properties['hostPlaneSummary'] -and $readiness.hostPlaneSummary -and $readiness.hostPlaneSummary.PSObject.Properties['path']) {
+  $hostPlaneSummaryPath = [string]$readiness.hostPlaneSummary.path
+} elseif ($readiness -and $readiness.PSObject.Properties['source'] -and $readiness.source -and $readiness.source.PSObject.Properties['hostPlaneSummaryPath']) {
+  $hostPlaneSummaryPath = [string]$readiness.source.hostPlaneSummaryPath
+}
+if (-not [string]::IsNullOrWhiteSpace($hostPlaneSummaryPath)) {
+  if (-not (Test-Path -LiteralPath $hostPlaneSummaryPath -PathType Leaf)) {
+    throw ("Declared host-plane summary artifact not found: {0}" -f $hostPlaneSummaryPath)
+  }
+  [void](Get-Content -LiteralPath $hostPlaneSummaryPath -Raw -ErrorAction Stop)
+}
+
 if ($hostPlane) {
   Write-LabVIEW2026HostPlaneConsole -Report $hostPlane
+}
+if (-not [string]::IsNullOrWhiteSpace($hostPlaneSummaryPath)) {
+  Write-Host ("[host-plane-split][summary] {0}" -f $hostPlaneSummaryPath) -ForegroundColor DarkCyan
 }
 Write-DockerFastLoopDockerDesktopPlaneDiagnostics -ContextObject $readiness | Out-Null
 $diagnostics = @(Write-DockerFastLoopDifferentiatedDiagnostics -Readiness $readiness -ResultsRoot $effectiveResultsRoot)

--- a/tools/Write-DockerFastLoopReadiness.ps1
+++ b/tools/Write-DockerFastLoopReadiness.ps1
@@ -61,6 +61,75 @@ function Convert-PairSetToText {
   return (@($PairSet.pairs | ForEach-Object { '{0}{1}{2}' -f [string]$_.left, $Separator, [string]$_.right }) -join ', ')
 }
 
+function Test-ReadableTextFile {
+  param([AllowNull()][AllowEmptyString()][string]$Path)
+  if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+  try {
+    [void](Get-Content -LiteralPath $Path -Raw -ErrorAction Stop)
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Get-HostPlaneSummaryAssessment {
+  param(
+    [AllowNull()]$Summary,
+    [AllowNull()]$HostPlane,
+    [AllowEmptyString()][string]$HostPlaneReportPath
+  )
+
+  $declaredPath = ''
+  if ($Summary -and $Summary.PSObject.Properties['hostPlaneSummaryPath']) {
+    $declaredPath = [string]$Summary.hostPlaneSummaryPath
+  }
+  if ([string]::IsNullOrWhiteSpace($declaredPath) -and $HostPlane -and $HostPlane.PSObject.Properties['summaryPath']) {
+    $declaredPath = [string]$HostPlane.summaryPath
+  }
+  if (-not [string]::IsNullOrWhiteSpace($declaredPath)) {
+    $declaredPath = Resolve-AbsolutePath -Path $declaredPath
+  }
+
+  $derivedPath = ''
+  if (-not [string]::IsNullOrWhiteSpace($HostPlaneReportPath)) {
+    $candidatePath = Join-Path (Split-Path -Parent $HostPlaneReportPath) 'labview-2026-host-plane-summary.md'
+    if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+      $derivedPath = Resolve-AbsolutePath -Path $candidatePath
+    }
+  }
+
+  $effectivePath = if (-not [string]::IsNullOrWhiteSpace($declaredPath)) { $declaredPath } else { $derivedPath }
+  $declared = -not [string]::IsNullOrWhiteSpace($declaredPath)
+  $status = 'not-present'
+  $reason = ''
+  $sha256 = ''
+  $readable = $false
+
+  if (-not [string]::IsNullOrWhiteSpace($effectivePath)) {
+    $readable = Test-ReadableTextFile -Path $effectivePath
+    if ($readable) {
+      $status = 'ok'
+      $sha256 = [string](Get-FileHash -LiteralPath $effectivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    } elseif ($declared) {
+      $status = 'missing'
+      $reason = 'declared-summary-unreadable'
+    } else {
+      $status = 'missing'
+      $reason = 'derived-summary-missing'
+    }
+  }
+
+  return [ordered]@{
+    status = $status
+    reason = $reason
+    path = $effectivePath
+    declared = $declared
+    readable = $readable
+    sha256 = $sha256
+  }
+}
+
 function Get-StepLane {
   param([Parameter(Mandatory)][string]$StepName)
   if ($StepName -like 'windows-*') { return 'windows' }
@@ -539,6 +608,7 @@ $hostPlaneReportPath = if ($summary.PSObject.Properties['hostPlaneReportPath']) 
 if ($null -eq $hostPlane -and -not [string]::IsNullOrWhiteSpace($hostPlaneReportPath)) {
   $hostPlane = Read-JsonOrNull -Path $hostPlaneReportPath
 }
+$hostPlaneSummary = Get-HostPlaneSummaryAssessment -Summary $summary -HostPlane $hostPlane -HostPlaneReportPath $hostPlaneReportPath
 $hostPlanes = if ($summary.PSObject.Properties['hostPlanes']) {
   $summary.hostPlanes
 } elseif ($hostPlane -and $hostPlane.PSObject.Properties['native'] -and $hostPlane.native -and $hostPlane.native.PSObject.Properties['planes']) {
@@ -554,6 +624,10 @@ $hostExecutionPolicy = if ($summary.PSObject.Properties['hostExecutionPolicy']) 
   $null
 }
 $dockerDesktopPlanes = Get-DockerFastLoopDockerDesktopPlaneProjection -ContextObject $summary -HostExecutionPolicy $hostExecutionPolicy
+if ($hostPlaneSummary.declared -and [string]$hostPlaneSummary.status -ne 'ok') {
+  $verdict = 'not-ready'
+  $statusRecommendation = 'do-not-push'
+}
 
 $readiness = [ordered]@{
   schema = 'vi-history/docker-fast-loop-readiness@v1'
@@ -577,6 +651,7 @@ $readiness = [ordered]@{
     statusPath = if (Test-Path -LiteralPath $statusResolved -PathType Leaf) { $statusResolved } else { '' }
     resultsRoot = $resultsRootResolved
     hostPlaneReportPath = $hostPlaneReportPath
+    hostPlaneSummaryPath = [string]$hostPlaneSummary.path
   }
   verdict = $verdict
   recommendation = $statusRecommendation
@@ -625,6 +700,7 @@ $readiness = [ordered]@{
   }
   history = $historical
   hostPlane = $hostPlane
+  hostPlaneSummary = $hostPlaneSummary
   hostPlanes = $hostPlanes
   hostExecutionPolicy = $hostExecutionPolicy
   dockerDesktopPlanes = $dockerDesktopPlanes
@@ -660,6 +736,18 @@ $mdLines.Add(('| Runtime Manager Daemon-Unavailable Count | `{0}` |' -f $readine
 $mdLines.Add(('| Runtime Manager Parse-Defect Count | `{0}` |' -f $readiness.runtimeManagerParseDefectCount)) | Out-Null
 if (-not [string]::IsNullOrWhiteSpace($hostPlaneReportPath)) {
   $mdLines.Add(('| Host Plane Report | `{0}` |' -f $hostPlaneReportPath)) | Out-Null
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hostPlaneSummary.path)) {
+  $mdLines.Add(('| Host Plane Summary | `{0}` |' -f [string]$hostPlaneSummary.path)) | Out-Null
+}
+if ([string]$hostPlaneSummary.status -ne 'not-present') {
+  $mdLines.Add(('| Host Plane Summary Status | `{0}` |' -f [string]$hostPlaneSummary.status)) | Out-Null
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hostPlaneSummary.sha256)) {
+  $mdLines.Add(('| Host Plane Summary SHA-256 | `{0}` |' -f [string]$hostPlaneSummary.sha256)) | Out-Null
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hostPlaneSummary.reason)) {
+  $mdLines.Add(('| Host Plane Summary Reason | `{0}` |' -f [string]$hostPlaneSummary.reason)) | Out-Null
 }
 if ($hostPlane -and $hostPlane.PSObject.Properties['host'] -and $hostPlane.host -and $hostPlane.host.PSObject.Properties['os']) {
   $mdLines.Add(('| Host OS | `{0}` |' -f [string]$hostPlane.host.os)) | Out-Null


### PR DESCRIPTION
## Summary
- consume the deterministic LabVIEW 2026 host-plane summary artifact from docker fast-loop readiness outputs
- surface the summary path and digest in readiness artifacts and replay diagnostics
- fail closed when a declared host-plane summary artifact is missing on the consumer side

## Testing
- `Invoke-Pester -Path tests/Write-DockerFastLoopReadiness.Tests.ps1,tests/Show-DockerFastLoopDiagnostics.Tests.ps1 -CI`

Closes #1181

## Agent Metadata
- Primary issue or standing-priority context: #1181
- Execution plane: personal
- Secondary parked lane while #1179 / #1180 is the live standing-priority path
