### PR TITLE
Preserve delivery-agent wrapper JSON output during fallback builds (#1316)

### DIFF
--- a/tools/priority/DeliveryAgentWrapper.Build.psm1
+++ b/tools/priority/DeliveryAgentWrapper.Build.psm1
@@ -1,0 +1,38 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+
+function Initialize-DeliveryAgentDistScript {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$DistScript,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WrapperLabel
+  )
+
+  if (Test-Path -LiteralPath $DistScript -PathType Leaf) {
+    return
+  }
+
+  # Keep wrapper stdout machine-readable when we have to build the compiled fallback first.
+  $buildOutput = & node (Join-Path $RepoRoot 'tools\npm\run-script.mjs') build 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    return
+  }
+
+  $detail = ($buildOutput |
+    ForEach-Object { $_.ToString().TrimEnd() } |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join [Environment]::NewLine
+
+  if ([string]::IsNullOrWhiteSpace($detail)) {
+    throw "TypeScript build failed for $WrapperLabel."
+  }
+
+  throw "TypeScript build failed for $WrapperLabel.`n$detail"
+}
+
+Export-ModuleMember -Function Initialize-DeliveryAgentDistScript

--- a/tools/priority/Ensure-WSLDeliveryPrereqs.ps1
+++ b/tools/priority/Ensure-WSLDeliveryPrereqs.ps1
@@ -7,14 +7,10 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'DeliveryAgentWrapper.Build.psm1') -Force
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $distScript = Join-Path $repoRoot 'dist\tools\priority\delivery-agent.js'
-if (-not (Test-Path -LiteralPath $distScript -PathType Leaf)) {
-  & node (Join-Path $repoRoot 'tools\npm\run-script.mjs') build
-  if ($LASTEXITCODE -ne 0) {
-    throw 'TypeScript build failed for delivery-agent prereq wrapper.'
-  }
-}
+Initialize-DeliveryAgentDistScript -RepoRoot $repoRoot -DistScript $distScript -WrapperLabel 'delivery-agent prereq wrapper'
 
 & node $distScript prereqs --wsl-distro $Distro --node-version $NodeVersion --report-path $ReportPath
 exit $LASTEXITCODE

