### PR TITLE
Add warm local runtime recovery and benchmark selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,18 @@ pwsh -NoLogo -NoProfile -File tools/Invoke-VIHistoryLocalRefinement.ps1 `
   -HistoryTargetPath fixtures/vi-attr/Head.vi
 ```
 
+When a warm runtime is already present, `warm-dev` now gates reuse on a fresh
+heartbeat. If the existing container is stale, stopped, or running the wrong
+image, the manager deterministically replaces it instead of blindly reusing it.
+You can force that recovery check without starting a review turn:
+
+```powershell
+node tools/npm/run-script.mjs history:local:warm-runtime:reconcile -- `
+  -RepoRoot . `
+  -ResultsRoot tests/results/local-vi-history/warm-dev `
+  -RuntimeDir tests/results/local-vi-history/runtime/warm-dev
+```
+
 The local refinement facade writes:
 
 - `local-refinement.json` (`schema: comparevi/local-refinement@v1`)
@@ -316,9 +328,16 @@ The local refinement facade writes:
 
 The warm runtime manager writes:
 
+- `local-runtime-lease.json` (`schema: comparevi/local-runtime-lease@v1`)
 - `local-runtime-state.json` (`schema: comparevi/local-runtime-state@v1`)
 - `local-runtime-health.json` (`schema: comparevi/local-runtime-health@v1`)
 - `local-runtime-heartbeat.json`
+
+Benchmark receipts now select the intended sample classes:
+
+- `proof-cold`
+- `dev-fast-cold`
+- `warm-dev-repeat`
 
 These receipts are intentionally local-first. They allow `comparevi-history`
 and downstream consumers to reuse the same runtime planes without changing the

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -216,6 +216,7 @@
         "docs/schemas/comparevi-local-refinement-v1.schema.json",
         "docs/schemas/comparevi-local-refinement-benchmark-v1.schema.json",
         "docs/schemas/comparevi-local-runtime-health-v1.schema.json",
+        "docs/schemas/comparevi-local-runtime-lease-v1.schema.json",
         "docs/schemas/comparevi-local-runtime-state-v1.schema.json",
         "docs/schemas/labview-2026-host-plane-report-v1.schema.json",
         "tests/VIHistoryLocalAcceleration.Tests.ps1",

--- a/docs/schemas/comparevi-local-refinement-benchmark-v1.schema.json
+++ b/docs/schemas/comparevi-local-refinement-benchmark-v1.schema.json
@@ -8,6 +8,7 @@
     "schema",
     "generatedAt",
     "latest",
+    "selectedSamples",
     "comparisons"
   ],
   "properties": {

--- a/docs/schemas/comparevi-local-refinement-v1.schema.json
+++ b/docs/schemas/comparevi-local-refinement-v1.schema.json
@@ -12,6 +12,7 @@
     "toolSource",
     "cacheReuseState",
     "coldWarmClass",
+    "benchmarkSampleKind",
     "repoRoot",
     "resultsRoot",
     "timings",
@@ -42,6 +43,10 @@
     },
     "coldWarmClass": {
       "enum": ["cold", "warm"]
+    },
+    "benchmarkSampleKind": {
+      "type": "string",
+      "minLength": 1
     },
     "repoRoot": {
       "type": "string",

--- a/docs/schemas/comparevi-local-runtime-lease-v1.schema.json
+++ b/docs/schemas/comparevi-local-runtime-lease-v1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/comparevi-local-runtime-lease-v1.schema.json",
+  "title": "CompareVI Local Runtime Lease",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "generatedAt",
+    "acquiredAt",
+    "owner",
+    "scopeKey",
+    "lock",
+    "runtime",
+    "artifacts"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi/local-runtime-lease@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "acquiredAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scopeKey": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "history:local:refine": "pwsh -NoLogo -NoProfile -File tools/Invoke-VIHistoryLocalRefinement.ps1 -Profile dev-fast",
     "history:local:warm-runtime": "pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action start",
     "history:local:warm-runtime:logs": "pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action logs",
+    "history:local:warm-runtime:reconcile": "pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action reconcile",
     "history:local:warm-runtime:status": "pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action status",
     "history:local:warm-runtime:stop": "pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action stop",
     "history:run": "pwsh -NoLogo -NoProfile -File scripts/Run-VIHistory.ps1",

--- a/tests/VIHistoryLocalAcceleration.Tests.ps1
+++ b/tests/VIHistoryLocalAcceleration.Tests.ps1
@@ -162,7 +162,12 @@ if ($scriptArgs[0] -eq 'run') {
       }
     }
   }
-  $image = [string]$scriptArgs[$scriptArgs.Count - 3]
+  $bashIndex = [Array]::IndexOf($scriptArgs, 'bash')
+  if ($bashIndex -gt 0) {
+    $image = [string]$scriptArgs[$bashIndex - 1]
+  } else {
+    $image = [string]$scriptArgs[$scriptArgs.Count - 3]
+  }
   $heartbeatContainerPath = [string]$envPairs['COMPAREVI_HEARTBEAT_PATH']
   if (-not [string]::IsNullOrWhiteSpace($heartbeatContainerPath)) {
     $heartbeatHostPath = Resolve-HostPathFromContainerPath -ContainerPath $heartbeatContainerPath -VolumeMap $volumeMap
@@ -307,11 +312,15 @@ if (-not [string]::IsNullOrWhiteSpace($logPath)) {
     image = $Image
   } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $logPath -Encoding utf8
 }
+$outcome = [Environment]::GetEnvironmentVariable('LOCAL_WARM_MANAGER_OUTCOME')
+if ([string]::IsNullOrWhiteSpace($outcome)) {
+  $outcome = 'reused'
+}
 $payload = [ordered]@{
   schema = 'comparevi/local-runtime-state@v1'
   generatedAt = (Get-Date).ToUniversalTime().ToString('o')
   action = $Action
-  outcome = 'reused'
+  outcome = $outcome
   container = [ordered]@{
     name = 'warm-stub'
     image = $Image
@@ -356,7 +365,7 @@ $payload | ConvertTo-Json -Depth 10
     ($buildRecord[0].args -join ' ') | Should -Match 'BASE_IMAGE=nationalinstruments/labview:2026q1-linux'
   }
 
-  It 'Manage-VIHistoryRuntimeInDocker writes deterministic state and health receipts' {
+  It 'Manage-VIHistoryRuntimeInDocker writes deterministic lease, state, and health receipts' {
     $work = Join-Path $TestDrive 'runtime-manager'
     New-Item -ItemType Directory -Path $work -Force | Out-Null
     $repoRoot = Join-Path $work 'repo'
@@ -380,6 +389,7 @@ $payload | ConvertTo-Json -Depth 10
       $startState = ($startJson -join "`n") | ConvertFrom-Json -Depth 20
       $startState.schema | Should -Be 'comparevi/local-runtime-state@v1'
       $startState.outcome | Should -Be 'started'
