### PR TITLE
#1391 split transport smoke from certification lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Keep it short, stable, and helper-oriented. Deep runbooks belong in checked-in d
 - Prefer the local parity loop before repeated GitHub Actions cycles:
   - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage`
   - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite`
+  - Treat `tools/PrePush-Checks.ps1` as the blocking rendered-review gate and `-NILinuxReviewSuite` as the broad
+    flag-combination certification lane.
 - Detached unattended delivery surfaces:
   - `node tools/npm/run-script.mjs priority:delivery:agent:ensure`
   - `node tools/npm/run-script.mjs priority:delivery:agent:status`
@@ -113,6 +115,9 @@ Keep it short, stable, and helper-oriented. Deep runbooks belong in checked-in d
   - `tests/results/_agent/pre-push-ni-image/vi-history-smoke-report.json`
 - The post-results rendering certification report is the explicit semantic gate for the
   active scenario pack; transport and VI-history reports remain separate support lanes.
+- The pre-push transport smoke lane is intentionally minimal. Broad flag-combination sweeps now belong in
+  `tests/results/docker-tools-parity/ni-linux-review-suite/flag-combination-certification.json` and the companion
+  Markdown/HTML artifacts emitted by `tools/Invoke-NILinuxReviewSuite.ps1`.
 
 ## References
 

--- a/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
+++ b/docs/knowledgebase/DOCKER_TOOLS_PARITY.md
@@ -7,6 +7,11 @@ tooling. It now covers both the non-LV parity path and the NI Linux review-suite
 The intended operating model is local-first: use Docker Desktop to clear deterministic markdown, workflow-drift,
 NI Linux smoke, and VI history artifact defects before paying for another GitHub Actions review cycle.
 
+The lane split is intentional:
+
+- `tools/PrePush-Checks.ps1` is the blocking rendered-review gate plus a minimal transport/bootstrap smoke.
+- `tools/Invoke-NILinuxReviewSuite.ps1` is the broader flag-combination certification surface.
+
 ## Environment prerequisites
 
 - Docker Desktop (or Engine) must be available. On Windows, confirm with `docker version`; the client/server details
@@ -31,6 +36,8 @@ pwsh -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -RequirementsVerific
   and writes GitHub Pages-ready HTML/JSON outputs under
   `tests/results/docker-tools-parity/ni-linux-review-suite/`, including:
   - `review-suite-summary.html`
+  - `flag-combination-certification.html`
+  - `flag-combination-certification.json`
   - `vi-history-report/results/history-report.html`
   - `vi-history-report/results/history-summary.json`
   - `vi-history-report/results/history-suite-inspection.html`
@@ -63,7 +70,8 @@ pwsh -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -RequirementsVerific
   - markdownlint is clean
   - workflow-drift checks are clean
   - requirements traceability / verification is updated locally
-  - NI Linux smoke is green
+  - the blocking rendered-review gate is green
+  - NI Linux certification artifacts are green when you are changing compare/runtime behavior
   - VI history review artifacts are coherent and reviewable
 - Treat hosted runs as confirmation and publication surfaces once the local loop
   is already green.

