### PR TITLE
Expose comparevi-history local refinement facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ These receipts are intentionally local-first. They allow `comparevi-history`
 and downstream consumers to reuse the same runtime planes without changing the
 review-bundle semantics or the canonical CI proof surface.
 
+When those consumers resolve the backend through an extracted `CompareVI.Tools`
+bundle, prefer the exported module facade
+`Invoke-CompareVIHistoryLocalRefinementFacade` over hard-coded script-path
+invocation.
+
 For a quicker end-to-end loop:
 
 - `scripts/Run-VIHistory.ps1` regenerates the history results, prints the

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -215,6 +215,7 @@
         "docs/SINGLE_HOST_LABVIEW_2026_PLANES.md",
         "docs/schemas/comparevi-local-refinement-v1.schema.json",
         "docs/schemas/comparevi-local-refinement-benchmark-v1.schema.json",
+        "docs/schemas/comparevi-tools-local-refinement-facade-v1.schema.json",
         "docs/schemas/comparevi-local-runtime-health-v1.schema.json",
         "docs/schemas/comparevi-local-runtime-lease-v1.schema.json",
         "docs/schemas/comparevi-local-runtime-state-v1.schema.json",

--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -240,6 +240,13 @@ Those receipts are the contract `comparevi-history` should consume when it adds
 profile-aware `local-review` and `local-proof` surfaces on top of the backend
 runtime planes.
 
+For extracted tooling bundles, prefer the module-level stable surface instead
+of hard-coding backend script paths:
+
+- `Invoke-CompareVIHistoryLocalRefinementFacade`
+- consumer contract:
+  `comparevi-tools/local-refinement-facade@v1`
+
 ### Recommended downstream workflow
 
 For a downstream maintainer, the intended loop is now:

