### PR TITLE
Update for standing priority #1364

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ target VI at each commit-parent pair, and invokes LVCompare in headless mode.
 
 Scope boundary: icon editor development is out of scope for this repository. The
 active icon editor project lives at `svelderrainruiz/labview-icon-editor`.
+The canonical downstream local-first adoption proof surface for VI history is
+`LabVIEW-Community-CI-CD/labview-icon-editor-demo` on `develop`.
 
 The latest rev streamlines the workflow inputs so SMEs only need to provide:
 
@@ -342,6 +344,12 @@ Benchmark receipts now select the intended sample classes:
 These receipts are intentionally local-first. They allow `comparevi-history`
 and downstream consumers to reuse the same runtime planes without changing the
 review-bundle semantics or the canonical CI proof surface.
+
+The first documented downstream consumer of that split is
+`LabVIEW-Community-CI-CD/labview-icon-editor-demo`. Use
+[docs/knowledgebase/CrossRepo-VIHistory.md](docs/knowledgebase/CrossRepo-VIHistory.md)
+for the supported `comparevi-history` local-review/local-proof loop that
+maintainers should run before opening a PR to `develop`.
 
 When those consumers resolve the backend through an extracted `CompareVI.Tools`
 bundle, prefer the exported module facade

--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -2,7 +2,9 @@
 # Cross-Repo VI History Capture
 
 This note records the supported steps for exercising the Compare-VIHistory
-tooling against an external repository. The pinned sample below uses
+tooling against an external repository. The canonical local-first downstream
+adoption proof uses `LabVIEW-Community-CI-CD/labview-icon-editor-demo` on
+`develop`, while the legacy one-off module sample below still uses
 `svelderrainruiz/labview-icon-editor`, which is the active downstream icon
 editor repository.
 
@@ -160,7 +162,65 @@ pwsh -NoLogo -NoProfile -File tools/Run-NILinuxContainerCompare.ps1 `
 }
 ```
 
