### PR TITLE
#1185 Project host-plane summary artifacts through docker fast-loop status surfaces

### DIFF
--- a/tests/Test-DockerDesktopFastLoop.Tests.ps1
+++ b/tests/Test-DockerDesktopFastLoop.Tests.ps1
@@ -872,6 +872,7 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
     Push-Location $repoRoot
     try {
       $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $githubOutputPath = Join-Path $resultsRoot 'github-output.txt'
       $env:COMPAREVI_NATIVE_LABVIEW_2026_64_PATH = $native64
       $env:COMPAREVI_NATIVE_LABVIEW_2026_32_PATH = $native32
       $env:COMPAREVI_NATIVE_LABVIEWCLI_2026_64_PATH = $sharedCli
@@ -880,6 +881,7 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
 
       $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
         -ResultsRoot $resultsRoot `
+        -GitHubOutputPath $githubOutputPath `
         -SkipWindowsProbe `
         -SkipLinuxProbe *>&1
       $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
@@ -909,6 +911,13 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       $readiness.hostExecutionPolicy.candidateParallelPairs.pairs.Count | Should -Be 2
       $readiness.hostPlanes.x64.status | Should -Be 'ready'
       $readiness.hostPlanes.x32.status | Should -Be 'ready'
+
+      $outputText = Get-Content -LiteralPath $githubOutputPath -Raw
+      $outputText | Should -Match ('labview-2026-host-plane-report-path={0}' -f [regex]::Escape($summary.hostPlaneReportPath))
+      $outputText | Should -Match ('labview-2026-host-plane-summary-path={0}' -f [regex]::Escape($summary.hostPlaneSummaryPath))
+      $outputText | Should -Match ('readiness-json-path={0}' -f [regex]::Escape($readinessPath))
+      $outputText | Should -Match ('docker-fast-loop-summary-path={0}' -f [regex]::Escape($summaryPath))
+      $outputText | Should -Match ('docker-fast-loop-status-path={0}' -f [regex]::Escape($statusPath))
     } finally {
       Remove-Item Env:COMPAREVI_NATIVE_LABVIEW_2026_64_PATH -ErrorAction SilentlyContinue
       Remove-Item Env:COMPAREVI_NATIVE_LABVIEW_2026_32_PATH -ErrorAction SilentlyContinue

--- a/tools/Test-DockerDesktopFastLoop.ps1
+++ b/tools/Test-DockerDesktopFastLoop.ps1
@@ -20,6 +20,7 @@ param(
   [string]$StatusPath = '',
   [string]$ReadinessJsonPath = '',
   [string]$ReadinessMarkdownPath = '',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
   [ValidateSet('none', 'smoke', 'history-core')]
   [string]$HistoryScenarioSet = 'none',
   [ValidateSet('both', 'windows', 'linux')]
@@ -172,6 +173,30 @@ function Resolve-AbsolutePath {
     return [System.IO.Path]::GetFullPath($Path)
   }
   return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Ensure-ParentDirectory {
+  param([Parameter(Mandatory)][string]$Path)
+
+  $directory = Split-Path -Parent $Path
+  if ($directory -and -not (Test-Path -LiteralPath $directory -PathType Container)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+  }
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  Ensure-ParentDirectory -Path $Path
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    New-Item -ItemType File -Path $Path -Force | Out-Null
+  }
+  Add-Content -LiteralPath $Path -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
 }
 
 function Get-RepoRootFromToolsScript {
@@ -1629,7 +1654,7 @@ $hostPlaneReport = & (Join-Path $PSScriptRoot 'Write-LabVIEW2026HostPlaneDiagnos
   -LVComparePath $nativeHostComparePath `
   -OutputPath $hostPlaneReportPath `
   -SummaryPath $hostPlaneSummaryPath `
-  -GitHubOutputPath '' `
+  -GitHubOutputPath $GitHubOutputPath `
   -PassThru
 $effectiveSkipWindowsProbe = [bool]$SkipWindowsProbe
 $effectiveSkipLinuxProbe = [bool]$SkipLinuxProbe
@@ -2497,8 +2522,11 @@ pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Write-DockerFastLoopRead
   -OutputJsonPath $readinessJsonResolved `
   -OutputMarkdownPath $readinessMarkdownResolved `
   -PrintDifferentiatedDiagnostics:$false `
-  -GitHubOutputPath '' `
+  -GitHubOutputPath $GitHubOutputPath `
   -StepSummaryPath '' | Out-Null
+
+Write-GitHubOutput -Key 'docker-fast-loop-summary-path' -Value $summaryPath -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'docker-fast-loop-status-path' -Value $statusResolved -Path $GitHubOutputPath
 
 $readinessEnvelope = $null
 if (Test-Path -LiteralPath $readinessJsonResolved -PathType Leaf) {


### PR DESCRIPTION
# Summary

Projects the LabVIEW 2026 host-plane summary artifact through the top-level Docker fast-loop status surfaces. The fast-loop driver now records the summary path alongside the existing host-plane report path so downstream consumers can trust the top-level contract instead of rediscovering the artifact.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1185`
- Files, tools, workflows, or policies touched: `tools/Test-DockerDesktopFastLoop.ps1`, `tests/Test-DockerDesktopFastLoop.Tests.ps1`
- Cross-repo or external-consumer impact: Docker fast-loop status consumers gain a first-class host-plane summary path and fail-closed expectations.
- Required checks, merge-queue behavior, or approval flows affected: none

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/Test-DockerDesktopFastLoop.Tests.ps1 -CI`
- Key artifacts, logs, or workflow runs:
  - `tests/results/**/docker-runtime-fastloop-status.json`
  - `tests/results/**/docker-runtime-fastloop-summary.json`
  - `tests/results/**/docker-runtime-fastloop-readiness.json`
- Risk-based checks not run:
  - `pwsh -File tools/PrePush-Checks.ps1` not run yet because this lane is intentionally parked behind the live standing lane.

## Risks and Follow-ups

- Residual risks: hosted validation still needs to confirm the projected summary path across the full CI planes.
- Follow-up issues or deferred work: none in this slice.
- Deployment, approval, or rollback notes: rollback is limited to the top-level fast-loop status projection path.

## Reviewer Focus

- Please verify: the top-level fast-loop status and readiness artifacts expose the same host-plane summary path deterministically.
- Areas where the reasoning is subtle: the fast-loop driver now delegates host-plane artifact writing to the checked-in diagnostics script instead of reconstructing the report inline.
- Manual spot checks requested: none
