### PR TITLE
Unblock actions/setup-node@6 dependabot workflow contracts (#1327)

### DIFF
--- a/.github/workflows/agent-review-policy.yml
+++ b/.github/workflows/agent-review-policy.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         repository: ${{ github.repository }}
         ref: ${{ github.event.pull_request.base.sha || github.sha }}
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -219,7 +219,7 @@ jobs:
         name: comparevi-cli-${{ runner.os }}
         path: dist/comparevi-cli/**/*
     - name: Setup Node with cache
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: "20"
         cache: "npm"
@@ -819,7 +819,7 @@ jobs:
 
     - name: Setup Node.js (derive env)
       if: always()
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -1293,5 +1293,3 @@ jobs:
       if: ${{ always() }}
       shell: pwsh
       run: pwsh -File tools/Write-RerunHint.ps1 -Workflow 'ci-orchestrated.yml' -IncludeIntegration '${{ inputs.include_integration || 'true' }}' -SampleId '${{ inputs.sample_id || '' }}'
-
-

--- a/.github/workflows/commit-integrity-drift-monitor.yml
+++ b/.github/workflows/commit-integrity-drift-monitor.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -42,4 +42,3 @@ jobs:
           name: commit-integrity-drift-${{ github.run_id }}-${{ github.run_attempt }}
           path: tests/results/_agent/commit-integrity/commit-integrity-drift-report.json
           if-no-files-found: error
-

--- a/.github/workflows/commit-integrity.yml
+++ b/.github/workflows/commit-integrity.yml
@@ -36,7 +36,7 @@ jobs:
         repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -100,4 +100,3 @@ jobs:
           tests/results/_agent/commit-integrity/commit-integrity-report.json
           tests/results/_agent/commit-integrity/commit-integrity-bypass-ledger.json
         if-no-files-found: error
-

--- a/.github/workflows/downstream-onboarding-feedback.yml
+++ b/.github/workflows/downstream-onboarding-feedback.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/human-go-no-go-feedback.yml
+++ b/.github/workflows/human-go-no-go-feedback.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/issue-snapshot.yml
+++ b/.github/workflows/issue-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Sync standing-priority snapshot
@@ -31,4 +31,3 @@ jobs:
           path: |
             tests/results/_agent/issue/*.json
             tests/results/_agent/issue/*.digest
-

--- a/.github/workflows/policy-guard-upstream.yml
+++ b/.github/workflows/policy-guard-upstream.yml
@@ -51,7 +51,7 @@ jobs:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login == github.repository_owner && github.event.pull_request.head.sha || github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
         fetch-depth: 0
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 

--- a/.github/workflows/policy-sync.yml
+++ b/.github/workflows/policy-sync.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -56,4 +56,3 @@ jobs:
             tests/results/_agent/policy/policy-drift-report.json
             tests/results/_agent/health/policy-sync-workspace-health.json
           if-no-files-found: error
-

--- a/.github/workflows/public-linux-diagnostics-harness.yml
+++ b/.github/workflows/public-linux-diagnostics-harness.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/queue-supervisor.yml
+++ b/.github/workflows/queue-supervisor.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -153,4 +153,3 @@ jobs:
             tests/results/_agent/slo/ops-governor-state.json
             tests/results/_agent/slo/remediation-slo-report.json
           if-no-files-found: error
-

--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -136,4 +136,3 @@ jobs:
             tests/results/_agent/release/release-conductor-report.json
             tests/results/_agent/policy/policy-state-snapshot.json
           if-no-files-found: error
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Node 20
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -763,4 +763,3 @@ jobs:
             tests/results/_agent/release/comparevi-tools-artifact.json
             tests/results/_agent/release/shared-source-resolution.json
           if-no-files-found: error
-

--- a/.github/workflows/runtime-harness-package-rehearsal.yml
+++ b/.github/workflows/runtime-harness-package-rehearsal.yml
@@ -39,7 +39,7 @@ jobs:
           pwsh -NoLogo -NoProfile -File tools/Assert-PromotionContractAlignment.ps1 -OutputJsonPath tests/results/promotion-contract/runtime-harness-package-alignment.json -StepSummaryPath $env:GITHUB_STEP_SUMMARY
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -190,4 +190,3 @@ jobs:
             tests/results/_agent/slo/runtime-harness-package-rehearsal-slo-metrics.json
             tests/results/_agent/release/runtime-harness-package/tarballs/*.tgz
           if-no-files-found: error
-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,7 +113,7 @@ jobs:
       run: |
         pwsh -NoLogo -NoProfile -File tools/Check-WorkflowDrift.ps1 -FailOnDrift
     - name: Setup Node with cache
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'
@@ -624,7 +624,7 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -701,7 +701,7 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
     - name: Install dependencies (no scripts)
@@ -731,7 +731,7 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
     - name: Install dependencies (no scripts)
@@ -764,7 +764,7 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
     - name: Install dependencies (no scripts)
@@ -796,7 +796,7 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
     - name: Sync standing-priority snapshot
@@ -1122,7 +1122,7 @@ jobs:
         phase: J2
         results-dir: tests/results
     - name: Setup Node 20
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -1442,4 +1442,3 @@ jobs:
           tests/results/local-parity/linux/runtime-manager-preflight-linux.json
           tests/results/local-parity/linux/runtime-manager-compare-linux.json
         if-no-files-found: warn
-

--- a/.github/workflows/validation-approval-helper.yml
+++ b/.github/workflows/validation-approval-helper.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -162,4 +162,3 @@ jobs:
             tests/results/_agent/approvals/validation-approval-decision.json
             tests/results/_agent/approvals/validation-approval-helper.json
           if-no-files-found: error
-

--- a/.github/workflows/weekly-scorecard.yml
+++ b/.github/workflows/weekly-scorecard.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -205,4 +205,3 @@ jobs:
           name: weekly-scorecard-canary-${{ github.run_id }}
           path: tests/results/_agent/canary/*.json
           if-no-files-found: warn
-

--- a/.github/workflows/windows-hosted-parity.yml
+++ b/.github/workflows/windows-hosted-parity.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -61,4 +61,3 @@ jobs:
         name: windows-hosted-parity
         path: tests/results/windows-hosted-parity/**
         if-no-files-found: warn
-

--- a/tools/priority/__tests__/agent-review-policy-contract.test.mjs
+++ b/tools/priority/__tests__/agent-review-policy-contract.test.mjs
@@ -25,7 +25,7 @@ test('agent-review-policy validates local-only review promotion state from pull_
   assert.doesNotMatch(workflow, /checkout-workflow-context/);
   assert.doesNotMatch(workflow, /repository:\s+\$\{\{\s*github\.event\.pull_request\.head\.repo\.full_name\s*\}\}/);
   assert.doesNotMatch(workflow, /ref:\s+\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/);
-  assert.match(workflow, /actions\/setup-node@v5/);
+  assert.match(workflow, /actions\/setup-node@v6/);
   assert.match(workflow, /name: Install Node dependencies\s+if: github\.event_name == 'pull_request_target'\s+run: npm ci --ignore-scripts/);
   assert.match(workflow, /name: Build TypeScript utilities\s+if: github\.event_name == 'pull_request_target'\s+run: node tools\/npm\/run-script\.mjs build/);
   assert.doesNotMatch(workflow, /Collect Copilot review signal/);

--- a/tools/priority/__tests__/runtime-harness-package-rehearsal-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/runtime-harness-package-rehearsal-workflow-contract.test.mjs
@@ -19,7 +19,7 @@ test('runtime-harness package rehearsal stays hosted-only and uses checked-in he
   assert.equal(job?.['runs-on'], 'ubuntu-latest');
   assert.ok(workflow?.on?.workflow_dispatch, 'workflow should be dispatchable');
   assert.ok(steps.some((step) => step?.uses === 'actions/checkout@v5'));
-  assert.ok(steps.some((step) => step?.uses === 'actions/setup-node@v5'));
+  assert.ok(steps.some((step) => step?.uses === 'actions/setup-node@v6'));
 
   const resolveStep = steps.find((step) => step?.name === 'Resolve runtime-harness publish context');
   const stageStep = steps.find((step) => step?.name === 'Stage runtime-harness package candidate');

--- a/tools/priority/__tests__/workflow-enclave-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-enclave-contract.test.mjs
@@ -120,7 +120,7 @@ test('workflow updater normalizes checkout insertion and docs-only expressions c
   assert.match(updater, /True in doc/);
   assert.match(updater, /def _find_step_uses_index/);
   assert.doesNotMatch(updater, /_find_step_index\(steps, 'actions\/checkout@v5'\)/);
-  assert.match(updater, /actions\/setup-node@v5/);
+  assert.match(updater, /actions\/setup-node@v6/);
   assert.doesNotMatch(updater, /actions\/setup-node@v4/);
   assert.match(updater, /::error::Failed to process/);
   assert.match(updater, /if failed_files:\s+return 4/);

--- a/tools/workflows/_update_workflows_impl.py
+++ b/tools/workflows/_update_workflows_impl.py
@@ -826,7 +826,7 @@ def ensure_lint_resiliency(doc, job_name: str, include_node: bool = True, markdo
     if include_node:
         node_step = {
             'name': 'Setup Node with cache',
-            'uses': 'actions/setup-node@v5',
+            'uses': 'actions/setup-node@v6',
             'with': {
                 'node-version': DQS('20'),
                 'cache': DQS('npm'),
@@ -1443,4 +1443,3 @@ def main(argv: List[str]) -> int:
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))
-

--- a/tools/workflows/tests/test_workflow_enclave.py
+++ b/tools/workflows/tests/test_workflow_enclave.py
@@ -212,7 +212,7 @@ class WorkflowUpdaterRoundTripTests(unittest.TestCase):
         self.assertFalse(any(step.get('name') == 'Run markdownlint' for step in lint_steps if isinstance(step, dict)))
         setup_node_steps = [step for step in lint_steps if step.get('name') == 'Setup Node with cache']
         self.assertEqual(len(setup_node_steps), 1)
-        self.assertEqual(setup_node_steps[0].get('uses'), 'actions/setup-node@v5')
+        self.assertEqual(setup_node_steps[0].get('uses'), 'actions/setup-node@v6')
 
     def test_lint_resiliency_normalizes_existing_setup_node_major(self) -> None:
         doc = {
@@ -241,7 +241,7 @@ class WorkflowUpdaterRoundTripTests(unittest.TestCase):
 
         self.assertTrue(changed)
         setup_node_step = next(step for step in doc['jobs']['lint']['steps'] if step.get('name') == 'Setup Node with cache')
-        self.assertEqual(setup_node_step.get('uses'), 'actions/setup-node@v5')
+        self.assertEqual(setup_node_step.get('uses'), 'actions/setup-node@v6')
 
     def test_force_run_output_uses_standard_false_literal(self) -> None:
         doc = {


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1327
- Issue title: Unblock actions/setup-node@6 dependabot workflow contracts
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1327
- Standing priority at PR creation: Yes (#1327)
- Base branch: `develop`
- Head branch: `issue/origin-1327-setup-node6-contracts`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
