### PR TITLE
#1307 Bound AGENTS entrypoint back to the checked-in contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,36 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Agent Handbook
 
-This file is the bounded agent entrypoint for `compare-vi-cli-action`.
-Keep it short, stable, and focused on the contract every session needs.
-Deep runbook material belongs in the referenced docs and machine-generated
-artifacts under `tests/results/_agent/`.
+This is the bounded agent entrypoint for `compare-vi-cli-action`.
+Keep it short, stable, and helper-oriented. Deep runbooks belong in checked-in docs or generated
+`tests/results/_agent/` artifacts.
 
 ## Primary Directive
 
-- The top objective is the issue carrying the active standing-priority label for
-  the current repository context:
-  - canonical/upstream: `standing-priority`
+- The top objective is the issue carrying the active standing-priority label:
+  - upstream: `standing-priority`
   - forks: `fork-standing-priority` with fallback to `standing-priority`
-- Start with `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1` so the
-  workspace is anchored to `develop` and the standing-priority cache/router are
-  refreshed.
-- Treat `queue-empty` as a valid idle state. If bootstrap emits
-  `tests/results/_agent/issue/no-standing-priority.json` with
-  `reason = queue-empty`, do not invent new work.
-- The operator is signed in with an admin GitHub token. Privileged operations
-  are allowed when they are safe and within repo policy.
+- Start every session with `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1`.
+- If bootstrap writes `tests/results/_agent/issue/no-standing-priority.json` with `reason = queue-empty`, treat the
+  repo as intentionally idle until a real tracked issue exists.
+- The operator token is admin-capable; privileged GitHub actions are allowed when they are safe and policy-aligned.
 - Reference `#<standing-number>` in automation-authored commits and PRs.
-- Scope boundary: this repository is for compare-vi CLI action workflows only.
-  LabVIEW icon editor development now lives in
-  `svelderrainruiz/labview-icon-editor`.
+- Scope boundary: this repo is for compare-vi CLI action workflows only. LabVIEW icon editor development lives in `svelderrainruiz/labview-icon-editor`.
 
 ## First Actions
 
 1. Run `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1`.
 2. Inspect `.agent_priority_cache.json` and `tests/results/_agent/issue/`.
-3. Run `node tools/npm/run-script.mjs priority:project:portfolio:check` when
-   project-board visibility matters.
-4. Run `node tools/npm/run-script.mjs priority:develop:sync` before creating or
-   refreshing a work lane.
-5. Work from a branch shaped like
-   `issue/<fork-remote>-<standing-number>-<slug>` when a fork lane is involved.
+3. Run `node tools/npm/run-script.mjs priority:project:portfolio:check` when project-board visibility matters.
+4. Run `node tools/npm/run-script.mjs priority:develop:sync` before creating or refreshing a work lane.
+5. Work from a clean branch shaped like `issue/<fork-remote>-<standing-number>-<slug>` when a fork lane is involved.
 
 ## Core Commands
 
-- Prefer sanitized wrappers:
-  - `node tools/npm/cli.mjs <command>`
-  - `node tools/npm/run-script.mjs <script>`
+- Prefer sanitized wrappers: `node tools/npm/cli.mjs <command>` and `node tools/npm/run-script.mjs <script>`.
 - Prefer `node tools/npm/run-script.mjs priority:pr` over raw `gh pr create`.
-- Prefer `node tools/npm/run-script.mjs priority:validate -- --ref <branch>`
-  over manual Validate dispatches.
-- Prefer the local Docker/Desktop parity loop before spending repeated GitHub
-  Actions cycles on the same defect class:
+- Prefer `node tools/npm/run-script.mjs priority:validate -- --ref <branch>` over manual Validate dispatches.
+- Prefer the local parity loop before repeated GitHub Actions cycles:
   - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage`
   - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite`
 - Detached unattended delivery surfaces:
@@ -58,100 +43,58 @@ artifacts under `tests/results/_agent/`.
 
 ## Workflow Maintenance
 
-- `ruamel.yaml` is the canonical workflow rewrite engine for this repo.
-- Python workflow mutation is confined to `tools/workflows/**`.
-- Use `pwsh -File tools/Check-WorkflowDrift.ps1` as the supported operator
-  entrypoint.
-- Repo-native command surfaces are:
+- `ruamel.yaml` is the canonical workflow rewrite engine; Python workflow mutation is confined to `tools/workflows/**`.
+- Use `pwsh -File tools/Check-WorkflowDrift.ps1` as the supported operator entrypoint.
+- Repo-native workflow surfaces:
   - `node tools/npm/run-script.mjs workflow:drift:ensure`
   - `node tools/npm/run-script.mjs workflow:drift:check`
   - `node tools/npm/run-script.mjs workflow:drift:write`
   - `node tools/npm/run-script.mjs lint:md`
 - The managed workflow set lives in `tools/workflows/workflow-manifest.json`.