--- a/docs/schemas/ni-linux-flag-combination-certification-v1.schema.json
+++ b/docs/schemas/ni-linux-flag-combination-certification-v1.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/ni-linux-flag-combination-certification-v1.schema.json",
+  "title": "NI Linux Flag Combination Certification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "image",
+    "resultsRoot",
+    "laneClass",
+    "blocking",
+    "planeApplicability",
+    "futureParityPlanes",
+    "summary",
+    "scenarios"
+  ],
+  "properties": {
+    "schema": {
+      "const": "ni-linux-flag-combination-certification@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "image": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resultsRoot": {
+      "type": "string",
+      "minLength": 1
+    },
+    "laneClass": {
+      "const": "certification"
+    },
+    "blocking": {
+      "const": false
+    },
+    "planeApplicability": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "futureParityPlanes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalScenarios",
+        "passingScenarios",
+        "failingScenarios"
+      ],
+      "properties": {
+        "totalScenarios": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "passingScenarios": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failingScenarios": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "requestedFlagsLabel",
+          "requestedFlags",
+          "flagsUsed",
+          "executionMode",
+          "resultClass",
+          "gateOutcome",
+          "reportPath",
+          "capturePath",
+          "runtimeSnapshotPath"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "requestedFlagsLabel": {
+            "type": "string"
+          },
+          "requestedFlags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "flagsUsed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "executionMode": {
+            "type": "string",
+            "minLength": 1
+          },
+          "resultClass": {
+            "type": "string",
+            "minLength": 1
+          },
+          "gateOutcome": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reportPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "capturePath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "runtimeSnapshotPath": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/NILinuxReviewSuiteCertification.Tests.ps1
+++ b/tests/NILinuxReviewSuiteCertification.Tests.ps1
@@ -1,0 +1,126 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'NI Linux review-suite flag certification artifacts' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ReviewSuiteScriptPath = Join-Path $repoRoot 'tools' 'Invoke-NILinuxReviewSuite.ps1'
+
+    if (-not (Test-Path -LiteralPath $script:ReviewSuiteScriptPath -PathType Leaf)) {
+      throw "Invoke-NILinuxReviewSuite.ps1 not found at $script:ReviewSuiteScriptPath"
+    }
+
+    function script:Get-ScriptFunctionDefinition {
+      param(
+        [string]$ScriptPath,
+        [string]$FunctionName
+      )
+
+      $tokens = $null
+      $parseErrors = $null
+      $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+      if ($parseErrors.Count -gt 0) {
+        throw ("Failed to parse {0}: {1}" -f $ScriptPath, ($parseErrors | ForEach-Object { $_.Message } | Join-String -Separator '; '))
+      }
+
+      $functionAst = $ast.Find(
+        {
+          param($node)
+          $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+          $node.Name -eq $FunctionName
+        },
+        $true
+      )
+      if ($null -eq $functionAst) {
+        throw ("Function {0} not found in {1}" -f $FunctionName, $ScriptPath)
+      }
+
+      return $functionAst.Extent.Text
+    }
+
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Get-RelativeArtifactPath')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Write-FlagCombinationCertificationArtifacts')
+  }
+
+  It 'writes explicit certification artifacts for the broad flag-combination sweep' {
+    $resultsRoot = Join-Path $TestDrive 'ni-linux-review-suite'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $resultsRoot 'flag-combinations' 'baseline') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $resultsRoot 'flag-combinations' 'noattr') -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $resultsRoot 'vi-history-report') -Force | Out-Null
+
+    $scenarioResults = @(
+      [pscustomobject]@{
+        kind = 'flag-combination'
+        name = 'baseline'
+        requestedFlagsLabel = '(none)'
+        requestedFlags = @()
+        flagsUsed = @('-Headless')
+        executionMode = 'docker-run'
+        resultClass = 'success-diff'
+        gateOutcome = 'pass'
+        reportPath = (Join-Path $resultsRoot 'flag-combinations' 'baseline' 'compare-report.html')
+        capturePath = (Join-Path $resultsRoot 'flag-combinations' 'baseline' 'ni-linux-container-capture.json')
+        runtimeSnapshotPath = (Join-Path $resultsRoot 'flag-combinations' 'baseline' 'runtime-determinism.json')
+      },
+      [pscustomobject]@{
+        kind = 'flag-combination'
+        name = 'noattr'
+        requestedFlagsLabel = '-noattr'
+        requestedFlags = @('-noattr')
+        flagsUsed = @('-Headless', '-noattr')
+        executionMode = 'docker-run'
+        resultClass = 'success-diff'
+        gateOutcome = 'pass'
+        reportPath = (Join-Path $resultsRoot 'flag-combinations' 'noattr' 'compare-report.html')
+        capturePath = (Join-Path $resultsRoot 'flag-combinations' 'noattr' 'ni-linux-container-capture.json')
+        runtimeSnapshotPath = (Join-Path $resultsRoot 'flag-combinations' 'noattr' 'runtime-determinism.json')
+      },
+      [pscustomobject]@{
+        kind = 'vi-history-report'
+        name = 'vi-history-report'
+        requestedFlagsLabel = 'vi-history-suite'
+        requestedFlags = @('vi-history-suite')
+        flagsUsed = @('-Headless')
+        executionMode = 'docker-run'
+        resultClass = 'success-diff'
+        gateOutcome = 'pass'
+        reportPath = (Join-Path $resultsRoot 'vi-history-report' 'history-report.html')
+        capturePath = (Join-Path $resultsRoot 'vi-history-report' 'ni-linux-container-capture.json')
+        runtimeSnapshotPath = (Join-Path $resultsRoot 'vi-history-report' 'runtime-determinism.json')
+      }
+    )
+
+    $artifacts = Write-FlagCombinationCertificationArtifacts `
+      -ResultsRoot $resultsRoot `
+      -Image 'nationalinstruments/labview:2026q1-linux' `
+      -ScenarioResults $scenarioResults
+
+    Test-Path -LiteralPath $artifacts.jsonPath | Should -BeTrue
+    Test-Path -LiteralPath $artifacts.markdownPath | Should -BeTrue
+    Test-Path -LiteralPath $artifacts.htmlPath | Should -BeTrue
+
+    $report = Get-Content -LiteralPath $artifacts.jsonPath -Raw | ConvertFrom-Json -Depth 12
+    $report.schema | Should -Be 'ni-linux-flag-combination-certification@v1'
+    $report.laneClass | Should -Be 'certification'
+    $report.blocking | Should -BeFalse
+    @($report.planeApplicability) | Should -Be @('linux-proof')
+    @($report.futureParityPlanes) | Should -Contain 'windows-mirror-proof'
+    @($report.futureParityPlanes) | Should -Contain 'host-32bit-shadow'
+    $report.summary.totalScenarios | Should -Be 2
+    $report.summary.passingScenarios | Should -Be 2
+    $report.summary.failingScenarios | Should -Be 0
+    @($report.scenarios | ForEach-Object { $_.name }) | Should -Be @('baseline', 'noattr')
+
+    $markdown = Get-Content -LiteralPath $artifacts.markdownPath -Raw
+    $markdown | Should -Match 'NI Linux flag-combination certification'
+    $markdown | Should -Match 'baseline'
+    $markdown | Should -Match 'noattr'
+
+    $html = Get-Content -LiteralPath $artifacts.htmlPath -Raw
+    $html | Should -Match 'flag-combination certification'
+    $html | Should -Match 'windows-mirror-proof'
+  }
+}

--- a/tests/PrePushKnownFlagScenarioReport.Tests.ps1
+++ b/tests/PrePushKnownFlagScenarioReport.Tests.ps1
@@ -52,6 +52,9 @@ Describe 'Pre-push known-flag scenario pack report' -Tag 'Unit' {
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Test-PrePushKnownFlagReviewerAssertion')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Test-PrePushKnownFlagRawModeBoundary')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'New-PrePushTransportMatrixScenarios')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'New-PrePushTransportSmokeScenarios')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Write-PrePushFlagScenarioCatalog')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'Select-PrePushBaselineTransportSmokeSource')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:PrePushScriptPath -FunctionName 'ConvertTo-PrePushKnownFlagScenarioResultArray')
 
     $script:KnownFlagContract = Get-Content -LiteralPath $script:KnownFlagContractPath -Raw | ConvertFrom-Json -Depth 20
@@ -82,7 +85,7 @@ Describe 'Pre-push known-flag scenario pack report' -Tag 'Unit' {
     @($resolved.scenarios[3].requestedFlags) | Should -Be @('-nobdcosm')
   }
 
-  It 'derives the transport smoke matrix from the unique declared requested flags' {
+  It 'retains the broad flag combinations as certification-only scenarios' {
     $transportMatrixScenarios = New-PrePushTransportMatrixScenarios -scenarioDefinitions @(
       [pscustomobject]@{ requestedFlags = @() },
       [pscustomobject]@{ requestedFlags = @('-noattr') },
@@ -100,6 +103,56 @@ Describe 'Pre-push known-flag scenario pack report' -Tag 'Unit' {
       'nofppos__nobdcosm',
       'noattr__nofppos__nobdcosm'
     )
+  }
+
+  It 'derives a minimal transport smoke catalog instead of every flag combination' {
+    $transportSmokeScenarios = New-PrePushTransportSmokeScenarios -scenarioDefinitions @(
+      [pscustomobject]@{ id = 'baseline-review-surface'; requestedFlags = @() },
+      [pscustomobject]@{ id = 'attribute-suppression-boundary'; requestedFlags = @('-noattr') },
+      [pscustomobject]@{ id = 'front-panel-position-boundary'; requestedFlags = @('-nofppos') }
+    )
+
+    @($transportSmokeScenarios | ForEach-Object { $_.name }) | Should -Be @('baseline')
+    @($transportSmokeScenarios[0].flags) | Should -Be @()
+    $transportSmokeScenarios[0].requestedFlagsLabel | Should -Be '(none)'
+    $transportSmokeScenarios[0].sourceScenarioId | Should -Be 'baseline-review-surface'
+  }
+
+  It 'writes a deterministic transport smoke scenario catalog for the bootstrap lane' {
+    $catalogPath = Join-Path $TestDrive 'scenario-catalog.tsv'
+    $writtenPath = Write-PrePushFlagScenarioCatalog `
+      -CatalogPath $catalogPath `
+      -ScenarioDefinitions @(
+        [pscustomobject]@{
+          name = 'baseline'
+          flags = @()
+        }
+      )
+
+    $writtenPath | Should -Be $catalogPath
+    Get-Content -LiteralPath $catalogPath | Should -Be @("baseline`t")
+  }
+
+  It 'selects the baseline transport smoke source from a generic list of scenario results' {
+    $scenarioResults = New-Object System.Collections.Generic.List[object]
+    $scenarioResults.Add([pscustomobject]@{
+      name = 'attribute-suppression-boundary'
+      requestedFlags = @('-noattr')
+      capturePath = 'attribute/capture.json'
+      reportPath = 'attribute/report.html'
+    }) | Out-Null
+    $scenarioResults.Add([pscustomobject]@{
+      name = 'baseline-review-surface'
+      requestedFlags = @()
+      capturePath = 'baseline/capture.json'
+      reportPath = 'baseline/report.html'
+    }) | Out-Null
+
+    $baseline = Select-PrePushBaselineTransportSmokeSource -ScenarioResults $scenarioResults
+
+    $baseline.name | Should -Be 'baseline-review-surface'
+    @($baseline.requestedFlags) | Should -Be @()
+    $baseline.capturePath | Should -Be 'baseline/capture.json'
   }
 
   It 'parses rendered semantic evidence from the inclusion list and headings' {

--- a/tests/RunNonLVChecksInDockerReceipt.Tests.ps1
+++ b/tests/RunNonLVChecksInDockerReceipt.Tests.ps1
@@ -1,0 +1,74 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Docker review-loop receipt git metadata' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:RunNonLVChecksScriptPath = Join-Path $repoRoot 'tools' 'Run-NonLVChecksInDocker.ps1'
+
+    if (-not (Test-Path -LiteralPath $script:RunNonLVChecksScriptPath -PathType Leaf)) {
+      throw "Run-NonLVChecksInDocker.ps1 not found at $script:RunNonLVChecksScriptPath"
+    }
+
+    function script:Get-ScriptFunctionDefinition {
+      param(
+        [string]$ScriptPath,
+        [string]$FunctionName
+      )
+
+      $tokens = $null
+      $parseErrors = $null
+      $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+      if ($parseErrors.Count -gt 0) {
+        throw ("Failed to parse {0}: {1}" -f $ScriptPath, ($parseErrors | ForEach-Object { $_.Message } | Join-String -Separator '; '))
+      }
+
+      $functionAst = $ast.Find(
+        {
+          param($node)
+          $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+          $node.Name -eq $FunctionName
+        },
+        $true
+      )
+      if ($null -eq $functionAst) {
+        throw ("Function {0} not found in {1}" -f $FunctionName, $ScriptPath)
+      }
+
+      return $functionAst.Extent.Text
+    }
+
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Invoke-GitReviewLoopCommand')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Get-GitReviewLoopMetadata')
+  }
+
+  It 'resolves git metadata for the current worktree even when git workspace env is poisoned' {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $expectedHead = (& git -C $repoRoot rev-parse HEAD).Trim()
+    $expectedBranch = (& git -C $repoRoot branch --show-current).Trim()
+    $expectedMergeBase = (& git -C $repoRoot merge-base HEAD upstream/develop 2>$null | Select-Object -First 1)
+    if ($null -ne $expectedMergeBase) {
+      $expectedMergeBase = [string]$expectedMergeBase
+      $expectedMergeBase = $expectedMergeBase.Trim()
+    }
+
+    $savedGitDir = [Environment]::GetEnvironmentVariable('GIT_DIR', 'Process')
+    $savedGitWorkTree = [Environment]::GetEnvironmentVariable('GIT_WORK_TREE', 'Process')
+    try {
+      [Environment]::SetEnvironmentVariable('GIT_DIR', 'C:\nonexistent\git-dir', 'Process')
+      [Environment]::SetEnvironmentVariable('GIT_WORK_TREE', 'C:\nonexistent\work-tree', 'Process')
+
+      $metadata = Get-GitReviewLoopMetadata -RepoRoot $repoRoot
+
+      $metadata.headSha | Should -Be $expectedHead
+      $metadata.branch | Should -Be $expectedBranch
+      $metadata.upstreamDevelopMergeBase | Should -Be $expectedMergeBase
+      $metadata.dirtyTracked | Should -BeOfType ([bool])
+    } finally {
+      [Environment]::SetEnvironmentVariable('GIT_DIR', $savedGitDir, 'Process')
+      [Environment]::SetEnvironmentVariable('GIT_WORK_TREE', $savedGitWorkTree, 'Process')
+    }
+  }
+}

