### PR TITLE
Fix delivery-memory shim fallback on clean checkouts (#1318)

### DIFF
--- a/tools/priority/__tests__/delivery-memory.test.mjs
+++ b/tools/priority/__tests__/delivery-memory.test.mjs
@@ -2,7 +2,22 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { buildDeliveryMemoryReport } from '../delivery-memory.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('delivery-memory shim exports named bindings after fallback build instead of static dist re-exports', async () => {
+  const content = await readFile(path.join(repoRoot, 'tools/priority/delivery-memory.mjs'), 'utf8');
+
+  assert.doesNotMatch(content, /export \* from '\.\.\/\.\.\/dist\/tools\/priority\/delivery-memory\.js';/);
+  assert.match(content, /export const buildDeliveryMemoryReport = imported\.buildDeliveryMemoryReport;/);
+  assert.match(content, /export const refreshDeliveryMemory = imported\.refreshDeliveryMemory;/);
+  assert.match(content, /export const parseArgs = imported\.parseArgs;/);
+  assert.match(content, /export const main = imported\.main;/);
+});
 
 test('delivery memory summarizes merged and poisoned-branch PR outcomes with effort and VI History classification', () => {
   const taskPackets = [

--- a/tools/priority/delivery-memory.mjs
+++ b/tools/priority/delivery-memory.mjs
@@ -21,12 +21,18 @@ if (!existsSync(distPath)) {
 }
 
 const imported = await import(pathToFileURL(distPath).href);
-export * from '../../dist/tools/priority/delivery-memory.js';
+export const DELIVERY_MEMORY_REPORT_SCHEMA = imported.DELIVERY_MEMORY_REPORT_SCHEMA;
+export const DEFAULT_RUNTIME_DIR = imported.DEFAULT_RUNTIME_DIR;
+export const DEFAULT_REPORT_FILENAME = imported.DEFAULT_REPORT_FILENAME;
+export const buildDeliveryMemoryReport = imported.buildDeliveryMemoryReport;
+export const refreshDeliveryMemory = imported.refreshDeliveryMemory;
+export const parseArgs = imported.parseArgs;
+export const main = imported.main;
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
-if (invokedPath && invokedPath === modulePath && typeof imported.main === 'function') {
+if (invokedPath && invokedPath === modulePath && typeof main === 'function') {
   try {
-    const exitCode = await imported.main(process.argv);
+    const exitCode = await main(process.argv);
     if (Number.isInteger(exitCode)) {
       process.exit(exitCode);
     }


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1318
- Issue title: Fix delivery-memory shim fallback on clean checkouts
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1318
- Standing priority at PR creation: Yes (#1318)
- Base branch: `develop`
- Head branch: `issue/origin-1318-delivery-memory-shim`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