-- `python tools/workflows/update_workflows.py --check|--write ...` remains the
-  low-level compatibility surface, not a free-form scripting escape hatch.
+- `python tools/workflows/update_workflows.py --check|--write ...` is the low-level compatibility surface only.
 
 ## Intake And PR Flow
 
-- Use the GitHub intake catalog in
-  `tools/priority/github-intake-catalog.json` before selecting issue forms or
-  PR templates by hand.
-- Prefer these helpers over ad-hoc GitHub CLI calls:
+- Use `tools/priority/github-intake-catalog.json` before selecting issue forms or PR templates by hand.
+- Prefer these helper surfaces over ad-hoc GitHub CLI calls:
   - `pwsh -File tools/Resolve-GitHubIntakeRoute.ps1 -ListScenarios`
   - `pwsh -File tools/New-GitHubIntakeDraft.ps1 -Scenario <name> -OutputPath <path>`
   - `pwsh -File tools/Invoke-GitHubIntakeScenario.ps1 -Scenario <name> -AsJson`
   - `pwsh -File tools/Write-GitHubIntakeAtlas.ps1`
-- Use `pwsh -File tools/Branch-Orchestrator.ps1 -Issue <number> -Execute` for
-  branch + PR orchestration and switch templates with
-  `-PRTemplate workflow-policy|human-change` when needed.
-- `New-IssueBody.ps1` and `New-PullRequestBody.ps1` remain the lower-level body
-  helpers; prefer the scenario-driven layer first.
-- Treat the GitHub wiki as a curated portal only. Checked-in repo docs remain
-  authoritative, and published wiki history lives in
-  `LabVIEW-Community-CI-CD/compare-vi-cli-action.wiki.git`.
-- Repo-owned GitHub instructions live under
-  `.github/instructions/*.instructions.md`. Keep them aligned with the
-  draft-only Copilot review contract: draft is the only Copilot iteration
-  state, and `ready_for_review` means final validation / promotion intent only.
-- Repo-owned Copilot CLI instructions live in `.github/copilot-instructions.md`.
-  Use the local Copilot CLI review plane only for draft-review acceleration and
-  keep hosted validation authoritative for final promotion.
-- GitHub-native automatic Copilot review is intentionally disabled here.
-  Hosted workflow policy must validate local review receipts and promotion
-  state, not request a second GitHub-side Copilot pass.
-- Instruction precedence for future agents:
-  - `AGENTS.md` is the repo-wide policy and standing-priority authority.
-  - `.github/copilot-instructions.md` narrows GitHub Copilot CLI behavior for
-    the local draft-review plane only.
-  - `.github/instructions/*.instructions.md` are GitHub-native phase overlays
-    and must not widen review, queue, or promotion authority beyond `AGENTS.md`
-    and `.github/copilot-instructions.md`.
+- Use `pwsh -File tools/Branch-Orchestrator.ps1 -Issue <number> -Execute -PRTemplate workflow-policy|human-change`
+  when the review surface needs a non-default template.
+- `New-IssueBody.ps1` and `New-PullRequestBody.ps1` remain the lower-level body helpers.
+- Treat the GitHub wiki as a curated portal only. Checked-in repo docs remain authoritative.
+- Repo-owned GitHub instructions live under `.github/instructions/*.instructions.md`, and repo-owned Copilot CLI
+  instructions live in `.github/copilot-instructions.md`.
+- `AGENTS.md` is the repo-wide policy and standing-priority authority.
+- Under the draft-only Copilot review contract, use local Copilot CLI review plane only for draft-review acceleration.
+- Draft is the only Copilot iteration state here; `ready_for_review` means final validation and promotion intent only.
+- After `ready_for_review`, do not request or wait for a second GitHub-side Copilot pass; return to draft if the head changes.
+- GitHub-native automatic Copilot review is disabled here; hosted policy validates local review receipts instead of
+  requesting another GitHub-side Copilot pass.
+- These instruction overlays must not widen review, queue, or promotion authority.
 
 ## Working Rules
 