--- a/tools/Invoke-NILinuxReviewSuite.ps1
+++ b/tools/Invoke-NILinuxReviewSuite.ps1
@@ -82,6 +82,127 @@ function Get-RelativeArtifactPath {
   return [System.IO.Path]::GetRelativePath($RootPath, $Path).Replace('\', '/')
 }
 
+function Write-FlagCombinationCertificationArtifacts {
+  param(
+    [Parameter(Mandatory = $true)][string]$ResultsRoot,
+    [Parameter(Mandatory = $true)][string]$Image,
+    [AllowNull()][object[]]$ScenarioResults
+  )
+
+  $flagCombinationResults = @(
+    @($ScenarioResults) | Where-Object {
+      $_ -and
+      $_.PSObject.Properties['kind'] -and
+      [string]::Equals([string]$_.kind, 'flag-combination', [System.StringComparison]::OrdinalIgnoreCase)
+    }
+  )
+  if ($flagCombinationResults.Count -eq 0) {
+    throw 'NI Linux review suite resolved no flag-combination scenarios for certification.'
+  }
+
+  $jsonPath = Join-Path $ResultsRoot 'flag-combination-certification.json'
+  $markdownPath = Join-Path $ResultsRoot 'flag-combination-certification.md'
+  $htmlPath = Join-Path $ResultsRoot 'flag-combination-certification.html'
+
+  $normalizedScenarios = @(
+    $flagCombinationResults | ForEach-Object {
+      [ordered]@{
+        name = [string]$_.name
+        requestedFlagsLabel = [string]$_.requestedFlagsLabel
+        requestedFlags = @($_.requestedFlags | ForEach-Object { [string]$_ })
+        flagsUsed = @($_.flagsUsed | ForEach-Object { [string]$_ })
+        executionMode = [string]$_.executionMode
+        resultClass = [string]$_.resultClass
+        gateOutcome = [string]$_.gateOutcome
+        reportPath = Get-RelativeArtifactPath -RootPath $ResultsRoot -Path ([string]$_.reportPath)
+        capturePath = Get-RelativeArtifactPath -RootPath $ResultsRoot -Path ([string]$_.capturePath)
+        runtimeSnapshotPath = Get-RelativeArtifactPath -RootPath $ResultsRoot -Path ([string]$_.runtimeSnapshotPath)
+      }
+    }
+  )
+
+  $payload = [ordered]@{
+    schema = 'ni-linux-flag-combination-certification@v1'
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    image = $Image
+    resultsRoot = $ResultsRoot
+    laneClass = 'certification'
+    blocking = $false
+    planeApplicability = @('linux-proof')
+    futureParityPlanes = @('windows-mirror-proof', 'host-32bit-shadow')
+    summary = [ordered]@{
+      totalScenarios = $normalizedScenarios.Count
+      passingScenarios = @($normalizedScenarios | Where-Object { [string]::Equals([string]$_.gateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase) }).Count
+      failingScenarios = @($normalizedScenarios | Where-Object { -not [string]::Equals([string]$_.gateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase) }).Count
+    }
+    scenarios = @($normalizedScenarios)
+  }
+  $payload | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $jsonPath -Encoding utf8
+
+  $markdownLines = @(
+    '# NI Linux flag-combination certification',
+    '',
+    '- Lane class: `certification`',
+    '- Blocking: `false`',
+    ('- Image: `{0}`' -f $Image),
+    ('- Plane applicability: `{0}`' -f ([string]::Join(', ', @($payload.planeApplicability)))),
+    ('- Future parity planes: `{0}`' -f ([string]::Join(', ', @($payload.futureParityPlanes)))),
+    ('- Total scenarios: `{0}`' -f $payload.summary.totalScenarios),
+    ('- Passing scenarios: `{0}`' -f $payload.summary.passingScenarios),
+    ('- Failing scenarios: `{0}`' -f $payload.summary.failingScenarios),
+    '',
+    '| Scenario | Requested Flags | Result | Report | Capture | Runtime |',
+    '| --- | --- | --- | --- | --- | --- |'
+  )
+  foreach ($scenario in @($normalizedScenarios)) {
+    $requestedFlagsLabel = if ([string]::IsNullOrWhiteSpace([string]$scenario.requestedFlagsLabel)) { '(none)' } else { [string]$scenario.requestedFlagsLabel }
+    $markdownLines += ('| {0} | {1} | {2}/{3} | [report](./{4}) | [capture](./{5}) | [runtime](./{6}) |' -f
+        $scenario.name,
+        $requestedFlagsLabel,
+        $scenario.resultClass,
+        $scenario.gateOutcome,
+        $scenario.reportPath,
+        $scenario.capturePath,
+        $scenario.runtimeSnapshotPath)
+  }
+  $markdownLines -join "`n" | Set-Content -LiteralPath $markdownPath -Encoding utf8
+
+  $htmlLines = @(
+    '<html><body><h1>NI Linux flag-combination certification</h1>',
+    ('<p>Lane class: <code>certification</code><br/>Blocking: <code>false</code><br/>Image: <code>{0}</code><br/>Plane applicability: <code>{1}</code><br/>Future parity planes: <code>{2}</code></p>' -f
+      $Image,
+      [string]::Join(', ', @($payload.planeApplicability)),
+      [string]::Join(', ', @($payload.futureParityPlanes))),
+    ('<p>Total scenarios: <code>{0}</code><br/>Passing scenarios: <code>{1}</code><br/>Failing scenarios: <code>{2}</code></p>' -f
+      $payload.summary.totalScenarios,
+      $payload.summary.passingScenarios,
+      $payload.summary.failingScenarios),
+    '<table border="1" cellspacing="0" cellpadding="4">',
+    '<thead><tr><th>Scenario</th><th>Requested Flags</th><th>Result</th><th>Report</th><th>Capture</th><th>Runtime</th></tr></thead>',
+    '<tbody>'
+  )
+  foreach ($scenario in @($normalizedScenarios)) {
+    $requestedFlagsLabel = if ([string]::IsNullOrWhiteSpace([string]$scenario.requestedFlagsLabel)) { '(none)' } else { [string]$scenario.requestedFlagsLabel }
+    $htmlLines += ('<tr><td>{0}</td><td>{1}</td><td>{2}/{3}</td><td><a href="./{4}">report</a></td><td><a href="./{5}">capture</a></td><td><a href="./{6}">runtime</a></td></tr>' -f
+        $scenario.name,
+        $requestedFlagsLabel,
+        $scenario.resultClass,
+        $scenario.gateOutcome,
+        $scenario.reportPath,
+        $scenario.capturePath,
+        $scenario.runtimeSnapshotPath)
+  }
+  $htmlLines += '</tbody></table></body></html>'
+  $htmlLines -join "`n" | Set-Content -LiteralPath $htmlPath -Encoding utf8
+
+  return [pscustomobject]@{
+    schema = 'ni-linux-flag-combination-certification@v1'
+    jsonPath = $jsonPath
+    markdownPath = $markdownPath
+    htmlPath = $htmlPath
+  }
+}
+
 function Resolve-HistoryRefSelection {
   param(
     [AllowEmptyString()][string]$RequestedBranchRef,
@@ -614,6 +735,11 @@ $scenarioResults += [pscustomobject]@{
   historyInspectionHtmlPath = $historyInspectionHtmlPath
 }
 
+$flagCombinationCertification = Write-FlagCombinationCertificationArtifacts `
+  -ResultsRoot $resultsRootResolved `
+  -Image $Image `
+  -ScenarioResults @($scenarioResults)
+
 $baselineTopLevelReportPath = Join-Path $resultsRootResolved 'compare-report.html'
 $summaryRows = foreach ($entry in @($scenarioResults)) {
   $historyMarkdownRelativePath = ''
@@ -675,6 +801,12 @@ $summaryPayload = [ordered]@{
     maxCommitCount = [int]$HistoryMaxCommitCount
   }
   baselineCompareReportPath = $baselineTopLevelReportPath
+  flagCombinationCertification = [ordered]@{
+    schema = [string]$flagCombinationCertification.schema
+    jsonPath = Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.jsonPath)
+    markdownPath = Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.markdownPath)
+    htmlPath = Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.htmlPath)
+  }
   scenarios = @($summaryRows)
 }
 $summaryPayload | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $summaryJsonPath -Encoding utf8
@@ -691,6 +823,7 @@ $markdownLines = @(
   ('- History effective branch ref: `{0}`' -f $historyRefSelection.effectiveBranchRef),
   ('- History effective baseline ref: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef })),
   ('- History max commit count: `{0}`' -f $HistoryMaxCommitCount),
+  ('- Flag certification: [flag-combination-certification.html](./{0}) ([json](./{1}), [md](./{2}))' -f $summaryPayload.flagCombinationCertification.htmlPath, $summaryPayload.flagCombinationCertification.jsonPath, $summaryPayload.flagCombinationCertification.markdownPath),
   '',
   '| Scenario | Kind | Requested Flags | Result | Report | Extra |',
   '| --- | --- | --- | --- | --- | --- |'
@@ -707,7 +840,7 @@ $markdownLines -join "`n" | Set-Content -LiteralPath $summaryMarkdownPath -Encod
 
 $htmlLines = @(
   '<html><body><h1>NI Linux review suite</h1>',
-  ('<p>Image: <code>{0}</code><br/>LabVIEW path: <code>{1}</code><br/>History ref source: <code>{2}</code><br/>History requested branch ref: <code>{3}</code><br/>History requested baseline ref: <code>{4}</code><br/>History effective branch ref: <code>{5}</code><br/>History effective baseline ref: <code>{6}</code><br/>History max commit count: <code>{7}</code></p>' -f $Image, $LabVIEWPath, $historyRefSelection.source, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBranchRef)) { '(default)' } else { $historyRefSelection.requestedBranchRef }), $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBaselineRef)) { '(default)' } else { $historyRefSelection.requestedBaselineRef }), $historyRefSelection.effectiveBranchRef, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef }), $HistoryMaxCommitCount),
+  ('<p>Image: <code>{0}</code><br/>LabVIEW path: <code>{1}</code><br/>History ref source: <code>{2}</code><br/>History requested branch ref: <code>{3}</code><br/>History requested baseline ref: <code>{4}</code><br/>History effective branch ref: <code>{5}</code><br/>History effective baseline ref: <code>{6}</code><br/>History max commit count: <code>{7}</code><br/>Flag certification: <a href="./{8}">html</a>, <a href="./{9}">json</a>, <a href="./{10}">md</a></p>' -f $Image, $LabVIEWPath, $historyRefSelection.source, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBranchRef)) { '(default)' } else { $historyRefSelection.requestedBranchRef }), $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBaselineRef)) { '(default)' } else { $historyRefSelection.requestedBaselineRef }), $historyRefSelection.effectiveBranchRef, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef }), $HistoryMaxCommitCount, $summaryPayload.flagCombinationCertification.htmlPath, $summaryPayload.flagCombinationCertification.jsonPath, $summaryPayload.flagCombinationCertification.markdownPath),
   '<table border="1" cellspacing="0" cellpadding="4">',
   '<thead><tr><th>Scenario</th><th>Kind</th><th>Requested Flags</th><th>Result</th><th>Report</th><th>Extra</th></tr></thead>',
   '<tbody>'
