### PR TITLE
Update for standing priority #1322

### DIFF
--- a/tests/Close-LabVIEW.Tests.ps1
+++ b/tests/Close-LabVIEW.Tests.ps1
@@ -1,0 +1,62 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Close-LabVIEW.ps1' -Tag 'Unit' {
+  It 'forwards TimeoutSeconds and normalized parameters to Invoke-LVOperation' {
+    $repoRoot = Join-Path $TestDrive 'repo'
+    $toolsDir = Join-Path $repoRoot 'tools'
+    New-Item -ItemType Directory -Path $repoRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $toolsDir -Force | Out-Null
+
+    $sourceRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Copy-Item -LiteralPath (Join-Path $sourceRoot 'tools' 'Close-LabVIEW.ps1') -Destination (Join-Path $toolsDir 'Close-LabVIEW.ps1') -Force
+
+    $capturePath = Join-Path $repoRoot 'invoke-capture.json'
+    $moduleStub = @"
+function Invoke-LVOperation {
+  param(
+    [string]`$Operation,
+    [hashtable]`$Params,
+    [string]`$Provider = 'auto',
+    [switch]`$Preview,
+    [int]`$TimeoutSeconds = 300
+  )
+
+  [ordered]@{
+    Operation      = `$Operation
+    Params         = `$Params
+    Provider       = `$Provider
+    Preview        = `$Preview.IsPresent
+    TimeoutSeconds = `$TimeoutSeconds
+  } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath '$capturePath' -Encoding utf8
+
+  return [pscustomobject]@{
+    provider = 'stub'
+    command  = 'stub-command'
+    exitCode = 0
+  }
+}
+
+Export-ModuleMember -Function Invoke-LVOperation
+"@
+    Set-Content -LiteralPath (Join-Path $toolsDir 'LabVIEWCli.psm1') -Value $moduleStub -Encoding UTF8
+
+    $labviewExe = Join-Path $repoRoot 'LabVIEW.exe'
+    Set-Content -LiteralPath $labviewExe -Value '' -Encoding ascii
+
+    & pwsh -NoLogo -NoProfile -File (Join-Path $toolsDir 'Close-LabVIEW.ps1') `
+      -LabVIEWExePath $labviewExe `
+      -Provider stub-provider `
+      -TimeoutSeconds 7 *> $null
+
+    $LASTEXITCODE | Should -Be 0
+    Test-Path -LiteralPath $capturePath | Should -BeTrue
+
+    $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 6
+    $capture.Operation | Should -Be 'CloseLabVIEW'
+    $capture.Provider | Should -Be 'stub-provider'
+    $capture.TimeoutSeconds | Should -Be 7
+    $capture.Preview | Should -BeFalse
+    $capture.Params.labviewPath | Should -Be $labviewExe
+  }
+}

--- a/tests/Force-CloseLabVIEW.Tests.ps1
+++ b/tests/Force-CloseLabVIEW.Tests.ps1
@@ -1,0 +1,34 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Force-CloseLabVIEW.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:scriptPath = Join-Path $repoRoot 'tools' 'Force-CloseLabVIEW.ps1'
+    Test-Path -LiteralPath $script:scriptPath | Should -BeTrue
+  }
+
+  It 'ignores PID-scoped targets whose process names do not match the requested LabVIEW surface' {
+    $work = Join-Path $TestDrive 'force-close'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $fakeLabVIEW = Join-Path $work 'LabVIEW.exe'
+    Copy-Item -LiteralPath (Join-Path $env:SystemRoot 'System32' 'cmd.exe') -Destination $fakeLabVIEW -Force
+
+    $labProc = Start-Process -FilePath $fakeLabVIEW -ArgumentList '/c','timeout /t 30 /nobreak >nul' -PassThru
+    $pwshProc = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') -ArgumentList '-NoLogo','-NoProfile','-Command','Start-Sleep -Seconds 30' -PassThru
+
+    try {
+      $raw = & $script:scriptPath -ProcessName LabVIEW -ProcessId @($labProc.Id, $pwshProc.Id) -DryRun -Quiet
+      $json = ($raw | Out-String) | ConvertFrom-Json -Depth 6
+
+      $json.result | Should -Be 'skipped'
+      @($json.targets).Count | Should -Be 1
+      @($json.targets | ForEach-Object { [int]$_.pid }) | Should -Contain $labProc.Id
+      @($json.targets | ForEach-Object { [int]$_.pid }) | Should -Not -Contain $pwshProc.Id
+    } finally {
+      try { if (-not $labProc.HasExited) { $labProc.Kill() } } catch {}
+      try { if (-not $pwshProc.HasExited) { $pwshProc.Kill() } } catch {}
+    }
+  }
+}

--- a/tests/PostRunCleanup.Tests.ps1
+++ b/tests/PostRunCleanup.Tests.ps1
@@ -14,7 +14,12 @@ Describe 'Post-Run-Cleanup.ps1' -Tag 'Unit' {
     Copy-Item -LiteralPath (Join-Path $sourceRoot 'tools' 'PostRun' 'PostRunRequests.psm1') -Destination (Join-Path $toolsDir 'PostRun' 'PostRunRequests.psm1') -Force
 
     $labStub = @"
-param()
+param(
+  [string]`$LabVIEWExePath,
+  [string]`$MinimumSupportedLVVersion,
+  [string]`$SupportedBitness,
+  [int]`$TimeoutSeconds
+)
 exit 0
 "@
     Set-Content -LiteralPath (Join-Path $toolsDir 'Close-LabVIEW.ps1') -Value $labStub -Encoding UTF8
@@ -26,27 +31,35 @@ exit 0
     Set-Content -LiteralPath (Join-Path $toolsDir 'Close-LVCompare.ps1') -Value $lvcompareStub -Encoding UTF8
 
     Push-Location $repoRoot
-    $requestsDir = Join-Path $repoRoot 'tests/results/_agent/post/requests'
-    New-Item -ItemType Directory -Force -Path $requestsDir | Out-Null
-    $labRequest = [ordered]@{
-      name   = 'close-labview'
-      source = 'test'
-      at     = (Get-Date).ToUniversalTime().ToString('o')
-      metadata = @{ version='2025'; bitness='64' }
-    }
-    $lvRequest = [ordered]@{
-      name   = 'close-lvcompare'
-      source = 'test'
-      at     = (Get-Date).ToUniversalTime().ToString('o')
-      metadata = @{ base='Base.vi'; head='Head.vi' }
-    }
-    $labRequest | ConvertTo-Json -Depth 6 | Out-File -FilePath (Join-Path $requestsDir 'close-labview-test.json') -Encoding utf8
-    $lvRequest | ConvertTo-Json -Depth 6 | Out-File -FilePath (Join-Path $requestsDir 'close-lvcompare-test.json') -Encoding utf8
-    @((Get-ChildItem -LiteralPath $requestsDir)).Count | Should -Be 2
+    try {
+      $requestsDir = Join-Path $repoRoot 'tests/results/_agent/post/requests'
+      New-Item -ItemType Directory -Force -Path $requestsDir | Out-Null
+      $neutralTrackerPath = Join-Path $repoRoot 'tests/results/_agent/post/neutral-labview-pid.json'
+      New-Item -ItemType Directory -Path (Split-Path -Parent $neutralTrackerPath) -Force | Out-Null
+      [ordered]@{ schema = 'labview-pid-tracker/v1'; pid = $null; running = $false } |
+        ConvertTo-Json -Depth 4 |
+        Set-Content -LiteralPath $neutralTrackerPath -Encoding utf8
+      $labRequest = [ordered]@{
+        name   = 'close-labview'
+        source = 'test'
+        at     = (Get-Date).ToUniversalTime().ToString('o')
+        metadata = @{ version='2099'; bitness='64'; trackerPath='tests/results/_agent/post/neutral-labview-pid.json' }
+      }
+      $lvRequest = [ordered]@{
+        name   = 'close-lvcompare'
+        source = 'test'
+        at     = (Get-Date).ToUniversalTime().ToString('o')
+        metadata = @{ base='Base.vi'; head='Head.vi' }
+      }
+      $labRequest | ConvertTo-Json -Depth 6 | Out-File -FilePath (Join-Path $requestsDir 'close-labview-test.json') -Encoding utf8
+      $lvRequest | ConvertTo-Json -Depth 6 | Out-File -FilePath (Join-Path $requestsDir 'close-lvcompare-test.json') -Encoding utf8
+      @((Get-ChildItem -LiteralPath $requestsDir)).Count | Should -Be 2
 
-    & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW -CloseLVCompare | Out-Null
-    & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW -CloseLVCompare | Out-Null
-    Pop-Location
+      & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW -CloseLVCompare | Out-Null
+      & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW -CloseLVCompare | Out-Null
+    } finally {
+      Pop-Location
+    }
 
     $markerDir = Join-Path $repoRoot 'tests/results/_agent/post'
     $labMarkerPath = Join-Path $markerDir 'once-close-labview.marker'
@@ -60,8 +73,8 @@ exit 0
     @((Get-ChildItem -LiteralPath (Join-Path $markerDir 'requests') -ErrorAction SilentlyContinue)).Count | Should -Be 0
   }
 
-  It 'retries LabVIEW close until process exits' {
-    $repoRoot = Join-Path $TestDrive 'repo-retry'
+  It 'treats a nonzero close result as non-fatal when the targeted process is already gone' {
+    $repoRoot = Join-Path $TestDrive 'repo-gone'
     $toolsDir = Join-Path $repoRoot 'tools'
     New-Item -ItemType Directory -Path $repoRoot -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $toolsDir 'PostRun') -Force | Out-Null
@@ -79,21 +92,30 @@ exit 0
 
     $forceLog = Join-Path $repoRoot 'force-close-log.txt'
 $forceStub = @'
-param([string[]]$ProcessName)
+param([string[]]$ProcessName,[int[]]$ProcessId)
 $logPath = $env:LABVIEW_FORCE_LOG
-if ($logPath) { "forced" | Set-Content -LiteralPath $logPath -Encoding utf8 }
-$forcePid = $env:LABVIEW_FORCE_PID
-if ($forcePid) {
-  try { Stop-Process -Id [int]$forcePid -Force -ErrorAction SilentlyContinue } catch {}
+if ($logPath) {
+  $payload = [ordered]@{
+    processName = @($ProcessName)
+    processId   = @($ProcessId)
+  } | ConvertTo-Json -Depth 4
+  Set-Content -LiteralPath $logPath -Value $payload -Encoding utf8
+}
+foreach ($id in @($ProcessId)) {
+  try { Stop-Process -Id [int]$id -Force -ErrorAction SilentlyContinue } catch {}
 }
 exit 0
 '@
     Set-Content -LiteralPath (Join-Path $toolsDir 'Force-CloseLabVIEW.ps1') -Value $forceStub -Encoding utf8
 
     $labStub = @'
-param()
+param(
+  [string]$LabVIEWExePath,
+  [string]$MinimumSupportedLVVersion,
+  [string]$SupportedBitness,
+  [int]$TimeoutSeconds
+)
 $statePath = $env:LABVIEW_STUB_STATE
-$pidPath = $env:LABVIEW_STUB_PID
 if (-not $statePath) { exit 1 }
 if (-not (Test-Path -LiteralPath $statePath)) { '0' | Set-Content -LiteralPath $statePath -Encoding utf8 }
 $count = [int](Get-Content -LiteralPath $statePath)
@@ -113,28 +135,106 @@ exit 0
     Copy-Item -LiteralPath (Join-Path $PSHOME 'pwsh.exe') -Destination $fakeLabVIEW -Force
     $proc = Start-Process -FilePath $fakeLabVIEW -ArgumentList '-NoLogo','-NoProfile','-Command','Start-Sleep -Seconds 120' -PassThru
     try {
+      $requestsDir = Join-Path $repoRoot 'tests/results/_agent/post/requests'
+      New-Item -ItemType Directory -Path $requestsDir -Force | Out-Null
+      [ordered]@{
+        name     = 'close-labview'
+        source   = 'test'
+        at       = (Get-Date).ToUniversalTime().ToString('o')
+        metadata = @{
+          pid        = $proc.Id
+          labviewPath = $fakeLabVIEW
+          trackerPath = 'tests/results/_agent/post/missing-labview-pid.json'
+        }
+      } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $requestsDir 'close-labview-test.json') -Encoding utf8
+
       Set-Content -LiteralPath $pidFile -Value $proc.Id -Encoding utf8
       $env:LABVIEW_STUB_STATE = $stateFile
       $env:LABVIEW_STUB_PID = $pidFile
       $env:LABVIEW_FORCE_LOG = $forceLog
-      $env:LABVIEW_FORCE_PID = $proc.Id.ToString()
+      Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
 
       Push-Location $repoRoot
       & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW | Out-Null
       Pop-Location
 
       $finalState = [int](Get-Content -LiteralPath $stateFile)
-      $finalState | Should -BeGreaterThan 2
+      $finalState | Should -Be 1
       $remaining = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
       $remaining | Should -BeNullOrEmpty
-      Test-Path -LiteralPath $forceLog | Should -BeTrue
-      (Get-Content -LiteralPath $forceLog -Raw) | Should -Match 'forced'
+      Test-Path -LiteralPath $forceLog | Should -BeFalse
     } finally {
       Remove-Item Env:LABVIEW_STUB_STATE -ErrorAction SilentlyContinue
       Remove-Item Env:LABVIEW_STUB_PID -ErrorAction SilentlyContinue
       Remove-Item Env:LABVIEW_FORCE_LOG -ErrorAction SilentlyContinue
-      Remove-Item Env:LABVIEW_FORCE_PID -ErrorAction SilentlyContinue
       try { if (-not $proc.HasExited) { $proc.Kill() } } catch {}
+    }
+  }
+
+  It 'passes a bounded timeout to Close-LabVIEW by default and honors override' {
+    $repoRoot = Join-Path $TestDrive 'repo-timeout'
+    $toolsDir = Join-Path $repoRoot 'tools'
+    New-Item -ItemType Directory -Path $repoRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $toolsDir 'PostRun') -Force | Out-Null
+
+    $sourceRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    Copy-Item -LiteralPath (Join-Path $sourceRoot 'tools' 'Post-Run-Cleanup.ps1') -Destination (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -Force
+    Copy-Item -LiteralPath (Join-Path $sourceRoot 'tools' 'Once-Guard.psm1') -Destination (Join-Path $toolsDir 'Once-Guard.psm1') -Force
+    Copy-Item -LiteralPath (Join-Path $sourceRoot 'tools' 'PostRun' 'PostRunRequests.psm1') -Destination (Join-Path $toolsDir 'PostRun' 'PostRunRequests.psm1') -Force
+
+    $timeoutCapture = Join-Path $repoRoot 'timeout-capture.txt'
+    $labStub = @"
+param(
+  [string]`$LabVIEWExePath,
+  [string]`$MinimumSupportedLVVersion,
+  [string]`$SupportedBitness,
+  [int]`$TimeoutSeconds
+)
+[ordered]@{
+  labviewExePath = `$LabVIEWExePath
+  minimumSupportedLVVersion = `$MinimumSupportedLVVersion
+  supportedBitness = `$SupportedBitness
+  timeoutSeconds = `$TimeoutSeconds
+} | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath '$timeoutCapture' -Encoding utf8
+exit 0
+"@
+    Set-Content -LiteralPath (Join-Path $toolsDir 'Close-LabVIEW.ps1') -Value $labStub -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $toolsDir 'Close-LVCompare.ps1') -Value "param() exit 0" -Encoding UTF8
+
+    Push-Location $repoRoot
+    try {
+      $requestsDir = Join-Path $repoRoot 'tests/results/_agent/post/requests'
+      New-Item -ItemType Directory -Path $requestsDir -Force | Out-Null
+      $neutralTrackerPath = Join-Path $repoRoot 'tests/results/_agent/post/neutral-labview-pid.json'
+      New-Item -ItemType Directory -Path (Split-Path -Parent $neutralTrackerPath) -Force | Out-Null
+      [ordered]@{ schema = 'labview-pid-tracker/v1'; pid = $null; running = $false } |
+        ConvertTo-Json -Depth 4 |
+        Set-Content -LiteralPath $neutralTrackerPath -Encoding utf8
+      [ordered]@{
+        name     = 'close-labview'
+        source   = 'test'
+        at       = (Get-Date).ToUniversalTime().ToString('o')
+        metadata = @{ version='2099'; bitness='64'; trackerPath='tests/results/_agent/post/neutral-labview-pid.json' }
+      } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $requestsDir 'close-labview-timeout.json') -Encoding utf8
+
+      & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW | Out-Null
+      $capture = Get-Content -LiteralPath $timeoutCapture -Raw | ConvertFrom-Json -Depth 4
+      $capture.timeoutSeconds | Should -Be 30
+
+      $env:POST_RUN_CLOSE_LABVIEW_TIMEOUT_SECONDS = '12'
+      Remove-Item -LiteralPath (Join-Path $repoRoot 'tests/results/_agent/post/once-close-labview.marker') -Force
+      [ordered]@{
+        name     = 'close-labview'
+        source   = 'test'
+        at       = (Get-Date).ToUniversalTime().ToString('o')
+        metadata = @{ version='2099'; bitness='64'; trackerPath='tests/results/_agent/post/neutral-labview-pid.json' }
+      } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $requestsDir 'close-labview-timeout.json') -Encoding utf8
+      & (Join-Path $toolsDir 'Post-Run-Cleanup.ps1') -CloseLabVIEW | Out-Null
+      $capture = Get-Content -LiteralPath $timeoutCapture -Raw | ConvertFrom-Json -Depth 4
+      $capture.timeoutSeconds | Should -Be 12
+    } finally {
+      Pop-Location
+      Remove-Item Env:POST_RUN_CLOSE_LABVIEW_TIMEOUT_SECONDS -ErrorAction SilentlyContinue
     }
   }
 }

--- a/tools/Close-LabVIEW.ps1
+++ b/tools/Close-LabVIEW.ps1
@@ -23,6 +23,9 @@
 .PARAMETER Provider
   Explicit provider name to use (defaults to 'auto').
 
+.PARAMETER TimeoutSeconds
+  Maximum time to wait for the selected provider to complete the close operation. Defaults to 300 seconds.
+
 .PARAMETER Preview
   When set, shows the resolved provider and command without executing it.
 #>
@@ -34,6 +37,7 @@ param(
   [string]$SupportedBitness,
   [string]$LabVIEWCliPath,
   [string]$Provider = 'auto',
+  [int]$TimeoutSeconds = 300,
   [switch]$Preview
 )
 
@@ -56,7 +60,7 @@ if ($PSBoundParameters.ContainsKey('LabVIEWCliPath') -and $LabVIEWCliPath) {
 }
 
 try {
-  $result = Invoke-LVOperation -Operation 'CloseLabVIEW' -Params $params -Provider $Provider -Preview:$Preview
+  $result = Invoke-LVOperation -Operation 'CloseLabVIEW' -Params $params -Provider $Provider -Preview:$Preview -TimeoutSeconds $TimeoutSeconds
   if ($Preview) {
     return $result
   }

--- a/tools/Force-CloseLabVIEW.ps1
+++ b/tools/Force-CloseLabVIEW.ps1
@@ -1,5 +1,6 @@
 param(
   [string[]]$ProcessName = @('LabVIEW','LVCompare'),
+  [int[]]$ProcessId,
   [switch]$DryRun,
   [int]$WaitSeconds = 5,
   [switch]$Quiet
@@ -18,6 +19,47 @@ function Write-Warn {
   Write-Warning $Message
 }
 
+function Get-ProcessExecutableBaseName {
+  param([Parameter(Mandatory)][object]$Process)
+
+  if ($Process.Path) {
+    try {
+      return [System.IO.Path]::GetFileNameWithoutExtension($Process.Path)
+    } catch {}
+  }
+
+  try {
+    $cim = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $Process.Id) -ErrorAction SilentlyContinue
+    if ($cim -and $cim.ExecutablePath) {
+      return [System.IO.Path]::GetFileNameWithoutExtension($cim.ExecutablePath)
+    }
+  } catch {}
+
+  return $null
+}
+
+function Test-MatchingProcessSurface {
+  param(
+    [Parameter(Mandatory)][object]$Process,
+    [string[]]$AllowedNames
+  )
+
+  if (-not $AllowedNames -or $AllowedNames.Count -eq 0) {
+    return $true
+  }
+
+  foreach ($name in $AllowedNames) {
+    if ([string]::IsNullOrWhiteSpace($name)) { continue }
+    if ($Process.ProcessName -ieq $name) { return $true }
+    $baseName = Get-ProcessExecutableBaseName -Process $Process
+    if ($baseName -and $baseName -ieq $name) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
 $names = @()
 foreach ($name in $ProcessName) {
   if (-not [string]::IsNullOrWhiteSpace($name)) {
@@ -29,15 +71,38 @@ if ($names.Count -eq 0) {
   exit 0
 }
 
+$targetIds = @()
+foreach ($id in @($ProcessId)) {
+  if ($null -ne $id -and [int]$id -gt 0) {
+    $targetIds += [int]$id
+  }
+}
+$targetIds = @($targetIds | Sort-Object -Unique)
+
 $initial = @()
-foreach ($name in $names) {
-  try {
-    $initial += @(Get-Process -Name $name -ErrorAction SilentlyContinue)
-  } catch {}
+if ($targetIds.Count -gt 0) {
+  foreach ($id in $targetIds) {
+    try {
+      $proc = Get-Process -Id $id -ErrorAction SilentlyContinue
+      if ($proc -and (Test-MatchingProcessSurface -Process $proc -AllowedNames $names)) {
+        $initial += @($proc)
+      }
+    } catch {}
+  }
+} else {
+  foreach ($name in $names) {
+    try {
+      $initial += @(Get-Process -Name $name -ErrorAction SilentlyContinue)
+    } catch {}
+  }
 }
 
 if ($initial.Count -eq 0) {
-  Write-Info ("Force-CloseLabVIEW: no matching processes found for {0}." -f ($names -join ','))
+  if ($targetIds.Count -gt 0) {
+    Write-Info ("Force-CloseLabVIEW: no matching processes found for PID(s) {0}." -f ($targetIds -join ','))
+  } else {
+    Write-Info ("Force-CloseLabVIEW: no matching processes found for {0}." -f ($names -join ','))
+  }
   exit 0
 }
 
@@ -71,10 +136,21 @@ foreach ($proc in $initial) {
 $deadline = (Get-Date).AddSeconds([Math]::Max(0,$WaitSeconds))
 do {
   $remaining = @()
-  foreach ($name in $names) {
-    try {
-      $remaining += @(Get-Process -Name $name -ErrorAction SilentlyContinue)
-    } catch {}
+  if ($targetIds.Count -gt 0) {
+    foreach ($id in $targetIds) {
+      try {
+        $proc = Get-Process -Id $id -ErrorAction SilentlyContinue
+        if ($proc -and (Test-MatchingProcessSurface -Process $proc -AllowedNames $names)) {
+          $remaining += @($proc)
+        }
+      } catch {}
+    }
+  } else {
+    foreach ($name in $names) {
+      try {
+        $remaining += @(Get-Process -Name $name -ErrorAction SilentlyContinue)
+      } catch {}
+    }
   }
   if ($remaining.Count -eq 0) { break }
   Start-Sleep -Milliseconds 250
@@ -92,7 +168,8 @@ if ($remaining.Count -eq 0 -and $errors.Count -eq 0) {
 }
 
 if ($remaining.Count -gt 0) {
-  Write-Warn ("Force-CloseLabVIEW: processes still running: {0}" -f ($remaining | ForEach-Object { "{0}(PID {1})" -f $_.ProcessName,$_.Id } | Sort-Object | -join ', '))
+  $remainingDetails = (($remaining | ForEach-Object { "{0}(PID {1})" -f $_.ProcessName,$_.Id } | Sort-Object) -join ', ')
+  Write-Warn ("Force-CloseLabVIEW: processes still running: {0}" -f $remainingDetails)
 }
 
 $summary['result'] = 'failed'

--- a/tools/Post-Run-Cleanup.ps1
+++ b/tools/Post-Run-Cleanup.ps1
@@ -76,9 +76,294 @@ function Remove-RequestFiles {
   }
 }
 
+function Resolve-LabVIEWCloseTimeoutSeconds {
+  $defaultTimeoutSeconds = 30
+  $override = [System.Environment]::GetEnvironmentVariable('POST_RUN_CLOSE_LABVIEW_TIMEOUT_SECONDS')
+  if ([string]::IsNullOrWhiteSpace($override)) {
+    return $defaultTimeoutSeconds
+  }
+  try {
+    $parsed = [int]$override
+    if ($parsed -gt 0) {
+      return $parsed
+    }
+  } catch {}
+  Write-Warning (
+    "POST_RUN_CLOSE_LABVIEW_TIMEOUT_SECONDS value '{0}' is invalid; using default {1}." -f
+    $override,
+    $defaultTimeoutSeconds
+  )
+  return $defaultTimeoutSeconds
+}
+
+function Get-LabVIEWProcessIdsFromTrackerPayload {
+  param([object]$Payload)
+
+  $ids = New-Object System.Collections.Generic.List[int]
+  if ($null -eq $Payload) { return @() }
+
+  $candidates = New-Object System.Collections.Generic.List[object]
+  $candidates.Add($Payload)
+
+  foreach ($propertyName in @('initial','final')) {
+    if ($Payload.PSObject.Properties.Name -contains $propertyName) {
+      $value = $Payload.$propertyName
+      if ($null -ne $value) { $candidates.Add($value) }
+    }
+  }
+
+  if ($Payload.PSObject.Properties.Name -contains 'observations' -and $Payload.observations) {
+    foreach ($entry in @($Payload.observations)) {
+      if ($null -ne $entry) { $candidates.Add($entry) }
+    }
+  }
+
+  foreach ($candidate in $candidates) {
+    if ($null -eq $candidate) { continue }
+    if ($candidate.PSObject.Properties.Name -notcontains 'pid') { continue }
+    if ($candidate.PSObject.Properties.Name -contains 'running') {
+      try {
+        if (-not [bool]$candidate.running) { continue }
+      } catch {}
+    } elseif ($candidate.PSObject.Properties.Name -contains 'note') {
+      $note = [string]$candidate.note
+      if ($note -and $note -notin @('selected-from-scan','still-running')) {
+        continue
+      }
+    }
+    $pidValue = $candidate.pid
+    if ($null -eq $pidValue) { continue }
+    try {
+      $pid = [int]$pidValue
+      if ($pid -gt 0 -and -not $ids.Contains($pid)) {
+        $ids.Add($pid)
+      }
+    } catch {}
+  }
+
+  return @($ids)
+}
+
+function Resolve-LabVIEWTargetProcessIds {
+  param([hashtable]$Metadata)
+
+  $ids = New-Object System.Collections.Generic.List[int]
+  $explicitPid = $false
+  foreach ($key in @('pid','processId','labviewPid','trackedPid')) {
+    if ($Metadata -and $Metadata.ContainsKey($key) -and $Metadata[$key]) {
+      try {
+        $pid = [int]$Metadata[$key]
+        if ($pid -gt 0 -and -not $ids.Contains($pid)) {
+          $ids.Add($pid)
+          $explicitPid = $true
+        }
+      } catch {}
+    }
+  }
+
+  $explicitTrackerPaths = New-Object System.Collections.Generic.List[string]
+  foreach ($key in @('trackerPath','labviewPidTrackerPath')) {
+    if ($Metadata -and $Metadata.ContainsKey($key) -and $Metadata[$key]) {
+      $candidate = [string]$Metadata[$key]
+      if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+        if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+          $candidate = Join-Path $repoRoot $candidate
+        }
+        $explicitTrackerPaths.Add($candidate)
+      }
+    }
+  }
+
+  $foundExplicitTrackerFile = $false
+  foreach ($trackerPath in @($explicitTrackerPaths | Select-Object -Unique)) {
+    if (-not (Test-Path -LiteralPath $trackerPath -PathType Leaf)) { continue }
+    $foundExplicitTrackerFile = $true
+    try {
+      $payload = Get-Content -LiteralPath $trackerPath -Raw | ConvertFrom-Json -Depth 8
+      foreach ($pid in @(Get-LabVIEWProcessIdsFromTrackerPayload -Payload $payload)) {
+        if ($pid -gt 0 -and -not $ids.Contains($pid)) {
+          $ids.Add($pid)
+        }
+      }
+    } catch {
+      Write-Log ("Failed to parse LabVIEW PID tracker {0}: {1}" -f $trackerPath, $_.Exception.Message)
+    }
+  }
+
+  if (-not $explicitPid -and (($explicitTrackerPaths.Count -eq 0) -or (-not $foundExplicitTrackerFile))) {
+    foreach ($trackerPath in @(
+      (Join-Path $repoRoot 'tests/results/_cli/_agent/labview-pid.json'),
+      (Join-Path $repoRoot 'tests/results/_warmup/_agent/labview-pid.json'),
+      (Join-Path $repoRoot 'tests/results/_invoker/labview-pid.json')
+    )) {
+      if (-not (Test-Path -LiteralPath $trackerPath -PathType Leaf)) { continue }
+      try {
+        $payload = Get-Content -LiteralPath $trackerPath -Raw | ConvertFrom-Json -Depth 8
+        foreach ($pid in @(Get-LabVIEWProcessIdsFromTrackerPayload -Payload $payload)) {
+          if ($pid -gt 0 -and -not $ids.Contains($pid)) {
+            $ids.Add($pid)
+          }
+        }
+      } catch {
+        Write-Log ("Failed to parse LabVIEW PID tracker {0}: {1}" -f $trackerPath, $_.Exception.Message)
+      }
+    }
+  }
+
+  return @($ids)
+}
+
+function Normalize-LabVIEWProcessPath {
+  param([string]$Path)
+  if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+  try {
+    return [System.IO.Path]::GetFullPath($Path).Trim().ToLowerInvariant()
+  } catch {
+    return $Path.Trim().ToLowerInvariant()
+  }
+}
+
+function Resolve-LabVIEWExpectedPath {
+  param([hashtable]$Metadata)
+
+  foreach ($key in @('labviewExe','labviewPath','path')) {
+    if ($Metadata -and $Metadata.ContainsKey($key) -and $Metadata[$key]) {
+      return (Normalize-LabVIEWProcessPath -Path ([string]$Metadata[$key]))
+    }
+  }
+
+  $version = $null
+  foreach ($key in @('version','labviewVersion')) {
+    if ($Metadata -and $Metadata.ContainsKey($key) -and $Metadata[$key]) {
+      $version = [string]$Metadata[$key]
+      break
+    }
+  }
+
+  if ([string]::IsNullOrWhiteSpace($version)) {
+    return $null
+  }
+
+  $bitness = '64'
+  foreach ($key in @('bitness','labviewBitness')) {
+    if ($Metadata -and $Metadata.ContainsKey($key) -and $Metadata[$key]) {
+      $bitness = [string]$Metadata[$key]
+      break
+    }
+  }
+
+  $candidate = $null
+  if ($bitness -eq '32') {
+    $root = ${env:ProgramFiles(x86)}
+    if (-not $root) { $root = $env:ProgramFiles }
+    if ($root) {
+      $candidate = Join-Path $root ("National Instruments\LabVIEW {0}\LabVIEW.exe" -f $version)
+    }
+  } else {
+    if ($env:ProgramFiles) {
+      $candidate = Join-Path $env:ProgramFiles ("National Instruments\LabVIEW {0}\LabVIEW.exe" -f $version)
+    }
+  }
+
+  return (Normalize-LabVIEWProcessPath -Path $candidate)
+}
+
+function Get-ProcessExecutableBaseName {
+  param([Parameter(Mandatory)][object]$Process)
+
+  if ($Process.Path) {
+    try {
+      return [System.IO.Path]::GetFileNameWithoutExtension($Process.Path)
+    } catch {}
+  }
+
+  try {
+    $cim = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $Process.Id) -ErrorAction SilentlyContinue
+    if ($cim -and $cim.ExecutablePath) {
+      return [System.IO.Path]::GetFileNameWithoutExtension($cim.ExecutablePath)
+    }
+  } catch {}
+
+  return $null
+}
+
+function Test-LabVIEWProcessIdentity {
+  param([Parameter(Mandatory)][object]$Process)
+
+  if ($Process.ProcessName -ieq 'LabVIEW') {
+    return $true
+  }
+
+  $baseName = Get-ProcessExecutableBaseName -Process $Process
+  if ($baseName) {
+    return ($baseName -ieq 'LabVIEW')
+  }
+
+  return $false
+}
+
+function Get-LabVIEWProcessesByScope {
+  param(
+    [int[]]$ProcessIds,
+    [switch]$UseNameFallback,
+    [string]$ExpectedPath
+  )
+
+  $processes = @()
+  $expectedNormalized = if ([string]::IsNullOrWhiteSpace($ExpectedPath)) { $null } else { Normalize-LabVIEWProcessPath -Path $ExpectedPath }
+  if ($ProcessIds -and $ProcessIds.Count -gt 0) {
+    foreach ($id in @($ProcessIds | Sort-Object -Unique)) {
+      try {
+        $proc = Get-Process -Id $id -ErrorAction SilentlyContinue
+        if (-not $proc) { continue }
+        $matchesIdentity = Test-LabVIEWProcessIdentity -Process $proc
+        if (-not $matchesIdentity -and $expectedNormalized) {
+          try {
+            if ($proc.Path) {
+              $matchesIdentity = ((Normalize-LabVIEWProcessPath -Path $proc.Path) -eq $expectedNormalized)
+            } else {
+              $cim = Get-CimInstance Win32_Process -Filter ("ProcessId={0}" -f $proc.Id) -ErrorAction SilentlyContinue
+              if ($cim -and $cim.ExecutablePath) {
+                $matchesIdentity = ((Normalize-LabVIEWProcessPath -Path $cim.ExecutablePath) -eq $expectedNormalized)
+              }
+            }
+          } catch {}
+        }
+        if ($matchesIdentity) { $processes += @($proc) }
+      } catch {}
+    }
+    return @($processes)
+  }
+
+  if (-not $UseNameFallback) {
+    return @()
+  }
+
+  try {
+    $all = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue)
+    if ([string]::IsNullOrWhiteSpace($ExpectedPath)) {
+      return $all
+    }
+    return @(
+      $all | Where-Object {
+        if (-not (Test-LabVIEWProcessIdentity -Process $_)) {
+          $false
+        } elseif ($_.Path) {
+          (Normalize-LabVIEWProcessPath -Path $_.Path) -eq $expectedNormalized
+        } else {
+          $false
+        }
+      }
+    )
+  } catch {
+    return @()
+  }
+}
+
 function Invoke-ForceCloseProcesses {
   param(
     [string[]]$ProcessNames,
+    [int[]]$ProcessIds,
     [string]$Label
   )
 
@@ -89,7 +374,9 @@ function Invoke-ForceCloseProcesses {
   }
 
   $processArgs = @()
-  if ($ProcessNames -and $ProcessNames.Count -gt 0) {
+  if ($ProcessIds -and $ProcessIds.Count -gt 0) {
+    $processArgs = @('-ProcessId', @($ProcessIds | Sort-Object -Unique))
+  } elseif ($ProcessNames -and $ProcessNames.Count -gt 0) {
     $processArgs = @('-ProcessName', $ProcessNames)
   }
 
@@ -101,8 +388,17 @@ function Invoke-ForceCloseProcesses {
 
   Start-Sleep -Milliseconds 300
   $remaining = @()
-  foreach ($name in $ProcessNames) {
-    try { $remaining += @(Get-Process -Name $name -ErrorAction SilentlyContinue) } catch {}
+  if ($ProcessIds -and $ProcessIds.Count -gt 0) {
+    foreach ($id in @($ProcessIds | Sort-Object -Unique)) {
+      try {
+        $proc = Get-Process -Id $id -ErrorAction SilentlyContinue
+        if ($proc) { $remaining += @($proc) }
+      } catch {}
+    }
+  } else {
+    foreach ($name in $ProcessNames) {
+      try { $remaining += @(Get-Process -Name $name -ErrorAction SilentlyContinue) } catch {}
+    }
   }
   if ($exitCode -eq 0 -and $remaining.Count -eq 0) {
     Write-Log ("Force close succeeded for {0}." -f ($ProcessNames -join ','))
@@ -141,7 +437,16 @@ function Invoke-CloseLabVIEW {
   if ($Metadata) {
     if ($Metadata.ContainsKey('version') -and $Metadata.version) { $params.MinimumSupportedLVVersion = $Metadata.version }
     if ($Metadata.ContainsKey('bitness') -and $Metadata.bitness) { $params.SupportedBitness = $Metadata.bitness }
+    foreach ($key in @('labviewExe','labviewPath')) {
+      if ($Metadata.ContainsKey($key) -and $Metadata[$key]) {
+        $params.LabVIEWExePath = $Metadata[$key]
+        break
+      }
+    }
   }
+  $params.TimeoutSeconds = Resolve-LabVIEWCloseTimeoutSeconds
+  $targetProcessIds = @(Resolve-LabVIEWTargetProcessIds -Metadata $Metadata)
+  $expectedLabVIEWPath = Resolve-LabVIEWExpectedPath -Metadata $Metadata
   $markerPath = Join-Path $logDir 'once-close-labview.marker'
   if (Test-Path -LiteralPath $markerPath) {
     Write-Log 'Close-LabVIEW already executed; skipping duplicate.'
@@ -162,23 +467,24 @@ function Invoke-CloseLabVIEW {
       Write-Warning ("Close-LabVIEW.ps1 exited with code {0} (attempt {1}/{2})." -f $exitCode,$attempt,$maxAttempts)
     }
     Start-Sleep -Milliseconds 300
-    $stillRunning = @()
-    try { $stillRunning = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue) } catch {}
-    if ($exitCode -eq 0 -and $stillRunning.Count -eq 0) {
+    $probeByName = ($targetProcessIds.Count -eq 0)
+    $stillRunning = @(Get-LabVIEWProcessesByScope -ProcessIds $targetProcessIds -UseNameFallback:$probeByName -ExpectedPath $expectedLabVIEWPath)
+    if ($stillRunning.Count -eq 0) {
+      if ($exitCode -ne 0) {
+        Write-Log ("Close-LabVIEW returned non-zero but no targeted LabVIEW process remained (attempt {0}/{1})." -f $attempt, $maxAttempts)
+      }
       $executed = Invoke-Once -Key 'close-labview' -Action { } -ScopeDirectory $logDir
       if ($executed) { Write-Log "Close-LabVIEW executed successfully." }
       return
     }
-    if ($stillRunning.Count -gt 0) {
-      Write-Warning ("Close-LabVIEW.ps1 completed but LabVIEW.exe still running (PID(s): {0})" -f ($stillRunning.Id -join ','))
+    Write-Warning ("Close-LabVIEW.ps1 completed but targeted LabVIEW.exe still running (PID(s): {0})" -f ($stillRunning.Id -join ','))
+    if ($attempt -lt $maxAttempts) {
+      Write-Log ("Close-LabVIEW retry scheduled ({0}/{1})." -f ($attempt + 1), $maxAttempts)
+      Start-Sleep -Seconds 1
     }
-  if ($attempt -lt $maxAttempts) {
-    Write-Log ("Close-LabVIEW retry scheduled ({0}/{1})." -f ($attempt + 1), $maxAttempts)
-    Start-Sleep -Seconds 1
   }
-}
   Write-Log "Close-LabVIEW helper retries exhausted; invoking force-close fallback."
-  if (Invoke-ForceCloseProcesses -ProcessNames @('LabVIEW') -Label 'LabVIEW') {
+  if (Invoke-ForceCloseProcesses -ProcessNames @('LabVIEW') -ProcessIds @($stillRunning | Select-Object -ExpandProperty Id) -Label 'LabVIEW') {
     $executed = Invoke-Once -Key 'close-labview' -Action { } -ScopeDirectory $logDir
     if ($executed) { Write-Log "Close-LabVIEW force-close executed successfully." }
     return
@@ -299,4 +605,3 @@ if ($postSnapshot -and $postSnapshot.groups) {
 }
 
 Write-Host 'Post-Run-Cleanup completed.' -ForegroundColor DarkGray
-


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1322
- Issue title: [bug]: Fix LabVIEW CLI cleanup timeout during full Pester sweep
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1322
- Standing priority at PR creation: Yes (#1322)
- Base branch: `develop`
- Head branch: `issue/origin-1322-labview-cli-close-timeout`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
