### PR TITLE
Restore run-delivery-turn-with-codex shim exports for draft-transition tests (#1269)

### DIFF
--- a/tools/priority/__tests__/run-delivery-turn-with-codex.test.mjs
+++ b/tools/priority/__tests__/run-delivery-turn-with-codex.test.mjs
@@ -323,6 +323,14 @@ test('runCodexDeliveryTurn plans review restoration from the original PR state, 
   );
 });
 
+test('run-delivery-turn shim avoids static dist re-exports so clean runners can build before import resolution', () => {
+  const source = readFileSync(path.join(repoRoot, 'tools/priority/run-delivery-turn-with-codex.mjs'), 'utf8');
+
+  assert.doesNotMatch(source, /export \* from '\.\.\/\.\.\/dist\/tools\/priority\/run-delivery-turn-with-codex\.js'/);
+  assert.match(source, /const imported = await import\(pathToFileURL\(distPath\)\.href\);/);
+  assert.match(source, /export const buildPullRequestTimelineArgs = imported\.buildPullRequestTimelineArgs;/);
+});
+
 test('runCodexDeliveryTurn records broker-managed PR ready-state helper calls even when the gh command fails', () => {
   const source = readFileSync(path.join(repoRoot, 'tools/priority/run-delivery-turn-with-codex.ts'), 'utf8');
 

--- a/tools/priority/run-delivery-turn-with-codex.mjs
+++ b/tools/priority/run-delivery-turn-with-codex.mjs
@@ -21,7 +21,15 @@ if (!existsSync(distPath)) {
 }
 
 const imported = await import(pathToFileURL(distPath).href);
-export * from '../../dist/tools/priority/run-delivery-turn-with-codex.js';
+export const buildCodexTurnPrompt = imported.buildCodexTurnPrompt;
+export const buildPrReadyArgs = imported.buildPrReadyArgs;
+export const buildPullRequestTimelineArgs = imported.buildPullRequestTimelineArgs;
+export const buildUnattendedCommandEnv = imported.buildUnattendedCommandEnv;
+export const planPullRequestReviewCycle = imported.planPullRequestReviewCycle;
+export const runCli = imported.runCli;
+export const runCodexDeliveryTurn = imported.runCodexDeliveryTurn;
+export const selectAuthoritativeDraftTransition = imported.selectAuthoritativeDraftTransition;
+export const waitForAuthoritativeDraftTransition = imported.waitForAuthoritativeDraftTransition;
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
 if (invokedPath && invokedPath === modulePath && typeof imported.runCli === 'function') {


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1269
- Issue title: Restore run-delivery-turn-with-codex shim exports for draft-transition tests
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1269
- Standing priority at PR creation: Yes (#1269)
- Base branch: `develop`
- Head branch: `issue/personal-1269-run-delivery-exports`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
