### PR TITLE
#1313 Refresh runtime supervisor standing-handoff fixture after selector precedence updates

### DIFF
--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -2686,7 +2686,11 @@ test('delivery broker finalizes merged standing issues by handing off priority a
         {
           number: 958,
           title: 'Upstream demo: land released comparevi-history diagnostics in labview-icon-editor-demo',
-          body: 'Track comparevi-history#23 as the blocker for the final public explicit-mode reviewer surface.',
+          body: [
+            'This issue remains open only as local blocked tracking under epic #930.',
+            'Blocked by LabVIEW-Community-CI-CD/comparevi-history#23.',
+            'Under the current standing selector, this issue is blocked tracking, not an active local standing lane.'
+          ].join('\n'),
           state: 'OPEN',
           labels: [],
           createdAt: '2026-03-09T00:00:00Z',
@@ -2711,7 +2715,11 @@ test('delivery broker finalizes merged standing issues by handing off priority a
         return {
           number: 958,
           title: 'Upstream demo: land released comparevi-history diagnostics in labview-icon-editor-demo',
-          body: 'Track comparevi-history#23 as the blocker for the final public explicit-mode reviewer surface.',
+          body: [
+            'This issue remains open only as local blocked tracking under epic #930.',
+            'Blocked by LabVIEW-Community-CI-CD/comparevi-history#23.',
+            'Under the current standing selector, this issue is blocked tracking, not an active local standing lane.'
+          ].join('\n'),
           updated_at: '2026-03-09T00:00:00Z',
           html_url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/958',
           url: 'https://api.github.com/repos/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/958',
@@ -2746,7 +2754,7 @@ test('delivery broker finalizes merged standing issues by handing off priority a
   );
   assert.equal(handoffCalls.length, 1);
   assert.equal(handoffCalls[0].issueNumber, 959);
-  assert.ok(ghFetchCalls.some((args) => args[0] === 'api'));
+  assert.equal(ghFetchCalls.length, 0);
   assert.equal(closeCalls.length, 1);
   assert.equal(closeCalls[0].issueNumber, 1010);
   assert.match(closeCalls[0].comment, /standing priority has advanced from #1010 to #959/i);


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1313
- Issue title: Refresh runtime supervisor standing-handoff fixture after selector precedence updates
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1313
- Standing priority at PR creation: Yes (#1313)
- Base branch: `develop`
- Head branch: `issue/personal-1313-runtime-supervisor-handoff`
- Template variant: `default-agent-template`
- Auto-close intent: Closes #1313

# Summary

Closes #1313 by refreshing the merged-standing runtime-supervisor fixture so it blocks `#958` from the live issue body, preserves the intended handoff target `#959`, and no longer depends on stale comment-only demotion data.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## What Changed

- updated `tools/priority/__tests__/runtime-supervisor.test.mjs`
- made the `#958` fixture explicitly blocked from current issue-body state
- kept the standing-handoff expectation on `#959`
- tightened the fixture so no extra REST hydration is required to make the right selection decision

## Validation Evidence

- `node --test tools/priority/__tests__/runtime-supervisor.test.mjs`
- `git diff --check`
- `node tools/priority/copilot-cli-review.mjs --profile pre-commit --receipt-path tests/results/_agent/reviews/runtime-supervisor-handoff-1313-bounded-receipt.json`

## Risks

- low; this is a focused contract-fixture refresh against current selector behavior

## Reviewer Focus

- confirm the fixture should model `#958` as blocked from its current issue body rather than from a stale continuity comment
- confirm the merged-standing handoff target remains `#959` for this scenario
