### PR TITLE
#1392 Add post-results rendering certification gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,11 @@ Keep it short, stable, and helper-oriented. Deep runbooks belong in checked-in d
 - Exactly one active scenario pack is allowed in that checked-in contract at a time.
 - Deterministic top-level receipts:
   - `tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json`
+  - `tests/results/_agent/pre-push-ni-image/post-results-rendering-certification-report.json`
   - `tests/results/_agent/pre-push-ni-image/transport-smoke-report.json`
   - `tests/results/_agent/pre-push-ni-image/vi-history-smoke-report.json`
+- The post-results rendering certification report is the explicit semantic gate for the
+  active scenario pack; transport and VI-history reports remain separate support lanes.
 
 ## References
 

--- a/tests/PrePushKnownFlagScenarioReport.Tests.ps1
+++ b/tests/PrePushKnownFlagScenarioReport.Tests.ps1
@@ -46,6 +46,7 @@ Describe 'Pre-push known-flag scenario pack report' -Tag 'Unit' {
 
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Resolve-PrePushKnownFlagScenarioPack')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushKnownFlagScenarioReport')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushRenderingCertificationReport')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushSupportLaneReport')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Get-PrePushKnownFlagScenarioSemanticEvidence')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Test-PrePushKnownFlagReviewerAssertion')
@@ -370,6 +371,63 @@ Describe 'Pre-push known-flag scenario pack report' -Tag 'Unit' {
     $report.observed.failureMessage | Should -Be 'scenario pack failed'
     $report.observed.activeScenarioId | Should -Be 'attribute-suppression-boundary'
     $report.results.Count | Should -Be 0
+  }
+
+  It 'writes a separate push-blocking post-results rendering certification report' {
+    $repoRoot = Join-Path $TestDrive 'non-git-render-cert'
+    $resultsRoot = Join-Path $repoRoot 'tests' 'results' '_agent' 'pre-push-ni-image'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+    $contract = [pscustomobject]@{
+      path = $script:KnownFlagContractPath
+      pack = $script:ActiveScenarioPack
+      resultsRoot = $resultsRoot
+    }
+
+    $scenarioResults = @(
+      [pscustomobject]@{
+        name = 'attribute-suppression-boundary'
+        semanticGateOutcome = 'pass'
+        reviewerAssertionResults = @(
+          [pscustomobject]@{ passed = $true }
+        )
+        rawModeBoundaryResults = @(
+          [pscustomobject]@{ passed = $true }
+        )
+      },
+      [pscustomobject]@{
+        name = 'front-panel-position-boundary'
+        semanticGateOutcome = 'fail'
+        reviewerAssertionResults = @(
+          [pscustomobject]@{ passed = $false }
+        )
+        rawModeBoundaryResults = @(
+          [pscustomobject]@{ passed = $true }
+        )
+      }
+    )
+
+    $reportPath = Write-PrePushRenderingCertificationReport `
+      -repoRoot $repoRoot `
+      -contract $contract `
+      -observedOutcome 'fail' `
+      -scenarioResults $scenarioResults `
+      -failureMessage 'render contradiction' `
+      -activeScenarioName 'front-panel-position-boundary' `
+      -activeCapturePath 'tests/results/_agent/pre-push-ni-image/front-panel-position-boundary/ni-linux-container-capture.json' `
+      -activeReportPath 'tests/results/_agent/pre-push-ni-image/front-panel-position-boundary/compare-report.html'
+
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 24
+    $report.schema | Should -Be 'pre-push-post-results-rendering-certification-report@v1'
+    $report.certificationPolicy.scope | Should -Be 'pre-push'
+    $report.certificationPolicy.blocking | Should -BeTrue
+    @($report.certificationPolicy.supportLaneReports) | Should -Contain 'transport-smoke-report.json'
+    @($report.certificationPolicy.supportLaneReports) | Should -Contain 'vi-history-smoke-report.json'
+    $report.summary.totalScenarios | Should -Be 2
+    $report.summary.passingScenarios | Should -Be 1
+    $report.summary.failingScenarios | Should -Be 1
+    $report.observed.outcome | Should -Be 'fail'
+    $report.observed.activeScenarioId | Should -Be 'front-panel-position-boundary'
   }
 
   It 'normalizes live scenario results into semantic report records' {

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -641,6 +641,94 @@ function Write-PrePushKnownFlagScenarioReport {
   return $reportPath
 }
 
+function Write-PrePushRenderingCertificationReport {
+  param(
+    [string]$repoRoot,
+    [object]$contract,
+    [ValidateSet('pass', 'fail')]
+    [string]$observedOutcome,
+    [object[]]$scenarioResults,
+    [string]$failureMessage,
+    [string]$activeScenarioName,
+    [string]$activeCapturePath,
+    [string]$activeReportPath
+  )
+
+  if ($null -eq $contract) {
+    return $null
+  }
+
+  $reportPath = Join-Path ([string]$contract.resultsRoot) 'post-results-rendering-certification-report.json'
+  $reportDir = Split-Path -Parent $reportPath
+  if (-not [string]::IsNullOrWhiteSpace($reportDir)) {
+    New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+  }
+
+  $branchName = $null
+  $sha = $null
+  try {
+    $branchRaw = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $branchRaw) {
+      $branchName = ($branchRaw | Select-Object -First 1).Trim()
+      if ($branchName -eq 'HEAD') {
+        $branchName = $null
+      }
+    }
+  } catch {}
+  try {
+    $shaRaw = & git -C $repoRoot rev-parse HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $shaRaw) {
+      $sha = ($shaRaw | Select-Object -First 1).Trim()
+    }
+  } catch {}
+
+  $allScenarioResults = @($scenarioResults)
+  $failingScenarioResults = @($allScenarioResults | Where-Object { -not [string]::Equals([string]$_.semanticGateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase) })
+
+  $report = [ordered]@{
+    schema = 'pre-push-post-results-rendering-certification-report@v1'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    contractPath = [string]$contract.path
+    branch = $branchName
+    headSha = $sha
+    certificationPolicy = [ordered]@{
+      scope = 'pre-push'
+      blocking = $true
+      subject = 'post-results-rendering'
+      supportLaneReports = @(
+        'transport-smoke-report.json',
+        'vi-history-smoke-report.json'
+      )
+    }
+    scenarioPack = [ordered]@{
+      id = [string]$contract.pack.id
+      description = [string]$contract.pack.description
+      image = [string]$contract.pack.image
+      expectedGateOutcome = [string]$contract.pack.expectedGateOutcome
+      target = [ordered]@{
+        kind = [string]$contract.pack.target.kind
+        baseVi = [string]$contract.pack.target.baseVi
+        headVi = [string]$contract.pack.target.headVi
+      }
+    }
+    summary = [ordered]@{
+      totalScenarios = $allScenarioResults.Count
+      passingScenarios = @($allScenarioResults | Where-Object { [string]::Equals([string]$_.semanticGateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase) }).Count
+      failingScenarios = $failingScenarioResults.Count
+    }
+    observed = [ordered]@{
+      outcome = $observedOutcome
+      activeScenarioId = $activeScenarioName
+      capturePath = $activeCapturePath
+      reportPath = $activeReportPath
+      failureMessage = $failureMessage
+    }
+    results = @($scenarioResults)
+  }
+  $report | ConvertTo-Json -Depth 24 | Set-Content -LiteralPath $reportPath -Encoding utf8
+  return $reportPath
+}
+
 function Write-PrePushSupportLaneReport {
   param(
     [string]$repoRoot,
@@ -1247,6 +1335,7 @@ $knownFlagScenarioResults = New-Object System.Collections.Generic.List[object]
 $transportSmokeResults = New-Object System.Collections.Generic.List[object]
 $viHistorySmokeResults = New-Object System.Collections.Generic.List[object]
 $scenarioReportPath = $null
+$renderingCertificationReportPath = $null
 $transportLaneReportPath = $null
 $viHistoryLaneReportPath = $null
 $knownFlagObservedScenarioName = ''
@@ -1403,6 +1492,16 @@ try {
     -activeCapturePath $knownFlagObservedCapturePath `
     -activeReportPath $knownFlagObservedReportPath
   Write-Host ("[pre-push] Known-flag scenario report: {0}" -f $scenarioReportPath) -ForegroundColor DarkGray
+  $renderingCertificationReportPath = Write-PrePushRenderingCertificationReport `
+    -repoRoot $root `
+    -contract $knownFlagScenarioContract `
+    -observedOutcome 'pass' `
+    -scenarioResults (ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $knownFlagScenarioResults) `
+    -failureMessage '' `
+    -activeScenarioName $knownFlagObservedScenarioName `
+    -activeCapturePath $knownFlagObservedCapturePath `
+    -activeReportPath $knownFlagObservedReportPath
+  Write-Host ("[pre-push] Rendering certification report: {0}" -f $renderingCertificationReportPath) -ForegroundColor DarkGray
 
   $currentLane = 'transport-smoke'
   $activeScenarioName = 'single-container-matrix'
@@ -1738,6 +1837,16 @@ try {
       ('- activeScenarioPackId=`{0}` expectedImage=`{1}` declaredScenarios=`{2}`' -f $knownFlagScenarioPackId, $expectedImage, @($knownFlagScenarioContract.scenarios).Count),
       ''
     )
+    $lines += '#### Rendering Certification'
+    $lines += ('- report=`{0}` blocking=`true` scope=`pre-push`' -f $renderingCertificationReportPath)
+    foreach ($scenarioResult in $knownFlagScenarioResults) {
+      $reviewerPassCount = @($scenarioResult.reviewerAssertionResults | Where-Object { $_.passed }).Count
+      $reviewerTotalCount = @($scenarioResult.reviewerAssertionResults).Count
+      $rawBoundaryPassCount = @($scenarioResult.rawModeBoundaryResults | Where-Object { $_.passed }).Count
+      $rawBoundaryTotalCount = @($scenarioResult.rawModeBoundaryResults).Count
+      $lines += ('- `{0}`: semanticGateOutcome=`{1}` reviewerAssertions=`{2}/{3}` rawBoundaries=`{4}/{5}`' -f $scenarioResult.name, $scenarioResult.semanticGateOutcome, $reviewerPassCount, $reviewerTotalCount, $rawBoundaryPassCount, $rawBoundaryTotalCount)
+    }
+    $lines += ''
     $lines += '#### Active Scenario Pack'
     foreach ($scenarioResult in $knownFlagScenarioResults) {
       $requestedFlags = if (@($scenarioResult.requestedFlags).Count -eq 0) { '(none)' } else { [string]::Join(', ', @($scenarioResult.requestedFlags)) }
@@ -1777,6 +1886,18 @@ try {
         -activeReportPath $observedReportPath
       if (-not [string]::IsNullOrWhiteSpace($scenarioReportPath)) {
         Write-Host ("[pre-push] Known-flag scenario report: {0}" -f $scenarioReportPath) -ForegroundColor Yellow
+      }
+      $renderingCertificationReportPath = Write-PrePushRenderingCertificationReport `
+        -repoRoot $root `
+        -contract $knownFlagScenarioContract `
+        -observedOutcome 'fail' `
+        -scenarioResults (ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $knownFlagScenarioResults) `
+        -failureMessage $failureMessage `
+        -activeScenarioName ([string]$activeScenarioName) `
+        -activeCapturePath $observedCapturePath `
+        -activeReportPath $observedReportPath
+      if (-not [string]::IsNullOrWhiteSpace($renderingCertificationReportPath)) {
+        Write-Host ("[pre-push] Rendering certification report: {0}" -f $renderingCertificationReportPath) -ForegroundColor Yellow
       }
     }
     'transport-smoke' {


### PR DESCRIPTION
## Summary
- emit a separate post-results rendering certification report for the active scenario pack
- keep the certification lane explicit in `PrePush-Checks.ps1` and the step summary
- document the new blocking report alongside the existing known-flag and support-lane receipts

## Validation
- `pwsh -NoLogo -NoProfile -File tests/PrePushKnownFlagScenarioReport.Tests.ps1`
- `node --test tools/priority/__tests__/prepush-known-flag-scenario-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`

Closes #1392

## Agent Metadata
- Agent: Codex
- Mode: Default
- Branch: `issue/origin-1392-post-results-rendering-gate`
- Issue: `#1392`
