### PR TITLE
#1187 Project host-plane summary provenance through docker fast-loop proof outputs

### DIFF
--- a/tests/Write-DockerFastLoopProof.Tests.ps1
+++ b/tests/Write-DockerFastLoopProof.Tests.ps1
@@ -378,6 +378,8 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $readinessPath = Join-Path $work 'docker-runtime-fastloop-readiness.json'
     $proofPath = Join-Path $work 'docker-fast-loop-proof.json'
     $ghOut = Join-Path $work 'github-output.txt'
+    $hostPlaneReportPath = Join-Path $work 'labview-2026-host-plane-report.json'
+    $hostPlaneSummaryPath = Join-Path $work 'labview-2026-host-plane-summary.md'
 
     ([ordered]@{
       schema = 'docker-desktop-fast-loop@v1'
@@ -389,6 +391,27 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       generatedAt = (Get-Date).ToUniversalTime().ToString('o')
     } | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $statusPath -Encoding utf8
     ([ordered]@{
+      schema = 'labview-2026-host-plane-report@v1'
+      runner = [ordered]@{
+        hostIsRunner = $true
+        runnerName = 'GHOST'
+      }
+      native = [ordered]@{
+        planes = [ordered]@{
+          x64 = [ordered]@{ status = 'ready' }
+          x32 = [ordered]@{ status = 'ready' }
+        }
+      }
+      executionPolicy = [ordered]@{
+        candidateParallelPairs = [ordered]@{
+          pairs = @(
+            [ordered]@{ left = 'docker-desktop/windows-container-2026'; right = 'native-labview-2026-64' }
+          )
+        }
+      }
+    } | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $hostPlaneReportPath -Encoding utf8
+    '# LabVIEW 2026 Host Plane Summary' | Set-Content -LiteralPath $hostPlaneSummaryPath -Encoding utf8
+    ([ordered]@{
       schema = 'vi-history/docker-fast-loop-readiness@v1'
       generatedAt = (Get-Date).ToUniversalTime().ToString('o')
       verdict = 'ready-to-push'
@@ -396,6 +419,25 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       source = [ordered]@{
         summaryPath = $summaryPath
         statusPath = $statusPath
+        hostPlaneReportPath = $hostPlaneReportPath
+        hostPlaneSummaryPath = $hostPlaneSummaryPath
+      }
+      hostPlane = [ordered]@{
+        runner = [ordered]@{
+          hostIsRunner = $true
+          runnerName = 'GHOST'
+        }
+      }
+      hostPlanes = [ordered]@{
+        x64 = [ordered]@{ status = 'ready' }
+        x32 = [ordered]@{ status = 'ready' }
+      }
+      hostExecutionPolicy = [ordered]@{
+        candidateParallelPairs = [ordered]@{
+          pairs = @(
+            [ordered]@{ left = 'docker-desktop/windows-container-2026'; right = 'native-labview-2026-64' }
+          )
+        }
       }
     } | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $readinessPath -Encoding utf8
 
@@ -406,6 +448,9 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
     Test-Path -LiteralPath $ghOut | Should -BeTrue
     $outText = Get-Content -LiteralPath $ghOut -Raw
+    $proof = Get-Content -LiteralPath $proofPath -Raw | ConvertFrom-Json -Depth 16
     $outText | Should -Match 'docker-fast-loop-proof-path='
+    $outText | Should -Match ('docker-fast-loop-proof-host-plane-summary-path={0}' -f [regex]::Escape($hostPlaneSummaryPath))
+    $outText | Should -Match ('docker-fast-loop-proof-host-plane-summary-sha256={0}' -f [regex]::Escape([string]$proof.hashes.hostPlaneSummarySha256))
   }
 }

--- a/tools/Write-DockerFastLoopProof.ps1
+++ b/tools/Write-DockerFastLoopProof.ps1
@@ -401,4 +401,6 @@ $proof | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $outputResolved -En
 $loopPrefix = Get-DockerFastLoopLogPrefix -ContextObject $proof
 Write-Host ("{0}[proof] {1}" -f $loopPrefix, $outputResolved)
 Write-GitHubOutput -Key 'docker-fast-loop-proof-path' -Value $outputResolved -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'docker-fast-loop-proof-host-plane-summary-path' -Value ([string]$hostPlaneSummaryProvenance.path) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'docker-fast-loop-proof-host-plane-summary-sha256' -Value ([string]$hostPlaneSummaryProvenance.sha256) -Path $GitHubOutputPath
 Write-Output $outputResolved


### PR DESCRIPTION
# Summary

Projects the LabVIEW 2026 host-plane summary provenance through the Docker fast-loop proof output surface. The proof artifact already carried the summary inside JSON; this slice makes the path and digest available through the top-level proof output contract so downstream automation does not need to reopen the JSON just to find them.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1187`
- Files, tools, workflows, or policies touched: `tools/Write-DockerFastLoopProof.ps1`, `tests/Write-DockerFastLoopProof.Tests.ps1`
- Cross-repo or external-consumer impact: proof-output consumers can read host-plane summary provenance directly from the proof output contract.
- Required checks, merge-queue behavior, or approval flows affected: none

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/Write-DockerFastLoopProof.Tests.ps1 -CI`
- Key artifacts, logs, or workflow runs:
  - `docker-fast-loop-proof.json`
  - `github-output.txt`
- Risk-based checks not run:
  - Full pre-push checks are deferred because this lane is intentionally parked behind the live standing lane.

## Risks and Follow-ups

- Residual risks: hosted validation still needs to prove the new proof output keys on the full workflow path.
- Follow-up issues or deferred work: none in this slice.
- Deployment, approval, or rollback notes: rollback is limited to the proof-output surface.

## Reviewer Focus

- Please verify: the proof output writes both the host-plane summary path and the matching SHA-256 when summary provenance is present.
- Areas where the reasoning is subtle: this slice projects existing proof JSON provenance outward; it does not widen proof verdict logic.
- Manual spot checks requested: none
