### PR TITLE
#1413 Guard containerized actionlint against stale tools images

### DIFF
--- a/tests/RunNonLVChecksInDockerActionlint.Tests.ps1
+++ b/tests/RunNonLVChecksInDockerActionlint.Tests.ps1
@@ -1,0 +1,109 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Docker actionlint surface selection' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:RunNonLVChecksScriptPath = Join-Path $repoRoot 'tools' 'Run-NonLVChecksInDocker.ps1'
+
+    if (-not (Test-Path -LiteralPath $script:RunNonLVChecksScriptPath -PathType Leaf)) {
+      throw "Run-NonLVChecksInDocker.ps1 not found at $script:RunNonLVChecksScriptPath"
+    }
+
+    function script:Get-ScriptFunctionDefinition {
+      param(
+        [string]$ScriptPath,
+        [string]$FunctionName
+      )
+
+      $tokens = $null
+      $parseErrors = $null
+      $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+      if ($parseErrors.Count -gt 0) {
+        throw ("Failed to parse {0}: {1}" -f $ScriptPath, ($parseErrors | ForEach-Object { $_.Message } | Join-String -Separator '; '))
+      }
+
+      $functionAst = $ast.Find(
+        {
+          param($node)
+          $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+          $node.Name -eq $FunctionName
+        },
+        $true
+      )
+      if ($null -eq $functionAst) {
+        throw ("Function {0} not found in {1}" -f $FunctionName, $ScriptPath)
+      }
+
+      return $functionAst.Extent.Text
+    }
+
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Get-ActionlintVersionFloor')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Test-ActionlintVersionAtLeast')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Resolve-ActionlintContainerInvocation')
+  }
+
+  It 'reads the actionlint version floor from the tools Dockerfile' {
+    $repoRoot = Join-Path $TestDrive 'repo'
+    $dockerDir = Join-Path $repoRoot 'tools' 'docker'
+    New-Item -ItemType Directory -Path $dockerDir -Force | Out-Null
+    @'
+# syntax=docker/dockerfile:1
+ARG ACTIONLINT_VERSION=1.7.8
+'@ | Set-Content -LiteralPath (Join-Path $dockerDir 'Dockerfile.tools') -Encoding utf8
+
+    $version = Get-ActionlintVersionFloor -RepoRoot $repoRoot
+
+    $version | Should -Be '1.7.8'
+  }
+
+  It 'compares actionlint versions against the required floor' {
+    (Test-ActionlintVersionAtLeast -Version '1.7.7' -MinimumVersion '1.7.8') | Should -BeFalse
+    (Test-ActionlintVersionAtLeast -Version '1.7.8' -MinimumVersion '1.7.8') | Should -BeTrue
+    (Test-ActionlintVersionAtLeast -Version '1.8.0' -MinimumVersion '1.7.8') | Should -BeTrue
+    (Test-ActionlintVersionAtLeast -Version '' -MinimumVersion '1.7.8') | Should -BeFalse
+  }
+
+  It 'uses the tools image when its actionlint version satisfies the floor' {
+    $repoRoot = Join-Path $TestDrive 'repo-tools'
+    $dockerDir = Join-Path $repoRoot 'tools' 'docker'
+    New-Item -ItemType Directory -Path $dockerDir -Force | Out-Null
+    'ARG ACTIONLINT_VERSION=1.7.8' | Set-Content -LiteralPath (Join-Path $dockerDir 'Dockerfile.tools') -Encoding utf8
+
+    function Get-ContainerActionlintVersion {
+      param([string]$Image, [string[]]$Arguments)
+      return '1.7.8'
+    }
+
+    $invocation = Resolve-ActionlintContainerInvocation -RepoRoot $repoRoot -UseToolsImage -ToolsImageTag 'ghcr.io/example/comparevi-tools:latest'
+
+    $invocation.image | Should -Be 'ghcr.io/example/comparevi-tools:latest'
+    @($invocation.arguments) | Should -Be @('actionlint', '-color')
+    $invocation.source | Should -Be 'tools-image'
+    $invocation.surface | Should -Be 'container-tools-image'
+    $invocation.fallbackReason | Should -Be ''
+  }
+
+  It 'falls back to the official image when the tools image actionlint version is stale' {
+    $repoRoot = Join-Path $TestDrive 'repo-fallback'
+    $dockerDir = Join-Path $repoRoot 'tools' 'docker'
+    New-Item -ItemType Directory -Path $dockerDir -Force | Out-Null
+    'ARG ACTIONLINT_VERSION=1.7.8' | Set-Content -LiteralPath (Join-Path $dockerDir 'Dockerfile.tools') -Encoding utf8
+
+    function Get-ContainerActionlintVersion {
+      param([string]$Image, [string[]]$Arguments)
+      return '1.7.7'
+    }
+
+    $invocation = Resolve-ActionlintContainerInvocation -RepoRoot $repoRoot -UseToolsImage -ToolsImageTag 'ghcr.io/example/comparevi-tools:latest'
+
+    $invocation.image | Should -Be 'rhysd/actionlint:1.7.8'
+    @($invocation.arguments) | Should -Be @('-color')
+    $invocation.source | Should -Be 'official-image-fallback'
+    $invocation.surface | Should -Be 'container-official-fallback'
+    $invocation.detectedVersion | Should -Be '1.7.7'
+    $invocation.fallbackReason | Should -Be 'tools-image-stale'
+  }
+}