-## Pinned sample flow
+## Canonical downstream demo adoption
+
+Treat `LabVIEW-Community-CI-CD/labview-icon-editor-demo` as the first
+documented downstream consumer for the local-first VI history loop.
+
+- Backend pin: reviewed `compare-vi-cli-action` release tag plus
+  `comparevi-tools-release.json`
+- Facade pin: immutable `comparevi-history` release used by the consumer
+  workflows and local-review scripts
+- Downstream repo: `LabVIEW-Community-CI-CD/labview-icon-editor-demo`
+- PR workflow target branch: `develop`
+- Downstream maintainer doc:
+  `docs/comparevi-history-diagnostics.md`
+- Representative VI:
+  `Tooling/deployment/VIP_Post-Install Custom Action.vi`
+
+For that repo, the supported local maintainer loop is:
+
+1. refine locally with `dev-fast`
+2. repeat locally with `warm-dev` when iteration is high-frequency
+3. run `proof` before opening the PR
+4. use GitHub CI only for publication and trust-boundary proof
+
+Example local review from a `comparevi-history` checkout:
+
+```powershell
+pwsh -NoLogo -NoProfile -File <comparevi-history-root>\scripts\Invoke-CompareVIHistoryLocalReview.ps1 `
+  -ConsumerRepositoryRoot <labview-icon-editor-demo-root> `
+  -ViPath 'Tooling/deployment/VIP_Post-Install Custom Action.vi'
+```
+
+Example repeated-turn warm runtime:
+
+```powershell
+pwsh -NoLogo -NoProfile -File <comparevi-history-root>\scripts\Invoke-CompareVIHistoryLocalReview.ps1 `
+  -ConsumerRepositoryRoot <labview-icon-editor-demo-root> `
+  -ViPath 'Tooling/deployment/VIP_Post-Install Custom Action.vi' `
+  -Profile warm-dev `
+  -WarmRuntimeDir tests/results/local-review/runtime `
+  -BaseRef develop `
+  -HeadRef HEAD
+```
+
+Example local proof before opening the PR:
+
+```powershell
+pwsh -NoLogo -NoProfile -File <comparevi-history-root>\scripts\Invoke-CompareVIHistoryLocalReview.ps1 `
+  -ConsumerRepositoryRoot <labview-icon-editor-demo-root> `
+  -ViPath 'Tooling/deployment/VIP_Post-Install Custom Action.vi' `
+  -Profile proof `
+  -BaseRef develop `
+  -HeadRef HEAD
+```
+
+Keep the checked-in GitHub workflows in the downstream repo as the publication
+surface. The local-first loop is for reviewer/runtime refinement before the PR
+exists, not a replacement for the published PR diagnostics.
+
+## Legacy module sample flow
 
 Use this exact sample when you need a documented cross-repo consumer reference:
 

--- a/tests/CompareVITools.Artifact.Tests.ps1
+++ b/tests/CompareVITools.Artifact.Tests.ps1
@@ -103,6 +103,8 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $metadata.consumerContract.localRuntimeProfiles.defaultProfile | Should -Be 'dev-fast'
     @($metadata.consumerContract.localRuntimeProfiles.stableFields) | Should -Contain 'benchmarkSampleKind'
     @($metadata.consumerContract.localRuntimeProfiles.stableFields) | Should -Contain 'warmRuntime'
+    ((@($metadata.consumerContract.localRuntimeProfiles.notes) -join [Environment]::NewLine)) | Should -Match 'labview-icon-editor-demo'
+    ((@($metadata.consumerContract.localRuntimeProfiles.notes) -join [Environment]::NewLine)) | Should -Match 'comparevi-history'
     $metadata.consumerContract.diagnosticsCommentRenderer.entryScriptPath | Should -Be 'tools/New-CompareVIHistoryDiagnosticsBody.ps1'
     @($metadata.consumerContract.diagnosticsCommentRenderer.variants) | Should -Be @(
       'comment-gated',
@@ -124,6 +126,10 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
 
     $bundleRoot = Join-Path $extractRoot $metadata.bundle.folder
     Test-Path -LiteralPath $bundleRoot | Should -BeTrue
+
+    $bundleReadme = Get-Content -LiteralPath (Join-Path $bundleRoot 'README.md') -Raw
+    $bundleReadme | Should -Match 'labview-icon-editor-demo'
+    $bundleReadme | Should -Match 'comparevi-history'
 
     $expectedFiles = @(
       'comparevi-tools-release.json',

--- a/tests/CrossRepoVIHistoryDocs.Tests.ps1
+++ b/tests/CrossRepoVIHistoryDocs.Tests.ps1
@@ -1,0 +1,30 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Cross-repo VI history docs' -Tag 'CompareVI' {
+  BeforeAll {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $crossRepoDocPath = Join-Path $repoRoot 'docs' 'knowledgebase' 'CrossRepo-VIHistory.md'
+    $readmePath = Join-Path $repoRoot 'README.md'
+
+    $crossRepoDocPath | Should -Exist
+    $readmePath | Should -Exist
+
+    $script:crossRepoDoc = Get-Content -LiteralPath $crossRepoDocPath -Raw
+    $script:readme = Get-Content -LiteralPath $readmePath -Raw
+  }
+
+  It 'documents the canonical downstream demo consumer for the local-first loop' {
+    $script:crossRepoDoc | Should -Match 'LabVIEW-Community-CI-CD/labview-icon-editor-demo'
+    $script:crossRepoDoc | Should -Match 'comparevi-history'
+    $script:crossRepoDoc | Should -Match 'local-review'
+    $script:crossRepoDoc | Should -Match 'local-proof'
+    $script:crossRepoDoc | Should -Match 'develop'
+    $script:crossRepoDoc | Should -Match 'VIP_Post-Install Custom Action\.vi'
+  }
+
+  It 'points README guidance at the downstream demo proof surface' {
+    $script:readme | Should -Match 'LabVIEW-Community-CI-CD/labview-icon-editor-demo'
+    $script:readme | Should -Match 'CrossRepo-VIHistory\.md'
+  }
+}

--- a/tools/Publish-CompareVIToolsArtifact.ps1
+++ b/tools/Publish-CompareVIToolsArtifact.ps1
@@ -233,6 +233,7 @@ try {
     '- Prefer `Invoke-CompareVIHistoryFacade` when downstream tooling needs a stable summary object plus the generated report paths.'
     '- For comparevi-history comment/summary rendering, resolve `tools/New-CompareVIHistoryDiagnosticsBody.ps1` from this bundle or from the workflow `tooling-path` output instead of copying inline PowerShell helpers.'
     '- For local-first VI history refinement, use `tools/Build-VIHistoryDevImage.ps1`, `tools/Invoke-VIHistoryLocalRefinement.ps1`, and `tools/Manage-VIHistoryRuntimeInDocker.ps1` from this bundle root.'
+    '- The first documented downstream local-first consumer is `LabVIEW-Community-CI-CD/labview-icon-editor-demo` via comparevi-history local-review/local-proof targeting `develop`.'
     '- The runtime facade JSON is written to `history-summary.json` under the selected results directory.'
     '- Real compare execution still requires the same LVCompare/LabVIEW prerequisites as the source repository.'
   ) | Set-Content -LiteralPath $bundleReadmePath -Encoding utf8
@@ -340,7 +341,8 @@ try {
       notes = @(
         'Use the module facade when comparevi-history or another downstream needs profile-aware local refinement without hard-coding backend script paths.',
         'The facade defaults RepoRoot to the caller working directory so extracted tooling bundles can target downstream repositories cleanly.',
-        'Proof stays the canonical runtime truth; dev-fast and warm-dev are local acceleration planes only.'
+        'Proof stays the canonical runtime truth; dev-fast and warm-dev are local acceleration planes only.',
+        'The first documented downstream adoption proof is LabVIEW-Community-CI-CD/labview-icon-editor-demo via comparevi-history local-review/local-proof targeting develop.'
       )
     }
     diagnosticsCommentRenderer = [ordered]@{


### PR DESCRIPTION
# Summary

Document the canonical downstream local-first VI history adoption surface around `LabVIEW-Community-CI-CD/labview-icon-editor-demo` on `develop` instead of leaving the public cross-repo guidance anchored to the wrong repository. The CompareVI.Tools bundle metadata and bundle README now carry the same downstream consumer guidance, and the lane includes a real local proof against the demo repo's PR31 VI change using `dev-fast`, `warm-dev`, `proof`, plus warm-runtime `status`/`stop` controls.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context:
  - `#1364`
