### PR TITLE
#1183 Consume host-plane summary artifacts in docker fast-loop proof

### DIFF
--- a/tests/Write-DockerFastLoopProof.Tests.ps1
+++ b/tests/Write-DockerFastLoopProof.Tests.ps1
@@ -21,6 +21,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $readinessPath = Join-Path $work 'docker-runtime-fastloop-readiness.json'
     $proofPath = Join-Path $work 'docker-fast-loop-proof.json'
     $hostPlaneReportPath = Join-Path $work 'labview-2026-host-plane-report.json'
+    $hostPlaneSummaryPath = Join-Path $work 'labview-2026-host-plane-summary.md'
 
     ([ordered]@{
       schema = 'docker-desktop-fast-loop@v1'
@@ -61,6 +62,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
         }
       }
     } | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $hostPlaneReportPath -Encoding utf8
+    '# LabVIEW 2026 Host Plane Summary' | Set-Content -LiteralPath $hostPlaneSummaryPath -Encoding utf8
 
     ([ordered]@{
       schema = 'vi-history/docker-fast-loop-readiness@v1'
@@ -89,6 +91,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
         summaryPath = $summaryPath
         statusPath = $statusPath
         hostPlaneReportPath = $hostPlaneReportPath
+        hostPlaneSummaryPath = $hostPlaneSummaryPath
       }
       hostPlane = [ordered]@{
         schema = 'labview-2026-host-plane-report@v1'
@@ -165,7 +168,9 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.runtimeManagerParseDefectCount | Should -Be 0
     $proof.runtimeManager.transitionCount | Should -Be 2
     $proof.hostPlaneReportPath | Should -Match 'labview-2026-host-plane-report\.json'
+    $proof.hostPlaneSummaryPath | Should -Match 'labview-2026-host-plane-summary\.md'
     $proof.hostPlaneProvenance.status | Should -Be 'ok'
+    $proof.hostPlaneSummaryProvenance.status | Should -Be 'ok'
     $proof.hostPlane.runner.hostIsRunner | Should -BeTrue
     $proof.hostPlane.runner.runnerName | Should -Be 'GHOST'
     $proof.hostPlanes.x64.status | Should -Be 'ready'
@@ -174,6 +179,7 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.hashes.summarySha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.statusSha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.hostPlaneReportSha256 | Should -Not -BeNullOrEmpty
+    $proof.hashes.hostPlaneSummarySha256 | Should -Not -BeNullOrEmpty
     $proof.lanes.windows.diffDetected | Should -BeTrue
     $proof.laneLifecycle.windows.stopClass | Should -Be 'completed'
     $proof.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
@@ -288,8 +294,10 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.hashes.summarySha256 | Should -Be $null
     $proof.hashes.statusSha256 | Should -Be $null
     $proof.hashes.hostPlaneReportSha256 | Should -Be $null
+    $proof.hashes.hostPlaneSummarySha256 | Should -Be $null
     $proof.hostPlaneProvenance.status | Should -Be 'missing'
     $proof.hostPlaneProvenance.reason | Should -Be 'host-plane-provenance-missing'
+    $proof.hostPlaneSummaryProvenance.status | Should -Be 'not-present'
   }
 
   It 'fails closed when host-plane report provenance is declared but unreadable' {
@@ -323,6 +331,42 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.hostPlaneProvenance.reason | Should -Be 'host-plane-report-missing'
     $proof.hostPlaneReportPath | Should -Match 'missing-host-plane-report\.json'
     $proof.hashes.hostPlaneReportSha256 | Should -Be $null
+  }
+
+  It 'fails closed when a declared host-plane summary artifact is unreadable' {
+    $work = Join-Path $TestDrive 'proof-missing-host-plane-summary'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $readinessPath = Join-Path $work 'docker-runtime-fastloop-readiness.json'
+    $proofPath = Join-Path $work 'docker-fast-loop-proof.json'
+    $declaredSummaryPath = Join-Path $work 'labview-2026-host-plane-summary.md'
+
+    ([ordered]@{
+      schema = 'vi-history/docker-fast-loop-readiness@v1'
+      generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      verdict = 'ready-to-push'
+      recommendation = 'push'
+      source = [ordered]@{
+        hostPlaneSummaryPath = $declaredSummaryPath
+      }
+      hostPlaneSummary = [ordered]@{
+        path = $declaredSummaryPath
+      }
+    } | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $readinessPath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ProofScript `
+      -ReadinessPath $readinessPath `
+      -OutputPath $proofPath `
+      -GitHubOutputPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $proof = Get-Content -LiteralPath $proofPath -Raw | ConvertFrom-Json -Depth 16
+    $proof.verdict | Should -Be 'not-ready'
+    $proof.recommendation | Should -Be 'do-not-push'
+    $proof.hostPlaneSummaryPath | Should -Match 'labview-2026-host-plane-summary\.md'
+    $proof.hostPlaneSummaryProvenance.status | Should -Be 'corrupt'
+    $proof.hostPlaneSummaryProvenance.reason | Should -Be 'host-plane-summary-missing'
+    $proof.hashes.hostPlaneSummarySha256 | Should -Be $null
   }
 
   It 'writes GitHub output path for proof artifact' {

--- a/tools/Write-DockerFastLoopProof.ps1
+++ b/tools/Write-DockerFastLoopProof.ps1
@@ -40,6 +40,18 @@ function Get-FileHashOrNull {
   return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
 }
 
+function Test-ReadableTextFile {
+  param([AllowNull()][AllowEmptyString()][string]$Path)
+  if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
+  try {
+    [void](Get-Content -LiteralPath $Path -Raw -ErrorAction Stop)
+    return $true
+  } catch {
+    return $false
+  }
+}
+
 function Read-JsonOrNull {
   param([AllowNull()][AllowEmptyString()][string]$Path)
   if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
@@ -95,6 +107,56 @@ function Get-HostPlaneProvenanceAssessment {
     reason = ''
     reportExists = [bool]$reportExists
     inlineEvidencePresent = $true
+  }
+}
+
+function Get-HostPlaneSummaryProvenanceAssessment {
+  param(
+    [AllowNull()][AllowEmptyString()][string]$DeclaredPath,
+    [AllowNull()][AllowEmptyString()][string]$HostPlaneReportPath
+  )
+
+  $effectiveDeclaredPath = if ([string]::IsNullOrWhiteSpace($DeclaredPath)) { '' } else { Resolve-AbsolutePath -Path $DeclaredPath }
+  $derivedPath = ''
+  if (-not [string]::IsNullOrWhiteSpace($HostPlaneReportPath)) {
+    $candidatePath = Join-Path (Split-Path -Parent $HostPlaneReportPath) 'labview-2026-host-plane-summary.md'
+    if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+      $derivedPath = Resolve-AbsolutePath -Path $candidatePath
+    }
+  }
+  $effectivePath = if (-not [string]::IsNullOrWhiteSpace($effectiveDeclaredPath)) { $effectiveDeclaredPath } else { $derivedPath }
+  $declared = -not [string]::IsNullOrWhiteSpace($effectiveDeclaredPath)
+  $readable = Test-ReadableTextFile -Path $effectivePath
+
+  if ($readable) {
+    return [ordered]@{
+      status = 'ok'
+      reason = ''
+      path = $effectivePath
+      declared = $declared
+      readable = $true
+      sha256 = [string](Get-FileHash -LiteralPath $effectivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+  }
+
+  if ($declared) {
+    return [ordered]@{
+      status = 'corrupt'
+      reason = 'host-plane-summary-missing'
+      path = $effectivePath
+      declared = $true
+      readable = $false
+      sha256 = $null
+    }
+  }
+
+  return [ordered]@{
+    status = 'not-present'
+    reason = ''
+    path = $effectivePath
+    declared = $false
+    readable = $false
+    sha256 = $null
   }
 }
 
@@ -252,6 +314,13 @@ $hostPlaneReportPath = if ($readiness.PSObject.Properties['source'] -and $readin
 } else {
   ''
 }
+$hostPlaneSummaryPath = if ($readiness.PSObject.Properties['hostPlaneSummary'] -and $readiness.hostPlaneSummary -and $readiness.hostPlaneSummary.PSObject.Properties['path']) {
+  [string]$readiness.hostPlaneSummary.path
+} elseif ($readiness.PSObject.Properties['source'] -and $readiness.source -and $readiness.source.PSObject.Properties['hostPlaneSummaryPath']) {
+  [string]$readiness.source.hostPlaneSummaryPath
+} else {
+  ''
+}
 $hostPlane = if ($readiness.PSObject.Properties['hostPlane']) {
   $readiness.hostPlane
 } elseif (-not [string]::IsNullOrWhiteSpace($hostPlaneReportPath)) {
@@ -278,9 +347,12 @@ $hostPlaneProvenance = Get-HostPlaneProvenanceAssessment `
   -HostPlane $hostPlane `
   -HostPlanes $hostPlanes `
   -HostExecutionPolicy $hostExecutionPolicy
+$hostPlaneSummaryProvenance = Get-HostPlaneSummaryProvenanceAssessment `
+  -DeclaredPath $hostPlaneSummaryPath `
+  -HostPlaneReportPath $hostPlaneReportPath
 $verdict = if ($readiness.PSObject.Properties['verdict']) { [string]$readiness.verdict } else { 'unknown' }
 $recommendation = if ($readiness.PSObject.Properties['recommendation']) { [string]$readiness.recommendation } else { 'unknown' }
-if ($hostPlaneProvenance.status -ne 'ok') {
+if ($hostPlaneProvenance.status -ne 'ok' -or ($hostPlaneSummaryProvenance.declared -and $hostPlaneSummaryProvenance.status -ne 'ok')) {
   $verdict = 'not-ready'
   $recommendation = 'do-not-push'
 }
@@ -308,15 +380,18 @@ $proof = [ordered]@{
   summaryPath = $summaryResolved
   statusPath = $statusResolved
   hostPlaneReportPath = $hostPlaneReportPath
+  hostPlaneSummaryPath = [string]$hostPlaneSummaryProvenance.path
   hashes = [ordered]@{
     readinessSha256 = Get-FileHashOrNull -Path $readinessResolved
     summarySha256 = Get-FileHashOrNull -Path $summaryResolved
     statusSha256 = Get-FileHashOrNull -Path $statusResolved
     hostPlaneReportSha256 = Get-FileHashOrNull -Path $hostPlaneReportPath
+    hostPlaneSummarySha256 = $hostPlaneSummaryProvenance.sha256
   }
   laneLifecycle = if ($readiness.PSObject.Properties['laneLifecycle']) { $readiness.laneLifecycle } elseif ($summary -and $summary.PSObject.Properties['laneLifecycle']) { $summary.laneLifecycle } else { $null }
   lanes = if ($readiness.PSObject.Properties['lanes']) { $readiness.lanes } else { $null }
   hostPlaneProvenance = $hostPlaneProvenance
+  hostPlaneSummaryProvenance = $hostPlaneSummaryProvenance
   hostPlane = $hostPlane
   hostPlanes = $hostPlanes
   hostExecutionPolicy = $hostExecutionPolicy


### PR DESCRIPTION
## Summary
- consume the deterministic LabVIEW 2026 host-plane summary artifact from docker fast-loop proof outputs
- record summary path and digest in the proof artifact
- fail closed when proof inputs declare a missing host-plane summary artifact

## Testing
- `Invoke-Pester -Path tests/Write-DockerFastLoopProof.Tests.ps1 -CI`

Closes #1183

## Agent Metadata
- Primary issue or standing-priority context: #1183
- Execution plane: personal
- Secondary parked lane while #1181 / #1182 is the live standing-priority path