@@ -730,7 +863,8 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubStepSummaryPath)) {
     ('- artifact root: `{0}`' -f $resultsRootResolved),
     ('- compare scenarios: `{0}`' -f $knownFlagScenarios.Count),
     ('- vi history report: `enabled`'),
-    ('- summary: `{0}`' -f (Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path $summaryMarkdownPath))
+    ('- summary: `{0}`' -f (Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path $summaryMarkdownPath)),
+    ('- flag certification: `{0}`' -f (Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.markdownPath)))
   ) -join "`n" | Out-File -FilePath $GitHubStepSummaryPath -Append -Encoding utf8
 }
 
@@ -739,6 +873,9 @@ Write-GitHubOutput -Key 'summary_json_path' -Value $summaryJsonPath -Path $GitHu
 Write-GitHubOutput -Key 'summary_markdown_path' -Value $summaryMarkdownPath -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'summary_html_path' -Value $summaryHtmlPath -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'baseline_report_path' -Value $baselineTopLevelReportPath -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'flag_combination_certification_json_path' -Value ([string]$flagCombinationCertification.jsonPath) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'flag_combination_certification_markdown_path' -Value ([string]$flagCombinationCertification.markdownPath) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'flag_combination_certification_html_path' -Value ([string]$flagCombinationCertification.htmlPath) -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'history_ref_source' -Value ([string]$historyRefSelection.source) -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'history_requested_branch_ref' -Value ([string]$historyRefSelection.requestedBranchRef) -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'history_requested_baseline_ref' -Value ([string]$historyRefSelection.requestedBaselineRef) -Path $GitHubOutputPath

--- a/tools/NILinux-FlagMatrixBootstrap.sh
+++ b/tools/NILinux-FlagMatrixBootstrap.sh
@@ -104,26 +104,50 @@ fi
 mkdir -p "\${RESULTS_DIR}" || exit 2
 : > "\${LEDGER_PATH}" || exit 2
 
-scenario_names=(
-  "baseline"
-  "noattr"
-  "nofppos"
-  "nobdcosm"
-  "noattr__nofppos"
-  "noattr__nobdcosm"
-  "nofppos__nobdcosm"
-  "noattr__nofppos__nobdcosm"
-)
-scenario_flags=(
-  ""
-  "-noattr"
-  "-nofppos"
-  "-nobdcosm"
-  "-noattr -nofppos"
-  "-noattr -nobdcosm"
-  "-nofppos -nobdcosm"
-  "-noattr -nofppos -nobdcosm"
-)
+scenario_names=()
+scenario_flags=()
+scenario_catalog_path="\${COMPAREVI_FLAG_MATRIX_SCENARIO_CATALOG:-}"
+
+if [ -n "\${scenario_catalog_path}" ]; then
+  if [ ! -f "\${scenario_catalog_path}" ]; then
+    echo "COMPAREVI_FLAG_MATRIX_SCENARIO_CATALOG does not exist: \${scenario_catalog_path}" 1>&2
+    exit 2
+  fi
+
+  while IFS=$'\t' read -r scenario_name scenario_flag_text || [ -n "\${scenario_name:-}" ]; do
+    if [ -z "\${scenario_name:-}" ]; then
+      continue
+    fi
+    scenario_names+=("\${scenario_name}")
+    scenario_flags+=("\${scenario_flag_text:-}")
+  done < "\${scenario_catalog_path}"
+else
+  scenario_names=(
+    "baseline"
+    "noattr"
+    "nofppos"
+    "nobdcosm"
+    "noattr__nofppos"
+    "noattr__nobdcosm"
+    "nofppos__nobdcosm"
+    "noattr__nofppos__nobdcosm"
+  )
+  scenario_flags=(
+    ""
+    "-noattr"
+    "-nofppos"
+    "-nobdcosm"
+    "-noattr -nofppos"
+    "-noattr -nobdcosm"
+    "-nofppos -nobdcosm"
+    "-noattr -nofppos -nobdcosm"
+  )
+fi
+
+if [ "\${#scenario_names[@]}" -eq 0 ]; then
+  echo "Flag matrix bootstrap resolved no scenarios." 1>&2
+  exit 2
+fi
 
 processed=0
 diffs=0

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -1029,6 +1029,112 @@ function New-PrePushTransportMatrixScenarios {
   return @($transportMatrixScenarioBuffer | Sort-Object @{ Expression = { $_.flags.Count } }, @{ Expression = { $_.orderKey } })
 }
 