- Files, tools, workflows, or policies touched:
  - `README.md`
  - `docs/knowledgebase/CrossRepo-VIHistory.md`
  - `tools/Publish-CompareVIToolsArtifact.ps1`
  - `tests/CompareVITools.Artifact.Tests.ps1`
  - `tests/CrossRepoVIHistoryDocs.Tests.ps1`
- Cross-repo or external-consumer impact:
  - public release-facing docs and CompareVI.Tools bundle metadata now point at the real downstream adoption target
  - proof evidence was executed locally against `svelderrainruiz/labview-icon-editor-demo` proof branch `proof/feature-changetovis-history-refresh`
- Required checks, merge-queue behavior, or approval flows affected:
  - no workflow contract changes
  - normal required checks plus pre-push gate evidence attached below

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/CompareVITools.Artifact.Tests.ps1 -CI`
  - `Invoke-Pester -Path tests/CrossRepoVIHistoryDocs.Tests.ps1 -CI`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `pwsh -NoLogo -NoProfile -File C:\dev\comparevi-history.downstream-adoption-174\scripts\Invoke-CompareVIHistoryLocalReview.ps1 -ConsumerRepositoryRoot C:\dev\labview-icon-editor-proof-31-refresh -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -BaseRef upstream/develop -HeadRef HEAD -Profile dev-fast -ResultsDir tests/results/local-review/dev-fast -CompilerPath C:\dev\comparevi-history.downstream-adoption-174\src\CompareVIHistory.ReviewCompiler\bin\Release\net8.0\win-x64\CompareVIHistory.ReviewCompiler.exe`
  - `pwsh -NoLogo -NoProfile -File C:\dev\comparevi-history.downstream-adoption-174\scripts\Invoke-CompareVIHistoryLocalReview.ps1 -ConsumerRepositoryRoot C:\dev\labview-icon-editor-proof-31-refresh -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -BaseRef upstream/develop -HeadRef HEAD -Profile warm-dev -WarmRuntimeDir tests/results/local-review/runtime -ResultsDir tests/results/local-review/warm-dev -CompilerPath C:\dev\comparevi-history.downstream-adoption-174\src\CompareVIHistory.ReviewCompiler\bin\Release\net8.0\win-x64\CompareVIHistory.ReviewCompiler.exe`
  - `pwsh -NoLogo -NoProfile -File C:\dev\comparevi-history.downstream-adoption-174\scripts\Invoke-CompareVIHistoryLocalReview.ps1 -ConsumerRepositoryRoot C:\dev\labview-icon-editor-proof-31-refresh -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -BaseRef upstream/develop -HeadRef HEAD -Profile proof -ResultsDir tests/results/local-review/proof -CompilerPath C:\dev\comparevi-history.downstream-adoption-174\src\CompareVIHistory.ReviewCompiler\bin\Release\net8.0\win-x64\CompareVIHistory.ReviewCompiler.exe`
  - `pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action status -RepoRoot C:\dev\labview-icon-editor-proof-31-refresh -ResultsRoot tests/results/local-review/warm-dev -RuntimeDir tests/results/local-review/runtime -Image comparevi-vi-history-dev:local`
  - `pwsh -NoLogo -NoProfile -File tools/Manage-VIHistoryRuntimeInDocker.ps1 -Action stop -RepoRoot C:\dev\labview-icon-editor-proof-31-refresh -ResultsRoot tests/results/local-review/warm-dev -RuntimeDir tests/results/local-review/runtime -Image comparevi-vi-history-dev:local`
- Key artifacts, logs, or workflow runs:
  - `C:\dev\labview-icon-editor-proof-31-refresh\tests\results\local-review\dev-fast\local-review.json`
  - `C:\dev\labview-icon-editor-proof-31-refresh\tests\results\local-review\warm-dev\local-review.json`
  - `C:\dev\labview-icon-editor-proof-31-refresh\tests\results\local-review\proof\local-review.json`
  - `C:\dev\labview-icon-editor-proof-31-refresh\tests\results\local-review\runtime\local-runtime-health.json`
  - `C:\dev\labview-icon-editor-proof-31-refresh\tests\results\local-review\runtime\local-runtime-state.json`
  - `C:\dev\compare-vi-cli-action.downstream-adoption-1364\tests\results\_agent\pre-push-ni-image\known-flag-scenario-report.json`
- Risk-based checks not run:
  - no GitHub workflow dispatches; this lane changes docs/bundle metadata only and uses local downstream proof instead

## Risks and Follow-ups

- Residual risks:
  - the downstream proof used a locally provided comparevi-history compiler path because `comparevi-history` local-review still has a published-compiler cache-directory bug when no compiler path is provided
- Follow-up issues or deferred work:
  - none in this lane; the cache-directory defect belongs in `comparevi-history`, not this repository
- Deployment, approval, or rollback notes:
  - rollback is limited to documentation and bundle metadata reversion; no workflow or release gating behavior changes

## Reviewer Focus

- Please verify:
  - the public docs now distinguish the canonical demo consumer from the legacy one-off icon-editor sample
  - bundle metadata/README keep the same downstream story as the docs
- Areas where the reasoning is subtle:
  - this lane proves downstream adoption without modifying the downstream repo because the consumer docs/workflows already landed there; the new work is aligning this repo's public contract and backing it with real local proof
- Manual spot checks requested:
  - inspect `docs/knowledgebase/CrossRepo-VIHistory.md`
  - inspect the downstream proof receipts under `C:\dev\labview-icon-editor-proof-31-refresh\tests\results\local-review\`