--- a/tools/Run-NonLVChecksInDocker.ps1
+++ b/tools/Run-NonLVChecksInDocker.ps1
@@ -335,6 +335,143 @@ function Read-JsonHashtable {
   return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable)
 }
 
+function Get-ActionlintVersionFloor {
+  param([Parameter(Mandatory)][string]$RepoRoot)
+
+  $dockerfilePath = Join-Path $RepoRoot 'tools' 'docker' 'Dockerfile.tools'
+  if (-not (Test-Path -LiteralPath $dockerfilePath -PathType Leaf)) {
+    throw ("Tools Dockerfile not found while resolving actionlint floor: {0}" -f $dockerfilePath)
+  }
+
+  $dockerfileContent = Get-Content -LiteralPath $dockerfilePath -Raw
+  $match = [regex]::Match($dockerfileContent, '(?m)^ARG ACTIONLINT_VERSION=(\d+\.\d+\.\d+)\s*$')
+  if (-not $match.Success) {
+    throw ("Unable to resolve ACTIONLINT_VERSION from {0}" -f $dockerfilePath)
+  }
+
+  return [string]$match.Groups[1].Value
+}
+
+function Test-ActionlintVersionAtLeast {
+  param(
+    [AllowEmptyString()][string]$Version,
+    [Parameter(Mandatory)][string]$MinimumVersion
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Version)) {
+    return $false
+  }
+
+  try {
+    return ([version]$Version) -ge ([version]$MinimumVersion)
+  } catch {
+    return $false
+  }
+}
+
+function Invoke-ContainerCapture {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string[]]$Arguments,
+    [string[]]$DockerRunArguments = @()
+  )
+
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = 'docker'
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  foreach ($arg in @('run') + $commonArgs + @($DockerRunArguments) + @($Image) + @($Arguments)) {
+    [void]$psi.ArgumentList.Add([string]$arg)
+  }
+
+  $proc = [System.Diagnostics.Process]::new()
+  $proc.StartInfo = $psi
+  try {
+    [void]$proc.Start()
+    $stdout = $proc.StandardOutput.ReadToEnd()
+    $stderr = $proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    $global:LASTEXITCODE = [int]$proc.ExitCode
+    return [pscustomobject]@{
+      exitCode = [int]$proc.ExitCode
+      stdout = $stdout
+      stderr = $stderr
+    }
+  } finally {
+    $proc.Dispose()
+  }
+}
+
+function Get-ContainerActionlintVersion {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string[]]$Arguments
+  )
+
+  $probe = Invoke-ContainerCapture -Image $Image -Arguments $Arguments
+  if ($probe.exitCode -ne 0) {
+    return ''
+  }
+
+  $combinedOutput = (($probe.stdout ?? '') + "`n" + ($probe.stderr ?? ''))
+  $match = [regex]::Match($combinedOutput, '(?m)^(?<version>\d+\.\d+\.\d+)\s*$')
+  if (-not $match.Success) {
+    return ''
+  }
+
+  return [string]$match.Groups['version'].Value
+}
+
+function Resolve-ActionlintContainerInvocation {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [switch]$UseToolsImage,
+    [AllowEmptyString()][string]$ToolsImageTag
+  )
+
+  $requiredVersion = Get-ActionlintVersionFloor -RepoRoot $RepoRoot
+  $officialImage = "rhysd/actionlint:$requiredVersion"
+  if (-not $UseToolsImage -or [string]::IsNullOrWhiteSpace($ToolsImageTag)) {
+    return [ordered]@{
+      image = $officialImage
+      arguments = @('-color')
+      label = 'actionlint'
+      surface = 'container-official'
+      source = 'official-image'
+      requiredVersion = $requiredVersion
+      detectedVersion = $requiredVersion
+      fallbackReason = ''
+    }
+  }
+
+  $detectedToolsVersion = Get-ContainerActionlintVersion -Image $ToolsImageTag -Arguments @('actionlint', '-version')
+  if (-not (Test-ActionlintVersionAtLeast -Version $detectedToolsVersion -MinimumVersion $requiredVersion)) {
+    Write-Host ("[docker] Tools image actionlint version '{0}' is below required '{1}'; using official fallback image '{2}'." -f $(if ([string]::IsNullOrWhiteSpace($detectedToolsVersion)) { '(unknown)' } else { $detectedToolsVersion }), $requiredVersion, $officialImage) -ForegroundColor Yellow
+    return [ordered]@{
+      image = $officialImage
+      arguments = @('-color')
+      label = 'actionlint (fallback)'
+      surface = 'container-official-fallback'
+      source = 'official-image-fallback'
+      requiredVersion = $requiredVersion
+      detectedVersion = $detectedToolsVersion
+      fallbackReason = 'tools-image-stale'
+    }
+  }
+
+  return [ordered]@{
+    image = $ToolsImageTag
+    arguments = @('actionlint', '-color')
+    label = 'actionlint (tools)'
+    surface = 'container-tools-image'
+    source = 'tools-image'
+    requiredVersion = $requiredVersion
+    detectedVersion = $detectedToolsVersion
+    fallbackReason = ''
+  }
+}
+
 function Invoke-GitReviewLoopCommand {
   param(
     [Parameter(Mandatory)][string]$RepoRoot,
@@ -673,6 +810,14 @@ if ($UseToolsImage -and -not $ToolsImageTag) {
   $ToolsImageTag = 'ghcr.io/labview-community-ci-cd/comparevi-tools:latest'
 }
 
+$actionlintInvocation = $null
+if (-not $SkipActionlint) {
+  $actionlintInvocation = Resolve-ActionlintContainerInvocation `
+    -RepoRoot $repoRootResolved `
+    -UseToolsImage:$UseToolsImage `
+    -ToolsImageTag $ToolsImageTag
+}
+
 $requiresDockerSocketPassthrough = $false
 if ($UseToolsImage -and $pesterRequested) {
   $requiresDockerSocketPassthrough = $DockerSocketPassthrough -or (Test-TargetsNILinuxContainerCompareSuite -Paths $PesterPath)
@@ -715,8 +860,14 @@ if ($checkStates.dotnetCliBuild.enabled) {
 
 if ($UseToolsImage -and $ToolsImageTag) {
   if ($checkStates.actionlint.enabled) {
+    $checkStates.actionlint.surface = [string]$actionlintInvocation.surface
+    $checkStates.actionlint.artifacts.image = [string]$actionlintInvocation.image
+    $checkStates.actionlint.artifacts.source = [string]$actionlintInvocation.source
+    $checkStates.actionlint.artifacts.requiredVersion = [string]$actionlintInvocation.requiredVersion
+    $checkStates.actionlint.artifacts.detectedVersion = [string]$actionlintInvocation.detectedVersion
+    $checkStates.actionlint.artifacts.fallbackReason = [string]$actionlintInvocation.fallbackReason
     Invoke-DockerParityStep -StepRecord $checkStates.actionlint -Name 'actionlint' -RunRecord $runRecord -Action {
-      Invoke-Container -Image $ToolsImageTag -Arguments @('actionlint','-color') -Label 'actionlint (tools)'
+      Invoke-Container -Image ([string]$actionlintInvocation.image) -Arguments @($actionlintInvocation.arguments) -Label ([string]$actionlintInvocation.label)
     }
   }
   if ($checkStates.markdownlint.enabled) {
@@ -745,8 +896,14 @@ if ($UseToolsImage -and $ToolsImageTag) {
   }
 } else {
   if ($checkStates.actionlint.enabled) {
+    $checkStates.actionlint.surface = [string]$actionlintInvocation.surface
+    $checkStates.actionlint.artifacts.image = [string]$actionlintInvocation.image
+    $checkStates.actionlint.artifacts.source = [string]$actionlintInvocation.source
+    $checkStates.actionlint.artifacts.requiredVersion = [string]$actionlintInvocation.requiredVersion
+    $checkStates.actionlint.artifacts.detectedVersion = [string]$actionlintInvocation.detectedVersion
+    $checkStates.actionlint.artifacts.fallbackReason = [string]$actionlintInvocation.fallbackReason
     Invoke-DockerParityStep -StepRecord $checkStates.actionlint -Name 'actionlint' -RunRecord $runRecord -Action {
-      Invoke-Container -Image 'rhysd/actionlint:1.7.8' -Arguments @('-color') -Label 'actionlint'
+      Invoke-Container -Image ([string]$actionlintInvocation.image) -Arguments @($actionlintInvocation.arguments) -Label ([string]$actionlintInvocation.label)
     }
   }
   if ($checkStates.markdownlint.enabled) {

--- a/tools/priority/__tests__/workflow-enclave-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-enclave-contract.test.mjs
@@ -174,3 +174,24 @@ test('workflow and composite lint surfaces use repo-owned markdown commands', ()
   assert.match(cliLintsAction, /node tools\/npm\/run-script\.mjs lint:md:changed/);
   assert.match(cliLintsAction, /markdownlint-cli2 --config docs\/relaxed\.markdownlint-cli2\.jsonc/);
 });
+
+test('actionlint version policy stays aligned across tools image and local/container lint helpers', () => {
+  const dockerfile = read('tools/docker/Dockerfile.tools');
+  assert.match(dockerfile, /ARG ACTIONLINT_VERSION=1\.7\.8/);
+
+  const dockerChecks = read('tools/Run-NonLVChecksInDocker.ps1');
+  assert.match(dockerChecks, /function Get-ActionlintVersionFloor/);
+  assert.match(dockerChecks, /Join-Path \$RepoRoot 'tools' 'docker' 'Dockerfile\.tools'/);
+  assert.match(dockerChecks, /rhysd\/actionlint:\$requiredVersion/);
+  assert.match(dockerChecks, /official-image-fallback/);
+  assert.match(dockerChecks, /container-tools-image/);
+
+  const prePush = read('tools/PrePush-Checks.ps1');
+  assert.match(prePush, /\[string\]\$ActionlintVersion = '1\.7\.8'/);
+
+  const validateWorkflow = read('.github/workflows/validate.yml');
+  assert.match(validateWorkflow, /ACTIONLINT_VERSION:\s*'\$\{\{\s*vars\.ACTIONLINT_VERSION \|\| ''1\.7\.8''\s*\}\}'/);
+
+  const workflowsLintWorkflow = read('.github/workflows/workflows-lint.yml');
+  assert.match(workflowsLintWorkflow, /ACTIONLINT_VERSION:\s*\$\{\{\s*vars\.ACTIONLINT_VERSION \|\| '1\.7\.8'\s*\}\}/);
+});


### PR DESCRIPTION
# Summary

Delivers issue #1413 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1413
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/origin-1413-node24-actionlint-tools-image`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1413