### PR TITLE
Dependabot policy guard: surface GH_TOKEN secret-scope guidance (#1329)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -472,7 +472,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   fail deterministically (for example in upstream policy guard workflows).
 - Policy guard workflows resolve token candidates with
   `tools/priority/Resolve-PolicyToken.ps1` and require an admin-capable token source. If policy guard fails with
-  `Authorization unavailable` or `authenticated-no-admin`, rotate `GH_TOKEN`/`GITHUB_TOKEN` secrets in upstream.
+  `Authorization unavailable` or `authenticated-no-admin`, rotate `GH_TOKEN`/`GITHUB_TOKEN` secrets in upstream. For
+  Dependabot-triggered runs, seed `GH_TOKEN` in Dependabot secret scope as well:
+  `gh secret set GH_TOKEN --repo <owner/repo> --app dependabot`.
 - Use `node tools/npm/run-script.mjs priority:policy:apply` only with admin token scope when you intentionally need to
   sync GitHub protections/rulesets back to `tools/priority/policy.json`.
 - Run `node tools/npm/run-script.mjs priority:commit-integrity -- --pr <number>` to evaluate commit trust posture

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -308,7 +308,10 @@ to confirm each workflow includes both triggers.
   gh api "repos/$repo" -H "Authorization: Bearer $token" --jq '.permissions.admin'
   $token | gh secret set GH_TOKEN --repo $repo
   $token | gh secret set GITHUB_TOKEN --repo $repo
+  $token | gh secret set GH_TOKEN --repo $repo --app dependabot
   ```
+  Dependabot-triggered workflow runs do not inherit the Actions secret scope automatically; keep the Dependabot
+  `GH_TOKEN` secret aligned with the upstream Actions secret when policy guard must run on Dependabot PRs.
 - **Release artifacts stale** – For release branches, rerun `priority:release` helpers or the finalize workflow to
   regenerate `tests/results/_agent/release/*` snapshots before broadcasting status updates.
 

--- a/tests/Resolve-PolicyToken.Tests.ps1
+++ b/tests/Resolve-PolicyToken.Tests.ps1
@@ -1,0 +1,95 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Resolve-PolicyToken.ps1' {
+  BeforeAll {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $scriptPath = Join-Path $repoRoot 'tools/priority/Resolve-PolicyToken.ps1'
+  }
+
+  It 'adds Dependabot remediation when admin-capable token resolution fails' {
+    function Invoke-RestMethod {
+      [PSCustomObject]@{
+        permissions = [PSCustomObject]@{
+          admin = $false
+        }
+      }
+    }
+
+    try {
+      $thrown = $null
+      try {
+        & $scriptPath `
+          -Repository 'LabVIEW-Community-CI-CD/compare-vi-cli-action' `
+          -PrimaryToken '' `
+          -SecondaryToken 'read-only-token' `
+          -TertiaryToken 'read-only-token' `
+          -Actor 'dependabot[bot]' `
+          -StepSummaryPath ''
+      } catch {
+        $thrown = $_.Exception
+      }
+
+      $thrown | Should -Not -BeNullOrEmpty
+      $thrown.Message | Should -Match 'No admin-capable token resolved'
+      $thrown.Message | Should -Match 'Dependabot-triggered runs use a separate secret scope'
+      $thrown.Message | Should -Match 'gh secret set GH_TOKEN --repo LabVIEW-Community-CI-CD/compare-vi-cli-action --app dependabot'
+    } finally {
+      Remove-Item Function:\Invoke-RestMethod -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'exports the selected token to GITHUB_ENV when an admin-capable token is available' {
+    function Invoke-RestMethod {
+      [PSCustomObject]@{
+        permissions = [PSCustomObject]@{
+          admin = $true
+        }
+      }
+    }
+
+    $envPath = Join-Path $TestDrive 'github.env'
+    $summaryPath = Join-Path $TestDrive 'summary.md'
+    $previousGitHubEnv = $env:GITHUB_ENV
+    $hadGitHubEnv = Test-Path Env:\GITHUB_ENV
+    $previousRunnerTemp = $env:RUNNER_TEMP
+    $hadRunnerTemp = Test-Path Env:\RUNNER_TEMP
+    $env:GITHUB_ENV = $envPath
+    $env:RUNNER_TEMP = $TestDrive
+
+    try {
+      & $scriptPath `
+        -Repository 'LabVIEW-Community-CI-CD/compare-vi-cli-action' `
+        -PrimaryToken 'admin-token' `
+        -SecondaryToken '' `
+        -TertiaryToken '' `
+        -TokenFileName 'policy-guard-gh-token.txt' `
+        -Actor 'github-actions[bot]' `
+        -StepSummaryPath $summaryPath
+
+      $envLines = Get-Content -LiteralPath $envPath
+      $envLines | Should -Contain 'GH_TOKEN=admin-token'
+      $envLines | Should -Contain 'POLICY_TOKEN_SOURCE=secrets.GH_TOKEN'
+      $envLines | Should -Contain 'POLICY_TOKEN_REPOSITORY=LabVIEW-Community-CI-CD/compare-vi-cli-action'
+
+      $tokenFile = Join-Path $TestDrive 'policy-guard-gh-token.txt'
+      (Get-Content -LiteralPath $tokenFile -Raw) | Should -Be 'admin-token'
+      (Get-Content -LiteralPath $summaryPath -Raw) | Should -Match 'Selected source: secrets.GH_TOKEN'
+    } finally {
+      if ($hadGitHubEnv) {
+        $env:GITHUB_ENV = $previousGitHubEnv
+      } else {
+        Remove-Item Env:\GITHUB_ENV -ErrorAction SilentlyContinue
+      }
+      if ($hadRunnerTemp) {
+        $env:RUNNER_TEMP = $previousRunnerTemp
+      } else {
+        Remove-Item Env:\RUNNER_TEMP -ErrorAction SilentlyContinue
+      }
+      Remove-Item Function:\Invoke-RestMethod -ErrorAction SilentlyContinue
+    }
+  }
+}

--- a/tools/priority/Resolve-PolicyToken.ps1
+++ b/tools/priority/Resolve-PolicyToken.ps1
@@ -6,6 +6,7 @@ param(
   [string]$TertiaryToken = $env:INPUT_TOKEN_TERTIARY,
   [string]$TokenFileName = 'policy-gh-token.txt',
   [bool]$RequireAdmin = $true,
+  [string]$Actor = $env:GITHUB_ACTOR,
   [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
 )
 
@@ -108,6 +109,21 @@ function Invoke-RepositoryProbe {
   }
 }
 
+function Test-IsDependabotActor {
+  param(
+    [string]$Value
+  )
+
+  $normalized = if ($Value) { $Value.Trim().ToLowerInvariant() } else { '' }
+  if ([string]::IsNullOrWhiteSpace($normalized)) {
+    return $false
+  }
+
+  return $normalized -eq 'dependabot[bot]' -or
+    $normalized -eq 'app/dependabot' -or
+    $normalized.Contains('dependabot')
+}
+
 $candidateList = [System.Collections.Generic.List[object]]::new()
 $candidateByToken = @{}
 
@@ -158,6 +174,9 @@ if (-not $selected) {
     'No admin-capable token resolved. Rotate/update secrets.GH_TOKEN (preferred) or secrets.GITHUB_TOKEN with repository administration access.'
   } else {
     'No authenticated token resolved.'
+  }
+  if ($RequireAdmin -and (Test-IsDependabotActor -Value $Actor)) {
+    $guidance += " Dependabot-triggered runs use a separate secret scope; seed GH_TOKEN there with: gh secret set GH_TOKEN --repo $Repository --app dependabot"
   }
   throw "$guidance Candidates: $resultText"
 }


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1329
- Issue title: Dependabot policy guard: surface GH_TOKEN secret-scope guidance
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1329
- Standing priority at PR creation: Yes (#1329)
- Base branch: `develop`
- Head branch: `issue/origin-1329-dependabot-policy-token-scope`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
