### PR TITLE
Fix pre-push known-flag scenario report writer on vi-history suite path (#1320)

### DIFF
--- a/tests/PrePushKnownFlagScenarioReport.Tests.ps1
+++ b/tests/PrePushKnownFlagScenarioReport.Tests.ps1
@@ -45,6 +45,7 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
     }
 
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushKnownFlagScenarioReport')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'ConvertTo-PrePushKnownFlagScenarioResultArray')
     $script:KnownFlagContract = Get-Content -LiteralPath $script:KnownFlagContractPath -Raw | ConvertFrom-Json -Depth 12
     $script:ActiveScenario = @($script:KnownFlagContract.scenarios | Where-Object { $_.isActive -eq $true }) | Select-Object -First 1
     if ($null -eq $script:ActiveScenario) {
@@ -137,5 +138,36 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
     $report.observed.outcome | Should -Be 'fail'
     $report.observed.failureMessage | Should -Be 'known-flag scenario failed'
     $report.results.Count | Should -Be 0
+  }
+
+  It 'normalizes live scenario result collections into plain report records' {
+    $scenarioResults = [System.Collections.Generic.List[object]]::new()
+    $scenarioResults.Add([pscustomobject]@{
+      name = 'baseline'
+      requestedFlags = @()
+      flags = @('-Headless')
+      resultClass = 'diff'
+      gateOutcome = 'pass'
+      capturePath = 'tests/results/_agent/pre-push-ni-image/baseline/ni-linux-container-capture.json'
+      reportPath = 'tests/results/_agent/pre-push-ni-image/baseline/compare-report.html'
+    }) | Out-Null
+    $scenarioResults.Add([pscustomobject]@{
+      name = 'vi-history-report'
+      requestedFlags = @('vi-history-suite')
+      flags = @('suite-manifest', 'history-report', 'history-summary')
+      resultClass = 'diff'
+      gateOutcome = 'pass'
+      capturePath = 'tests/results/_agent/pre-push-ni-image/vi-history-report/results/ni-linux-container-capture.json'
+      reportPath = 'tests/results/_agent/pre-push-ni-image/vi-history-report/results/history-report.html'
+    }) | Out-Null
+
+    $normalized = ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $scenarioResults
+
+    $normalized.Count | Should -Be 2
+    $normalized[0].name | Should -Be 'baseline'
+    $normalized[0].flags | Should -Be @('-Headless')
+    $normalized[1].name | Should -Be 'vi-history-report'
+    $normalized[1].requestedFlags | Should -Be @('vi-history-suite')
+    $normalized[1].reportPath | Should -Be 'tests/results/_agent/pre-push-ni-image/vi-history-report/results/history-report.html'
   }
 }

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -522,6 +522,42 @@ function Write-PrePushKnownFlagScenarioReport {
   return $reportPath
 }
 
+function ConvertTo-PrePushKnownFlagScenarioResultArray {
+  param(
+    [AllowNull()]
+    [object]$scenarioResults
+  )
+
+  $normalizedResults = New-Object System.Collections.Generic.List[object]
+  foreach ($scenarioResult in $scenarioResults) {
+    if ($null -eq $scenarioResult) {
+      continue
+    }
+
+    $requestedFlags = @()
+    if ($scenarioResult.PSObject.Properties['requestedFlags'] -and $scenarioResult.requestedFlags) {
+      $requestedFlags = @($scenarioResult.requestedFlags | ForEach-Object { [string]$_ })
+    }
+
+    $flags = @()
+    if ($scenarioResult.PSObject.Properties['flags'] -and $scenarioResult.flags) {
+      $flags = @($scenarioResult.flags | ForEach-Object { [string]$_ })
+    }
+
+    $normalizedResults.Add([pscustomobject]@{
+      name = [string]$scenarioResult.name
+      requestedFlags = $requestedFlags
+      flags = $flags
+      resultClass = [string]$scenarioResult.resultClass
+      gateOutcome = [string]$scenarioResult.gateOutcome
+      capturePath = [string]$scenarioResult.capturePath
+      reportPath = [string]$scenarioResult.reportPath
+    }) | Out-Null
+  }
+
+  return @($normalizedResults.ToArray())
+}
+
 $root = (Get-RepoRoot).Path
 Invoke-WorkspaceHealthGate -repoRoot $root
 $guardScript = Join-Path (Split-Path -Parent $PSCommandPath) 'Assert-NoAmbiguousRemoteRefs.ps1'
@@ -687,6 +723,8 @@ $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
 $capturePath = Join-Path $scenarioDir 'ni-linux-container-capture.json'
 $scenarioResults = New-Object System.Collections.Generic.List[object]
 $scenarioReportPath = $null
+$observedCapturePath = [string]$capturePath
+$observedReportPath = [string]$reportPath
 
 try {
   Write-Host ("[pre-push] Running active known-flag scenario '{0}' (real container compare)" -f $knownFlagScenarioId) -ForegroundColor Cyan
@@ -698,6 +736,8 @@ try {
     $reportPath = Join-Path $scenarioDir 'compare-report.html'
     $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
     $capturePath = Join-Path $scenarioDir 'ni-linux-container-capture.json'
+    $observedCapturePath = [string]$capturePath
+    $observedReportPath = [string]$reportPath
 
     Write-Host ("[pre-push] Running NI image flag scenario '{0}' requestedFlags={1}" -f $activeScenarioName, [string]$scenario.requestedFlagsLabel) -ForegroundColor Cyan
     Push-Location $root
@@ -764,6 +804,8 @@ try {
       capturePath = $capturePath
       reportPath = $reportPath
     }) | Out-Null
+    $observedCapturePath = [string]$capturePath
+    $observedReportPath = [string]$reportPath
   }
 
   $activeScenarioName = 'single-container-matrix'