--- a/tools/priority/Manage-UnattendedDeliveryAgent.ps1
+++ b/tools/priority/Manage-UnattendedDeliveryAgent.ps1
@@ -37,14 +37,10 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'DeliveryAgentWrapper.Build.psm1') -Force
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $distScript = Join-Path $repoRoot 'dist\tools\priority\delivery-agent.js'
-if (-not (Test-Path -LiteralPath $distScript -PathType Leaf)) {
-  & node (Join-Path $repoRoot 'tools\npm\run-script.mjs') build
-  if ($LASTEXITCODE -ne 0) {
-    throw 'TypeScript build failed for delivery-agent wrapper.'
-  }
-}
+Initialize-DeliveryAgentDistScript -RepoRoot $repoRoot -DistScript $distScript -WrapperLabel 'delivery-agent wrapper'
 
 $command = if ($Ensure) { 'ensure' } elseif ($Stop) { 'stop' } elseif ($Status) { 'status' } else { throw 'Specify one of -Ensure, -Status, or -Stop.' }
 $args = @(

--- a/tools/priority/Run-UnattendedDeliveryAgent.ps1
+++ b/tools/priority/Run-UnattendedDeliveryAgent.ps1
@@ -33,14 +33,10 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'DeliveryAgentWrapper.Build.psm1') -Force
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $distScript = Join-Path $repoRoot 'dist\tools\priority\delivery-agent.js'
-if (-not (Test-Path -LiteralPath $distScript -PathType Leaf)) {
-  & node (Join-Path $repoRoot 'tools\npm\run-script.mjs') build
-  if ($LASTEXITCODE -ne 0) {
-    throw 'TypeScript build failed for delivery-agent runner wrapper.'
-  }
-}
+Initialize-DeliveryAgentDistScript -RepoRoot $repoRoot -DistScript $distScript -WrapperLabel 'delivery-agent runner wrapper'
 
 $args = @(
   $distScript,

--- a/tools/priority/__tests__/delivery-agent-manager-contract.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-manager-contract.test.mjs
@@ -3,7 +3,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile as execFileCb } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -19,6 +19,42 @@ async function readText(relativePath) {
 async function writeJson(filePath, payload) {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+async function copyRepoFile(relativePath, tempRoot) {
+  const destinationPath = path.join(tempRoot, relativePath);
+  await mkdir(path.dirname(destinationPath), { recursive: true });
+  await copyFile(path.join(repoRoot, relativePath), destinationPath);
+  return destinationPath;
+}
+
+async function writeFakeDeliveryAgentBuildScript(tempRoot) {
+  const scriptPath = path.join(tempRoot, 'tools', 'npm', 'run-script.mjs');
+  await mkdir(path.dirname(scriptPath), { recursive: true });
+  await writeFile(
+    scriptPath,
+    `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+process.stdout.write('added 66 packages in 2s\\n');
+process.stdout.write('> compare-vi-cli-action@0.6.3 build\\n');
+const distDir = path.join(repoRoot, 'dist', 'tools', 'priority');
+mkdirSync(distDir, { recursive: true });
+writeFileSync(
+  path.join(distDir, 'delivery-agent.js'),
+  "#!/usr/bin/env node\\n" +
+    "const command = process.argv[2] || '';\\n" +
+    "const reportPathIndex = process.argv.indexOf('--report-path');\\n" +
+    "const reportPath = reportPathIndex >= 0 ? process.argv[reportPathIndex + 1] : null;\\n" +
+    "process.stdout.write(JSON.stringify({ schema: 'test/delivery-agent@v1', command, reportPath }, null, 2) + '\\\\n');\\n",
+  'utf8',
+);
+`,
+    'utf8',
+  );
 }
 
 async function invokeManagerStatus(relativeRuntimeDir) {
@@ -88,10 +124,19 @@ test('delivery-agent wrappers delegate to the compiled node CLI', async () => {
   assert.match(manager, /'ensure'|\"ensure\"/);
   assert.match(manager, /'status'|\"status\"/);
   assert.match(manager, /'stop'|\"stop\"/);
+  assert.match(manager, /DeliveryAgentWrapper\.Build\.psm1/);
+  assert.match(manager, /Initialize-DeliveryAgentDistScript/);
   assert.match(runner, /delivery-agent\.js/);
   assert.match(runner, /'run'|\"run\"/);
+  assert.match(runner, /DeliveryAgentWrapper\.Build\.psm1/);
+  assert.match(runner, /Initialize-DeliveryAgentDistScript/);
   assert.match(ensurePrereqs, /delivery-agent\.js/);
   assert.match(ensurePrereqs, /prereqs/);
+  assert.match(ensurePrereqs, /DeliveryAgentWrapper\.Build\.psm1/);
+  assert.match(ensurePrereqs, /Initialize-DeliveryAgentDistScript/);
+  assert.doesNotMatch(manager, /run-script\.mjs'\) build/);
+  assert.doesNotMatch(runner, /run-script\.mjs'\) build/);
+  assert.doesNotMatch(ensurePrereqs, /run-script\.mjs'\) build/);
   assert.doesNotMatch(manager, /Start-Process -FilePath 'pwsh'/);
   assert.doesNotMatch(runner, /Start-Process -FilePath 'pwsh'/);
   assert.match(cli, /ensureManagerCommand/);
@@ -176,6 +221,81 @@ test('delivery-agent manager status ignores stale heartbeat state from before th
   assert.equal(status.heartbeatDiagnostics.reason, 'stale-before-current-manager');
   assert.deepEqual(status.logTail.daemon, []);
   assert.match(traceText, /"eventType":"status"/);
+});
+
+test('Manage-UnattendedDeliveryAgent suppresses fallback build chatter before JSON status output', async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'delivery-agent-wrapper-status-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  await copyRepoFile('tools/priority/Manage-UnattendedDeliveryAgent.ps1', tempRoot);
+  await copyRepoFile('tools/priority/DeliveryAgentWrapper.Build.psm1', tempRoot);
+  await writeFakeDeliveryAgentBuildScript(tempRoot);
+
+  const { stdout, stderr } = await execFile(
+    'pwsh',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-File',
+      path.join(tempRoot, 'tools', 'priority', 'Manage-UnattendedDeliveryAgent.ps1'),
+      '-Status',
+      '-RuntimeDir',
+      'tests/results/_agent/runtime'
+    ],
+    {
+      cwd: tempRoot,
+      windowsHide: true
+    }
+  );
+
+  assert.equal(stderr, '');
+  assert.doesNotMatch(stdout, /added 66 packages|compare-vi-cli-action@0\.6\.3 build/i);
+  assert.deepEqual(JSON.parse(stdout), {
+    schema: 'test/delivery-agent@v1',
+    command: 'status',
+    reportPath: null
+  });
+});
+
+test('Ensure-WSLDeliveryPrereqs suppresses fallback build chatter before JSON prereq output', async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'delivery-agent-wrapper-prereqs-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  await copyRepoFile('tools/priority/Ensure-WSLDeliveryPrereqs.ps1', tempRoot);
+  await copyRepoFile('tools/priority/DeliveryAgentWrapper.Build.psm1', tempRoot);
+  await writeFakeDeliveryAgentBuildScript(tempRoot);
+
+  const { stdout, stderr } = await execFile(
+    'pwsh',
+    [
+      '-NoLogo',
+      '-NoProfile',
+      '-File',
+      path.join(tempRoot, 'tools', 'priority', 'Ensure-WSLDeliveryPrereqs.ps1'),
+      '-Distro',
+      'Ubuntu',
+      '-NodeVersion',
+      'v24.13.1',
+      '-ReportPath',
+      'tests/results/_agent/runtime/wsl-delivery-prereqs.json'
+    ],
+    {
+      cwd: tempRoot,
+      windowsHide: true
+    }
+  );
+
+  assert.equal(stderr, '');
+  assert.doesNotMatch(stdout, /added 66 packages|compare-vi-cli-action@0\.6\.3 build/i);
+  assert.deepEqual(JSON.parse(stdout), {
+    schema: 'test/delivery-agent@v1',
+    command: 'prereqs',
+    reportPath: 'tests/results/_agent/runtime/wsl-delivery-prereqs.json'
+  });
 });
 
 test('delivery-agent manager status derives from a fresh heartbeat when no delivery state exists', async (t) => {


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1316
- Issue title: Preserve delivery-agent wrapper JSON output during fallback builds
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1316
- Standing priority at PR creation: Yes (#1316)
- Base branch: `develop`
- Head branch: `issue/origin-1316-delivery-agent-json-fallback`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
