### PR TITLE
Update for standing priority #1324

### DIFF
--- a/.github/workflows/pester-diagnostics-nightly.yml
+++ b/.github/workflows/pester-diagnostics-nightly.yml
@@ -57,4 +57,3 @@ jobs:
               "- Duration (s): $($data.duration_s)")
             $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           }
-

--- a/.github/workflows/pester-reusable.yml
+++ b/.github/workflows/pester-reusable.yml
@@ -436,6 +436,7 @@ jobs:
           if ($exitCode -ne 0) {
             Write-Host "::error::Pester dispatcher exited with code $exitCode"
           }
+          $global:LASTEXITCODE = 0
 
       - name: Summarize dispatcher log (failure)
         if: ${{ steps.dispatcher.outputs.exit_code != '0' }}
@@ -761,4 +762,3 @@ jobs:
         if: always()
         shell: pwsh
         run: pwsh -File tools/Print-AgentHandoff.ps1 -AutoTrim
-

--- a/tools/priority/__tests__/pester-diagnostics-nightly-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-diagnostics-nightly-workflow-contract.test.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('pester diagnostics nightly keeps synthetic-failure diagnostics in notice-only mode', () => {
+  const workflow = readRepoFile('.github/workflows/pester-diagnostics-nightly.yml');
+
+  assert.match(workflow, /name:\s+Pester diagnostics nightly/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /sample_id:/);
+  assert.match(workflow, /jobs:\s*\n\s*diagnostics:\s*\n\s*uses:\s+\.\s*\/\.github\/workflows\/pester-reusable\.yml/);
+  assert.match(workflow, /diagnostic_fail:\s+\$\{\{\s*'true'\s*\}\}/);
+  assert.match(workflow, /continue_on_error:\s+\$\{\{\s*'true'\s*\}\}/);
+  assert.match(workflow, /verify:\s*\n\s*needs:\s+diagnostics\s*\n\s*if:\s+always\(\)/);
+  assert.match(workflow, /Download Pester artifacts/);
+  assert.match(workflow, /continue-on-error:\s+true/);
+  assert.match(workflow, /Verify failure JSON emitted \(notice-only\)/);
+  assert.match(workflow, /Nightly Diagnostics \(Synthetic Failure\)/);
+});
+
+test('pester reusable honors continue_on_error at the job boundary', () => {
+  const workflow = readRepoFile('.github/workflows/pester-reusable.yml');
+
+  assert.match(workflow, /continue_on_error:/);
+  assert.doesNotMatch(workflow, /pester:\s*\n(?:[^\n]*\n){0,6}\s{4}continue-on-error:/);
+  assert.match(workflow, /"exit_code=\$exitCode"/);
+  assert.match(workflow, /\$global:LASTEXITCODE = 0/);
+  assert.match(workflow, /Propagate dispatcher failure/);
+  assert.match(workflow, /inputs\.continue_on_error != 'true'/);
+});


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1324
- Issue title: [bug]: Keep Pester diagnostics nightly green in notice-only mode
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1324
- Standing priority at PR creation: Yes (#1324)
- Base branch: `develop`
- Head branch: `issue/origin-1324-pester-diagnostics-nightly-notice-only`
- Template variant: `workflow-policy`
- Auto-close intent: `Closes #1324`

# Summary

Keep the nightly synthetic-failure workflow in notice-only mode by neutralizing the dispatcher step's native non-zero exit after it writes `exit_code`, then rely on the existing explicit `Propagate dispatcher failure` gate for blocking behavior. This preserves the diagnostics artifacts and summary surface for the nightly workflow while keeping unrelated failures blocking.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
  - `.github/workflows/pester-diagnostics-nightly.yml`
  - `.github/workflows/pester-reusable.yml`
  - `tools/priority/__tests__/pester-diagnostics-nightly-workflow-contract.test.mjs`
- Check names, required-status contracts, or merge-queue behavior affected:
  - affects `Pester diagnostics nightly` only
  - no required-status contract changes
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
  - none
- Manual dispatch, comment command, or branch-protection effects:
  - manual/scheduled nightly runs keep the synthetic diagnostics surface without forcing the workflow red from the dispatcher step alone

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/pester-diagnostics-nightly-workflow-contract.test.mjs`
  - `bash -lc 'cd /mnt/c/dev/compare-vi-cli-action/compare-vi-cli-action.pester-diagnostics-nightly-1324 && ./bin/actionlint .github/workflows/pester-diagnostics-nightly.yml .github/workflows/pester-reusable.yml'`
  - `git diff --check`
  - `node tools/priority/copilot-cli-review.mjs --profile pre-commit --receipt-path tests/results/_agent/reviews/pester-diagnostics-nightly-notice-only-1324-bounded-receipt.json`
- Contract, schema, or guard tests:
  - `tools/priority/__tests__/pester-diagnostics-nightly-workflow-contract.test.mjs`
- Live workflow or dry-run evidence:
  - upstream repro run stayed red on current `develop`: `https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/23135286817`
  - milestone hygiene control check passed after `#1322` closure: `https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/actions/runs/23135286723`
  - Copilot receipt: `tests/results/_agent/reviews/pester-diagnostics-nightly-notice-only-1324-bounded-receipt.json`

## Rollout and Rollback

- Rollout notes:
  - no policy flip required; merge and rerun `Pester diagnostics nightly`
- Rollback path:
  - revert the dispatcher exit normalization and workflow contract test together
- Residual risks:
  - if a later step after dispatcher execution is genuinely failing, the nightly run can still remain red; this patch only removes the synthetic dispatcher exit as an accidental blocker

## Reviewer Focus

- Please verify:
  - the dispatcher step should always export `exit_code` and leave blocking ownership to `Propagate dispatcher failure`
  - the new workflow test is narrow enough to protect the contract without overfitting whitespace
- Policy assumptions to double-check:
  - nightly synthetic-failure runs are intended to be notice-only, not red by default
- Follow-up issues or guardrails:
  - none beyond `#1324`