@@ -774,6 +816,8 @@ try {
   $reportPath = Join-Path $scenarioDir 'compare-report.html'
   $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
   $capturePath = Join-Path $scenarioDir 'ni-linux-container-capture.json'
+  $observedCapturePath = [string]$capturePath
+  $observedReportPath = [string]$reportPath
   $singleContainerContractPath = Join-Path $scenarioDir 'runtime-bootstrap.json'
   $singleContainerLedgerPath = Join-Path $singleContainerResultsDir 'flag-matrix-ledger.tsv'
   $singleContainerMarkerPath = Join-Path $singleContainerResultsDir 'flag-matrix-ran.txt'
@@ -912,6 +956,8 @@ try {
     capturePath = $capturePath
     reportPath = $reportPath
   }) | Out-Null
+  $observedCapturePath = [string]$capturePath
+  $observedReportPath = [string]$reportPath
 
   $activeScenarioName = 'vi-history-report'
   $activeScenarioFlags = @('vi-history-suite')
@@ -930,6 +976,8 @@ try {
   $viHistorySummaryJsonPath = Join-Path $viHistoryResultsDir 'history-summary.json'
   $viHistoryInspectionJsonPath = Join-Path $viHistoryResultsDir 'history-suite-inspection.json'
   $viHistoryInspectionHtmlPath = Join-Path $viHistoryResultsDir 'history-suite-inspection.html'
+  $observedCapturePath = [string]$capturePath
+  $observedReportPath = [string]$reportPath
   $viHistoryContract = [ordered]@{
     schema = 'ni-linux-runtime-bootstrap/v1'
     mode = 'vi-history-suite-smoke'
@@ -1054,6 +1102,8 @@ try {
     capturePath = $capturePath
     reportPath = $viHistoryHtmlPath
   }) | Out-Null
+  $observedCapturePath = [string]$capturePath
+  $observedReportPath = [string]$viHistoryHtmlPath
 
   if ($env:GITHUB_STEP_SUMMARY) {
     $lines = @(
@@ -1073,11 +1123,11 @@ try {
     -repoRoot $root `
     -contract $knownFlagScenarioContract `
     -observedOutcome 'pass' `
-    -scenarioResults @($scenarioResults) `
+    -scenarioResults (ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $scenarioResults) `
     -failureMessage '' `
-    -activeScenarioName $activeScenarioName `
-    -activeCapturePath $capturePath `
-    -activeReportPath $reportPath
+    -activeScenarioName ([string]$activeScenarioName) `
+    -activeCapturePath $observedCapturePath `
+    -activeReportPath $observedReportPath
   Write-Host ("[pre-push] Known-flag scenario report: {0}" -f $scenarioReportPath) -ForegroundColor DarkGray
   Write-Host ("[pre-push] Active known-flag scenario '{0}' OK" -f $knownFlagScenarioId) -ForegroundColor Green
 } catch {
@@ -1086,11 +1136,11 @@ try {
     -repoRoot $root `
     -contract $knownFlagScenarioContract `
     -observedOutcome 'fail' `
-    -scenarioResults @($scenarioResults) `
+    -scenarioResults (ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $scenarioResults) `
     -failureMessage $failureMessage `
-    -activeScenarioName $activeScenarioName `
-    -activeCapturePath $capturePath `
-    -activeReportPath $reportPath
+    -activeScenarioName ([string]$activeScenarioName) `
+    -activeCapturePath $observedCapturePath `
+    -activeReportPath $observedReportPath
   if (-not [string]::IsNullOrWhiteSpace($scenarioReportPath)) {
     Write-Host ("[pre-push] Known-flag scenario report: {0}" -f $scenarioReportPath) -ForegroundColor Yellow
   }

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -44,6 +44,8 @@ test('PrePush NI image known-flag scenario consumes the checked-in active scenar
   assert.match(content, /\$failureMarkers = @\(/);
   assert.match(content, /Select-String -Path \$resolvedEntryLogPath -SimpleMatch -Quiet -Pattern \$failureMarkers/);
   assert.match(content, /Write-PrePushKnownFlagScenarioReport/);
+  assert.match(content, /\$observedCapturePath = \[string\]\$capturePath/);
+  assert.match(content, /\$observedReportPath = \[string\]\$viHistoryHtmlPath/);
   assert.match(content, /Active known-flag scenario '\{0\}' OK/);
   assert.doesNotMatch(content, /pwsh\s+-NoLogo\s+-NoProfile\s+-File\s+\$niCompareScript/);
   assert.doesNotMatch(content, /Render-VIHistoryReport\.ps1/);


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1320
- Issue title: Fix pre-push known-flag scenario report writer on vi-history suite path
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1320
- Standing priority at PR creation: Yes (#1320)
- Base branch: `develop`
- Head branch: `issue/origin-1320-prepush-known-flag-report`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
