### PR TITLE
Update for standing priority #1390

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Keep it short, stable, and helper-oriented. Deep runbooks belong in checked-in d
 ## Local Gates
 
 - `tools/PrePush-Checks.ps1` consumes `tools/policy/prepush-known-flag-scenarios.json`.
-- Exactly one active known-flag scenario is allowed in that checked-in contract at a time.
+- Exactly one active scenario pack is allowed in that checked-in contract at a time.
 - Deterministic top-level receipts:
   - `tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json`
   - `tests/results/_agent/pre-push-ni-image/transport-smoke-report.json`

--- a/docs/schemas/prepush-known-flag-scenario-packs-v1.schema.json
+++ b/docs/schemas/prepush-known-flag-scenario-packs-v1.schema.json
@@ -1,0 +1,321 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/prepush-known-flag-scenario-packs-v1.schema.json",
+  "title": "Pre-push Known-Flag Scenario Packs",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "activeScenarioPackId",
+    "scenarioPacks"
+  ],
+  "properties": {
+    "schema": {
+      "const": "prepush-known-flag-scenario-packs/v1"
+    },
+    "schemaVersion": {
+      "type": "string"
+    },
+    "activeScenarioPackId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scenarioPacks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/scenarioPack"
+      }
+    }
+  },
+  "$defs": {
+    "priorityClass": {
+      "type": "string",
+      "enum": [
+        "pre-push",
+        "certification",
+        "nightly"
+      ]
+    },
+    "planeApplicability": {
+      "type": "string",
+      "enum": [
+        "linux-proof",
+        "windows-mirror",
+        "host-shadow"
+      ]
+    },
+    "suppressedCategory": {
+      "type": "string",
+      "enum": [
+        "vi-attributes",
+        "front-panel-position-size",
+        "block-diagram-cosmetic"
+      ]
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "baseVi",
+        "headVi"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "fixture-diff",
+            "vi-history-source"
+          ]
+        },
+        "baseVi": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headVi": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resultsRoot",
+        "reportPath",
+        "incidentInputPath",
+        "incidentEventPath"
+      ],
+      "properties": {
+        "resultsRoot": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reportPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "incidentInputPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "incidentEventPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "suppressionSemantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "suppressedCategories",
+        "reviewerSurfaceIntent",
+        "rawModeBoundaryIntent"
+      ],
+      "properties": {
+        "suppressedCategories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/suppressedCategory"
+          },
+          "uniqueItems": true
+        },
+        "reviewerSurfaceIntent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rawModeBoundaryIntent": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "reviewerAssertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "surface",
+        "requirement"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "surface": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requirement": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "rawModeBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "mode",
+        "surfaceRole",
+        "expectation"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "surfaceRole": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expectation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "description",
+        "requestedFlags",
+        "intendedSuppressionSemantics",
+        "expectedReviewerAssertions",
+        "expectedRawModeEvidenceBoundaries"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requestedFlags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^-"
+          },
+          "uniqueItems": true
+        },
+        "planeApplicability": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/planeApplicability"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "priorityClass": {
+          "$ref": "#/$defs/priorityClass"
+        },
+        "intendedSuppressionSemantics": {
+          "$ref": "#/$defs/suppressionSemantics"
+        },
+        "expectedReviewerAssertions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/reviewerAssertion"
+          }
+        },
+        "expectedRawModeEvidenceBoundaries": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/rawModeBoundary"
+          }
+        }
+      }
+    },
+    "scenarioPack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "isActive",
+        "description",
+        "image",
+        "labviewPathEnv",
+        "defaultLabviewPath",
+        "planeApplicability",
+        "priorityClass",
+        "expectedGateOutcome",
+        "target",
+        "evidence",
+        "scenarios"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "image": {
+          "type": "string",
+          "minLength": 1
+        },
+        "labviewPathEnv": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultLabviewPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "planeApplicability": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/planeApplicability"
+          },
+          "uniqueItems": true
+        },
+        "priorityClass": {
+          "$ref": "#/$defs/priorityClass"
+        },
+        "expectedGateOutcome": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "fail"
+          ]
+        },
+        "target": {
+          "$ref": "#/$defs/target"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "scenarios": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/scenario"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/PrePushKnownFlagScenarioReport.Tests.ps1
+++ b/tests/PrePushKnownFlagScenarioReport.Tests.ps1
@@ -3,7 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
+Describe 'Pre-push known-flag scenario pack report' -Tag 'Unit' {
   BeforeAll {
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
     $script:PrePushScriptPath = Join-Path $repoRoot 'tools' 'PrePush-Checks.ps1'
@@ -44,36 +44,133 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
       return $functionAst.Extent.Text
     }
 
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Resolve-PrePushKnownFlagScenarioPack')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushKnownFlagScenarioReport')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushSupportLaneReport')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'New-PrePushTransportMatrixScenarios')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'ConvertTo-PrePushKnownFlagScenarioResultArray')
-    $script:KnownFlagContract = Get-Content -LiteralPath $script:KnownFlagContractPath -Raw | ConvertFrom-Json -Depth 12
-    $script:ActiveScenario = @($script:KnownFlagContract.scenarios | Where-Object { $_.isActive -eq $true }) | Select-Object -First 1
-    if ($null -eq $script:ActiveScenario) {
-      throw 'Active known-flag scenario not found in contract.'
+
+    $script:KnownFlagContract = Get-Content -LiteralPath $script:KnownFlagContractPath -Raw | ConvertFrom-Json -Depth 20
+    $script:ActiveScenarioPack = @($script:KnownFlagContract.scenarioPacks | Where-Object { $_.isActive -eq $true }) | Select-Object -First 1
+    if ($null -eq $script:ActiveScenarioPack) {
+      throw 'Active known-flag scenario pack not found in contract.'
     }
   }
 
-  It 'writes a deterministic report that mirrors the active scenario contract and observed evidence paths' {
+  It 'resolves the active scenario pack and preserves declared scenario order without generating flag combinations' {
+    $resolved = Resolve-PrePushKnownFlagScenarioPack -repoRoot (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+    $resolved.pack.id | Should -Be $script:KnownFlagContract.activeScenarioPackId
+    $resolved.pack.image | Should -Be 'nationalinstruments/labview:2026q1-linux'
+    $resolved.pack.priorityClass | Should -Be 'pre-push'
+    @($resolved.pack.planeApplicability) | Should -Be @('linux-proof')
+    $resolved.baseVi | Should -Match '[\\/]VI1\.vi$'
+    $resolved.headVi | Should -Match '[\\/]VI2\.vi$'
+    @($resolved.scenarios | ForEach-Object { $_.id }) | Should -Be @(
+      'baseline-review-surface',
+      'attribute-suppression-boundary',
+      'front-panel-position-boundary',
+      'block-diagram-cosmetic-boundary'
+    )
+    @($resolved.scenarios[0].requestedFlags) | Should -Be @()
+    @($resolved.scenarios[1].requestedFlags) | Should -Be @('-noattr')
+    @($resolved.scenarios[2].requestedFlags) | Should -Be @('-nofppos')
+    @($resolved.scenarios[3].requestedFlags) | Should -Be @('-nobdcosm')
+  }
+
+  It 'derives the transport smoke matrix from the unique declared requested flags' {
+    $transportMatrixScenarios = New-PrePushTransportMatrixScenarios -scenarioDefinitions @(
+      [pscustomobject]@{ requestedFlags = @() },
+      [pscustomobject]@{ requestedFlags = @('-noattr') },
+      [pscustomobject]@{ requestedFlags = @('-nofppos') },
+      [pscustomobject]@{ requestedFlags = @('-nobdcosm') }
+    )
+
+    @($transportMatrixScenarios | ForEach-Object { $_.name }) | Should -Be @(
+      'baseline',
+      'noattr',
+      'nofppos',
+      'nobdcosm',
+      'noattr__nofppos',
+      'noattr__nobdcosm',
+      'nofppos__nobdcosm',
+      'noattr__nofppos__nobdcosm'
+    )
+  }
+
+  It 'writes a deterministic report that mirrors the active scenario pack contract and declared semantic expectations' {
     $repoRoot = Join-Path $TestDrive 'non-git-repo'
     $resultsRoot = Join-Path $repoRoot 'tests' 'results' '_agent' 'pre-push-ni-image'
     New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
 
     $contract = [pscustomobject]@{
       path = $script:KnownFlagContractPath
-      scenario = $script:ActiveScenario
-      flags = @($script:ActiveScenario.flags)
+      pack = $script:ActiveScenarioPack
+      scenarios = @(
+        [pscustomobject]@{
+          id = 'baseline-review-surface'
+          description = 'Full-surface baseline.'
+          requestedFlags = @()
+          requestedFlagsLabel = '(none)'
+          planeApplicability = @('linux-proof')
+          priorityClass = 'pre-push'
+          intendedSuppressionSemantics = [pscustomobject]@{
+            suppressedCategories = @()
+            reviewerSurfaceIntent = 'full-review-surface'
+            rawModeBoundaryIntent = 'primary-review-surface'
+          }
+          expectedReviewerAssertions = @(
+            [pscustomobject]@{
+              id = 'compare-report-rendered'
+              surface = 'compare-report.html'
+              requirement = 'rendered'
+            }
+          )
+          expectedRawModeEvidenceBoundaries = @(
+            [pscustomobject]@{
+              id = 'baseline-raw-mode-boundary'
+              mode = 'compare-report'
+              surfaceRole = 'reviewer-primary'
+              expectation = 'full-surface'
+            }
+          )
+        }
+      )
       reportPath = Join-Path $resultsRoot 'known-flag-scenario-report.json'
     }
+
     $scenarioResults = @(
       [pscustomobject]@{
-        name = 'ni-linux-known-flag-bundle-v1'
-        requestedFlags = @('-noattr', '-nofppos', '-nobdcosm')
-        flags = @('-noattr', '-nofppos', '-nobdcosm')
+        name = 'baseline-review-surface'
+        description = 'Full-surface baseline.'
+        requestedFlags = @()
+        flags = @('-Headless')
+        planeApplicability = @('linux-proof')
+        priorityClass = 'pre-push'
+        intendedSuppressionSemantics = [pscustomobject]@{
+          suppressedCategories = @()
+          reviewerSurfaceIntent = 'full-review-surface'
+          rawModeBoundaryIntent = 'primary-review-surface'
+        }
+        expectedReviewerAssertions = @(
+          [pscustomobject]@{
+            id = 'compare-report-rendered'
+            surface = 'compare-report.html'
+            requirement = 'rendered'
+          }
+        )
+        expectedRawModeEvidenceBoundaries = @(
+          [pscustomobject]@{
+            id = 'baseline-raw-mode-boundary'
+            mode = 'compare-report'
+            surfaceRole = 'reviewer-primary'
+            expectation = 'full-surface'
+          }
+        )
         resultClass = 'pass'
         gateOutcome = 'pass'
-        capturePath = 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/capture.json'
-        reportPath = 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/report.html'
+        capturePath = 'tests/results/_agent/pre-push-ni-image/baseline-review-surface/capture.json'
+        reportPath = 'tests/results/_agent/pre-push-ni-image/baseline-review-surface/report.html'
       }
     )
 
@@ -83,44 +180,51 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
       -observedOutcome 'pass' `
       -scenarioResults $scenarioResults `
       -failureMessage '' `
-      -activeScenarioName 'ni-linux-known-flag-bundle-v1' `
-      -activeCapturePath 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/capture.json' `
-      -activeReportPath 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/report.html'
+      -activeScenarioName 'baseline-review-surface' `
+      -activeCapturePath 'tests/results/_agent/pre-push-ni-image/baseline-review-surface/capture.json' `
+      -activeReportPath 'tests/results/_agent/pre-push-ni-image/baseline-review-surface/report.html'
 
     $reportPath | Should -Be $contract.reportPath
     Test-Path -LiteralPath $reportPath | Should -BeTrue
 
-    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 16
-    $report.schema | Should -Be 'pre-push-known-flag-scenario-report@v1'
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 24
+    $report.schema | Should -Be 'pre-push-known-flag-scenario-pack-report@v1'
     $report.contractPath | Should -Be $script:KnownFlagContractPath
     $report.branch | Should -BeNullOrEmpty
     $report.headSha | Should -BeNullOrEmpty
-    $report.scenario.id | Should -Be $script:KnownFlagContract.activeScenarioId
-    $report.scenario.image | Should -Be $script:ActiveScenario.image
-    $report.scenario.labviewPathEnv | Should -Be $script:ActiveScenario.labviewPathEnv
-    $report.scenario.defaultLabviewPath | Should -Be $script:ActiveScenario.defaultLabviewPath
-    $report.scenario.requestedFlags | Should -Be @($script:ActiveScenario.flags)
-    $report.scenario.expectedGateOutcome | Should -Be $script:ActiveScenario.expectedGateOutcome
+    $report.scenarioPack.id | Should -Be $script:KnownFlagContract.activeScenarioPackId
+    $report.scenarioPack.image | Should -Be $script:ActiveScenarioPack.image
+    $report.scenarioPack.labviewPathEnv | Should -Be $script:ActiveScenarioPack.labviewPathEnv
+    $report.scenarioPack.defaultLabviewPath | Should -Be $script:ActiveScenarioPack.defaultLabviewPath
+    @($report.scenarioPack.planeApplicability) | Should -Be @('linux-proof')
+    $report.scenarioPack.priorityClass | Should -Be 'pre-push'
+    $report.scenarioPack.target.kind | Should -Be 'fixture-diff'
+    $report.scenarioPack.target.baseVi | Should -Be 'VI1.vi'
+    $report.scenarioPack.target.headVi | Should -Be 'VI2.vi'
     $report.observed.outcome | Should -Be 'pass'
-    $report.observed.activeScenarioName | Should -Be 'ni-linux-known-flag-bundle-v1'
-    $report.observed.capturePath | Should -Be 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/capture.json'
-    $report.observed.reportPath | Should -Be 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/report.html'
-    $report.observed.failureMessage | Should -BeNullOrEmpty
+    $report.observed.activeScenarioId | Should -Be 'baseline-review-surface'
+    $report.observed.capturePath | Should -Be 'tests/results/_agent/pre-push-ni-image/baseline-review-surface/capture.json'
+    $report.observed.reportPath | Should -Be 'tests/results/_agent/pre-push-ni-image/baseline-review-surface/report.html'
     $report.results.Count | Should -Be 1
-    $report.results[0].gateOutcome | Should -Be 'pass'
-    $report.results[0].capturePath | Should -Be 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/capture.json'
-    $report.results[0].reportPath | Should -Be 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/report.html'
+    $report.results[0].name | Should -Be 'baseline-review-surface'
+    $report.results[0].description | Should -Be 'Full-surface baseline.'
+    @($report.results[0].planeApplicability) | Should -Be @('linux-proof')
+    $report.results[0].priorityClass | Should -Be 'pre-push'
+    @($report.results[0].intendedSuppressionSemantics.suppressedCategories) | Should -Be @()
+    $report.results[0].intendedSuppressionSemantics.reviewerSurfaceIntent | Should -Be 'full-review-surface'
+    $report.results[0].expectedReviewerAssertions[0].id | Should -Be 'compare-report-rendered'
+    $report.results[0].expectedRawModeEvidenceBoundaries[0].expectation | Should -Be 'full-surface'
   }
 
-  It 'writes failure outcome and evidence paths without depending on a git checkout' {
+  It 'writes failure outcome and active scenario id without depending on a git checkout' {
     $repoRoot = Join-Path $TestDrive 'non-git-failure-repo'
     $resultsRoot = Join-Path $repoRoot 'tests' 'results' '_agent' 'pre-push-ni-image'
     New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
 
     $contract = [pscustomobject]@{
       path = $script:KnownFlagContractPath
-      scenario = $script:ActiveScenario
-      flags = @($script:ActiveScenario.flags)
+      pack = $script:ActiveScenarioPack
+      scenarios = @()
       reportPath = Join-Path $resultsRoot 'known-flag-scenario-report.json'
     }
 
@@ -129,47 +233,65 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
       -contract $contract `
       -observedOutcome 'fail' `
       -scenarioResults @() `
-      -failureMessage 'known-flag scenario failed' `
-      -activeScenarioName 'ni-linux-known-flag-bundle-v1' `
-      -activeCapturePath 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/capture.json' `
-      -activeReportPath 'tests/results/_agent/pre-push-ni-image/ni-linux-known-flag-bundle-v1/report.html'
+      -failureMessage 'scenario pack failed' `
+      -activeScenarioName 'attribute-suppression-boundary' `
+      -activeCapturePath 'tests/results/_agent/pre-push-ni-image/attribute-suppression-boundary/capture.json' `
+      -activeReportPath 'tests/results/_agent/pre-push-ni-image/attribute-suppression-boundary/report.html'
 
-    $reportPath | Should -Be $contract.reportPath
-    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 16
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 24
     $report.observed.outcome | Should -Be 'fail'
-    $report.observed.failureMessage | Should -Be 'known-flag scenario failed'
+    $report.observed.failureMessage | Should -Be 'scenario pack failed'
+    $report.observed.activeScenarioId | Should -Be 'attribute-suppression-boundary'
     $report.results.Count | Should -Be 0
   }
 
-  It 'normalizes live scenario result collections into plain report records' {
+  It 'normalizes live scenario results into semantic report records' {
     $scenarioResults = [System.Collections.Generic.List[object]]::new()
     $scenarioResults.Add([pscustomobject]@{
-      name = 'baseline'
-      requestedFlags = @()
-      flags = @('-Headless')
+      name = 'attribute-suppression-boundary'
+      description = 'Attribute suppression boundary.'
+      requestedFlags = @('-noattr')
+      flags = @('-Headless', '-noattr')
+      planeApplicability = @('linux-proof')
+      priorityClass = 'pre-push'
+      intendedSuppressionSemantics = [pscustomobject]@{
+        suppressedCategories = @('vi-attributes')
+        reviewerSurfaceIntent = 'attribute-boundary'
+        rawModeBoundaryIntent = 'raw-report-suppresses-vi-attributes'
+      }
+      expectedReviewerAssertions = @(
+        [pscustomobject]@{
+          id = 'raw-boundary-explicit'
+          surface = 'compare-report.html'
+          requirement = 'attribute-suppression-boundary-visible'
+        }
+      )
+      expectedRawModeEvidenceBoundaries = @(
+        [pscustomobject]@{
+          id = 'attribute-raw-mode-boundary'
+          mode = 'compare-report'
+          surfaceRole = 'raw-mode-boundary'
+          expectation = 'vi-attributes-suppressed'
+        }
+      )
       resultClass = 'diff'
       gateOutcome = 'pass'
-      capturePath = 'tests/results/_agent/pre-push-ni-image/baseline/ni-linux-container-capture.json'
-      reportPath = 'tests/results/_agent/pre-push-ni-image/baseline/compare-report.html'
-    }) | Out-Null
-    $scenarioResults.Add([pscustomobject]@{
-      name = 'vi-history-report'
-      requestedFlags = @('vi-history-suite')
-      flags = @('suite-manifest', 'history-report', 'history-summary')
-      resultClass = 'diff'
-      gateOutcome = 'pass'
-      capturePath = 'tests/results/_agent/pre-push-ni-image/vi-history-report/results/ni-linux-container-capture.json'
-      reportPath = 'tests/results/_agent/pre-push-ni-image/vi-history-report/results/history-report.html'
+      capturePath = 'tests/results/_agent/pre-push-ni-image/attribute-suppression-boundary/ni-linux-container-capture.json'
+      reportPath = 'tests/results/_agent/pre-push-ni-image/attribute-suppression-boundary/compare-report.html'
     }) | Out-Null
 
     $normalized = ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $scenarioResults
 
-    $normalized.Count | Should -Be 2
-    $normalized[0].name | Should -Be 'baseline'
-    $normalized[0].flags | Should -Be @('-Headless')
-    $normalized[1].name | Should -Be 'vi-history-report'
-    $normalized[1].requestedFlags | Should -Be @('vi-history-suite')
-    $normalized[1].reportPath | Should -Be 'tests/results/_agent/pre-push-ni-image/vi-history-report/results/history-report.html'
+    $normalized.Count | Should -Be 1
+    $normalized[0].name | Should -Be 'attribute-suppression-boundary'
+    $normalized[0].description | Should -Be 'Attribute suppression boundary.'
+    @($normalized[0].requestedFlags) | Should -Be @('-noattr')
+    @($normalized[0].flags) | Should -Be @('-Headless', '-noattr')
+    @($normalized[0].planeApplicability) | Should -Be @('linux-proof')
+    $normalized[0].priorityClass | Should -Be 'pre-push'
+    @($normalized[0].intendedSuppressionSemantics.suppressedCategories) | Should -Be @('vi-attributes')
+    $normalized[0].expectedReviewerAssertions[0].requirement | Should -Be 'attribute-suppression-boundary-visible'
+    $normalized[0].expectedRawModeEvidenceBoundaries[0].expectation | Should -Be 'vi-attributes-suppressed'
   }
 
   It 'writes deterministic support-lane reports for transport and vi-history smoke lanes' {
@@ -181,8 +303,18 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
     $transportResults = @(
       [pscustomobject]@{
         name = 'single-container-matrix'
+        description = 'Transport smoke.'
         requestedFlags = @('all combinations')
         flags = @('-Headless')
+        planeApplicability = @('linux-proof')
+        priorityClass = 'certification'
+        intendedSuppressionSemantics = [pscustomobject]@{
+          suppressedCategories = @()
+          reviewerSurfaceIntent = 'transport-smoke'
+          rawModeBoundaryIntent = 'transport-only'
+        }
+        expectedReviewerAssertions = @()
+        expectedRawModeEvidenceBoundaries = @()
         resultClass = 'diff'
         gateOutcome = 'pass'
         capturePath = 'tests/results/_agent/pre-push-ni-image/single-container-matrix/ni-linux-container-capture.json'
@@ -202,7 +334,6 @@ Describe 'Pre-push known-flag scenario report' -Tag 'Unit' {
       -capturePath 'tests/results/_agent/pre-push-ni-image/single-container-matrix/ni-linux-container-capture.json' `
       -reportArtifactPath 'tests/results/_agent/pre-push-ni-image/single-container-matrix/compare-report.html'
 
-    $reportPath | Should -Be $transportPath
     $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 16
     $report.schema | Should -Be 'pre-push-ni-transport-smoke-report@v1'
     $report.lane.name | Should -Be 'single-container-matrix'

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -306,7 +306,9 @@ function Write-PrePushNIKnownFlagIncidentEvent {
     [string]$containerLabVIEWPath,
     [string[]]$scenarioFlags,
     [string]$reportPath,
-    [string]$runtimeSnapshotPath
+    [string]$runtimeSnapshotPath,
+    [string]$incidentInputPath,
+    [string]$incidentEventPath
   )
 
   $eventIngestScript = Join-Path $repoRoot 'tools' 'priority' 'event-ingest.mjs'
@@ -316,9 +318,20 @@ function Write-PrePushNIKnownFlagIncidentEvent {
   }
 
   $canaryDir = Join-Path $repoRoot 'tests' 'results' '_agent' 'canary'
-  New-Item -ItemType Directory -Path $canaryDir -Force | Out-Null
-  $inputPath = Join-Path $canaryDir 'pre-push-ni-known-flag-incident-input.json'
-  $eventReportPath = Join-Path $canaryDir 'pre-push-ni-known-flag-incident-event.json'
+  if ([string]::IsNullOrWhiteSpace($incidentInputPath)) {
+    $incidentInputPath = Join-Path $canaryDir 'pre-push-ni-known-flag-incident-input.json'
+  }
+  if ([string]::IsNullOrWhiteSpace($incidentEventPath)) {
+    $incidentEventPath = Join-Path $canaryDir 'pre-push-ni-known-flag-incident-event.json'
+  }
+  $inputDir = Split-Path -Parent $incidentInputPath
+  $eventDir = Split-Path -Parent $incidentEventPath
+  if (-not [string]::IsNullOrWhiteSpace($inputDir)) {
+    New-Item -ItemType Directory -Path $inputDir -Force | Out-Null
+  }
+  if (-not [string]::IsNullOrWhiteSpace($eventDir)) {
+    New-Item -ItemType Directory -Path $eventDir -Force | Out-Null
+  }
   $repository = if ([string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY)) {
     'local/compare-vi-cli-action'
   } else {
@@ -371,82 +384,184 @@ function Write-PrePushNIKnownFlagIncidentEvent {
     }
   }
 
-  $payload | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $inputPath -Encoding utf8
+  $payload | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $incidentInputPath -Encoding utf8
   & node $eventIngestScript `
     --source-type incident-event `
-    --input $inputPath `
-    --report $eventReportPath
+    --input $incidentInputPath `
+    --report $incidentEventPath
   if ($LASTEXITCODE -ne 0) {
     Write-Warning ("[pre-push] NI known-flag incident normalization failed (exit={0})." -f $LASTEXITCODE)
     return $null
   }
 
-  return $eventReportPath
+  return $incidentEventPath
 }
 
-function Resolve-PrePushKnownFlagScenario {
+function Resolve-PrePushKnownFlagScenarioPack {
   param([string]$repoRoot)
 
   $contractPath = Join-Path $repoRoot 'tools' 'policy' 'prepush-known-flag-scenarios.json'
   if (-not (Test-Path -LiteralPath $contractPath -PathType Leaf)) {
-    throw ("Pre-push known-flag scenario contract not found: {0}" -f $contractPath)
+    throw ("Pre-push known-flag scenario-pack contract not found: {0}" -f $contractPath)
   }
 
   try {
     $contract = Get-Content -LiteralPath $contractPath -Raw | ConvertFrom-Json -Depth 20
   } catch {
-    throw ("Unable to parse pre-push known-flag scenario contract: {0}" -f $contractPath)
+    throw ("Unable to parse pre-push known-flag scenario-pack contract: {0}" -f $contractPath)
   }
 
-  if ([string]$contract.schema -ne 'prepush-known-flag-scenarios/v1') {
-    throw ("Unexpected pre-push known-flag scenario contract schema in {0}: {1}" -f $contractPath, $contract.schema)
+  if ([string]$contract.schema -ne 'prepush-known-flag-scenario-packs/v1') {
+    throw ("Unexpected pre-push known-flag scenario-pack contract schema in {0}: {1}" -f $contractPath, $contract.schema)
   }
-  $scenarios = @($contract.scenarios)
-  if ($scenarios.Count -lt 1) {
-    throw ("Pre-push known-flag scenario contract defines no scenarios: {0}" -f $contractPath)
+  $scenarioPacks = @($contract.scenarioPacks)
+  if ($scenarioPacks.Count -lt 1) {
+    throw ("Pre-push known-flag scenario-pack contract defines no scenario packs: {0}" -f $contractPath)
   }
-  $activeScenarios = @($scenarios | Where-Object { $_.isActive -eq $true })
-  if ($activeScenarios.Count -ne 1) {
-    throw ("Pre-push known-flag scenario contract must define exactly one active scenario: {0}" -f $contractPath)
+  $activeScenarioPacks = @($scenarioPacks | Where-Object { $_.isActive -eq $true })
+  if ($activeScenarioPacks.Count -ne 1) {
+    throw ("Pre-push known-flag scenario-pack contract must define exactly one active scenario pack: {0}" -f $contractPath)
   }
 
-  $activeScenario = $activeScenarios[0]
-  if ([string]::IsNullOrWhiteSpace([string]$activeScenario.id)) {
-    throw ("Pre-push known-flag scenario contract active scenario is missing id: {0}" -f $contractPath)
+  $activeScenarioPack = $activeScenarioPacks[0]
+  if ([string]::IsNullOrWhiteSpace([string]$activeScenarioPack.id)) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing id: {0}" -f $contractPath)
   }
-  if (-not [string]::IsNullOrWhiteSpace([string]$contract.activeScenarioId) -and
-      -not [string]::Equals([string]$contract.activeScenarioId, [string]$activeScenario.id, [System.StringComparison]::Ordinal)) {
-    throw ("Pre-push known-flag scenario contract activeScenarioId did not match the active scenario id in {0}" -f $contractPath)
+  if (-not [string]::IsNullOrWhiteSpace([string]$contract.activeScenarioPackId) -and
+      -not [string]::Equals([string]$contract.activeScenarioPackId, [string]$activeScenarioPack.id, [System.StringComparison]::Ordinal)) {
+    throw ("Pre-push known-flag scenario-pack contract activeScenarioPackId did not match the active scenario pack id in {0}" -f $contractPath)
   }
-  if ([string]::IsNullOrWhiteSpace([string]$activeScenario.image)) {
-    throw ("Pre-push known-flag scenario contract active scenario is missing image: {0}" -f $contractPath)
+  if ([string]::IsNullOrWhiteSpace([string]$activeScenarioPack.image)) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing image: {0}" -f $contractPath)
   }
-  if ([string]::IsNullOrWhiteSpace([string]$activeScenario.expectedGateOutcome)) {
-    throw ("Pre-push known-flag scenario contract active scenario is missing expectedGateOutcome: {0}" -f $contractPath)
+  if ([string]::IsNullOrWhiteSpace([string]$activeScenarioPack.expectedGateOutcome)) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing expectedGateOutcome: {0}" -f $contractPath)
   }
-  $scenarioFlags = @($activeScenario.flags | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-  if ($scenarioFlags.Count -lt 1) {
-    throw ("Pre-push known-flag scenario contract active scenario is missing flags: {0}" -f $contractPath)
+  $packPlaneApplicability = @($activeScenarioPack.planeApplicability | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  if ($packPlaneApplicability.Count -lt 1) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing planeApplicability: {0}" -f $contractPath)
   }
-  foreach ($flag in $scenarioFlags) {
-    if (-not $flag.StartsWith('-', [System.StringComparison]::Ordinal)) {
-      throw ("Pre-push known-flag scenario contract flag must start with '-': {0}" -f $flag)
+  if ([string]::IsNullOrWhiteSpace([string]$activeScenarioPack.priorityClass)) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing priorityClass: {0}" -f $contractPath)
+  }
+  if (-not $activeScenarioPack.target) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing target: {0}" -f $contractPath)
+  }
+  if ([string]::IsNullOrWhiteSpace([string]$activeScenarioPack.target.baseVi) -or
+      [string]::IsNullOrWhiteSpace([string]$activeScenarioPack.target.headVi)) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack target is missing baseVi/headVi: {0}" -f $contractPath)
+  }
+  if (-not $activeScenarioPack.evidence) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing evidence paths: {0}" -f $contractPath)
+  }
+  if ([string]::IsNullOrWhiteSpace([string]$activeScenarioPack.evidence.resultsRoot) -or
+      [string]::IsNullOrWhiteSpace([string]$activeScenarioPack.evidence.reportPath) -or
+      [string]::IsNullOrWhiteSpace([string]$activeScenarioPack.evidence.incidentInputPath) -or
+      [string]::IsNullOrWhiteSpace([string]$activeScenarioPack.evidence.incidentEventPath)) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack is missing evidence paths: {0}" -f $contractPath)
+  }
+
+  $declaredScenarios = @($activeScenarioPack.scenarios)
+  if ($declaredScenarios.Count -lt 1) {
+    throw ("Pre-push known-flag scenario-pack contract active scenario pack defines no scenarios: {0}" -f $contractPath)
+  }
+
+  $resolvedScenarioList = New-Object System.Collections.Generic.List[object]
+  $scenarioIds = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::Ordinal)
+  foreach ($declaredScenario in $declaredScenarios) {
+    $scenarioId = [string]$declaredScenario.id
+    if ([string]::IsNullOrWhiteSpace($scenarioId)) {
+      throw ("Pre-push known-flag scenario-pack contract scenario is missing id: {0}" -f $contractPath)
     }
-  }
-  if (-not $activeScenario.evidence) {
-    throw ("Pre-push known-flag scenario contract active scenario is missing evidence paths: {0}" -f $contractPath)
-  }
-  if ([string]::IsNullOrWhiteSpace([string]$activeScenario.evidence.resultsRoot) -or
-      [string]::IsNullOrWhiteSpace([string]$activeScenario.evidence.reportPath)) {
-    throw ("Pre-push known-flag scenario contract active scenario is missing resultsRoot/reportPath: {0}" -f $contractPath)
+    if (-not $scenarioIds.Add($scenarioId)) {
+      throw ("Pre-push known-flag scenario-pack contract scenario ids must be unique: {0}" -f $scenarioId)
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$declaredScenario.description)) {
+      throw ("Pre-push known-flag scenario-pack contract scenario '{0}' is missing description: {1}" -f $scenarioId, $contractPath)
+    }
+
+    $scenarioFlags = @($declaredScenario.requestedFlags | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    foreach ($flag in $scenarioFlags) {
+      if (-not $flag.StartsWith('-', [System.StringComparison]::Ordinal)) {
+        throw ("Pre-push known-flag scenario-pack contract flag must start with '-': {0}" -f $flag)
+      }
+    }
+
+    if (-not $declaredScenario.intendedSuppressionSemantics) {
+      throw ("Pre-push known-flag scenario-pack contract scenario '{0}' is missing intendedSuppressionSemantics: {1}" -f $scenarioId, $contractPath)
+    }
+    if (-not $declaredScenario.expectedReviewerAssertions -or @($declaredScenario.expectedReviewerAssertions).Count -lt 1) {
+      throw ("Pre-push known-flag scenario-pack contract scenario '{0}' is missing expectedReviewerAssertions: {1}" -f $scenarioId, $contractPath)
+    }
+    if (-not $declaredScenario.expectedRawModeEvidenceBoundaries -or @($declaredScenario.expectedRawModeEvidenceBoundaries).Count -lt 1) {
+      throw ("Pre-push known-flag scenario-pack contract scenario '{0}' is missing expectedRawModeEvidenceBoundaries: {1}" -f $scenarioId, $contractPath)
+    }
+
+    $scenarioPlaneApplicability = @()
+    if ($declaredScenario.PSObject.Properties['planeApplicability'] -and $declaredScenario.planeApplicability) {
+      $scenarioPlaneApplicability = @($declaredScenario.planeApplicability | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+    if ($scenarioPlaneApplicability.Count -lt 1) {
+      $scenarioPlaneApplicability = @($packPlaneApplicability)
+    }
+    $scenarioPriorityClass = if (-not $declaredScenario.PSObject.Properties['priorityClass'] -or [string]::IsNullOrWhiteSpace([string]$declaredScenario.priorityClass)) {
+      [string]$activeScenarioPack.priorityClass
+    } else {
+      [string]$declaredScenario.priorityClass
+    }
+
+    $suppressedCategories = @()
+    if ($declaredScenario.intendedSuppressionSemantics.PSObject.Properties['suppressedCategories'] -and
+        $declaredScenario.intendedSuppressionSemantics.suppressedCategories) {
+      $suppressedCategories = @($declaredScenario.intendedSuppressionSemantics.suppressedCategories | ForEach-Object { [string]$_ })
+    }
+
+    $expectedReviewerAssertions = New-Object System.Collections.Generic.List[object]
+    foreach ($assertion in @($declaredScenario.expectedReviewerAssertions)) {
+      $expectedReviewerAssertions.Add([pscustomobject]@{
+        id = [string]$assertion.id
+        surface = [string]$assertion.surface
+        requirement = [string]$assertion.requirement
+      }) | Out-Null
+    }
+
+    $expectedRawModeEvidenceBoundaries = New-Object System.Collections.Generic.List[object]
+    foreach ($boundary in @($declaredScenario.expectedRawModeEvidenceBoundaries)) {
+      $expectedRawModeEvidenceBoundaries.Add([pscustomobject]@{
+        id = [string]$boundary.id
+        mode = [string]$boundary.mode
+        surfaceRole = [string]$boundary.surfaceRole
+        expectation = [string]$boundary.expectation
+      }) | Out-Null
+    }
+
+    $resolvedScenarioList.Add([pscustomobject]@{
+      id = $scenarioId
+      description = [string]$declaredScenario.description
+      requestedFlags = @($scenarioFlags)
+      requestedFlagsLabel = if ($scenarioFlags.Count -eq 0) { '(none)' } else { [string]::Join(', ', $scenarioFlags) }
+      planeApplicability = @($scenarioPlaneApplicability)
+      priorityClass = $scenarioPriorityClass
+      intendedSuppressionSemantics = [pscustomobject]@{
+        suppressedCategories = @($suppressedCategories)
+        reviewerSurfaceIntent = [string]$declaredScenario.intendedSuppressionSemantics.reviewerSurfaceIntent
+        rawModeBoundaryIntent = [string]$declaredScenario.intendedSuppressionSemantics.rawModeBoundaryIntent
+      }
+      expectedReviewerAssertions = @($expectedReviewerAssertions.ToArray())
+      expectedRawModeEvidenceBoundaries = @($expectedRawModeEvidenceBoundaries.ToArray())
+    }) | Out-Null
   }
 
   return [pscustomobject]@{
     path = $contractPath
-    scenario = $activeScenario
-    flags = @($scenarioFlags)
-    resultsRoot = Join-Path $repoRoot ([string]$activeScenario.evidence.resultsRoot)
-    reportPath = Join-Path $repoRoot ([string]$activeScenario.evidence.reportPath)
+    pack = $activeScenarioPack
+    scenarios = @($resolvedScenarioList.ToArray())
+    resultsRoot = Join-Path $repoRoot ([string]$activeScenarioPack.evidence.resultsRoot)
+    reportPath = Join-Path $repoRoot ([string]$activeScenarioPack.evidence.reportPath)
+    incidentInputPath = Join-Path $repoRoot ([string]$activeScenarioPack.evidence.incidentInputPath)
+    incidentEventPath = Join-Path $repoRoot ([string]$activeScenarioPack.evidence.incidentEventPath)
+    baseVi = Join-Path $repoRoot ([string]$activeScenarioPack.target.baseVi)
+    headVi = Join-Path $repoRoot ([string]$activeScenarioPack.target.headVi)
   }
 }
 
@@ -492,23 +607,30 @@ function Write-PrePushKnownFlagScenarioReport {
   } catch {}
 
   $report = [ordered]@{
-    schema = 'pre-push-known-flag-scenario-report@v1'
+    schema = 'pre-push-known-flag-scenario-pack-report@v1'
     generatedAt = (Get-Date).ToUniversalTime().ToString('o')
     contractPath = [string]$contract.path
     branch = $branchName
     headSha = $sha
-    scenario = [ordered]@{
-      id = [string]$contract.scenario.id
-      description = [string]$contract.scenario.description
-      image = [string]$contract.scenario.image
-      labviewPathEnv = [string]$contract.scenario.labviewPathEnv
-      defaultLabviewPath = [string]$contract.scenario.defaultLabviewPath
-      requestedFlags = @($contract.flags)
-      expectedGateOutcome = [string]$contract.scenario.expectedGateOutcome
+    scenarioPack = [ordered]@{
+      id = [string]$contract.pack.id
+      description = [string]$contract.pack.description
+      image = [string]$contract.pack.image
+      labviewPathEnv = [string]$contract.pack.labviewPathEnv
+      defaultLabviewPath = [string]$contract.pack.defaultLabviewPath
+      planeApplicability = @($contract.pack.planeApplicability | ForEach-Object { [string]$_ })
+      priorityClass = [string]$contract.pack.priorityClass
+      expectedGateOutcome = [string]$contract.pack.expectedGateOutcome
+      target = [ordered]@{
+        kind = [string]$contract.pack.target.kind
+        baseVi = [string]$contract.pack.target.baseVi
+        headVi = [string]$contract.pack.target.headVi
+      }
+      scenarioIds = @($contract.scenarios | ForEach-Object { [string]$_.id })
     }
     observed = [ordered]@{
       outcome = $observedOutcome
-      activeScenarioName = $activeScenarioName
+      activeScenarioId = $activeScenarioName
       capturePath = $activeCapturePath
       reportPath = $activeReportPath
       failureMessage = $failureMessage
@@ -582,6 +704,56 @@ function Write-PrePushSupportLaneReport {
   return $reportPath
 }
 
+function New-PrePushTransportMatrixScenarios {
+  param(
+    [AllowNull()]
+    [object[]]$scenarioDefinitions
+  )
+
+  $baseFlagOptions = New-Object System.Collections.Generic.List[object]
+  $seenFlags = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::Ordinal)
+  foreach ($scenarioDefinition in @($scenarioDefinitions)) {
+    if ($null -eq $scenarioDefinition) {
+      continue
+    }
+    $requestedFlags = @()
+    if ($scenarioDefinition.PSObject.Properties['requestedFlags'] -and $scenarioDefinition.requestedFlags) {
+      $requestedFlags = @($scenarioDefinition.requestedFlags | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+    foreach ($requestedFlag in $requestedFlags) {
+      if ($seenFlags.Add($requestedFlag)) {
+        $baseFlagOptions.Add([pscustomobject]@{
+          label = ([string]$requestedFlag).TrimStart('-')
+          flag = [string]$requestedFlag
+        }) | Out-Null
+      }
+    }
+  }
+
+  $transportMatrixScenarioBuffer = New-Object System.Collections.Generic.List[object]
+  for ($mask = 0; $mask -lt (1 -shl $baseFlagOptions.Count); $mask++) {
+    $scenarioFlags = @()
+    $scenarioLabels = @()
+    $selectedIndices = @()
+    for ($i = 0; $i -lt $baseFlagOptions.Count; $i++) {
+      if (($mask -band (1 -shl $i)) -ne 0) {
+        $scenarioFlags += [string]$baseFlagOptions[$i].flag
+        $scenarioLabels += [string]$baseFlagOptions[$i].label
+        $selectedIndices += $i
+      }
+    }
+
+    $transportMatrixScenarioBuffer.Add([pscustomobject]@{
+      name = if ($scenarioLabels.Count -eq 0) { 'baseline' } else { [string]::Join('__', $scenarioLabels) }
+      flags = @($scenarioFlags)
+      requestedFlagsLabel = if ($scenarioFlags.Count -eq 0) { '(none)' } else { [string]::Join(', ', $scenarioFlags) }
+      orderKey = if ($selectedIndices.Count -eq 0) { 'none' } else { [string]::Join('-', @($selectedIndices | ForEach-Object { '{0:d2}' -f $_ })) }
+    }) | Out-Null
+  }
+
+  return @($transportMatrixScenarioBuffer | Sort-Object @{ Expression = { $_.flags.Count } }, @{ Expression = { $_.orderKey } })
+}
+
 function ConvertTo-PrePushKnownFlagScenarioResultArray {
   param(
     [AllowNull()]
@@ -604,10 +776,70 @@ function ConvertTo-PrePushKnownFlagScenarioResultArray {
       $flags = @($scenarioResult.flags | ForEach-Object { [string]$_ })
     }
 
+    $planeApplicability = @()
+    if ($scenarioResult.PSObject.Properties['planeApplicability'] -and $scenarioResult.planeApplicability) {
+      $planeApplicability = @($scenarioResult.planeApplicability | ForEach-Object { [string]$_ })
+    }
+
+    $suppressedCategories = @()
+    $reviewerSurfaceIntent = ''
+    $rawModeBoundaryIntent = ''
+    if ($scenarioResult.PSObject.Properties['intendedSuppressionSemantics'] -and $scenarioResult.intendedSuppressionSemantics) {
+      if ($scenarioResult.intendedSuppressionSemantics.PSObject.Properties['suppressedCategories'] -and
+          $scenarioResult.intendedSuppressionSemantics.suppressedCategories) {
+        $suppressedCategories = @($scenarioResult.intendedSuppressionSemantics.suppressedCategories | ForEach-Object { [string]$_ })
+      }
+      if ($scenarioResult.intendedSuppressionSemantics.PSObject.Properties['reviewerSurfaceIntent']) {
+        $reviewerSurfaceIntent = [string]$scenarioResult.intendedSuppressionSemantics.reviewerSurfaceIntent
+      }
+      if ($scenarioResult.intendedSuppressionSemantics.PSObject.Properties['rawModeBoundaryIntent']) {
+        $rawModeBoundaryIntent = [string]$scenarioResult.intendedSuppressionSemantics.rawModeBoundaryIntent
+      }
+    }
+
+    $expectedReviewerAssertions = New-Object System.Collections.Generic.List[object]
+    if ($scenarioResult.PSObject.Properties['expectedReviewerAssertions'] -and $scenarioResult.expectedReviewerAssertions) {
+      foreach ($assertion in @($scenarioResult.expectedReviewerAssertions)) {
+        if ($null -eq $assertion) {
+          continue
+        }
+        $expectedReviewerAssertions.Add([pscustomobject]@{
+          id = [string]$assertion.id
+          surface = [string]$assertion.surface
+          requirement = [string]$assertion.requirement
+        }) | Out-Null
+      }
+    }
+
+    $expectedRawModeEvidenceBoundaries = New-Object System.Collections.Generic.List[object]
+    if ($scenarioResult.PSObject.Properties['expectedRawModeEvidenceBoundaries'] -and $scenarioResult.expectedRawModeEvidenceBoundaries) {
+      foreach ($boundary in @($scenarioResult.expectedRawModeEvidenceBoundaries)) {
+        if ($null -eq $boundary) {
+          continue
+        }
+        $expectedRawModeEvidenceBoundaries.Add([pscustomobject]@{
+          id = [string]$boundary.id
+          mode = [string]$boundary.mode
+          surfaceRole = [string]$boundary.surfaceRole
+          expectation = [string]$boundary.expectation
+        }) | Out-Null
+      }
+    }
+
     $normalizedResults.Add([pscustomobject]@{
       name = [string]$scenarioResult.name
+      description = if ($scenarioResult.PSObject.Properties['description']) { [string]$scenarioResult.description } else { '' }
       requestedFlags = $requestedFlags
       flags = $flags
+      planeApplicability = $planeApplicability
+      priorityClass = if ($scenarioResult.PSObject.Properties['priorityClass']) { [string]$scenarioResult.priorityClass } else { '' }
+      intendedSuppressionSemantics = [pscustomobject]@{
+        suppressedCategories = @($suppressedCategories)
+        reviewerSurfaceIntent = $reviewerSurfaceIntent
+        rawModeBoundaryIntent = $rawModeBoundaryIntent
+      }
+      expectedReviewerAssertions = @($expectedReviewerAssertions.ToArray())
+      expectedRawModeEvidenceBoundaries = @($expectedRawModeEvidenceBoundaries.ToArray())
       resultClass = [string]$scenarioResult.resultClass
       gateOutcome = [string]$scenarioResult.gateOutcome
       capturePath = [string]$scenarioResult.capturePath
@@ -700,7 +932,7 @@ $skipNiImageChecks = $SkipNiImageFlagScenarios `
   -or ($env:PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS -match '^(1|true|yes|on)$') `
   -or ($env:PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS -match '^(1|true|yes|on)$')
 if ($skipNiImageChecks) {
-  Write-Host '[pre-push] Skipping VI Comparison Report flag combination scenarios by request' -ForegroundColor Yellow
+  Write-Host '[pre-push] Skipping VI Comparison Report scenario-pack and support lanes by request' -ForegroundColor Yellow
   return
 }
 
@@ -708,33 +940,33 @@ $niCompareScript = Join-Path $root 'tools' 'Run-NILinuxContainerCompare.ps1'
 if (-not (Test-Path -LiteralPath $niCompareScript -PathType Leaf)) {
   throw ("NI image compare script not found: {0}" -f $niCompareScript)
 }
-$baseVi = Join-Path $root 'VI1.vi'
-$headVi = Join-Path $root 'VI2.vi'
+$knownFlagScenarioContract = Resolve-PrePushKnownFlagScenarioPack -repoRoot $root
+$knownFlagScenarioPackId = [string]$knownFlagScenarioContract.pack.id
+$baseVi = [string]$knownFlagScenarioContract.baseVi
+$headVi = [string]$knownFlagScenarioContract.headVi
 if (-not (Test-Path -LiteralPath $baseVi -PathType Leaf)) {
-  throw ("Base VI not found for NI image known-flag scenario: {0}" -f $baseVi)
+  throw ("Base VI not found for NI image known-flag scenario pack '{0}': {1}" -f $knownFlagScenarioPackId, $baseVi)
 }
 if (-not (Test-Path -LiteralPath $headVi -PathType Leaf)) {
-  throw ("Head VI not found for NI image known-flag scenario: {0}" -f $headVi)
+  throw ("Head VI not found for NI image known-flag scenario pack '{0}': {1}" -f $knownFlagScenarioPackId, $headVi)
 }
 
-$knownFlagScenarioContract = Resolve-PrePushKnownFlagScenario -repoRoot $root
-$knownFlagScenarioId = [string]$knownFlagScenarioContract.scenario.id
-$expectedImage = [string]$knownFlagScenarioContract.scenario.image
-$labviewPathEnvName = [string]$knownFlagScenarioContract.scenario.labviewPathEnv
+$expectedImage = [string]$knownFlagScenarioContract.pack.image
+$labviewPathEnvName = [string]$knownFlagScenarioContract.pack.labviewPathEnv
 $labviewPathFromEnv = if (-not [string]::IsNullOrWhiteSpace($labviewPathEnvName)) {
   [Environment]::GetEnvironmentVariable($labviewPathEnvName, 'Process')
 } else {
   $null
 }
 $containerLabVIEWPath = if ([string]::IsNullOrWhiteSpace($labviewPathFromEnv)) {
-  ([string]$knownFlagScenarioContract.scenario.defaultLabviewPath).Trim()
+  ([string]$knownFlagScenarioContract.pack.defaultLabviewPath).Trim()
 } else {
   ([string]$labviewPathFromEnv).Trim()
 }
 if ([string]::IsNullOrWhiteSpace($containerLabVIEWPath)) {
-  throw ("Pre-push known-flag scenario '{0}' resolved an empty LabVIEW path." -f $knownFlagScenarioId)
+  throw ("Pre-push known-flag scenario pack '{0}' resolved an empty LabVIEW path." -f $knownFlagScenarioPackId)
 }
-Write-Host ("[pre-push] Active known-flag scenario '{0}' image={1} flags={2}" -f $knownFlagScenarioId, $expectedImage, [string]::Join(', ', @($knownFlagScenarioContract.flags))) -ForegroundColor Cyan
+Write-Host ("[pre-push] Active known-flag scenario pack '{0}' image={1} scenarios={2}" -f $knownFlagScenarioPackId, $expectedImage, @($knownFlagScenarioContract.scenarios).Count) -ForegroundColor Cyan
 $singleContainerBootstrapScript = Join-Path $root 'tools' 'NILinux-FlagMatrixBootstrap.sh'
 if (-not (Test-Path -LiteralPath $singleContainerBootstrapScript -PathType Leaf)) {
   throw ("Single-container flag matrix bootstrap script not found: {0}" -f $singleContainerBootstrapScript)
@@ -743,35 +975,8 @@ $viHistoryBootstrapScript = Join-Path $root 'tools' 'NILinux-VIHistorySuiteBoots
 if (-not (Test-Path -LiteralPath $viHistoryBootstrapScript -PathType Leaf)) {
   throw ("VI history bootstrap script not found: {0}" -f $viHistoryBootstrapScript)
 }
-$baseFlagOptions = @(
-  $knownFlagScenarioContract.flags | ForEach-Object {
-    [ordered]@{
-      label = ([string]$_).TrimStart('-')
-      flag = [string]$_
-    }
-  }
-)
-$knownFlagScenarioBuffer = New-Object System.Collections.Generic.List[object]
-for ($mask = 0; $mask -lt (1 -shl $baseFlagOptions.Count); $mask++) {
-  $scenarioFlags = @()
-  $scenarioLabels = @()
-  $selectedIndices = @()
-  for ($i = 0; $i -lt $baseFlagOptions.Count; $i++) {
-    if (($mask -band (1 -shl $i)) -ne 0) {
-      $scenarioFlags += [string]$baseFlagOptions[$i].flag
-      $scenarioLabels += [string]$baseFlagOptions[$i].label
-      $selectedIndices += $i
-    }
-  }
-
-  $knownFlagScenarioBuffer.Add([pscustomobject]@{
-    name = if ($scenarioLabels.Count -eq 0) { 'baseline' } else { [string]::Join('__', $scenarioLabels) }
-    flags = @($scenarioFlags)
-    requestedFlagsLabel = if ($scenarioFlags.Count -eq 0) { '(none)' } else { [string]::Join(', ', $scenarioFlags) }
-    orderKey = if ($selectedIndices.Count -eq 0) { 'none' } else { [string]::Join('-', @($selectedIndices | ForEach-Object { '{0:d2}' -f $_ })) }
-  }) | Out-Null
-}
-$knownFlagScenarios = @($knownFlagScenarioBuffer | Sort-Object @{ Expression = { $_.flags.Count } }, @{ Expression = { $_.orderKey } })
+$knownFlagScenarios = @($knownFlagScenarioContract.scenarios)
+$transportMatrixScenarios = @(New-PrePushTransportMatrixScenarios -scenarioDefinitions $knownFlagScenarios)
 $scenarioRoot = [string]$knownFlagScenarioContract.resultsRoot
 New-Item -ItemType Directory -Path $scenarioRoot -Force | Out-Null
 $scenarioContractReportPath = [string]$knownFlagScenarioContract.reportPath
@@ -801,11 +1006,11 @@ $observedCapturePath = [string]$capturePath
 $observedReportPath = [string]$reportPath
 
 try {
-  Write-Host ("[pre-push] Running active known-flag scenario '{0}' (real container compare)" -f $knownFlagScenarioId) -ForegroundColor Cyan
+  Write-Host ("[pre-push] Running active known-flag scenario pack '{0}' (real container compare)" -f $knownFlagScenarioPackId) -ForegroundColor Cyan
   $currentLane = 'known-flag'
   foreach ($scenario in $knownFlagScenarios) {
-    $activeScenarioName = [string]$scenario.name
-    $activeScenarioFlags = @($scenario.flags | ForEach-Object { [string]$_ })
+    $activeScenarioName = [string]$scenario.id
+    $activeScenarioFlags = @($scenario.requestedFlags | ForEach-Object { [string]$_ })
     $scenarioDir = Join-Path $scenarioRoot $activeScenarioName
     New-Item -ItemType Directory -Path $scenarioDir -Force | Out-Null
     $reportPath = Join-Path $scenarioDir 'compare-report.html'
@@ -814,7 +1019,7 @@ try {
     $observedCapturePath = [string]$capturePath
     $observedReportPath = [string]$reportPath
 
-    Write-Host ("[pre-push] Running NI image flag scenario '{0}' requestedFlags={1}" -f $activeScenarioName, [string]$scenario.requestedFlagsLabel) -ForegroundColor Cyan
+    Write-Host ("[pre-push] Running NI image scenario-pack member '{0}' requestedFlags={1}" -f $activeScenarioName, [string]$scenario.requestedFlagsLabel) -ForegroundColor Cyan
     Push-Location $root
     try {
       & $niCompareScript `
@@ -872,8 +1077,14 @@ try {
 
     $knownFlagScenarioResults.Add([pscustomobject]@{
       name = $activeScenarioName
+      description = [string]$scenario.description
       requestedFlags = @($activeScenarioFlags)
       flags = @($flagsUsed)
+      planeApplicability = @($scenario.planeApplicability)
+      priorityClass = [string]$scenario.priorityClass
+      intendedSuppressionSemantics = $scenario.intendedSuppressionSemantics
+      expectedReviewerAssertions = @($scenario.expectedReviewerAssertions)
+      expectedRawModeEvidenceBoundaries = @($scenario.expectedRawModeEvidenceBoundaries)
       resultClass = $resultClass
       gateOutcome = $gateOutcome
       capturePath = $capturePath
@@ -987,8 +1198,8 @@ try {
   }
 
   $ledgerRows = @(Get-Content -LiteralPath $singleContainerLedgerPath | Where-Object { $_ -and $_.Trim() })
-  if ($ledgerRows.Count -ne $knownFlagScenarios.Count) {
-    throw ("NI image flag scenario '{0}' ledger count mismatch ({1} != {2})." -f $activeScenarioName, $ledgerRows.Count, $knownFlagScenarios.Count)
+  if ($ledgerRows.Count -ne $transportMatrixScenarios.Count) {
+    throw ("NI image flag scenario '{0}' ledger count mismatch ({1} != {2})." -f $activeScenarioName, $ledgerRows.Count, $transportMatrixScenarios.Count)
   }
   $ledgerEntries = @(
     $ledgerRows | ForEach-Object {
@@ -1005,7 +1216,7 @@ try {
       }
     }
   )
-  $expectedScenarioNames = @($knownFlagScenarios | ForEach-Object { [string]$_.name })
+  $expectedScenarioNames = @($transportMatrixScenarios | ForEach-Object { [string]$_.name })
   $actualScenarioNames = @($ledgerEntries | ForEach-Object { [string]$_.name })
   $scenarioNameDifferences = @(Compare-Object -ReferenceObject $expectedScenarioNames -DifferenceObject $actualScenarioNames)
   if ($scenarioNameDifferences.Count -gt 0) {
@@ -1227,13 +1438,14 @@ try {
     $lines = @(
       '### Pre-push NI Image Scenarios',
       '',
-      ('- activeScenarioId=`{0}` expectedImage=`{1}` requestedFlags=`{2}`' -f $knownFlagScenarioId, $expectedImage, [string]::Join(', ', @($knownFlagScenarioContract.flags))),
+      ('- activeScenarioPackId=`{0}` expectedImage=`{1}` declaredScenarios=`{2}`' -f $knownFlagScenarioPackId, $expectedImage, @($knownFlagScenarioContract.scenarios).Count),
       ''
     )
-    $lines += '#### Active Known-Flag Scenario'
+    $lines += '#### Active Scenario Pack'
     foreach ($scenarioResult in $knownFlagScenarioResults) {
       $requestedFlags = if (@($scenarioResult.requestedFlags).Count -eq 0) { '(none)' } else { [string]::Join(', ', @($scenarioResult.requestedFlags)) }
       $lines += ('- `{0}`: resultClass=`{1}` gateOutcome=`{2}` requestedFlags=`{3}` effectiveFlags=`{4}`' -f $scenarioResult.name, $scenarioResult.resultClass, $scenarioResult.gateOutcome, $requestedFlags, [string]::Join(', ', @($scenarioResult.flags)))
+      $lines += ('  description=`{0}` priorityClass=`{1}` planes=`{2}`' -f $scenarioResult.description, $scenarioResult.priorityClass, [string]::Join(', ', @($scenarioResult.planeApplicability)))
       $lines += ('  capture=`{0}` report=`{1}`' -f $scenarioResult.capturePath, $scenarioResult.reportPath)
     }
     $lines += ''
@@ -1252,7 +1464,7 @@ try {
     }
     $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
   }
-  Write-Host ("[pre-push] Active known-flag scenario '{0}' OK" -f $knownFlagScenarioId) -ForegroundColor Green
+  Write-Host ("[pre-push] Active known-flag scenario pack '{0}' OK" -f $knownFlagScenarioPackId) -ForegroundColor Green
 } catch {
   $failureMessage = if ($_.Exception -and $_.Exception.Message) { $_.Exception.Message } else { [string]$_ }
   switch ($currentLane) {
@@ -1306,7 +1518,7 @@ try {
   $eventReportPath = Write-PrePushNIKnownFlagIncidentEvent `
     -repoRoot $root `
     -errorMessage $failureMessage `
-    -scenarioId $knownFlagScenarioId `
+    -scenarioId $knownFlagScenarioPackId `
     -scenarioName $activeScenarioName `
     -scenarioDir $scenarioDir `
     -capturePath $capturePath `
@@ -1314,7 +1526,9 @@ try {
     -containerLabVIEWPath $containerLabVIEWPath `
     -scenarioFlags $activeScenarioFlags `
     -reportPath $reportPath `
-    -runtimeSnapshotPath $runtimeSnapshotPath
+    -runtimeSnapshotPath $runtimeSnapshotPath `
+    -incidentInputPath $knownFlagScenarioContract.incidentInputPath `
+    -incidentEventPath $knownFlagScenarioContract.incidentEventPath
   if (-not [string]::IsNullOrWhiteSpace($eventReportPath)) {
     Write-Host ("[pre-push] NI known-flag incident event report: {0}" -f $eventReportPath) -ForegroundColor Yellow
   }

--- a/tools/policy/prepush-known-flag-scenarios.json
+++ b/tools/policy/prepush-known-flag-scenarios.json
@@ -1,27 +1,165 @@
 {
-  "schema": "prepush-known-flag-scenarios/v1",
+  "schema": "prepush-known-flag-scenario-packs/v1",
   "schemaVersion": "1.0.0",
-  "activeScenarioId": "ni-linux-known-flag-bundle-v1",
-  "scenarios": [
+  "activeScenarioPackId": "ni-linux-reviewer-rendering-pack-v1",
+  "scenarioPacks": [
     {
-      "id": "ni-linux-known-flag-bundle-v1",
+      "id": "ni-linux-reviewer-rendering-pack-v1",
       "isActive": true,
-      "description": "Canonical NI Linux pre-push known-flag scenario for deterministic local gate coverage.",
+      "description": "Canonical NI Linux pre-push scenario pack for reviewer and rendering semantics.",
       "image": "nationalinstruments/labview:2026q1-linux",
       "labviewPathEnv": "NI_LINUX_LABVIEW_PATH",
       "defaultLabviewPath": "/usr/local/natinst/LabVIEW-2026-64/labview",
-      "flags": [
-        "-noattr",
-        "-nofppos",
-        "-nobdcosm"
+      "planeApplicability": [
+        "linux-proof"
       ],
+      "priorityClass": "pre-push",
       "expectedGateOutcome": "pass",
+      "target": {
+        "kind": "fixture-diff",
+        "baseVi": "VI1.vi",
+        "headVi": "VI2.vi"
+      },
       "evidence": {
         "resultsRoot": "tests/results/_agent/pre-push-ni-image",
         "reportPath": "tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json",
         "incidentInputPath": "tests/results/_agent/canary/pre-push-ni-known-flag-incident-input.json",
         "incidentEventPath": "tests/results/_agent/canary/pre-push-ni-known-flag-incident-event.json"
-      }
+      },
+      "scenarios": [
+        {
+          "id": "baseline-review-surface",
+          "description": "Baseline full-surface compare used to exercise the primary rendered review surface.",
+          "requestedFlags": [],
+          "intendedSuppressionSemantics": {
+            "suppressedCategories": [],
+            "reviewerSurfaceIntent": "full-review-surface",
+            "rawModeBoundaryIntent": "primary-review-surface"
+          },
+          "expectedReviewerAssertions": [
+            {
+              "id": "compare-report-rendered",
+              "surface": "compare-report.html",
+              "requirement": "rendered"
+            },
+            {
+              "id": "capture-flags-match-request",
+              "surface": "ni-linux-container-capture.json",
+              "requirement": "requested-flags-observed"
+            }
+          ],
+          "expectedRawModeEvidenceBoundaries": [
+            {
+              "id": "baseline-raw-mode-boundary",
+              "mode": "compare-report",
+              "surfaceRole": "reviewer-primary",
+              "expectation": "full-surface"
+            }
+          ]
+        },
+        {
+          "id": "attribute-suppression-boundary",
+          "description": "Targeted suppression case that exercises the raw-report boundary when VI attributes are disabled.",
+          "requestedFlags": [
+            "-noattr"
+          ],
+          "intendedSuppressionSemantics": {
+            "suppressedCategories": [
+              "vi-attributes"
+            ],
+            "reviewerSurfaceIntent": "attribute-boundary",
+            "rawModeBoundaryIntent": "raw-report-suppresses-vi-attributes"
+          },
+          "expectedReviewerAssertions": [
+            {
+              "id": "compare-report-rendered",
+              "surface": "compare-report.html",
+              "requirement": "rendered"
+            },
+            {
+              "id": "raw-boundary-explicit",
+              "surface": "compare-report.html",
+              "requirement": "attribute-suppression-boundary-visible"
+            }
+          ],
+          "expectedRawModeEvidenceBoundaries": [
+            {
+              "id": "attribute-raw-mode-boundary",
+              "mode": "compare-report",
+              "surfaceRole": "raw-mode-boundary",
+              "expectation": "vi-attributes-suppressed"
+            }
+          ]
+        },
+        {
+          "id": "front-panel-position-boundary",
+          "description": "Targeted suppression case that exercises the raw-report boundary when front panel position and size are disabled.",
+          "requestedFlags": [
+            "-nofppos"
+          ],
+          "intendedSuppressionSemantics": {
+            "suppressedCategories": [
+              "front-panel-position-size"
+            ],
+            "reviewerSurfaceIntent": "front-panel-position-boundary",
+            "rawModeBoundaryIntent": "raw-report-suppresses-front-panel-position-size"
+          },
+          "expectedReviewerAssertions": [
+            {
+              "id": "compare-report-rendered",
+              "surface": "compare-report.html",
+              "requirement": "rendered"
+            },
+            {
+              "id": "raw-boundary-explicit",
+              "surface": "compare-report.html",
+              "requirement": "front-panel-position-boundary-visible"
+            }
+          ],
+          "expectedRawModeEvidenceBoundaries": [
+            {
+              "id": "front-panel-position-raw-mode-boundary",
+              "mode": "compare-report",
+              "surfaceRole": "raw-mode-boundary",
+              "expectation": "front-panel-position-size-suppressed"
+            }
+          ]
+        },
+        {
+          "id": "block-diagram-cosmetic-boundary",
+          "description": "Targeted suppression case that exercises the raw-report boundary when block diagram cosmetic changes are disabled.",
+          "requestedFlags": [
+            "-nobdcosm"
+          ],
+          "intendedSuppressionSemantics": {
+            "suppressedCategories": [
+              "block-diagram-cosmetic"
+            ],
+            "reviewerSurfaceIntent": "block-diagram-cosmetic-boundary",
+            "rawModeBoundaryIntent": "raw-report-suppresses-block-diagram-cosmetic"
+          },
+          "expectedReviewerAssertions": [
+            {
+              "id": "compare-report-rendered",
+              "surface": "compare-report.html",
+              "requirement": "rendered"
+            },
+            {
+              "id": "raw-boundary-explicit",
+              "surface": "compare-report.html",
+              "requirement": "block-diagram-cosmetic-boundary-visible"
+            }
+          ],
+          "expectedRawModeEvidenceBoundaries": [
+            {
+              "id": "block-diagram-cosmetic-raw-mode-boundary",
+              "mode": "compare-report",
+              "surfaceRole": "raw-mode-boundary",
+              "expectation": "block-diagram-cosmetic-suppressed"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tools/priority/__tests__/prepush-known-flag-scenario-contract.test.mjs
+++ b/tools/priority/__tests__/prepush-known-flag-scenario-contract.test.mjs
@@ -4,6 +4,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
 
 const repoRoot = process.cwd();
 
@@ -11,32 +13,63 @@ function readRepoFile(relativePath) {
   return readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
 
-test('pre-push known-flag contract defines exactly one active scenario with deterministic evidence paths', () => {
-  const contract = JSON.parse(readRepoFile('tools/policy/prepush-known-flag-scenarios.json'));
-  assert.equal(contract.schema, 'prepush-known-flag-scenarios/v1');
+function readRepoJson(relativePath) {
+  return JSON.parse(readRepoFile(relativePath));
+}
+
+test('pre-push known-flag contract defines exactly one active scenario pack with declared rendering semantics', () => {
+  const schema = readRepoJson('docs/schemas/prepush-known-flag-scenario-packs-v1.schema.json');
+  const contract = readRepoJson('tools/policy/prepush-known-flag-scenarios.json');
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  assert.equal(validate(contract), true, JSON.stringify(validate.errors, null, 2));
+  assert.equal(contract.schema, 'prepush-known-flag-scenario-packs/v1');
   assert.equal(contract.schemaVersion, '1.0.0');
-  assert.ok(Array.isArray(contract.scenarios));
-  const active = contract.scenarios.filter((scenario) => scenario.isActive === true);
+
+  const active = contract.scenarioPacks.filter((pack) => pack.isActive === true);
   assert.equal(active.length, 1);
-  const scenario = active[0];
-  assert.equal(contract.activeScenarioId, scenario.id);
-  assert.equal(scenario.id, 'ni-linux-known-flag-bundle-v1');
-  assert.equal(scenario.image, 'nationalinstruments/labview:2026q1-linux');
-  assert.deepEqual(scenario.flags, ['-noattr', '-nofppos', '-nobdcosm']);
-  assert.equal(scenario.expectedGateOutcome, 'pass');
-  assert.equal(scenario.labviewPathEnv, 'NI_LINUX_LABVIEW_PATH');
-  assert.equal(scenario.defaultLabviewPath, '/usr/local/natinst/LabVIEW-2026-64/labview');
-  assert.equal(scenario.evidence.resultsRoot, 'tests/results/_agent/pre-push-ni-image');
-  assert.equal(scenario.evidence.reportPath, 'tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json');
-  assert.equal(scenario.evidence.incidentInputPath, 'tests/results/_agent/canary/pre-push-ni-known-flag-incident-input.json');
-  assert.equal(scenario.evidence.incidentEventPath, 'tests/results/_agent/canary/pre-push-ni-known-flag-incident-event.json');
+  const pack = active[0];
+  assert.equal(contract.activeScenarioPackId, pack.id);
+  assert.equal(pack.id, 'ni-linux-reviewer-rendering-pack-v1');
+  assert.equal(pack.image, 'nationalinstruments/labview:2026q1-linux');
+  assert.deepEqual(pack.planeApplicability, ['linux-proof']);
+  assert.equal(pack.priorityClass, 'pre-push');
+  assert.equal(pack.expectedGateOutcome, 'pass');
+  assert.equal(pack.target.kind, 'fixture-diff');
+  assert.equal(pack.target.baseVi, 'VI1.vi');
+  assert.equal(pack.target.headVi, 'VI2.vi');
+  assert.equal(pack.evidence.resultsRoot, 'tests/results/_agent/pre-push-ni-image');
+  assert.equal(pack.evidence.reportPath, 'tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json');
+  assert.equal(pack.evidence.incidentInputPath, 'tests/results/_agent/canary/pre-push-ni-known-flag-incident-input.json');
+  assert.equal(pack.evidence.incidentEventPath, 'tests/results/_agent/canary/pre-push-ni-known-flag-incident-event.json');
+
+  assert.deepEqual(
+    pack.scenarios.map((scenario) => scenario.id),
+    [
+      'baseline-review-surface',
+      'attribute-suppression-boundary',
+      'front-panel-position-boundary',
+      'block-diagram-cosmetic-boundary'
+    ]
+  );
+  assert.deepEqual(pack.scenarios[0].requestedFlags, []);
+  assert.deepEqual(pack.scenarios[1].requestedFlags, ['-noattr']);
+  assert.deepEqual(pack.scenarios[2].requestedFlags, ['-nofppos']);
+  assert.deepEqual(pack.scenarios[3].requestedFlags, ['-nobdcosm']);
+  assert.deepEqual(pack.scenarios[1].intendedSuppressionSemantics.suppressedCategories, ['vi-attributes']);
+  assert.deepEqual(pack.scenarios[2].intendedSuppressionSemantics.suppressedCategories, ['front-panel-position-size']);
+  assert.deepEqual(pack.scenarios[3].intendedSuppressionSemantics.suppressedCategories, ['block-diagram-cosmetic']);
+  assert.ok(pack.scenarios.every((scenario) => Array.isArray(scenario.expectedReviewerAssertions) && scenario.expectedReviewerAssertions.length > 0));
+  assert.ok(pack.scenarios.every((scenario) => Array.isArray(scenario.expectedRawModeEvidenceBoundaries) && scenario.expectedRawModeEvidenceBoundaries.length > 0));
 });
 
-test('AGENTS documents the active pre-push known-flag contract surface', () => {
+test('AGENTS documents the active pre-push scenario-pack contract surface', () => {
   const content = readRepoFile('AGENTS.md');
   assert.match(content, /prepush-known-flag-scenarios\.json/);
   assert.match(content, /known-flag-scenario-report\.json/);
   assert.match(content, /transport-smoke-report\.json/);
   assert.match(content, /vi-history-smoke-report\.json/);
-  assert.match(content, /exactly one active known-flag scenario/i);
+  assert.match(content, /exactly one active scenario pack/i);
 });

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -28,14 +28,13 @@ test('PrePush-Checks invokes workspace health gate in optional lease mode', () =
   assert.match(content, /if \(\$null -eq \$mount\) \{\s*continue\s*\}/);
 });
 
-test('PrePush NI image known-flag scenario consumes the checked-in active scenario contract', () => {
+test('PrePush NI image known-flag scenario consumes the checked-in active scenario-pack contract', () => {
   const content = readRepoFile('tools/PrePush-Checks.ps1');
   assert.match(content, /Run-NILinuxContainerCompare\.ps1/);
-  assert.match(content, /Resolve-PrePushKnownFlagScenario/);
+  assert.match(content, /Resolve-PrePushKnownFlagScenarioPack/);
   assert.match(content, /prepush-known-flag-scenarios\.json/);
-  assert.match(content, /Active known-flag scenario/);
-  assert.match(content, /\$knownFlagScenarioContract\.flags/);
-  assert.match(content, /name = if \(\$scenarioLabels\.Count -eq 0\) \{ 'baseline' \}/);
+  assert.match(content, /Active known-flag scenario pack/);
+  assert.match(content, /\$knownFlagScenarioContract\.scenarios/);
   assert.match(content, /& \$niCompareScript/);
   assert.match(content, /-LabVIEWPath \$containerLabVIEWPath/);
   assert.match(content, /-ContainerNameLabel \$activeScenarioName/);
@@ -47,15 +46,13 @@ test('PrePush NI image known-flag scenario consumes the checked-in active scenar
   assert.match(content, /Write-PrePushSupportLaneReport/);
   assert.match(content, /transport-smoke-report\.json/);
   assert.match(content, /vi-history-smoke-report\.json/);
-  assert.match(content, /#### Active Known-Flag Scenario/);
+  assert.match(content, /#### Active Scenario Pack/);
   assert.match(content, /#### Transport Smoke/);
   assert.match(content, /#### VI History Smoke/);
-  assert.match(content, /Active known-flag scenario '\{0\}' OK/);
+  assert.match(content, /Active known-flag scenario pack '\{0\}' OK/);
+  assert.match(content, /New-PrePushTransportMatrixScenarios/);
   assert.doesNotMatch(content, /pwsh\s+-NoLogo\s+-NoProfile\s+-File\s+\$niCompareScript/);
   assert.doesNotMatch(content, /Render-VIHistoryReport\.ps1/);
-  assert.doesNotMatch(content, /label = 'noattr'; flag = '-noattr'/);
-  assert.doesNotMatch(content, /label = 'nofppos'; flag = '-nofppos'/);
-  assert.doesNotMatch(content, /label = 'nobdcosm'; flag = '-nobdcosm'/);
 });
 
 test('single-container flag matrix bootstrap clears stale reports and writes per-scenario CLI logs', () => {


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1390
- Issue title: Define scenario-pack contracts for reviewer and rendering semantics
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1390
- Standing priority at PR creation: Yes (#1390)
- Base branch: `develop`
- Head branch: `issue/origin-1390-scenario-pack-contract`
- Template variant: `workflow-policy`

# Summary

Define a named scenario-pack contract for the pre-push reviewer-rendering lane so semantic review assertions come from declared scenarios instead of a blind flag power-set.

The active pre-push reviewer lane now:
- resolves one checked-in active scenario pack from `tools/policy/prepush-known-flag-scenarios.json`
- runs its ordered semantic scenarios against the NI Linux compare surface
- emits a `pre-push-known-flag-scenario-pack-report@v1` receipt
- keeps the broad transport matrix as a separate support lane derived from the union of declared flags

This keeps reviewer-surface intent explicit while preserving broad transport smoke coverage.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
  - `tools/PrePush-Checks.ps1`
  - `tools/policy/prepush-known-flag-scenarios.json`
  - `docs/schemas/prepush-known-flag-scenario-packs-v1.schema.json`
- Check names, required-status contracts, or merge-queue behavior affected:
  - no required status names changed
  - pre-push reviewer-rendering semantics now come from the active scenario-pack contract
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
  - none
- Manual dispatch, comment command, or branch-protection effects:
  - none

## Validation Evidence

- Commands run:
  - `Invoke-Pester -Path tests/PrePushKnownFlagScenarioReport.Tests.ps1 -CI`
  - `node --test tools/priority/__tests__/prepush-known-flag-scenario-contract.test.mjs tools/priority/__tests__/workspace-health-contract.test.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `git diff --check`
- Contract, schema, or guard tests:
  - schema coverage for `prepush-known-flag-scenario-packs/v1`
  - workspace-health contract coverage for active scenario-pack consumption and deterministic incident-event paths
- Live workflow or dry-run evidence:
  - `tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json`
  - `tests/results/_agent/pre-push-ni-image/transport-smoke-report.json`
  - `tests/results/_agent/pre-push-ni-image/vi-history-smoke-report.json`

## Rollout and Rollback

- Rollout notes:
  - keep `#1388` and `#1392` queued behind this change so semantic result assertions and push-blocking post-results certification consume the same declared scenario pack
- Rollback path:
  - revert this PR to restore the previous implicit flag-sweep reviewer lane
- Residual risks:
  - semantic assertion enforcement is still a follow-on; this PR defines the contract and active-lane selection surface first

## Reviewer Focus

- Please verify:
  - the active scenario-pack structure is the right long-term contract surface
  - transport smoke remaining broad but decoupled from reviewer semantics is the correct split
- Policy assumptions to double-check:
  - `#1391` should keep broad sweeps as certification/parity evidence only, not as the reviewer-semantics source of truth
- Follow-up issues or guardrails:
  - `#1388` semantic output assertions against rendered results
  - `#1392` push-blocking post-results rendering certification
  - `#1391` demote broad sweeps to transport smoke / parity certification
  - `#1400` host-RAM-aware parallel lane budgeting
  - `#1401` leverage content-based LabVIEW file detection and artifact-first report linking patterns from `gregr-ni/labview-ci-cd#1`
