### PR TITLE
#1189 Project host-plane summary provenance through docker fast-loop replay diagnostics

### DIFF
--- a/tests/Show-DockerFastLoopDiagnostics.Tests.ps1
+++ b/tests/Show-DockerFastLoopDiagnostics.Tests.ps1
@@ -109,6 +109,7 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
       hostPlaneSummary = [ordered]@{
         status = 'ok'
         path = $hostPlaneSummaryPath
+        sha256 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
       }
       steps = @(
         [ordered]@{
@@ -140,7 +141,7 @@ Describe 'Show-DockerFastLoopDiagnostics.ps1' -Tag 'Unit' {
 
     $outputText = $output -join "`n"
     $outputText | Should -Match '\[native-labview-2026-64\]\[host-plane\] status=ready'
-    $outputText | Should -Match '\[host-plane-split\]\[summary\] .*labview-2026-host-plane-summary.md'
+    $outputText | Should -Match '\[host-plane-split\]\[summary\] .*labview-2026-host-plane-summary.md status=ok sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
     $outputText | Should -Match '\[host-plane-split\]\[runner\] hostIsRunner=True runnerName=GHOST githubActions=False'
     $outputText | Should -Match 'candidateParallelPairs=docker-desktop/windows-container-2026\+native-labview-2026-64,native-labview-2026-64\+native-labview-2026-32'
     $outputText | Should -Match '\[windows-docker-fast-loop\]\[docker-plane\] requested=docker-desktop/windows-container-2026 exclusiveRequired=False exclusiveSatisfied=True pairCount=1'

--- a/tools/Show-DockerFastLoopDiagnostics.ps1
+++ b/tools/Show-DockerFastLoopDiagnostics.ps1
@@ -66,8 +66,16 @@ if ($null -eq $hostPlane -and $readiness -and $readiness.PSObject.Properties['so
 }
 
 $hostPlaneSummaryPath = ''
+$hostPlaneSummaryStatus = ''
+$hostPlaneSummarySha256 = ''
 if ($readiness -and $readiness.PSObject.Properties['hostPlaneSummary'] -and $readiness.hostPlaneSummary -and $readiness.hostPlaneSummary.PSObject.Properties['path']) {
   $hostPlaneSummaryPath = [string]$readiness.hostPlaneSummary.path
+  if ($readiness.hostPlaneSummary.PSObject.Properties['status']) {
+    $hostPlaneSummaryStatus = [string]$readiness.hostPlaneSummary.status
+  }
+  if ($readiness.hostPlaneSummary.PSObject.Properties['sha256']) {
+    $hostPlaneSummarySha256 = [string]$readiness.hostPlaneSummary.sha256
+  }
 } elseif ($readiness -and $readiness.PSObject.Properties['source'] -and $readiness.source -and $readiness.source.PSObject.Properties['hostPlaneSummaryPath']) {
   $hostPlaneSummaryPath = [string]$readiness.source.hostPlaneSummaryPath
 }
@@ -82,7 +90,15 @@ if ($hostPlane) {
   Write-LabVIEW2026HostPlaneConsole -Report $hostPlane
 }
 if (-not [string]::IsNullOrWhiteSpace($hostPlaneSummaryPath)) {
-  Write-Host ("[host-plane-split][summary] {0}" -f $hostPlaneSummaryPath) -ForegroundColor DarkCyan
+  $summaryParts = New-Object System.Collections.Generic.List[string]
+  [void]$summaryParts.Add($hostPlaneSummaryPath)
+  if (-not [string]::IsNullOrWhiteSpace($hostPlaneSummaryStatus)) {
+    [void]$summaryParts.Add(("status={0}" -f $hostPlaneSummaryStatus))
+  }
+  if (-not [string]::IsNullOrWhiteSpace($hostPlaneSummarySha256)) {
+    [void]$summaryParts.Add(("sha256={0}" -f $hostPlaneSummarySha256))
+  }
+  Write-Host ("[host-plane-split][summary] {0}" -f ([string]::Join(' ', @($summaryParts.ToArray())))) -ForegroundColor DarkCyan
 }
 Write-DockerFastLoopDockerDesktopPlaneDiagnostics -ContextObject $readiness | Out-Null
 $diagnostics = @(Write-DockerFastLoopDifferentiatedDiagnostics -Readiness $readiness -ResultsRoot $effectiveResultsRoot)


### PR DESCRIPTION
# Summary

Projects host-plane summary provenance through the Docker fast-loop replay diagnostics surface. Operators can now see the host-plane summary status and SHA-256 directly in replay output instead of reopening the readiness JSON just to verify summary provenance.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1189`
- Files, tools, workflows, or policies touched: `tools/Show-DockerFastLoopDiagnostics.ps1`, `tests/Show-DockerFastLoopDiagnostics.Tests.ps1`
- Cross-repo or external-consumer impact: replay/console consumers gain explicit host-plane summary provenance without reopening machine-readable artifacts.
- Required checks, merge-queue behavior, or approval flows affected: none

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/Show-DockerFastLoopDiagnostics.Tests.ps1 -CI`
- Key artifacts, logs, or workflow runs:
  - replay output from `Show-DockerFastLoopDiagnostics.ps1`
- Risk-based checks not run:
  - Full pre-push checks are deferred because this lane is intentionally parked behind the live standing lane.

## Risks and Follow-ups

- Residual risks: hosted validation still needs to confirm the replay output on the full workflow path.
- Follow-up issues or deferred work: none in this slice.
- Deployment, approval, or rollback notes: rollback is limited to the replay diagnostics surface.

## Reviewer Focus

- Please verify: replay output prints the host-plane summary path, status, and SHA-256 on the same operator-facing line.
- Areas where the reasoning is subtle: the slice only projects existing provenance from readiness; it does not recalculate summary hashes.
- Manual spot checks requested: none
