### PR TITLE
Prevent standing-priority auto-selection from reviving out-of-scope demo issues (#1265)

### DIFF
--- a/tools/priority/__tests__/standing-priority-handoff.test.mjs
+++ b/tools/priority/__tests__/standing-priority-handoff.test.mjs
@@ -286,6 +286,41 @@ test('handoffStandingPriority rejects non-positive explicit issue numbers', asyn
   );
 });
 
+test('handoffStandingPriority reports ineligible out-of-scope queues truthfully during auto-select', async () => {
+  await assert.rejects(
+    handoffStandingPriority(null, {
+      auto: true,
+      ghRunner: (args) => {
+        if (args[0] === 'issue' && args[1] === 'list' && args.includes('--label')) {
+          return '[]';
+        }
+        if (args[0] === 'issue' && args[1] === 'list') {
+          return JSON.stringify([
+            {
+              number: 946,
+              title: 'Upstream demo: land released comparevi-history diagnostics in labview-icon-editor-demo',
+              body: 'Out-of-scope downstream demo work.',
+              labels: [],
+              createdAt: '2026-03-01T00:00:00Z',
+              updatedAt: '2026-03-01T00:00:00Z'
+            }
+          ]);
+        }
+        return '';
+      },
+      patchIssueLabelsFn: () => {},
+      syncFn: async () => {},
+      leaseReleaseFn: async () => ({ status: 'released' }),
+      logger: () => {},
+      env: {
+        GITHUB_REPOSITORY: 'owner/repo',
+        AGENT_PRIORITY_UPSTREAM_REPOSITORY: 'owner/repo'
+      }
+    }),
+    /none are eligible in-scope candidates/i
+  );
+});
+
 test('handoffStandingPriority fails loudly when label verification remains stale after mutation', async () => {
   await assert.rejects(
     handoffStandingPriority(315, {

--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -350,6 +350,41 @@ test('selectAutoStandingPriorityCandidate skips excluded standing issues and dep
   assert.equal(selected?.cadence, false);
 });
 
+test('selectAutoStandingPriorityCandidate excludes out-of-scope icon-editor demo issues', () => {
+  const selected = selectAutoStandingPriorityCandidate([
+    {
+      number: 946,
+      title: 'Upstream demo: land released comparevi-history diagnostics in labview-icon-editor-demo',
+      body: 'Out-of-scope downstream demo work.',
+      labels: [],
+      createdAt: '2026-03-01T00:00:00Z'
+    },
+    {
+      number: 951,
+      title: 'Epic: harden Copilot remediation by drafting PRs before fix pushes',
+      body: 'Remaining in-repo work.',
+      labels: ['program'],
+      createdAt: '2026-03-02T00:00:00Z'
+    }
+  ]);
+
+  assert.equal(selected?.number, 951);
+});
+
+test('selectAutoStandingPriorityCandidate keeps non-demo labview-icon-editor references eligible', () => {
+  const selected = selectAutoStandingPriorityCandidate([
+    {
+      number: 960,
+      title: '[P1] align compare-vi docs with labview-icon-editor release notes',
+      body: 'In-scope compare-vi documentation work.',
+      labels: ['ci'],
+      createdAt: '2026-03-01T00:00:00Z'
+    }
+  ]);
+
+  assert.equal(selected?.number, 960);
+});
+
 test('shouldPersistCacheUpdate skips cache materialization by default on fresh clones', () => {
   const nextCache = {
     number: 805,
@@ -389,6 +424,33 @@ test('autoSelectStandingPriorityIssue selects and labels next issue via injected
   assert.equal(result.status, 'selected');
   assert.equal(result.issue?.number, 911);
   assert.deepEqual(calls, [911]);
+});
+
+test('autoSelectStandingPriorityIssue reports empty when only out-of-scope demo issues remain', async () => {
+  const result = await autoSelectStandingPriorityIssue('/tmp/repo', 'owner/repo', {
+    targetSlug: 'owner/repo',
+    runGhList: () => ({
+      status: 0,
+      stdout: JSON.stringify([
+        {
+          number: 946,
+          title: 'Upstream demo: land released comparevi-history diagnostics in labview-icon-editor-demo',
+          body: 'Out-of-scope downstream demo work.',
+          labels: [],
+          createdAt: '2026-03-01T00:00:00Z'
+        }
+      ])
+    }),
+    runGhAddLabel: () => {
+      throw new Error('should not label an out-of-scope issue');
+    },
+    runRestList: async () => ({ status: 'error', error: 'not-used' }),
+    runRestAddLabel: async () => ({ status: 'error', error: 'not-used' }),
+    warn: () => {}
+  });
+
+  assert.equal(result.status, 'empty');
+  assert.equal(result.openIssueCount, 1);
 });
 
 test('buildNoStandingPriorityReport emits deterministic schema payload', () => {

--- a/tools/priority/standing-priority-handoff.mjs
+++ b/tools/priority/standing-priority-handoff.mjs
@@ -205,6 +205,11 @@ function resolveTargetIssue(nextIssue, auto, openIssues, excludedIssueNumbers) {
     excludeIssueNumbers: excludedIssueNumbers
   });
   if (!selected?.number) {
+    if (Array.isArray(openIssues) && openIssues.length > 0) {
+      throw new Error(
+        'Open issues remain, but none are eligible in-scope candidates for standing-priority in this repository.'
+      );
+    }
     throw new Error('No open issues remain that can receive standing-priority in this repository.');
   }
 

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -129,6 +129,12 @@ function isCadenceAlertIssue(title, body) {
   );
 }
 
+function isOutOfScopeStandingCandidate(title, body) {
+  return /labview-icon-editor-demo|labview icon editor demo|icon[- ]editor demo/i.test(
+    `${String(title || '')}\n${String(body || '')}`
+  );
+}
+
 function parseDateMs(value) {
   if (!value) {
     return Number.POSITIVE_INFINITY;
@@ -164,7 +170,8 @@ function normalizeOpenIssueCandidate(entry) {
     priority: parsePriorityOrdinal(title),
     epic: isEpicTitle(title),
     umbrella: hasChildTracksSection(body),
-    cadence: isCadenceAlertIssue(title, body)
+    cadence: isCadenceAlertIssue(title, body),
+    outOfScope: isOutOfScopeStandingCandidate(title, body)
   };
 }
 
@@ -178,7 +185,7 @@ export function selectAutoStandingPriorityCandidate(entries = [], options = {}) 
   );
   const normalized = entries
     .map((entry) => normalizeOpenIssueCandidate(entry))
-    .filter((entry) => entry && !excludedIssueNumbers.has(entry.number));
+    .filter((entry) => entry && !excludedIssueNumbers.has(entry.number) && !entry.outOfScope);
   if (normalized.length === 0) {
     return null;
   }
@@ -1424,7 +1431,12 @@ export async function autoSelectStandingPriorityIssue(
 
   const selected = selectAutoStandingPriorityCandidate(openIssues.issues || []);
   if (!selected) {
-    return { status: 'empty', source: openIssues.source || null, repoSlug: targetSlug };
+    return {
+      status: 'empty',
+      source: openIssues.source || null,
+      repoSlug: targetSlug,
+      openIssueCount: Array.isArray(openIssues.issues) ? openIssues.issues.length : 0
+    };
   }
 
   const labelResult = await addStandingPriorityLabelToIssue(repoRoot, targetSlug, selected.number, options);
@@ -2008,9 +2020,18 @@ export async function main(options = {}) {
               source: 'auto-select'
             };
           } else if (autoSelect.status === 'empty') {
-            noStandingReason = 'queue-empty';
-            noStandingOpenIssueCount = 0;
-            noStandingMessage = `No open issues remain in ${autoSelect.repoSlug || slug || 'current repository'}; the standing-priority queue is empty.`;
+            const autoSelectOpenIssueCount =
+              Number.isInteger(autoSelect.openIssueCount) && autoSelect.openIssueCount >= 0
+                ? autoSelect.openIssueCount
+                : null;
+            if (autoSelectOpenIssueCount === 0) {
+              noStandingReason = 'queue-empty';
+              noStandingOpenIssueCount = 0;
+              noStandingMessage = `No open issues remain in ${autoSelect.repoSlug || slug || 'current repository'}; the standing-priority queue is empty.`;
+            } else {
+              noStandingOpenIssueCount = autoSelectOpenIssueCount;
+              noStandingMessage = `${noStandingMessage} Auto-select found no eligible in-scope issue.`;
+            }
           } else if (autoSelect.status === 'error' && autoSelect.error) {
             noStandingMessage = `${noStandingMessage} Auto-select failed: ${autoSelect.error}`;
           }


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1265
- Issue title: Prevent standing-priority auto-selection from reviving out-of-scope demo issues
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1265
- Standing priority at PR creation: Yes (#1265)
- Base branch: `develop`
- Head branch: `issue/personal-1265-standing-autoselect-scope`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
