### PR TITLE
#1311 Refresh root markdown layout contract for PROMPT_AUTONOMY authority

### DIFF
--- a/tools/priority/__tests__/root-markdown-layout-contract.test.mjs
+++ b/tools/priority/__tests__/root-markdown-layout-contract.test.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(process.cwd());
 
-test('repo root markdown surface stays minimal', () => {
+test('repo root markdown surface stays minimal while keeping the canonical autonomy prompt at root', () => {
   const rootMarkdown = readdirSync(repoRoot)
     .filter((entry) => entry.endsWith('.md'))
     .sort();
@@ -14,6 +14,7 @@ test('repo root markdown surface stays minimal', () => {
     'AGENTS.md',
     'CHANGELOG.md',
     'CONTRIBUTING.md',
+    'PROMPT_AUTONOMY.md',
     'README.md',
     'SECURITY.md',
   ]);


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1311
- Issue title: Refresh root markdown layout contract for PROMPT_AUTONOMY authority
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1311
- Standing priority at PR creation: Yes (#1311)
- Base branch: `develop`
- Head branch: `issue/personal-1311-root-markdown-contract`
- Template variant: `default-agent-template`
- Auto-close intent: Closes #1311

# Summary

Closes #1311 by refreshing the root-markdown layout contract so it matches the current supported repo-root markdown surface on `develop`, including the canonical `PROMPT_AUTONOMY.md` prompt file.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## What Changed

- updated `tools/priority/__tests__/root-markdown-layout-contract.test.mjs`
- kept the root surface bounded while explicitly allowing `PROMPT_AUTONOMY.md`
- clarified the test name so the contract intent is explicit

## Validation Evidence

- `node --test tools/priority/__tests__/root-markdown-layout-contract.test.mjs`
- `git diff --check`
- `node tools/priority/copilot-cli-review.mjs --profile pre-commit --receipt-path tests/results/_agent/reviews/root-markdown-contract-1311-bounded-receipt.json`

## Risks

- low; this is a test-only contract refresh against the existing repo layout

## Reviewer Focus

- confirm `PROMPT_AUTONOMY.md` is intended to remain a supported root-level markdown surface
- confirm no other root markdown contract tightening is needed in the same lane