--- a/docs/schemas/comparevi-tools-local-refinement-facade-v1.schema.json
+++ b/docs/schemas/comparevi-tools-local-refinement-facade-v1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/comparevi-tools-local-refinement-facade-v1.schema.json",
+  "title": "CompareVI.Tools Local Refinement Facade v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAtUtc",
+    "backendReceiptSchema",
+    "runtimeProfile",
+    "image",
+    "toolSource",
+    "cacheReuseState",
+    "coldWarmClass",
+    "benchmarkSampleKind",
+    "repoRoot",
+    "resultsRoot",
+    "timings",
+    "history",
+    "artifacts",
+    "finalStatus"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-tools/local-refinement-facade@v1"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "backendReceiptSchema": {
+      "const": "comparevi/local-refinement@v1"
+    },
+    "runtimeProfile": {
+      "enum": ["proof", "dev-fast", "warm-dev"]
+    },
+    "image": {
+      "type": "string"
+    },
+    "toolSource": {
+      "type": "string"
+    },
+    "cacheReuseState": {
+      "type": "string"
+    },
+    "coldWarmClass": {
+      "enum": ["cold", "warm"]
+    },
+    "benchmarkSampleKind": {
+      "type": "string"
+    },
+    "repoRoot": {
+      "type": "string"
+    },
+    "resultsRoot": {
+      "type": "string"
+    },
+    "timings": {
+      "type": "object"
+    },
+    "history": {
+      "type": "object"
+    },
+    "reviewSuite": {
+      "type": ["object", "null"]
+    },
+    "reviewLoop": {
+      "type": ["object", "null"]
+    },
+    "warmRuntime": {
+      "type": ["object", "null"]
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "localRefinementPath",
+        "benchmarkPath"
+      ],
+      "properties": {
+        "localRefinementPath": {
+          "type": ["string", "null"]
+        },
+        "benchmarkPath": {
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "finalStatus": {
+      "enum": ["succeeded", "failed"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/comparevi-tools-release-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-tools-release-manifest-v1.schema.json
@@ -113,7 +113,8 @@
     "consumerContract": {
       "type": "object",
       "required": [
-        "historyFacade"
+        "historyFacade",
+        "localRuntimeProfiles"
       ],
       "properties": {
         "historyFacade": {
@@ -137,6 +138,59 @@
               "type": "string"
             },
             "resultsRelativePath": {
+              "type": "string"
+            },
+            "stableFields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "notes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "localRuntimeProfiles": {
+          "type": "object",
+          "required": [
+            "schema",
+            "schemaUrl",
+            "exportedFunction",
+            "resultsRelativePath",
+            "benchmarkRelativePath",
+            "runtimeProfiles",
+            "defaultProfile",
+            "stableFields",
+            "notes"
+          ],
+          "properties": {
+            "schema": {
+              "type": "string"
+            },
+            "schemaUrl": {
+              "type": "string"
+            },
+            "exportedFunction": {
+              "type": "string"
+            },
+            "resultsRelativePath": {
+              "type": "string"
+            },
+            "benchmarkRelativePath": {
+              "type": "string"
+            },
+            "runtimeProfiles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "defaultProfile": {
               "type": "string"
             },
             "stableFields": {

--- a/tests/CompareVITools.Artifact.Tests.ps1
+++ b/tests/CompareVITools.Artifact.Tests.ps1
@@ -80,6 +80,7 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $metadata.module.version | Should -Be $moduleVersion
     $metadata.module.releaseVersion | Should -Be $moduleReleaseVersion
     @($metadata.module.exportedFunctions) | Should -Contain 'Invoke-CompareVIHistoryFacade'
+    @($metadata.module.exportedFunctions) | Should -Contain 'Invoke-CompareVIHistoryLocalRefinementFacade'
     $metadata.source.repository | Should -Be 'owner/repo'
     $metadata.source.ref | Should -Be 'refs/tags/v9.9.9'
     $metadata.source.sha | Should -Be '0123456789abcdef0123456789abcdef01234567'
@@ -90,6 +91,18 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $metadata.consumerContract.historyFacade.resultsRelativePath | Should -Be 'history-summary.json'
     @($metadata.consumerContract.historyFacade.stableFields) | Should -Contain 'target.sourceBranchRef'
     @($metadata.consumerContract.historyFacade.stableFields) | Should -Contain 'target.branchBudget'
+    $metadata.consumerContract.localRuntimeProfiles.schema | Should -Be 'comparevi-tools/local-refinement-facade@v1'
+    $metadata.consumerContract.localRuntimeProfiles.exportedFunction | Should -Be 'Invoke-CompareVIHistoryLocalRefinementFacade'
+    $metadata.consumerContract.localRuntimeProfiles.resultsRelativePath | Should -Be 'local-refinement.json'
+    $metadata.consumerContract.localRuntimeProfiles.benchmarkRelativePath | Should -Be 'local-refinement-benchmark.json'
+    @($metadata.consumerContract.localRuntimeProfiles.runtimeProfiles) | Should -Be @(
+      'proof',
+      'dev-fast',
+      'warm-dev'
+    )
+    $metadata.consumerContract.localRuntimeProfiles.defaultProfile | Should -Be 'dev-fast'
+    @($metadata.consumerContract.localRuntimeProfiles.stableFields) | Should -Contain 'benchmarkSampleKind'
+    @($metadata.consumerContract.localRuntimeProfiles.stableFields) | Should -Contain 'warmRuntime'
     $metadata.consumerContract.diagnosticsCommentRenderer.entryScriptPath | Should -Be 'tools/New-CompareVIHistoryDiagnosticsBody.ps1'
     @($metadata.consumerContract.diagnosticsCommentRenderer.variants) | Should -Be @(
       'comment-gated',
@@ -322,6 +335,146 @@ if ($GitHubOutputPath) {
     $result.observedInterpretation.coverageClass | Should -Be 'catalog-partial'
     @($result.observedInterpretation.outcomeLabels) | Should -Be @('clean', 'signal-diff')
     @($result.modes | ForEach-Object { [string]$_.slug }) | Should -Be @('default')
+
+    Test-Path -LiteralPath $capturePath | Should -BeTrue
+    $capturedRoot = (Get-Content -LiteralPath $capturePath -Raw).Trim()
+    $capturedRoot | Should -Be $bundleRoot
+  }
+
+  It 'returns the stabilized local refinement facade when invoking the module wrapper' {
+    $bundleRoot = Join-Path $TestDrive 'bundle-local-refinement-facade'
+    $moduleRoot = Join-Path $bundleRoot 'tools' 'CompareVI.Tools'
+    $toolsRoot = Join-Path $bundleRoot 'tools'
+    $downstreamRepoRoot = Join-Path $TestDrive 'downstream-repo'
+    New-Item -ItemType Directory -Path $moduleRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $downstreamRepoRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $downstreamRepoRoot 'fixtures/vi-attr') -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $downstreamRepoRoot 'fixtures/vi-attr/Base.vi') -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $downstreamRepoRoot 'fixtures/vi-attr/Head.vi') -Value 'head' -Encoding utf8
+
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'CompareVI.Tools' 'CompareVI.Tools.psd1') -Destination (Join-Path $moduleRoot 'CompareVI.Tools.psd1')
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'CompareVI.Tools' 'CompareVI.Tools.psm1') -Destination (Join-Path $moduleRoot 'CompareVI.Tools.psm1')
+
+    $capturePath = Join-Path $TestDrive 'local-refinement-scripts-root.txt'
+    @'
+param(
+  [string]$Profile = 'dev-fast',
+  [string]$RepoRoot = '',
+  [string]$ResultsRoot = '',
+  [switch]$PassThru
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Set-Content -LiteralPath $env:COMPAREVI_CAPTURE_PATH -Value $env:COMPAREVI_SCRIPTS_ROOT -Encoding utf8
+$resolvedRepoRoot = if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+  (Get-Location).Path
+} elseif ([System.IO.Path]::IsPathRooted($RepoRoot)) {
+  [System.IO.Path]::GetFullPath($RepoRoot)
+} else {
+  [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $RepoRoot))
+}
+$resolvedResultsRoot = if ([string]::IsNullOrWhiteSpace($ResultsRoot)) {
+  Join-Path $resolvedRepoRoot 'tests/results/local-vi-history/warm-dev'
+} elseif ([System.IO.Path]::IsPathRooted($ResultsRoot)) {
+  [System.IO.Path]::GetFullPath($ResultsRoot)
+} else {
+  [System.IO.Path]::GetFullPath((Join-Path $resolvedRepoRoot $ResultsRoot))
+}
+New-Item -ItemType Directory -Path $resolvedResultsRoot -Force | Out-Null
+$receiptPath = Join-Path $resolvedResultsRoot 'local-refinement.json'
+$benchmarkPath = Join-Path $resolvedResultsRoot 'local-refinement-benchmark.json'
+$receipt = [ordered]@{
+  schema = 'comparevi/local-refinement@v1'
+  generatedAt = '2026-03-19T00:00:00Z'
+  runtimeProfile = $Profile
+  image = 'comparevi-vi-history-dev:local'
+  toolSource = 'local-dev-image'
+  cacheReuseState = 'warm-runtime-reused'
+  coldWarmClass = 'warm'
+  benchmarkSampleKind = 'warm-dev-repeat'
+  repoRoot = $resolvedRepoRoot
+  resultsRoot = $resolvedResultsRoot
+  timings = [ordered]@{
+    elapsedMilliseconds = 1234
+    elapsedSeconds = 1.234
+  }
+  history = [ordered]@{
+    targetPath = (Join-Path $resolvedRepoRoot 'fixtures/vi-attr/Head.vi')
+    branchRef = 'HEAD'
+    baselineRef = ''
+    maxPairs = 2
+    maxCommitCount = 64
+  }
+  reviewSuite = [ordered]@{
+    schema = 'ni-linux-review-suite@v1'
+    image = 'comparevi-vi-history-dev:local'
+    scenarioCount = 1
+    summaryPath = (Join-Path $resolvedResultsRoot 'review-suite-summary.json')
+  }
+  reviewLoop = [ordered]@{
+    schema = 'ni-linux-review-suite-review-loop@v1'
+    path = (Join-Path $resolvedResultsRoot 'vi-history-review-loop-receipt.json')
+  }
+  warmRuntime = [ordered]@{
+    schema = 'comparevi/local-runtime-state@v1'
+    action = 'reconcile'
+    outcome = 'healthy'
+    container = [ordered]@{
+      name = 'warm-stub'
+      image = 'comparevi-vi-history-dev:local'
+    }
+    artifacts = [ordered]@{
+      statePath = (Join-Path $resolvedResultsRoot 'runtime/local-runtime-state.json')
+      leasePath = (Join-Path $resolvedResultsRoot 'runtime/local-runtime-lease.json')
+      healthPath = (Join-Path $resolvedResultsRoot 'runtime/local-runtime-health.json')
+      heartbeatPath = (Join-Path $resolvedResultsRoot 'runtime/local-runtime-heartbeat.json')
+    }
+  }
+  finalStatus = 'succeeded'
+}
+$receipt | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $receiptPath -Encoding utf8
+[ordered]@{
+  schema = 'comparevi/local-refinement-benchmark@v1'
+  generatedAt = '2026-03-19T00:00:01Z'
+  latest = [ordered]@{}
+  selectedSamples = [ordered]@{}
+  comparisons = [ordered]@{}
+} | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $benchmarkPath -Encoding utf8
+if ($PassThru) {
+  [pscustomobject]$receipt
+}
+'@ | Set-Content -LiteralPath (Join-Path $toolsRoot 'Invoke-VIHistoryLocalRefinement.ps1') -Encoding utf8
+
+    $schemaPath = Join-Path $repoRoot 'docs' 'schemas' 'comparevi-tools-local-refinement-facade-v1.schema.json'
+    $schemaReportPath = Join-Path $TestDrive 'local-refinement-facade.json'
+    $env:COMPAREVI_CAPTURE_PATH = $capturePath
+    try {
+      Import-Module (Join-Path $moduleRoot 'CompareVI.Tools.psd1') -Force
+      Push-Location $downstreamRepoRoot
+      try {
+        $result = Invoke-CompareVIHistoryLocalRefinementFacade -Profile 'warm-dev'
+      } finally {
+        Pop-Location | Out-Null
+      }
+    } finally {
+      Remove-Module CompareVI.Tools -Force -ErrorAction SilentlyContinue
+      Remove-Item Env:COMPAREVI_CAPTURE_PATH -ErrorAction SilentlyContinue
+      Remove-Item Env:COMPAREVI_SCRIPTS_ROOT -ErrorAction SilentlyContinue
+    }
+
+    $result | Should -Not -BeNullOrEmpty
+    $result.schema | Should -Be 'comparevi-tools/local-refinement-facade@v1'
+    $result.backendReceiptSchema | Should -Be 'comparevi/local-refinement@v1'
+    $result.runtimeProfile | Should -Be 'warm-dev'
+    $result.benchmarkSampleKind | Should -Be 'warm-dev-repeat'
+    $result.repoRoot | Should -Be $downstreamRepoRoot
+    $result.warmRuntime.container.name | Should -Be 'warm-stub'
+    $result.artifacts.localRefinementPath | Should -Be (Join-Path $downstreamRepoRoot 'tests/results/local-vi-history/warm-dev/local-refinement.json')
+    $result.artifacts.benchmarkPath | Should -Be (Join-Path $downstreamRepoRoot 'tests/results/local-vi-history/warm-dev/local-refinement-benchmark.json')
+
+    $result | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $schemaReportPath -Encoding utf8
+    & $schemaScript -JsonPath $schemaReportPath -SchemaPath $schemaPath
+    $LASTEXITCODE | Should -Be 0
 
     Test-Path -LiteralPath $capturePath | Should -BeTrue
     $capturedRoot = (Get-Content -LiteralPath $capturePath -Raw).Trim()

--- a/tools/CompareVI.Tools/CompareVI.Tools.psd1
+++ b/tools/CompareVI.Tools/CompareVI.Tools.psd1
@@ -10,6 +10,7 @@
   FunctionsToExport = @(
     'Invoke-CompareVIHistory',
     'Invoke-CompareVIHistoryFacade',
+    'Invoke-CompareVIHistoryLocalRefinementFacade',
     'Invoke-CompareRefsToTemp'
   )
   CmdletsToExport   = @()

--- a/tools/CompareVI.Tools/CompareVI.Tools.psm1
+++ b/tools/CompareVI.Tools/CompareVI.Tools.psm1
@@ -132,6 +132,104 @@ function Resolve-CompareVIHistorySummary {
   return Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 12
 }
 
+function Invoke-CompareVILocalRefinementScript {
+  param(
+    [Parameter(Mandatory = $true)]
+    [hashtable]$Parameters
+  )
+
+  $refinementScript = Get-CompareVIScriptPath -Name 'Invoke-VIHistoryLocalRefinement.ps1'
+  $parametersWithPassThru = @{}
+  foreach ($entry in $Parameters.GetEnumerator()) {
+    $parametersWithPassThru[$entry.Key] = $entry.Value
+  }
+  $parametersWithPassThru['PassThru'] = $true
+
+  $env:COMPAREVI_SCRIPTS_ROOT = $script:BundleRoot
+  try {
+    return & $refinementScript @parametersWithPassThru
+  } finally {
+    Remove-Item Env:COMPAREVI_SCRIPTS_ROOT -ErrorAction SilentlyContinue
+  }
+}
+
+function ConvertTo-CompareVILocalRefinementFacade {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Receipt
+  )
+
+  if (-not $Receipt) {
+    throw 'Local refinement receipt was not produced.'
+  }
+  if ([string]$Receipt.schema -ne 'comparevi/local-refinement@v1') {
+    throw ("Unexpected local refinement receipt schema: {0}" -f [string]$Receipt.schema)
+  }
+
+  $resultsRoot = Resolve-CompareVIOutputPath -PathValue ([string]$Receipt.resultsRoot)
+  $localRefinementPath = if ($resultsRoot) { Join-Path $resultsRoot 'local-refinement.json' } else { $null }
+  $benchmarkPath = if ($resultsRoot) { Join-Path $resultsRoot 'local-refinement-benchmark.json' } else { $null }
+
+  function Get-FacadeValue {
+    param(
+      [AllowNull()]$InputObject,
+      [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+      return $null
+    }
+    if ($InputObject -is [System.Collections.IDictionary]) {
+      return $InputObject[$Name]
+    }
+    if ($InputObject.PSObject.Properties[$Name]) {
+      return $InputObject.$Name
+    }
+    return $null
+  }
+
+  $warmRuntimeReceipt = Get-FacadeValue -InputObject $Receipt -Name 'warmRuntime'
+  $warmRuntimeFacade = $null
+  if ($warmRuntimeReceipt) {
+    $warmRuntimeContainer = Get-FacadeValue -InputObject $warmRuntimeReceipt -Name 'container'
+    $warmRuntimeFacade = [ordered]@{
+      schema = [string](Get-FacadeValue -InputObject $warmRuntimeReceipt -Name 'schema')
+      action = [string](Get-FacadeValue -InputObject $warmRuntimeReceipt -Name 'action')
+      outcome = [string](Get-FacadeValue -InputObject $warmRuntimeReceipt -Name 'outcome')
+      container = [ordered]@{
+        name = [string](Get-FacadeValue -InputObject $warmRuntimeContainer -Name 'name')
+        image = [string](Get-FacadeValue -InputObject $warmRuntimeContainer -Name 'image')
+      }
+      health = Get-FacadeValue -InputObject $warmRuntimeReceipt -Name 'health'
+      artifacts = Get-FacadeValue -InputObject $warmRuntimeReceipt -Name 'artifacts'
+    }
+  }
+
+  return [pscustomobject]@{
+    schema = 'comparevi-tools/local-refinement-facade@v1'
+    generatedAtUtc = [string]$Receipt.generatedAt
+    backendReceiptSchema = [string]$Receipt.schema
+    runtimeProfile = [string]$Receipt.runtimeProfile
+    image = [string]$Receipt.image
+    toolSource = [string]$Receipt.toolSource
+    cacheReuseState = [string]$Receipt.cacheReuseState
+    coldWarmClass = [string]$Receipt.coldWarmClass
+    benchmarkSampleKind = if ($Receipt.PSObject.Properties['benchmarkSampleKind']) { [string]$Receipt.benchmarkSampleKind } else { '' }
+    repoRoot = [string]$Receipt.repoRoot
+    resultsRoot = [string]$Receipt.resultsRoot
+    timings = $Receipt.timings
+    history = $Receipt.history
+    reviewSuite = if ($Receipt.PSObject.Properties['reviewSuite']) { $Receipt.reviewSuite } else { $null }
+    reviewLoop = if ($Receipt.PSObject.Properties['reviewLoop']) { $Receipt.reviewLoop } else { $null }
+    warmRuntime = $warmRuntimeFacade
+    artifacts = [ordered]@{
+      localRefinementPath = $localRefinementPath
+      benchmarkPath = $benchmarkPath
+    }
+    finalStatus = [string]$Receipt.finalStatus
+  }
+}
+
 function Invoke-CompareVIHistory {
   [CmdletBinding(DefaultParameterSetName = 'Default')]
   param(
@@ -251,6 +349,42 @@ function Invoke-CompareVIHistoryFacade {
   }
 }
 
+function Invoke-CompareVIHistoryLocalRefinementFacade {
+  [CmdletBinding()]
+  param(
+    [ValidateSet('proof', 'dev-fast', 'warm-dev')]
+    [string]$Profile = 'dev-fast',
+    [string]$BaseVi = 'fixtures/vi-attr/Base.vi',
+    [string]$HeadVi = 'fixtures/vi-attr/Head.vi',
+    [string]$RepoRoot = '',
+    [string]$HistoryTargetPath = 'fixtures/vi-attr/Head.vi',
+    [string]$HistoryBranchRef = 'HEAD',
+    [string]$HistoryBaselineRef = '',
+    [Nullable[int]]$HistoryMaxPairs,
+    [Nullable[int]]$HistoryMaxCommitCount,
+    [string]$ResultsRoot = '',
+    [string]$WarmRuntimeDir = '',
+    [string]$ProofImage = 'nationalinstruments/labview:2026q1-linux',
+    [string]$DevImage = 'comparevi-vi-history-dev:local',
+    [string]$LabVIEWPath = '/usr/local/natinst/LabVIEW-2026-64/labview',
+    [switch]$SkipDevImageBuild
+  )
+
+  $invokeParameters = @{}
+  foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+    if ($null -ne $entry.Value) {
+      $invokeParameters[$entry.Key] = $entry.Value
+    }
+  }
+
+  if (-not $invokeParameters.ContainsKey('RepoRoot') -or [string]::IsNullOrWhiteSpace([string]$invokeParameters['RepoRoot'])) {
+    $invokeParameters['RepoRoot'] = (Get-Location).Path
+  }
+
+  $receipt = Invoke-CompareVILocalRefinementScript -Parameters $invokeParameters
+  return ConvertTo-CompareVILocalRefinementFacade -Receipt $receipt
+}
+
 function Invoke-CompareRefsToTemp {
   [CmdletBinding(DefaultParameterSetName = 'ByPath')]
   param(
@@ -282,4 +416,4 @@ function Invoke-CompareRefsToTemp {
   & $compareScript @PSBoundParameters
 }
 
-Export-ModuleMember -Function Invoke-CompareVIHistory, Invoke-CompareVIHistoryFacade, Invoke-CompareRefsToTemp
+Export-ModuleMember -Function Invoke-CompareVIHistory, Invoke-CompareVIHistoryFacade, Invoke-CompareVIHistoryLocalRefinementFacade, Invoke-CompareRefsToTemp

--- a/tools/Publish-CompareVIToolsArtifact.ps1
+++ b/tools/Publish-CompareVIToolsArtifact.ps1
@@ -310,6 +310,39 @@ try {
         'When source-branch budgeting is requested, the facade also records the evaluated branch budget so downstream consumers can audit the safeguard without parsing raw git state.'
       )
     }
+    localRuntimeProfiles = [ordered]@{
+      schema = 'comparevi-tools/local-refinement-facade@v1'
+      schemaUrl = 'https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/comparevi-tools-local-refinement-facade-v1.schema.json'
+      exportedFunction = 'Invoke-CompareVIHistoryLocalRefinementFacade'
+      resultsRelativePath = 'local-refinement.json'
+      benchmarkRelativePath = 'local-refinement-benchmark.json'
+      runtimeProfiles = @(
+        'proof',
+        'dev-fast',
+        'warm-dev'
+      )
+      defaultProfile = 'dev-fast'
+      stableFields = @(
+        'runtimeProfile',
+        'image',
+        'toolSource',
+        'cacheReuseState',
+        'coldWarmClass',
+        'benchmarkSampleKind',
+        'timings',
+        'history',
+        'reviewSuite',
+        'reviewLoop',
+        'warmRuntime',
+        'artifacts',
+        'finalStatus'
+      )
+      notes = @(
+        'Use the module facade when comparevi-history or another downstream needs profile-aware local refinement without hard-coding backend script paths.',
+        'The facade defaults RepoRoot to the caller working directory so extracted tooling bundles can target downstream repositories cleanly.',
+        'Proof stays the canonical runtime truth; dev-fast and warm-dev are local acceleration planes only.'
+      )
+    }
     diagnosticsCommentRenderer = [ordered]@{
       entryScriptPath = 'tools/New-CompareVIHistoryDiagnosticsBody.ps1'
       variants = @(


### PR DESCRIPTION
## Summary
- export a stable `Invoke-CompareVIHistoryLocalRefinementFacade` from `CompareVI.Tools`
- advertise the local runtime profile contract in the published bundle metadata and release-manifest schema
- document the extracted-bundle consumer path and lock it with artifact tests

## Testing
- `Invoke-Pester -Path tests/CompareVITools.Artifact.Tests.ps1 -CI`
- `Invoke-Pester -Path tests/VIHistoryLocalAcceleration.Tests.ps1 -CI`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `git diff --check`

## Issue
- Closes #1363
