### PR TITLE
#1309 Align validation approval decision schema with emitted review-run metadata

### DIFF
--- a/docs/schemas/validation-approval-decision-v1.schema.json
+++ b/docs/schemas/validation-approval-decision-v1.schema.json
@@ -282,6 +282,24 @@
         "staleReviewCount": {
           "type": "integer"
         },
+        "reviewRunState": {
+          "type": "string"
+        },
+        "reviewRunId": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "reviewRunCompletedClean": {
+          "type": "boolean"
+        },
+        "reviewRunInProgress": {
+          "type": "boolean"
+        },
+        "reviewRunCompletedFailure": {
+          "type": "boolean"
+        },
         "errorCount": {
           "type": "integer"
         },

--- a/tools/priority/__tests__/validation-approval-broker-schema.test.mjs
+++ b/tools/priority/__tests__/validation-approval-broker-schema.test.mjs
@@ -157,4 +157,31 @@ test('validation approval decision schema validates a generated ready artifact',
   assert.equal(validate(payload), true, JSON.stringify(validate.errors, null, 2));
   assert.equal(payload.schema, 'validation-approval-decision@v1');
   assert.equal(payload.decision.state, 'ready');
+  assert.deepEqual(payload.providers.reviewSignal, {
+    path: signalPath,
+    available: true,
+    status: 'pass',
+    reviewState: 'clean',
+    headSha,
+    pullRequestNumber: prNumber,
+    hasCurrentHeadReview: true,
+    actionableCommentCount: 0,
+    unresolvedThreadCount: 0,
+    staleReviewCount: 0,
+    reviewRunState: 'unobserved',
+    reviewRunId: null,
+    reviewRunCompletedClean: false,
+    reviewRunInProgress: false,
+    reviewRunCompletedFailure: false,
+    errorCount: 0,
+  });
+
+  const legacyPayload = structuredClone(payload);
+  delete legacyPayload.providers.reviewSignal.reviewRunState;
+  delete legacyPayload.providers.reviewSignal.reviewRunId;
+  delete legacyPayload.providers.reviewSignal.reviewRunCompletedClean;
+  delete legacyPayload.providers.reviewSignal.reviewRunInProgress;
+  delete legacyPayload.providers.reviewSignal.reviewRunCompletedFailure;
+
+  assert.equal(validate(legacyPayload), true, JSON.stringify(validate.errors, null, 2));
 });


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1309
- Issue title: Align validation approval decision schema with emitted review-run metadata
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1309
- Standing priority at PR creation: Yes (#1309)
- Base branch: `develop`
- Head branch: `issue/personal-1309-validation-approval-schema`
- Template variant: `workflow-policy`
- Auto-close intent: Closes #1309

# Summary

Closes #1309 by aligning `validation-approval-decision@v1` with the review-run metadata that
`validation-approval-broker.mjs` already emits, without breaking older `@v1` artifacts.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
  - none; schema and focused tests only
- Check names, required-status contracts, or merge-queue behavior affected:
  - none
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
  - the approval-decision schema now accepts the emitted review-run fields in `providers.reviewSignal`
- Manual dispatch, comment command, or branch-protection effects:
  - none

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/validation-approval-broker-schema.test.mjs`
  - `node --test tools/priority/__tests__/validation-approval-broker.test.mjs`
  - `git diff --check`
  - `node tools/priority/copilot-cli-review.mjs --profile pre-commit --receipt-path tests/results/_agent/reviews/validation-approval-schema-1309-bounded-receipt.json`
- Contract, schema, or guard tests:
  - schema validation covers current emitted review-run metadata and legacy `@v1` payload compatibility
- Live workflow or dry-run evidence:
  - `tests/results/_agent/reviews/validation-approval-schema-1309-bounded-receipt.json`

## Rollout and Rollback

- Rollout notes:
  - no rollout sequencing required; this is a backward-compatible schema extension
- Rollback path:
  - revert the schema/test commit if downstream consumers show an unexpected interpretation issue
- Residual risks:
  - low; change is limited to schema acceptance and focused contract coverage

## Reviewer Focus

- Please verify:
  - `providers.reviewSignal` matches the broker output shape
  - legacy `@v1` artifacts without review-run keys still validate
- Policy assumptions to double-check:
  - keeping the new fields optional in `@v1` is the correct compatibility choice
- Follow-up issues or guardrails:
  - none