+function New-PrePushTransportSmokeScenarios {
+  param(
+    [AllowNull()]
+    [object[]]$scenarioDefinitions
+  )
+
+  $baselineScenario = @(
+    @($scenarioDefinitions) | Where-Object {
+      $requestedFlags = @()
+      if ($_.PSObject.Properties['requestedFlags'] -and $_.requestedFlags) {
+        $requestedFlags = @($_.requestedFlags | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+      }
+      $requestedFlags.Count -eq 0
+    }
+  ) | Select-Object -First 1
+
+  if ($null -eq $baselineScenario) {
+    return @(
+      [pscustomobject]@{
+        name = 'baseline'
+        flags = @()
+        requestedFlagsLabel = '(none)'
+        sourceScenarioId = ''
+      }
+    )
+  }
+
+  return @(
+    [pscustomobject]@{
+      name = 'baseline'
+      flags = @()
+      requestedFlagsLabel = '(none)'
+      sourceScenarioId = [string]$baselineScenario.id
+    }
+  )
+}
+
+function Write-PrePushFlagScenarioCatalog {
+  param(
+    [Parameter(Mandatory)]
+    [string]$CatalogPath,
+
+    [AllowNull()]
+    [object[]]$ScenarioDefinitions
+  )
+
+  $catalogDir = Split-Path -Parent $CatalogPath
+  if (-not [string]::IsNullOrWhiteSpace($catalogDir)) {
+    New-Item -ItemType Directory -Path $catalogDir -Force | Out-Null
+  }
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  foreach ($scenarioDefinition in @($ScenarioDefinitions)) {
+    if ($null -eq $scenarioDefinition) {
+      continue
+    }
+
+    $scenarioName = if ($scenarioDefinition.PSObject.Properties['name']) {
+      [string]$scenarioDefinition.name
+    } else {
+      ''
+    }
+    if ([string]::IsNullOrWhiteSpace($scenarioName)) {
+      continue
+    }
+
+    $requestedFlags = @()
+    if ($scenarioDefinition.PSObject.Properties['flags'] -and $scenarioDefinition.flags) {
+      $requestedFlags = @($scenarioDefinition.flags | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    $lines.Add(("{0}`t{1}" -f $scenarioName, ([string]::Join(' ', $requestedFlags)))) | Out-Null
+  }
+
+  if ($lines.Count -eq 0) {
+    throw ("Pre-push transport smoke scenario catalog resolved no entries: {0}" -f $CatalogPath)
+  }
+
+  $lines | Set-Content -LiteralPath $CatalogPath -Encoding utf8
+  return $CatalogPath
+}
+
+function Select-PrePushBaselineTransportSmokeSource {
+  param(
+    [AllowNull()]
+    [object]$ScenarioResults
+  )
+
+  foreach ($scenarioResult in $ScenarioResults) {
+    if ($null -eq $scenarioResult) {
+      continue
+    }
+
+    $requestedFlags = @()
+    if ($scenarioResult.PSObject.Properties['requestedFlags'] -and $scenarioResult.requestedFlags) {
+      $requestedFlags = @($scenarioResult.requestedFlags | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    if ($requestedFlags.Count -eq 0) {
+      return $scenarioResult
+    }
+  }
+
+  return $null
+}
+
 function ConvertTo-PrePushKnownFlagScenarioResultArray {
   param(
     [AllowNull()]
@@ -1309,16 +1415,11 @@ if ([string]::IsNullOrWhiteSpace($containerLabVIEWPath)) {
   throw ("Pre-push known-flag scenario pack '{0}' resolved an empty LabVIEW path." -f $knownFlagScenarioPackId)
 }
 Write-Host ("[pre-push] Active known-flag scenario pack '{0}' image={1} scenarios={2}" -f $knownFlagScenarioPackId, $expectedImage, @($knownFlagScenarioContract.scenarios).Count) -ForegroundColor Cyan
-$singleContainerBootstrapScript = Join-Path $root 'tools' 'NILinux-FlagMatrixBootstrap.sh'
-if (-not (Test-Path -LiteralPath $singleContainerBootstrapScript -PathType Leaf)) {
-  throw ("Single-container flag matrix bootstrap script not found: {0}" -f $singleContainerBootstrapScript)
-}
 $viHistoryBootstrapScript = Join-Path $root 'tools' 'NILinux-VIHistorySuiteBootstrap.sh'
 if (-not (Test-Path -LiteralPath $viHistoryBootstrapScript -PathType Leaf)) {
   throw ("VI history bootstrap script not found: {0}" -f $viHistoryBootstrapScript)
 }
 $knownFlagScenarios = @($knownFlagScenarioContract.scenarios)
-$transportMatrixScenarios = @(New-PrePushTransportMatrixScenarios -scenarioDefinitions $knownFlagScenarios)
 $scenarioRoot = [string]$knownFlagScenarioContract.resultsRoot
 New-Item -ItemType Directory -Path $scenarioRoot -Force | Out-Null
 $scenarioContractReportPath = [string]$knownFlagScenarioContract.reportPath
@@ -1504,164 +1605,43 @@ try {
   Write-Host ("[pre-push] Rendering certification report: {0}" -f $renderingCertificationReportPath) -ForegroundColor DarkGray
 
   $currentLane = 'transport-smoke'
-  $activeScenarioName = 'single-container-matrix'
-  $activeScenarioFlags = @()
-  $scenarioDir = Join-Path $scenarioRoot $activeScenarioName
-  $singleContainerResultsDir = Join-Path $scenarioDir 'matrix-results'
-  New-Item -ItemType Directory -Path $singleContainerResultsDir -Force | Out-Null
-  $reportPath = Join-Path $scenarioDir 'compare-report.html'
-  $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
-  $capturePath = Join-Path $scenarioDir 'ni-linux-container-capture.json'
-  $observedCapturePath = [string]$capturePath
-  $observedReportPath = [string]$reportPath
-  $singleContainerContractPath = Join-Path $scenarioDir 'runtime-bootstrap.json'
-  $singleContainerLedgerPath = Join-Path $singleContainerResultsDir 'flag-matrix-ledger.tsv'
-  $singleContainerMarkerPath = Join-Path $singleContainerResultsDir 'flag-matrix-ran.txt'
-  $singleContainerContract = [ordered]@{
-    schema = 'ni-linux-runtime-bootstrap/v1'
-    mode = 'flag-matrix-single-container'
-    scriptPath = $singleContainerBootstrapScript
-    env = @(
-      [ordered]@{
-        name = 'COMPAREVI_FLAG_MATRIX_RESULTS_DIR'
-        value = '/opt/comparevi/flag-matrix'
-      }
-    )
-    mounts = @(
-      [ordered]@{
-        hostPath = $singleContainerResultsDir
-        containerPath = '/opt/comparevi/flag-matrix'
-      }
-    )
-  }
-  $singleContainerContract | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $singleContainerContractPath -Encoding utf8
-
-  Write-Host '[pre-push] Running NI image flag scenario group single-container-matrix requestedFlags=all combinations' -ForegroundColor Cyan
-  Push-Location $root
-  try {
-    & $niCompareScript `
-      -BaseVi $baseVi `
-      -HeadVi $headVi `
-      -Image $expectedImage `
-      -ReportPath $reportPath `
-      -LabVIEWPath $containerLabVIEWPath `
-      -ContainerNameLabel $activeScenarioName `
-      -TimeoutSeconds 240 `
-      -HeartbeatSeconds 15 `
-      -AutoRepairRuntime:$true `
-      -RuntimeEngineReadyTimeoutSeconds 120 `
-      -RuntimeEngineReadyPollSeconds 3 `
-      -RuntimeSnapshotPath $runtimeSnapshotPath `
-      -RuntimeBootstrapContractPath $singleContainerContractPath
-    $compareExit = $LASTEXITCODE
-    if ($compareExit -notin @(0, 1)) {
-      throw ("NI image flag scenario '{0}' compare failed (exit={1})." -f $activeScenarioName, $compareExit)
-    }
-  } finally {
-    Pop-Location | Out-Null
+  $baselineTransportSource = Select-PrePushBaselineTransportSmokeSource -ScenarioResults $knownFlagScenarioResults
+  if ($null -eq $baselineTransportSource) {
+    throw ("Pre-push known-flag scenario pack '{0}' does not define a baseline transport smoke source." -f $knownFlagScenarioPackId)
   }
 
-  if (-not (Test-Path -LiteralPath $capturePath -PathType Leaf)) {
-    throw ("NI image flag scenario '{0}' capture missing: {1}" -f $activeScenarioName, $capturePath)
-  }
-  $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 20
-  $gateOutcome = if ($capture.PSObject.Properties['gateOutcome']) { [string]$capture.gateOutcome } else { '' }
-  $resultClass = if ($capture.PSObject.Properties['resultClass']) { [string]$capture.resultClass } else { '' }
-  $imageUsed = if ($capture.PSObject.Properties['image']) { [string]$capture.image } else { '' }
-  $commandText = if ($capture.PSObject.Properties['command']) { [string]$capture.command } else { '' }
-  $flagsUsed = @()
-  if ($capture.PSObject.Properties['flags'] -and $capture.flags) {
-    $flagsUsed = @($capture.flags | ForEach-Object { [string]$_ })
-  }
-
-  if (-not [string]::Equals($imageUsed, $expectedImage, [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw ("NI image flag scenario '{0}' used unexpected image: {1}" -f $activeScenarioName, $imageUsed)
-  }
-  if (-not [string]::Equals($gateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw ("NI image flag scenario '{0}' did not pass (resultClass={1}, gateOutcome={2})." -f $activeScenarioName, $resultClass, $gateOutcome)
-  }
-  if ([string]::IsNullOrWhiteSpace($commandText) -or $commandText -notmatch '(?i)docker run') {
-    throw ("NI image flag scenario '{0}' did not emit a docker run command in capture evidence." -f $activeScenarioName)
-  }
-  if ($flagsUsed -notcontains '-Headless') {
-    throw ("NI image flag scenario '{0}' missing enforced -Headless flag in capture." -f $activeScenarioName)
-  }
-  if (-not (Test-Path -LiteralPath $singleContainerLedgerPath -PathType Leaf)) {
-    throw ("NI image flag scenario '{0}' missing single-container ledger: {1}" -f $activeScenarioName, $singleContainerLedgerPath)
-  }
-  if (-not (Test-Path -LiteralPath $singleContainerMarkerPath -PathType Leaf)) {
-    throw ("NI image flag scenario '{0}' missing single-container marker: {1}" -f $activeScenarioName, $singleContainerMarkerPath)
-  }
-
-  $ledgerRows = @(Get-Content -LiteralPath $singleContainerLedgerPath | Where-Object { $_ -and $_.Trim() })
-  if ($ledgerRows.Count -ne $transportMatrixScenarios.Count) {
-    throw ("NI image flag scenario '{0}' ledger count mismatch ({1} != {2})." -f $activeScenarioName, $ledgerRows.Count, $transportMatrixScenarios.Count)
-  }
-  $ledgerEntries = @(
-    $ledgerRows | ForEach-Object {
-      $parts = [string]$_ -split "`t"
-      [pscustomobject]@{
-        index = if ($parts.Count -gt 0) { [int]$parts[0] } else { 0 }
-        name = if ($parts.Count -gt 1) { [string]$parts[1] } else { '' }
-        requestedFlags = if ($parts.Count -gt 2) { [string]$parts[2] } else { '' }
-        exitCode = if ($parts.Count -gt 3) { [int]$parts[3] } else { 0 }
-        status = if ($parts.Count -gt 4) { [string]$parts[4] } else { '' }
-        diff = if ($parts.Count -gt 5) { [string]$parts[5] } else { '' }
-        reportPath = if ($parts.Count -gt 6) { [string]$parts[6] } else { '' }
-        logPath = if ($parts.Count -gt 7) { [string]$parts[7] } else { '' }
-      }
-    }
-  )
-  $expectedScenarioNames = @($transportMatrixScenarios | ForEach-Object { [string]$_.name })
-  $actualScenarioNames = @($ledgerEntries | ForEach-Object { [string]$_.name })
-  $scenarioNameDifferences = @(Compare-Object -ReferenceObject $expectedScenarioNames -DifferenceObject $actualScenarioNames)
-  if ($scenarioNameDifferences.Count -gt 0) {
-    throw ("NI image flag scenario '{0}' ledger names did not match the expected combination set." -f $activeScenarioName)
-  }
-  $failureMarkers = @(
-    'Report path already exists:'
-    'Use -o to overwrite existing report.'
-    'CreateComparisonReport operation failed.'
-  )
-  foreach ($entry in $ledgerEntries) {
-    $resolvedEntryLogPath = Resolve-ContainerMountedHostPath -Path $entry.logPath -Mounts @($capture.runtimeInjection.mounts)
-    if ([string]::IsNullOrWhiteSpace($resolvedEntryLogPath) -or -not (Test-Path -LiteralPath $resolvedEntryLogPath -PathType Leaf)) {
-      throw ("NI image flag scenario '{0}' missing single-container CLI log for {1}: {2} (resolved: {3})" -f $activeScenarioName, $entry.name, $entry.logPath, $resolvedEntryLogPath)
-    }
-    if (-not [string]::Equals($entry.status, 'completed', [System.StringComparison]::OrdinalIgnoreCase)) {
-      $entryLogTail = Get-LogTailText -Path $resolvedEntryLogPath
-      throw ("NI image flag scenario '{0}' recorded non-completed ledger status for {1}: {2}`nlog={3}`n{4}" -f $activeScenarioName, $entry.name, $entry.status, $resolvedEntryLogPath, $entryLogTail)
-    }
-    $hasFailureText = Select-String -Path $resolvedEntryLogPath -SimpleMatch -Quiet -Pattern $failureMarkers -ErrorAction SilentlyContinue
-    if ($hasFailureText) {
-      $entryLogTail = Get-LogTailText -Path $resolvedEntryLogPath
-      throw ("NI image flag scenario '{0}' detected wrapper/tool failure text for {1}`nlog={2}`n{3}" -f $activeScenarioName, $entry.name, $resolvedEntryLogPath, $entryLogTail)
-    }
-    $resolvedEntryReportPath = Resolve-ContainerMountedHostPath -Path $entry.reportPath -Mounts @($capture.runtimeInjection.mounts)
-    if (-not (Test-Path -LiteralPath $resolvedEntryReportPath -PathType Leaf)) {
-      throw ("NI image flag scenario '{0}' missing single-container report for {1}: {2} (resolved: {3})" -f $activeScenarioName, $entry.name, $entry.reportPath, $resolvedEntryReportPath)
-    }
-  }
-
+  $activeScenarioName = [string]$baselineTransportSource.name
+  $observedCapturePath = [string]$baselineTransportSource.capturePath
+  $observedReportPath = [string]$baselineTransportSource.reportPath
   $transportSmokeResults.Add([pscustomobject]@{
-    name = $activeScenarioName
-    requestedFlags = @('all combinations')
-    flags = @($flagsUsed)
-    resultClass = $resultClass
-    gateOutcome = $gateOutcome
-    capturePath = $capturePath
-    reportPath = $reportPath
+    name = 'baseline-transport-smoke'
+    description = 'Minimal transport smoke projected from the baseline rendered-review run.'
+    requestedFlags = @($baselineTransportSource.requestedFlags)
+    flags = @($baselineTransportSource.flags)
+    planeApplicability = @('linux-proof')
+    priorityClass = 'transport-smoke'
+    intendedSuppressionSemantics = [pscustomobject]@{
+      suppressedCategories = @()
+      reviewerSurfaceIntent = 'transport-smoke'
+      rawModeBoundaryIntent = 'transport-only'
+    }
+    expectedReviewerAssertions = @()
+    expectedRawModeEvidenceBoundaries = @()
+    resultClass = [string]$baselineTransportSource.resultClass
+    gateOutcome = [string]$baselineTransportSource.gateOutcome
+    capturePath = [string]$baselineTransportSource.capturePath
+    reportPath = [string]$baselineTransportSource.reportPath
   }) | Out-Null
-  $transportObservedCapturePath = [string]$capturePath
-  $transportObservedReportPath = [string]$reportPath
-  $observedCapturePath = [string]$capturePath
-  $observedReportPath = [string]$reportPath
+  $transportObservedCapturePath = [string]$baselineTransportSource.capturePath
+  $transportObservedReportPath = [string]$baselineTransportSource.reportPath
+  $observedCapturePath = [string]$baselineTransportSource.capturePath
+  $observedReportPath = [string]$baselineTransportSource.reportPath
   $transportLaneReportPath = Write-PrePushSupportLaneReport `
     -repoRoot $root `
     -reportPath $transportSmokeReportPath `
     -schema 'pre-push-ni-transport-smoke-report@v1' `
-    -laneName 'single-container-matrix' `
-    -description 'Transport-oriented single-container matrix smoke for NI Linux compare execution.' `
+    -laneName 'baseline-transport-smoke' `
+    -description 'Minimal transport smoke projected from the baseline rendered-review run.' `
     -observedOutcome 'pass' `
     -scenarioResults (ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $transportSmokeResults) `
     -failureMessage '' `
@@ -1905,8 +1885,8 @@ try {
         -repoRoot $root `
         -reportPath $transportSmokeReportPath `
         -schema 'pre-push-ni-transport-smoke-report@v1' `
-        -laneName 'single-container-matrix' `
-        -description 'Transport-oriented single-container matrix smoke for NI Linux compare execution.' `
+        -laneName 'single-container-smoke' `
+        -description 'Minimal transport-oriented single-container bootstrap smoke for NI Linux compare execution.' `
         -observedOutcome 'fail' `
         -scenarioResults (ConvertTo-PrePushKnownFlagScenarioResultArray -scenarioResults $transportSmokeResults) `
         -failureMessage $failureMessage `

--- a/tools/Run-NonLVChecksInDocker.ps1
+++ b/tools/Run-NonLVChecksInDocker.ps1
@@ -335,26 +335,82 @@ function Read-JsonHashtable {
   return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable)
 }
 
+function Invoke-GitReviewLoopCommand {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string[]]$Arguments
+  )
+
+  $gitPath = (Get-Command git -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+  $gitEnvNames = @(
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_COMMON_DIR',
+    'GIT_INDEX_FILE',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_PREFIX',
+    'GIT_CEILING_DIRECTORIES'
+  )
+
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = $gitPath
+  $psi.WorkingDirectory = $RepoRoot
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  foreach ($arg in @($Arguments)) {
+    [void]$psi.ArgumentList.Add([string]$arg)
+  }
+  foreach ($envName in $gitEnvNames) {
+    [void]$psi.Environment.Remove($envName)
+  }
+
+  $proc = [System.Diagnostics.Process]::new()
+  $proc.StartInfo = $psi
+  try {
+    [void]$proc.Start()
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    $global:LASTEXITCODE = [int]$proc.ExitCode
+    return [pscustomobject]@{
+      exitCode = [int]$proc.ExitCode
+      stdout = if ([string]::IsNullOrWhiteSpace($stdout)) { @() } else { @($stdout -split "(`r`n|`n|`r)" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) }
+      stderr = $stderr
+    }
+  } finally {
+    $proc.Dispose()
+  }
+}
+
 function Get-GitReviewLoopMetadata {
   param([string]$RepoRoot)
 
-  $headSha = (& git -C $RepoRoot rev-parse HEAD 2>$null | Select-Object -First 1)
-  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($headSha)) {
+  $headCommand = Invoke-GitReviewLoopCommand -RepoRoot $RepoRoot -Arguments @('rev-parse', 'HEAD')
+  $headSha = @($headCommand.stdout | Select-Object -First 1)
+  $headSha = if ($headSha.Count -gt 0) { [string]$headSha[0] } else { '' }
+  if ($headCommand.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($headSha)) {
     throw 'Unable to resolve git HEAD for Docker/Desktop review-loop receipt generation.'
   }
 
-  $branchName = (& git -C $RepoRoot branch --show-current 2>$null | Select-Object -First 1)
-  if ($LASTEXITCODE -ne 0) {
+  $branchCommand = Invoke-GitReviewLoopCommand -RepoRoot $RepoRoot -Arguments @('branch', '--show-current')
+  $branchName = @($branchCommand.stdout | Select-Object -First 1)
+  $branchName = if ($branchName.Count -gt 0) { [string]$branchName[0] } else { '' }
+  if ($branchCommand.exitCode -ne 0) {
     $branchName = ''
   }
 
-  $mergeBase = (& git -C $RepoRoot merge-base HEAD upstream/develop 2>$null | Select-Object -First 1)
-  if ($LASTEXITCODE -ne 0) {
+  $mergeBaseCommand = Invoke-GitReviewLoopCommand -RepoRoot $RepoRoot -Arguments @('merge-base', 'HEAD', 'upstream/develop')
+  $mergeBase = @($mergeBaseCommand.stdout | Select-Object -First 1)
+  $mergeBase = if ($mergeBase.Count -gt 0) { [string]$mergeBase[0] } else { '' }
+  if ($mergeBaseCommand.exitCode -ne 0) {
     $mergeBase = ''
   }
 
-  $trackedStatus = (& git -C $RepoRoot status --short --untracked-files=no 2>$null)
-  if ($LASTEXITCODE -ne 0) {
+  $trackedStatusCommand = Invoke-GitReviewLoopCommand -RepoRoot $RepoRoot -Arguments @('status', '--short', '--untracked-files=no')
+  $trackedStatus = @($trackedStatusCommand.stdout)
+  if ($trackedStatusCommand.exitCode -ne 0) {
     $trackedStatus = @()
   }
 
@@ -729,6 +785,8 @@ if ($checkStates.niLinuxReviewSuite.enabled) {
     $resultsRootResolved = [System.IO.Path]::GetFullPath((Join-Path $repoRootResolved $NILinuxReviewSuiteResultsRoot))
     $reviewSuiteSummaryHtmlPath = Join-Path $resultsRootResolved 'review-suite-summary.html'
     $reviewSuiteSummaryJsonPath = Join-Path $resultsRootResolved 'review-suite-summary.json'
+    $flagCombinationCertificationJsonPath = Join-Path $resultsRootResolved 'flag-combination-certification.json'
+    $flagCombinationCertificationHtmlPath = Join-Path $resultsRootResolved 'flag-combination-certification.html'
     $historyMarkdownPath = Join-Path $resultsRootResolved 'vi-history-report/results/history-report.md'
     $historyHtmlPath = Join-Path $resultsRootResolved 'vi-history-report/results/history-report.html'
     $historySummaryPath = Join-Path $resultsRootResolved 'vi-history-report/results/history-summary.json'
@@ -775,6 +833,8 @@ if ($checkStates.niLinuxReviewSuite.enabled) {
     foreach ($artifactPath in @(
         $reviewSuiteSummaryHtmlPath,
         $reviewSuiteSummaryJsonPath,
+        $flagCombinationCertificationJsonPath,
+        $flagCombinationCertificationHtmlPath,
         $historyMarkdownPath,
         $historyHtmlPath,
         $historySummaryPath,
@@ -789,12 +849,15 @@ if ($checkStates.niLinuxReviewSuite.enabled) {
     $checkStates.niLinuxReviewSuite.artifacts.resultsRoot = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $resultsRootResolved
     $checkStates.niLinuxReviewSuite.artifacts.reviewSuiteSummaryJsonPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $reviewSuiteSummaryJsonPath
     $checkStates.niLinuxReviewSuite.artifacts.reviewSuiteSummaryHtmlPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $reviewSuiteSummaryHtmlPath
+    $checkStates.niLinuxReviewSuite.artifacts.flagCombinationCertificationJsonPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $flagCombinationCertificationJsonPath
+    $checkStates.niLinuxReviewSuite.artifacts.flagCombinationCertificationHtmlPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $flagCombinationCertificationHtmlPath
     $checkStates.niLinuxReviewSuite.artifacts.historyReportHtmlPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $historyHtmlPath
     $checkStates.niLinuxReviewSuite.artifacts.historySummaryPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $historySummaryPath
     $checkStates.niLinuxReviewSuite.artifacts.historyReviewReceiptPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $historyReviewReceiptPath
 
-    Write-Host ("[docker] ni-linux-review-suite OK (summary={0}; history={1}; facade={2})" -f
+    Write-Host ("[docker] ni-linux-review-suite OK (summary={0}; certification={1}; history={2}; facade={3})" -f
         ([System.IO.Path]::GetRelativePath($repoRootResolved, $reviewSuiteSummaryHtmlPath).Replace('\', '/')),
+        ([System.IO.Path]::GetRelativePath($repoRootResolved, $flagCombinationCertificationHtmlPath).Replace('\', '/')),
         ([System.IO.Path]::GetRelativePath($repoRootResolved, $historyHtmlPath).Replace('\', '/')),
         ([System.IO.Path]::GetRelativePath($repoRootResolved, $historySummaryPath).Replace('\', '/'))) -ForegroundColor Green
   }
@@ -925,4 +988,3 @@ Write-Host 'Non-LabVIEW container checks completed.' -ForegroundColor Green
     -NILinuxResultsRoot $NILinuxReviewSuiteResultsRoot `
     -RequirementsResultsRoot $RequirementsVerificationResultsRoot
 }
-

--- a/tools/priority/__tests__/workspace-health-contract.test.mjs
+++ b/tools/priority/__tests__/workspace-health-contract.test.mjs
@@ -28,7 +28,7 @@ test('PrePush-Checks invokes workspace health gate in optional lease mode', () =
   assert.match(content, /if \(\$null -eq \$mount\) \{\s*continue\s*\}/);
 });
 
-test('PrePush NI image known-flag scenario consumes the checked-in active scenario-pack contract', () => {
+test('PrePush NI image known-flag scenario uses rendered semantic certification and a projected transport smoke lane', () => {
   const content = readRepoFile('tools/PrePush-Checks.ps1');
   assert.match(content, /Run-NILinuxContainerCompare\.ps1/);
   assert.match(content, /Resolve-PrePushKnownFlagScenarioPack/);
@@ -38,19 +38,26 @@ test('PrePush NI image known-flag scenario consumes the checked-in active scenar
   assert.match(content, /& \$niCompareScript/);
   assert.match(content, /-LabVIEWPath \$containerLabVIEWPath/);
   assert.match(content, /-ContainerNameLabel \$activeScenarioName/);
-  assert.match(content, /history-summary\.json/);
-  assert.match(content, /logPath = if \(\$parts.Count -gt 7\)/);
-  assert.match(content, /\$failureMarkers = @\(/);
-  assert.match(content, /Select-String -Path \$resolvedEntryLogPath -SimpleMatch -Quiet -Pattern \$failureMarkers/);
-  assert.match(content, /Write-PrePushKnownFlagScenarioReport/);
+  assert.match(content, /Get-PrePushKnownFlagScenarioSemanticEvidence/);
+  assert.match(content, /Test-PrePushKnownFlagReviewerAssertion/);
+  assert.match(content, /Test-PrePushKnownFlagRawModeBoundary/);
+  assert.match(content, /Write-PrePushRenderingCertificationReport/);
+  assert.match(content, /function Select-PrePushBaselineTransportSmokeSource/);
+  assert.match(content, /\$baselineTransportSource = Select-PrePushBaselineTransportSmokeSource -ScenarioResults \$knownFlagScenarioResults/);
+  assert.match(content, /baseline-transport-smoke/);
+  assert.match(content, /Minimal transport smoke projected from the baseline rendered-review run\./);
   assert.match(content, /Write-PrePushSupportLaneReport/);
+  assert.match(content, /history-summary\.json/);
+  assert.match(content, /Write-PrePushKnownFlagScenarioReport/);
+  assert.match(content, /Write-PrePushFlagScenarioCatalog/);
   assert.match(content, /transport-smoke-report\.json/);
   assert.match(content, /vi-history-smoke-report\.json/);
   assert.match(content, /#### Active Scenario Pack/);
+  assert.match(content, /#### Rendering Certification/);
   assert.match(content, /#### Transport Smoke/);
   assert.match(content, /#### VI History Smoke/);
   assert.match(content, /Active known-flag scenario pack '\{0\}' OK/);
-  assert.match(content, /New-PrePushTransportMatrixScenarios/);
+  assert.match(content, /New-PrePushTransportSmokeScenarios/);
   assert.doesNotMatch(content, /pwsh\s+-NoLogo\s+-NoProfile\s+-File\s+\$niCompareScript/);
   assert.doesNotMatch(content, /Render-VIHistoryReport\.ps1/);
 });
@@ -138,6 +145,8 @@ test('Run-NonLVChecksInDocker exposes Docker Desktop NI Linux review-suite parit
   assert.match(content, /Verify-RequirementsGate\.ps1/);
   assert.match(content, /schema = 'docker-tools-parity-review-loop@v1'/);
   assert.match(content, /review-suite-summary\.html/);
+  assert.match(content, /flag-combination-certification\.html/);
+  assert.match(content, /flag-combination-certification\.json/);
   assert.match(content, /history-report\.html/);
   assert.match(content, /history-summary\.json/);
   assert.match(content, /vi-history-review-loop-receipt\.json/);
@@ -157,6 +166,7 @@ test('AGENTS documents the Docker Desktop local-first review loop for repeat pas
   assert.match(content, /Run-NonLVChecksInDocker\.ps1 -UseToolsImage/);
   assert.match(content, /Run-NonLVChecksInDocker\.ps1 -UseToolsImage -NILinuxReviewSuite/);
   assert.match(content, /iterate locally through Docker\s+Desktop first/i);
+  assert.match(content, /flag-combination-certification\.json/);
   assert.match(content, /DOCKER_TOOLS_PARITY\.md/);
 });
 
@@ -167,6 +177,7 @@ test('Docker parity knowledgebase distinguishes current host-plane behavior from
   assert.match(content, /Targeted single-VI history follow-up/);
   assert.match(content, /touch-aware for deep branches such as `develop`/);
   assert.match(content, /NILinuxReviewSuiteHistoryTargetPath/);
+  assert.match(content, /flag-combination-certification\.html/);
   assert.match(content, /vi-history-review-loop-receipt\.json/);
   assert.match(content, /review-loop-receipt\.json/);
 });


### PR DESCRIPTION
## Summary
- make `tools/PrePush-Checks.ps1` the blocking rendered-review gate with a minimal projected transport-smoke support lane
- move the broad NI Linux flag sweep into explicit certification artifacts emitted by `tools/Invoke-NILinuxReviewSuite.ps1`
- harden Docker/Desktop review-loop receipt git metadata so worktree and poisoned git env states do not break receipt generation

## Validation
- `pwsh -NoLogo -NoProfile -File tests/PrePushKnownFlagScenarioReport.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/NILinuxReviewSuiteCertification.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/RunNonLVChecksInDockerReceipt.Tests.ps1`
- `node --test tools/priority/__tests__/workspace-health-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage -NILinuxReviewSuite -SkipActionlint -SkipDocs -SkipWorkflow -SkipMarkdown -SkipDotnetCliBuild`
- `git diff --check`

## Follow-ups
- #1413
- #1414

## Agent Metadata
- Agent: Codex
- Mode: unattended execution
- Standing issue: #1391