-- Issues, labels, policy files, and checked-in docs are the source of truth.
-  The project board is visibility only.
-- Keep workflows deterministic and green. Required status contexts are defined
-  in `tools/policy/branch-required-checks.json`.
-- Use safe repo helpers instead of hand-rolled git mutation flows whenever a
-  helper exists.
-- For second and later review passes on markdown, workflow drift, NI Linux
-  smoke, or VI history artifact quality, iterate locally through Docker
-  Desktop first and use GitHub Actions for confirmation only after the local
-  parity loop is green.
-- For targeted VI History review on deep branches, prefer the Docker/Desktop
-  single-VI path via `tools/Run-NonLVChecksInDocker.ps1` with
-  `-NILinuxReviewSuiteHistoryTargetPath`,
-  `-NILinuxReviewSuiteHistoryBranchRef`,
-  `-NILinuxReviewSuiteHistoryBaselineRef`, and
-  `-NILinuxReviewSuiteHistoryMaxCommitCount`. Read
-  `tests/results/docker-tools-parity/review-loop-receipt.json` first after
-  compaction; it now also mirrors the current requirements-verification state to
-  `tests/results/_agent/verification/docker-review-loop-summary.json` and points to
-  `tests/results/docker-tools-parity/ni-linux-review-suite/vi-history-review-loop-receipt.json`
-  and the rest of the authoritative local review artifacts. The receipt now
-  includes `git.headSha`, `git.branch`, and `git.upstreamDevelopMergeBase`; use
-  those fields to confirm the local parity result belongs to the current branch
-  head before trusting it. When the daemon is
-  active, the same summary is mirrored into
-  `tests/results/_agent/runtime/delivery-agent-state.json` and
-  `tests/results/_agent/runtime/delivery-agent-lanes/*.json` under the
-  `localReviewLoop` node so future agents can resume from runtime state before
-  reopening deeper receipts.
-- Keep bulky diagnostics out of source. Large logs and artifacts belong in
-  issue attachments or generated artifact folders, not in committed history.
-- Use vendor resolvers from `tools/VendorTools.psm1` rather than ad-hoc PATH
-  lookups for `actionlint`, markdownlint, and LVCompare.
+- Issues, labels, policy files, and checked-in docs are the source of truth; the project board is visibility only.
+- Keep workflows deterministic and green. Required status contexts live in `tools/policy/branch-required-checks.json`.
+- Use safe repo helpers instead of ad-hoc git mutation when a helper exists.
+- For repeat passes, iterate locally through Docker Desktop first.
+- Before trusting prior local review evidence, verify the current branch head against
+  `tests/results/docker-tools-parity/review-loop-receipt.json`,
+  `tests/results/_agent/verification/docker-review-loop-summary.json`, or daemon-mirrored `localReviewLoop` state.
+- Confirm receipt freshness with `git.headSha`, `git.branch`, and `git.upstreamDevelopMergeBase`, not head SHA alone.
+- Keep bulky diagnostics out of source; prefer issue attachments or generated artifact folders.
+- Use vendor resolvers from `tools/VendorTools.psm1` rather than ad-hoc PATH lookups.
 - For multiline GitHub bodies in mixed Windows/WSL shells, use `--body-file`.
 
 ## Handoff And Live State
 
 - `AGENT_HANDOFF.txt` is the stable handoff entrypoint.
-- `node tools/npm/run-script.mjs handoff:entrypoint:check` validates the
-  handoff entrypoint and refreshes the machine-readable index at
-  `tests/results/_agent/handoff/entrypoint-status.json`.
-- `node tools/npm/run-script.mjs priority:handoff` prints the current handoff
-  bundle, including that machine-readable index.
+- `node tools/npm/run-script.mjs handoff:entrypoint:check` refreshes the machine-readable index at `tests/results/_agent/handoff/entrypoint-status.json`.
+- `node tools/npm/run-script.mjs priority:handoff` prints that machine-readable index and
+  `tests/results/_agent/verification/docker-review-loop-summary.json`.
 - Primary live-state artifacts:
   - `.agent_priority_cache.json`
   - `tests/results/_agent/issue/router.json`
@@ -159,14 +102,11 @@ artifacts under `tests/results/_agent/`.
   - `tests/results/_agent/handoff/entrypoint-status.json`
   - `tests/results/_agent/runtime/`
 
-## Local gates
+## Local Gates
 
-- `tools/PrePush-Checks.ps1` consumes
-  `tools/policy/prepush-known-flag-scenarios.json` for the NI image known-flag
-  contract.
-- Exactly one active known-flag scenario is allowed in that checked-in contract
-  at a time.
-- The deterministic top-level receipt for that gate is
+- `tools/PrePush-Checks.ps1` consumes `tools/policy/prepush-known-flag-scenarios.json`.
+- Exactly one active known-flag scenario is allowed in that checked-in contract at a time.
+- The deterministic top-level receipt is
   `tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json`.
 
 ## References


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1307
- Issue title: Bound AGENTS.md back to the checked-in entrypoint contract
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1307
- Standing priority at PR creation: Yes (#1307)
- Base branch: `develop`
- Head branch: `issue/personal-1307-agents-entrypoint-boundary`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