+      $startState.lease.schema | Should -Be 'comparevi/local-runtime-lease@v1'
 
       $healthJson = & $script:ManagerScript `
         -Action status `
@@ -397,9 +407,67 @@ $payload | ConvertTo-Json -Depth 10
     }
 
     $statePath = Join-Path $runtimeDir 'local-runtime-state.json'
+    $leasePath = Join-Path $runtimeDir 'local-runtime-lease.json'
     $healthPath = Join-Path $runtimeDir 'local-runtime-health.json'
     (Test-Path -LiteralPath $statePath -PathType Leaf) | Should -BeTrue
+    (Test-Path -LiteralPath $leasePath -PathType Leaf) | Should -BeTrue
     (Test-Path -LiteralPath $healthPath -PathType Leaf) | Should -BeTrue
+  }
+
+  It 'Manage-VIHistoryRuntimeInDocker reconciles stale heartbeat runtimes by replacing the container' {
+    $work = Join-Path $TestDrive 'runtime-manager-stale'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    $repoRoot = Join-Path $work 'repo'
+    $resultsRoot = Join-Path $repoRoot 'tests/results/local-vi-history/warm-dev'
+    $runtimeDir = Join-Path $repoRoot 'tests/results/local-vi-history/runtime/warm-dev'
+    New-Item -ItemType Directory -Path (Join-Path $repoRoot '.git') -Force | Out-Null
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $runtimeDir -Force | Out-Null
+    $dockerStub = New-DockerStub -Root $work
+    $dockerLog = Join-Path $work 'docker-log.jsonl'
+
+    try {
+      $env:DOCKER_STUB_IMAGE_EXISTS = '1'
+      $env:DOCKER_STUB_LOG = $dockerLog
+      & $script:ManagerScript `
+        -Action start `
+        -RepoRoot $repoRoot `
+        -ResultsRoot $resultsRoot `
+        -RuntimeDir $runtimeDir `
+        -Image 'comparevi-vi-history-dev:local' `
+        -DockerCommand $dockerStub.CommandPath | Out-Null
+      $LASTEXITCODE | Should -Be 0
+
+      $heartbeatPath = Join-Path $runtimeDir 'local-runtime-heartbeat.json'
+      $staleHeartbeat = [ordered]@{
+        schema = 'comparevi/local-runtime-heartbeat@v1'
+        generatedAt = (Get-Date).ToUniversalTime().AddMinutes(-10).ToString('o')
+        status = 'running'
+      }
+      $staleHeartbeat | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $heartbeatPath -Encoding utf8
+
+      $reconcileJson = & $script:ManagerScript `
+        -Action reconcile `
+        -RepoRoot $repoRoot `
+        -ResultsRoot $resultsRoot `
+        -RuntimeDir $runtimeDir `
+        -Image 'comparevi-vi-history-dev:local' `
+        -DockerCommand $dockerStub.CommandPath
+      $LASTEXITCODE | Should -Be 0
+    } finally {
+      Remove-Item Env:DOCKER_STUB_IMAGE_EXISTS -ErrorAction SilentlyContinue
+      Remove-Item Env:DOCKER_STUB_LOG -ErrorAction SilentlyContinue
+    }
+
+    $reconcileState = ($reconcileJson -join "`n") | ConvertFrom-Json -Depth 20
+    $reconcileState.outcome | Should -Be 'recovered-stale-runtime'
+    $reconcileState.recovery.attempted | Should -BeTrue
+    $reconcileState.recovery.previousHealth.reason | Should -Be 'heartbeat-stale'
+    $reconcileState.health.status | Should -Be 'healthy'
+
+    $records = Get-Content -LiteralPath $dockerLog | ForEach-Object { $_ | ConvertFrom-Json }
+    @($records | Where-Object { $_.args[0] -eq 'run' }).Count | Should -Be 2
+    @($records | Where-Object { $_.args[0] -eq 'rm' -and $_.args[1] -eq '-f' }).Count | Should -BeGreaterThan 0
   }
 
   It 'Invoke-VIHistoryLocalRefinement writes a dev-fast receipt and benchmark' {
@@ -441,6 +509,7 @@ $payload | ConvertTo-Json -Depth 10
     $receipt.schema | Should -Be 'comparevi/local-refinement@v1'
     $receipt.runtimeProfile | Should -Be 'dev-fast'
     $receipt.cacheReuseState | Should -Be 'built-local-image'
+    $receipt.benchmarkSampleKind | Should -Be 'dev-fast-cold'
     $receipt.finalStatus | Should -Be 'succeeded'
     $benchmark = Get-Content -LiteralPath $benchmarkPath -Raw | ConvertFrom-Json -Depth 20
     $benchmark.schema | Should -Be 'comparevi/local-refinement-benchmark@v1'
@@ -457,6 +526,7 @@ $payload | ConvertTo-Json -Depth 10
     $buildStub = Join-Path $work 'build-stub.ps1'
     $reviewStub = Join-Path $work 'review-stub.ps1'
     $warmManagerStub = Join-Path $work 'warm-manager-stub.ps1'
+    $warmManagerLog = Join-Path $work 'warm-manager.log'
     New-BuildStub -Path $buildStub
     New-ReviewSuiteStub -Path $reviewStub
     New-WarmManagerStub -Path $warmManagerStub
@@ -466,6 +536,7 @@ $payload | ConvertTo-Json -Depth 10
     try {
       $env:DOCKER_STUB_IMAGE_EXISTS = '1'
       $env:LOCAL_REVIEW_SUITE_STUB_LOG = $reviewLog
+      $env:LOCAL_WARM_MANAGER_STUB_LOG = $warmManagerLog
       $env:PATH = ("{0}{1}{2}" -f (Split-Path -Parent $dockerStub.CommandPath), [System.IO.Path]::PathSeparator, $originalPath)
 
       & $script:WrapperScript `
@@ -479,6 +550,7 @@ $payload | ConvertTo-Json -Depth 10
       $env:PATH = $originalPath
       Remove-Item Env:DOCKER_STUB_IMAGE_EXISTS -ErrorAction SilentlyContinue
       Remove-Item Env:LOCAL_REVIEW_SUITE_STUB_LOG -ErrorAction SilentlyContinue
+      Remove-Item Env:LOCAL_WARM_MANAGER_STUB_LOG -ErrorAction SilentlyContinue
     }
 
     $receiptPath = Join-Path $repoRoot 'tests/results/local-vi-history/warm-dev/local-refinement.json'
@@ -487,10 +559,73 @@ $payload | ConvertTo-Json -Depth 10
     $receipt.runtimeProfile | Should -Be 'warm-dev'
     $receipt.cacheReuseState | Should -Be 'warm-runtime-reused'
     $receipt.coldWarmClass | Should -Be 'warm'
+    $receipt.benchmarkSampleKind | Should -Be 'warm-dev-repeat'
 
     $reviewLogObject = Get-Content -LiteralPath $reviewLog -Raw | ConvertFrom-Json -Depth 10
     $reviewLogObject.reuseContainerName | Should -Be 'warm-stub'
     $reviewLogObject.reuseRepoContainerPath | Should -Be '/opt/comparevi/source'
+
+    $warmManagerLogObject = Get-Content -LiteralPath $warmManagerLog -Raw | ConvertFrom-Json -Depth 10
+    $warmManagerLogObject.action | Should -Be 'reconcile'
+  }
+
+  It 'Invoke-VIHistoryLocalRefinement benchmarks proof cold, dev-fast cold, and warm-dev repeat samples' {
+    $work = Join-Path $TestDrive 'local-refinement-benchmark-samples'
+    $repoRoot = Join-Path $work 'repo'
+    New-Item -ItemType Directory -Path $repoRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $repoRoot 'fixtures/vi-attr') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $repoRoot 'fixtures/vi-attr/Base.vi') -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $repoRoot 'fixtures/vi-attr/Head.vi') -Value 'head' -Encoding utf8
+    $dockerStub = New-DockerStub -Root $work
+    $buildStub = Join-Path $work 'build-stub.ps1'
+    $reviewStub = Join-Path $work 'review-stub.ps1'
+    $warmManagerStub = Join-Path $work 'warm-manager-stub.ps1'
+    New-BuildStub -Path $buildStub
+    New-ReviewSuiteStub -Path $reviewStub
+    New-WarmManagerStub -Path $warmManagerStub
+
+    $originalPath = $env:PATH
+    try {
+      $env:PATH = ("{0}{1}{2}" -f (Split-Path -Parent $dockerStub.CommandPath), [System.IO.Path]::PathSeparator, $originalPath)
+
+      & $script:WrapperScript `
+        -Profile 'proof' `
+        -RepoRoot $repoRoot `
+        -ReviewSuiteScriptPath $reviewStub
+      $LASTEXITCODE | Should -Be 0
+
+      $env:DOCKER_STUB_IMAGE_EXISTS = '0'
+      & $script:WrapperScript `
+        -Profile 'dev-fast' `
+        -RepoRoot $repoRoot `
+        -BuildImageScriptPath $buildStub `
+        -ReviewSuiteScriptPath $reviewStub
+      $LASTEXITCODE | Should -Be 0
+
+      $env:DOCKER_STUB_IMAGE_EXISTS = '1'
+      $env:LOCAL_WARM_MANAGER_OUTCOME = 'reused'
+      & $script:WrapperScript `
+        -Profile 'warm-dev' `
+        -RepoRoot $repoRoot `
+        -BuildImageScriptPath $buildStub `
+        -ReviewSuiteScriptPath $reviewStub `
+        -WarmRuntimeManagerScriptPath $warmManagerStub
+      $LASTEXITCODE | Should -Be 0
+    } finally {
+      $env:PATH = $originalPath
+      Remove-Item Env:DOCKER_STUB_IMAGE_EXISTS -ErrorAction SilentlyContinue
+      Remove-Item Env:LOCAL_WARM_MANAGER_OUTCOME -ErrorAction SilentlyContinue
+    }
+
+    $benchmarkPath = Join-Path $repoRoot 'tests/results/local-vi-history/warm-dev/local-refinement-benchmark.json'
+    $benchmark = Get-Content -LiteralPath $benchmarkPath -Raw | ConvertFrom-Json -Depth 20
+    $benchmark.selectedSamples.proofCold.benchmarkSampleKind | Should -Be 'proof-cold'
+    $benchmark.selectedSamples.devFastCold.benchmarkSampleKind | Should -Be 'dev-fast-cold'
+    $benchmark.selectedSamples.warmDevRepeat.benchmarkSampleKind | Should -Be 'warm-dev-repeat'
+    $benchmark.comparisons.devFastVsProof.left | Should -Be 'proof-cold'
+    $benchmark.comparisons.devFastVsProof.right | Should -Be 'dev-fast-cold'
+    $benchmark.comparisons.warmDevVsDevFast.left | Should -Be 'dev-fast-cold'
+    $benchmark.comparisons.warmDevVsDevFast.right | Should -Be 'warm-dev-repeat'
   }
 
   It 'Invoke-VIHistoryLocalRefinement derives the warm runtime directory from ResultsRoot' {

--- a/tools/Invoke-VIHistoryLocalRefinement.ps1
+++ b/tools/Invoke-VIHistoryLocalRefinement.ps1
@@ -116,6 +116,52 @@ function Read-JsonText {
   }
 }
 
+function Parse-UtcDateTime {
+  param([AllowEmptyString()][string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return $null
+  }
+
+  try {
+    return [datetime]::Parse(
+      $Value,
+      [System.Globalization.CultureInfo]::InvariantCulture,
+      [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    )
+  } catch {
+    return $null
+  }
+}
+
+function Get-BenchmarkSampleKind {
+  param(
+    [Parameter(Mandatory)][string]$RuntimeProfile,
+    [Parameter(Mandatory)][string]$ColdWarmClass,
+    [Parameter(Mandatory)][string]$CacheReuseState
+  )
+
+  switch ($RuntimeProfile) {
+    'proof' {
+      return 'proof-cold'
+    }
+    'dev-fast' {
+      if ($ColdWarmClass -eq 'cold') {
+        return 'dev-fast-cold'
+      }
+      return 'dev-fast-repeat'
+    }
+    'warm-dev' {
+      if ($CacheReuseState -eq 'warm-runtime-reused' -and $ColdWarmClass -eq 'warm') {
+        return 'warm-dev-repeat'
+      }
+      return 'warm-dev-cold-start'
+    }
+  }
+
+  return ('{0}-{1}' -f $RuntimeProfile, $ColdWarmClass)
+}
+
 $repoRootResolved = if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
   Resolve-AbsolutePath -Path '..' -BasePath $PSScriptRoot
 } else {
@@ -128,7 +174,10 @@ $resultsRootResolved = if ([string]::IsNullOrWhiteSpace($ResultsRoot)) {
 }
 New-Item -ItemType Directory -Path $resultsRootResolved -Force | Out-Null
 
-$buildImageScriptResolved = Resolve-ScriptPath -PathValue $BuildImageScriptPath -DefaultPath 'tools/Build-VIHistoryDevImage.ps1' -RepoRootResolved $repoRootResolved
+$buildImageScriptResolved = ''
+if ($Profile -ne 'proof') {
+  $buildImageScriptResolved = Resolve-ScriptPath -PathValue $BuildImageScriptPath -DefaultPath 'tools/Build-VIHistoryDevImage.ps1' -RepoRootResolved $repoRootResolved
+}
 $reviewSuiteScriptResolved = Resolve-ScriptPath -PathValue $ReviewSuiteScriptPath -DefaultPath 'tools/Invoke-NILinuxReviewSuite.ps1' -RepoRootResolved $repoRootResolved
 $warmRuntimeManagerScriptResolved = ''
 if ($Profile -eq 'warm-dev') {
@@ -183,7 +232,7 @@ if ($Profile -eq 'warm-dev') {
     -ResultsRootResolved $resultsRootResolved
   New-Item -ItemType Directory -Path $warmRuntimeDir -Force | Out-Null
   $warmRuntimeJson = & $warmRuntimeManagerScriptResolved `
-    -Action start `
+    -Action reconcile `
     -RepoRoot $repoRootResolved `
     -ResultsRoot $resultsRootResolved `
     -RuntimeDir $warmRuntimeDir `
@@ -195,12 +244,22 @@ if ($Profile -eq 'warm-dev') {
   if (-not $warmRuntimeState) {
     throw 'Warm runtime manager did not emit valid JSON state.'
   }
-  if ($warmRuntimeState.outcome -eq 'reused') {
-    $cacheReuseState = 'warm-runtime-reused'
-    $coldWarmClass = 'warm'
-  } else {
-    $cacheReuseState = 'warm-runtime-started'
-    $coldWarmClass = 'cold'
+  switch ([string]$warmRuntimeState.outcome) {
+    { $_ -in @('healthy', 'reused') } {
+      $cacheReuseState = 'warm-runtime-reused'
+      $coldWarmClass = 'warm'
+      break
+    }
+    'recovered-stale-runtime' {
+      $cacheReuseState = 'warm-runtime-recovered'
+      $coldWarmClass = 'cold'
+      break
+    }
+    default {
+      $cacheReuseState = 'warm-runtime-started'
+      $coldWarmClass = 'cold'
+      break
+    }
   }
 
   $reviewParams.ReuseContainerName = [string]$warmRuntimeState.container.name
@@ -245,6 +304,7 @@ $receipt = [ordered]@{
   toolSource = $toolSource
   cacheReuseState = $cacheReuseState
   coldWarmClass = $coldWarmClass
+  benchmarkSampleKind = Get-BenchmarkSampleKind -RuntimeProfile $Profile -ColdWarmClass $coldWarmClass -CacheReuseState $cacheReuseState
   repoRoot = $repoRootResolved
   resultsRoot = $resultsRootResolved
   timings = [ordered]@{
@@ -287,6 +347,7 @@ if (Test-Path -LiteralPath $benchmarkRoot -PathType Container) {
   $allReceipts = @(Get-ChildItem -Path $benchmarkRoot -Recurse -Filter 'local-refinement.json' -File -ErrorAction SilentlyContinue)
 }
 $latestByProfile = @{}
+$latestBySampleKind = @{}
 foreach ($candidate in $allReceipts) {
   try {
     $candidateReceipt = Get-Content -LiteralPath $candidate.FullName -Raw | ConvertFrom-Json -Depth 20 -ErrorAction Stop
@@ -300,14 +361,30 @@ foreach ($candidate in $allReceipts) {
   if ([string]::IsNullOrWhiteSpace($profileName)) {
     continue
   }
-  $currentGeneratedAt = [datetime]::Parse([string]$candidateReceipt.generatedAt, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
-  if (-not $latestByProfile.ContainsKey($profileName)) {
-    $latestByProfile[$profileName] = $candidateReceipt
+  $currentGeneratedAt = Parse-UtcDateTime -Value ([string]$candidateReceipt.generatedAt)
+  if (-not $currentGeneratedAt) {
     continue
   }
-  $previousGeneratedAt = [datetime]::Parse([string]$latestByProfile[$profileName].generatedAt, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
-  if ($currentGeneratedAt -gt $previousGeneratedAt) {
+  if (-not $latestByProfile.ContainsKey($profileName)) {
     $latestByProfile[$profileName] = $candidateReceipt
+  } else {
+    $previousGeneratedAt = Parse-UtcDateTime -Value ([string]$latestByProfile[$profileName].generatedAt)
+    if ($previousGeneratedAt -and $currentGeneratedAt -gt $previousGeneratedAt) {
+      $latestByProfile[$profileName] = $candidateReceipt
+    }
+  }
+
+  $sampleKind = [string]$candidateReceipt.benchmarkSampleKind
+  if ([string]::IsNullOrWhiteSpace($sampleKind)) {
+    continue
+  }
+  if (-not $latestBySampleKind.ContainsKey($sampleKind)) {
+    $latestBySampleKind[$sampleKind] = $candidateReceipt
+    continue
+  }
+  $previousSampleGeneratedAt = Parse-UtcDateTime -Value ([string]$latestBySampleKind[$sampleKind].generatedAt)
+  if ($previousSampleGeneratedAt -and $currentGeneratedAt -gt $previousSampleGeneratedAt) {
+    $latestBySampleKind[$sampleKind] = $candidateReceipt
   }
 }
 
@@ -345,9 +422,22 @@ $benchmarkPayload = [ordered]@{
     devFast = if ($latestByProfile.ContainsKey('dev-fast')) { $latestByProfile['dev-fast'] } else { $null }
     warmDev = if ($latestByProfile.ContainsKey('warm-dev')) { $latestByProfile['warm-dev'] } else { $null }
   }
+  selectedSamples = [ordered]@{
+    proofCold = if ($latestBySampleKind.ContainsKey('proof-cold')) { $latestBySampleKind['proof-cold'] } else { $null }
+    devFastCold = if ($latestBySampleKind.ContainsKey('dev-fast-cold')) { $latestBySampleKind['dev-fast-cold'] } else { $null }
+    warmDevRepeat = if ($latestBySampleKind.ContainsKey('warm-dev-repeat')) { $latestBySampleKind['warm-dev-repeat'] } else { $null }
+  }
   comparisons = [ordered]@{
-    devFastVsProof = New-BenchmarkComparison -Left $(if ($latestByProfile.ContainsKey('proof')) { $latestByProfile['proof'] } else { $null }) -Right $(if ($latestByProfile.ContainsKey('dev-fast')) { $latestByProfile['dev-fast'] } else { $null }) -LeftLabel 'proof' -RightLabel 'dev-fast'
-    warmDevVsDevFast = New-BenchmarkComparison -Left $(if ($latestByProfile.ContainsKey('dev-fast')) { $latestByProfile['dev-fast'] } else { $null }) -Right $(if ($latestByProfile.ContainsKey('warm-dev')) { $latestByProfile['warm-dev'] } else { $null }) -LeftLabel 'dev-fast' -RightLabel 'warm-dev'
+    devFastVsProof = New-BenchmarkComparison `
+      -Left $(if ($latestBySampleKind.ContainsKey('proof-cold')) { $latestBySampleKind['proof-cold'] } else { $null }) `
+      -Right $(if ($latestBySampleKind.ContainsKey('dev-fast-cold')) { $latestBySampleKind['dev-fast-cold'] } else { $null }) `
+      -LeftLabel 'proof-cold' `
+      -RightLabel 'dev-fast-cold'
+    warmDevVsDevFast = New-BenchmarkComparison `
+      -Left $(if ($latestBySampleKind.ContainsKey('dev-fast-cold')) { $latestBySampleKind['dev-fast-cold'] } else { $null }) `
+      -Right $(if ($latestBySampleKind.ContainsKey('warm-dev-repeat')) { $latestBySampleKind['warm-dev-repeat'] } else { $null }) `
+      -LeftLabel 'dev-fast-cold' `
+      -RightLabel 'warm-dev-repeat'
   }
 }
 $benchmarkPath = Join-Path $resultsRootResolved 'local-refinement-benchmark.json'

--- a/tools/Manage-VIHistoryRuntimeInDocker.ps1
+++ b/tools/Manage-VIHistoryRuntimeInDocker.ps1
@@ -22,8 +22,10 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $stateSchema = 'comparevi/local-runtime-state@v1'
+$leaseSchema = 'comparevi/local-runtime-lease@v1'
 $healthSchema = 'comparevi/local-runtime-health@v1'
 $logsSchema = 'comparevi/local-runtime-logs@v1'
+$heartbeatSchema = 'comparevi/local-runtime-heartbeat@v1'
 
 function Resolve-AbsolutePath {
   param(
@@ -129,6 +131,38 @@ function Get-OwnerStamp {
   $user = if (-not [string]::IsNullOrWhiteSpace($env:USERNAME)) { $env:USERNAME } else { 'unknown-user' }
   $hostName = if (-not [string]::IsNullOrWhiteSpace($env:COMPUTERNAME)) { $env:COMPUTERNAME } else { 'unknown-host' }
   return ('{0}@{1}' -f $user, $hostName)
+}
+
+function Parse-UtcDateTime {
+  param([AllowEmptyString()][string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return $null
+  }
+
+  try {
+    return [datetime]::Parse(
+      $Value,
+      [System.Globalization.CultureInfo]::InvariantCulture,
+      [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    )
+  } catch {
+    return $null
+  }
+}
+
+function Get-ScopeKey {
+  param([Parameter(Mandatory)][string]$Seed)
+
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($Seed)
+  $hasher = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $hash = ($hasher.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join ''
+  } finally {
+    $hasher.Dispose()
+  }
+
+  return $hash.Substring(0, 16)
 }
 
 function New-ContainerName {
@@ -245,6 +279,7 @@ function Get-Paths {
     resultsRoot = $ResultsRootResolved
     runtimeDir = $RuntimeDirResolved
     statePath = Join-Path $RuntimeDirResolved 'local-runtime-state.json'
+    leasePath = Join-Path $RuntimeDirResolved 'local-runtime-lease.json'
     healthPath = Join-Path $RuntimeDirResolved 'local-runtime-health.json'
     logsPath = Join-Path $RuntimeDirResolved 'local-runtime-logs.json'
     logsTextPath = Join-Path $RuntimeDirResolved 'local-runtime-logs.txt'
@@ -260,6 +295,141 @@ function Get-Paths {
   }
 }
 
+function Clear-HeartbeatArtifact {
+  param([Parameter(Mandatory)]$Paths)
+
+  if (Test-Path -LiteralPath $Paths.heartbeatPath -PathType Leaf) {
+    Remove-Item -LiteralPath $Paths.heartbeatPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Write-LeaseReceipt {
+  param(
+    [Parameter(Mandatory)]$Paths,
+    [Parameter(Mandatory)][string]$Owner,
+    [Parameter(Mandatory)][datetime]$AcquiredAtUtc
+  )
+
+  $payload = [ordered]@{
+    schema = $leaseSchema
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    acquiredAt = $AcquiredAtUtc.ToString('o')
+    owner = $Owner
+    scopeKey = Get-ScopeKey -Seed ('{0}|{1}|{2}' -f $Paths.repoRoot, $Paths.runtimeDir, $Paths.containerName)
+    lock = [ordered]@{
+      strategy = 'exclusive-file-lock'
+      path = $Paths.lockPath
+      processId = $PID
+    }
+    runtime = [ordered]@{
+      containerName = $Paths.containerName
+      image = $Paths.image
+      repositoryRoot = $Paths.repoRoot
+      resultsRoot = $Paths.resultsRoot
+      runtimeDir = $Paths.runtimeDir
+    }
+    artifacts = [ordered]@{
+      statePath = $Paths.statePath
+      healthPath = $Paths.healthPath
+      leasePath = $Paths.leasePath
+      heartbeatPath = $Paths.heartbeatPath
+    }
+  }
+
+  Write-JsonFile -Path $Paths.leasePath -Payload $payload
+  return $payload
+}
+
+function Get-HealthAssessment {
+  param(
+    [Parameter(Mandatory)]$Paths,
+    [AllowNull()]$Record
+  )
+
+  $heartbeat = Read-JsonFile -Path $Paths.heartbeatPath
+  $heartbeatGeneratedAt = $null
+  if ($heartbeat -and $heartbeat.PSObject.Properties['generatedAt']) {
+    $heartbeatGeneratedAt = Parse-UtcDateTime -Value ([string]$heartbeat.generatedAt)
+  }
+
+  $startedAtUtc = $null
+  $finishedAtUtc = $null
+  $containerAgeSeconds = $null
+  if ($Record) {
+    $startedAtUtc = Parse-UtcDateTime -Value ([string]$Record.startedAt)
+    $finishedAtUtc = Parse-UtcDateTime -Value ([string]$Record.finishedAt)
+    if ($startedAtUtc) {
+      $containerAgeSeconds = [int][math]::Floor(((Get-Date).ToUniversalTime() - $startedAtUtc).TotalSeconds)
+    }
+  }
+
+  $ageSeconds = if ($heartbeatGeneratedAt) {
+    [int][math]::Floor(((Get-Date).ToUniversalTime() - $heartbeatGeneratedAt).TotalSeconds)
+  } else {
+    $null
+  }
+
+  $status = 'missing'
+  $reason = 'container-not-found'
+  $recoveryRequired = $true
+  $reuseAllowed = $false
+  $imageMatches = $true
+
+  if ($Record) {
+    $imageMatches = [string]::Equals([string]$Record.image, $Paths.image, [System.StringComparison]::OrdinalIgnoreCase)
+    if (-not $imageMatches) {
+      $status = 'stale'
+      $reason = 'image-mismatch'
+    } elseif (-not $Record.running) {
+      $status = 'not-running'
+      $reason = if ([string]::IsNullOrWhiteSpace($Record.status)) { 'container-not-running' } else { [string]$Record.status }
+    } elseif ($heartbeatGeneratedAt -and $ageSeconds -le $HeartbeatFreshSeconds) {
+      $status = 'healthy'
+      $reason = 'heartbeat-fresh'
+      $recoveryRequired = $false
+      $reuseAllowed = $true
+    } elseif ($heartbeatGeneratedAt) {
+      $status = 'stale'
+      $reason = 'heartbeat-stale'
+    } elseif ($containerAgeSeconds -ne $null -and $containerAgeSeconds -le $HeartbeatFreshSeconds) {
+      $status = 'starting'
+      $reason = 'heartbeat-pending'
+      $recoveryRequired = $false
+      $reuseAllowed = $true
+    } else {
+      $status = 'stale'
+      $reason = 'heartbeat-missing'
+    }
+  }
+
+  return [ordered]@{
+    schema = $healthSchema
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    containerName = $Paths.containerName
+    image = $Paths.image
+    status = $status
+    reason = $reason
+    heartbeatFreshSeconds = $HeartbeatFreshSeconds
+    heartbeat = [ordered]@{
+      schema = $heartbeatSchema
+      path = $Paths.heartbeatPath
+      present = [bool]$heartbeat
+      generatedAt = if ($heartbeatGeneratedAt) { $heartbeatGeneratedAt.ToString('o') } else { $null }
+      ageSeconds = $ageSeconds
+    }
+    container = [ordered]@{
+      running = if ($Record) { [bool]$Record.running } else { $false }
+      status = if ($Record) { [string]$Record.status } else { '' }
+      startedAt = if ($startedAtUtc) { $startedAtUtc.ToString('o') } else { '' }
+      finishedAt = if ($finishedAtUtc) { $finishedAtUtc.ToString('o') } else { '' }
+      ageSeconds = $containerAgeSeconds
+      imageMatches = $imageMatches
+    }
+    recoveryRequired = $recoveryRequired
+    reuseAllowed = $reuseAllowed
+  }
+}
+
 function Start-LocalRuntimeContainer {
   param([Parameter(Mandatory)]$Paths)
 
@@ -272,6 +442,7 @@ function Start-LocalRuntimeContainer {
   if ($existingRecord) {
     Invoke-Docker -Arguments @('rm', '-f', $Paths.containerName) -IgnoreExitCode | Out-Null
   }
+  Clear-HeartbeatArtifact -Paths $Paths
 
   $heartbeatScript = New-HeartbeatCommand -HeartbeatPathContainer $Paths.heartbeatContainerPath
   $dockerArgs = [System.Collections.Generic.List[string]]::new()
@@ -341,6 +512,7 @@ function New-State {
     }
     artifacts = [ordered]@{
       statePath = $Paths.statePath
+      leasePath = $Paths.leasePath
       healthPath = $Paths.healthPath
       logsPath = $Paths.logsPath
       logsTextPath = $Paths.logsTextPath
@@ -355,55 +527,7 @@ function Write-Health {
     [AllowNull()]$Record
   )
 
-  $heartbeat = Read-JsonFile -Path $Paths.heartbeatPath
-  $heartbeatGeneratedAt = $null
-  if ($heartbeat -and $heartbeat.PSObject.Properties['generatedAt']) {
-    try {
-      $heartbeatGeneratedAt = [datetime]::Parse([string]$heartbeat.generatedAt, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
-    } catch {
-      $heartbeatGeneratedAt = $null
-    }
-  }
-  $ageSeconds = if ($heartbeatGeneratedAt) { [int][math]::Floor(((Get-Date).ToUniversalTime() - $heartbeatGeneratedAt).TotalSeconds) } else { $null }
-  $status = 'missing'
-  $reason = 'container-not-found'
-  if ($Record -and $Record.running) {
-    if ($heartbeatGeneratedAt -and $ageSeconds -le $HeartbeatFreshSeconds) {
-      $status = 'healthy'
-      $reason = 'heartbeat-fresh'
-    } elseif ($heartbeatGeneratedAt) {
-      $status = 'stale'
-      $reason = 'heartbeat-stale'
-    } else {
-      $status = 'starting'
-      $reason = 'heartbeat-pending'
-    }
-  } elseif ($Record) {
-    $status = 'not-running'
-    $reason = if ([string]::IsNullOrWhiteSpace($Record.status)) { 'container-not-running' } else { $Record.status }
-  }
-
-  $health = [ordered]@{
-    schema = $healthSchema
-    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
-    containerName = $Paths.containerName
-    image = $Paths.image
-    status = $status
-    reason = $reason
-    heartbeatFreshSeconds = $HeartbeatFreshSeconds
-    heartbeat = [ordered]@{
-      path = $Paths.heartbeatPath
-      present = [bool]$heartbeat
-      generatedAt = if ($heartbeatGeneratedAt) { $heartbeatGeneratedAt.ToString('o') } else { $null }
-      ageSeconds = $ageSeconds
-    }
-    container = [ordered]@{
-      running = if ($Record) { [bool]$Record.running } else { $false }
-      status = if ($Record) { [string]$Record.status } else { '' }
-      startedAt = if ($Record) { [string]$Record.startedAt } else { '' }
-    }
-  }
-
+  $health = Get-HealthAssessment -Paths $Paths -Record $Record
   Write-JsonFile -Path $Paths.healthPath -Payload $health
   return $health
 }
@@ -426,35 +550,47 @@ $paths = Get-Paths `
 
 $lockStream = Acquire-LockStream -LockPath $paths.lockPath -WaitSeconds $LockWaitSeconds
 try {
+  $leaseOwner = Get-OwnerStamp
+  $leaseAcquiredAt = (Get-Date).ToUniversalTime()
+  $leaseReceipt = Write-LeaseReceipt -Paths $paths -Owner $leaseOwner -AcquiredAtUtc $leaseAcquiredAt
   $existing = Get-ContainerRecord -Name $paths.containerName
+  $existingHealth = Get-HealthAssessment -Paths $paths -Record $existing
 
   switch ($Action) {
     'start' {
-      if ($existing -and $existing.running -and [string]::Equals([string]$existing.image, $paths.image, [System.StringComparison]::OrdinalIgnoreCase)) {
+      if ($existingHealth.reuseAllowed) {
         $state = New-State -Outcome 'reused' -Paths $paths -Record $existing
-        Write-JsonFile -Path $paths.statePath -Payload $state
-        $health = Write-Health -Paths $paths -Record $existing
-        $state.health = $health
+        $state.lease = $leaseReceipt
+        $state.health = Write-Health -Paths $paths -Record $existing
+        $state.recovery = [ordered]@{
+          attempted = $false
+          reason = ''
+        }
         Write-JsonFile -Path $paths.statePath -Payload $state
         $state | ConvertTo-Json -Depth 20
         break
       }
+
       $record = Start-LocalRuntimeContainer -Paths $paths
-      $state = New-State -Outcome 'started' -Paths $paths -Record $record
-      Write-JsonFile -Path $paths.statePath -Payload $state
-      $health = Write-Health -Paths $paths -Record $record
-      $state.health = $health
+      $outcome = if ($existing) { 'recovered-stale-runtime' } else { 'started' }
+      $state = New-State -Outcome $outcome -Paths $paths -Record $record
+      $state.lease = $leaseReceipt
+      $state.health = Write-Health -Paths $paths -Record $record
+      $state.recovery = [ordered]@{
+        attempted = [bool]$existing
+        previousHealth = if ($existing) { $existingHealth } else { $null }
+        action = if ($existing) { 'replace-container' } else { 'start-container' }
+      }
       Write-JsonFile -Path $paths.statePath -Payload $state
       $state | ConvertTo-Json -Depth 20
       break
     }
     'status' {
       $state = New-State -Outcome 'status' -Paths $paths -Record $existing
+      $state.lease = $leaseReceipt
+      $state.health = Write-Health -Paths $paths -Record $existing
       Write-JsonFile -Path $paths.statePath -Payload $state
-      $health = Write-Health -Paths $paths -Record $existing
-      $state.health = $health
-      Write-JsonFile -Path $paths.statePath -Payload $state
-      $health | ConvertTo-Json -Depth 20
+      $state.health | ConvertTo-Json -Depth 20
       break
     }
     'logs' {
@@ -484,28 +620,38 @@ try {
           Invoke-Docker -Arguments @('stop', $paths.containerName) -IgnoreExitCode | Out-Null
         }
       }
+      Clear-HeartbeatArtifact -Paths $paths
       $record = Get-ContainerRecord -Name $paths.containerName
       $state = New-State -Outcome 'stopped' -Paths $paths -Record $record
-      Write-JsonFile -Path $paths.statePath -Payload $state
-      $health = Write-Health -Paths $paths -Record $record
-      $state.health = $health
+      $state.lease = $leaseReceipt
+      $state.health = Write-Health -Paths $paths -Record $record
       Write-JsonFile -Path $paths.statePath -Payload $state
       $state | ConvertTo-Json -Depth 20
       break
     }
     'reconcile' {
-      $health = Write-Health -Paths $paths -Record $existing
-      if ($health.status -in @('healthy', 'starting')) {
+      if ($existingHealth.reuseAllowed) {
         $state = New-State -Outcome 'healthy' -Paths $paths -Record $existing
-        $state.health = $health
+        $state.lease = $leaseReceipt
+        $state.health = Write-Health -Paths $paths -Record $existing
+        $state.recovery = [ordered]@{
+          attempted = $false
+          reason = ''
+        }
         Write-JsonFile -Path $paths.statePath -Payload $state
         $state | ConvertTo-Json -Depth 20
         break
       }
+
       $record = Start-LocalRuntimeContainer -Paths $paths
-      $state = New-State -Outcome 'restarted' -Paths $paths -Record $record
-      $health = Write-Health -Paths $paths -Record $record
-      $state.health = $health
+      $state = New-State -Outcome $(if ($existing) { 'recovered-stale-runtime' } else { 'started' }) -Paths $paths -Record $record
+      $state.lease = $leaseReceipt
+      $state.health = Write-Health -Paths $paths -Record $record
+      $state.recovery = [ordered]@{
+        attempted = [bool]$existing
+        previousHealth = $existingHealth
+        action = if ($existing) { 'replace-container' } else { 'start-container' }
+      }
       Write-JsonFile -Path $paths.statePath -Payload $state
       $state | ConvertTo-Json -Depth 20
       break


### PR DESCRIPTION
## Summary
- harden the warm local Docker runtime manager with explicit lease receipts, heartbeat-gated reuse, and stale-runtime recovery
- make `warm-dev` local refinement use runtime reconciliation and classify benchmark samples as `proof-cold`, `dev-fast-cold`, and `warm-dev-repeat`
- add regression coverage, docs, and the warm-runtime reconcile command surface

## Testing
- `Invoke-Pester -Path tests/VIHistoryLocalAcceleration.Tests.ps1 -CI`
- `Invoke-Pester -Path tests/CompareVITools.Artifact.Tests.ps1 -CI`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope linux -StepTimeoutSeconds 600`
- `git diff --check`

## Issue
- Closes #1362
