### PR TITLE
Fix security intake pagination

### DIFF
--- a/tools/priority/__tests__/security-intake.test.mjs
+++ b/tools/priority/__tests__/security-intake.test.mjs
@@ -11,7 +11,9 @@ import {
   buildRemediationCandidates,
   evaluateOverride,
   evaluateSecurityBreaches,
+  listDependabotAlerts,
   normalizeDependabotAlert,
+  parseNextLinkFromHeader,
   parseArgs,
   runSecurityIntake,
   summarizeDependabotAlerts
@@ -139,6 +141,18 @@ test('summaries and breaches calculate expected values', () => {
   );
 });
 
+test('normalizeDependabotAlert maps GitHub medium severity to moderate', () => {
+  const alert = normalizeDependabotAlert(
+    sampleAlert({
+      security_advisory: {
+        severity: 'medium'
+      }
+    }),
+    new Date('2026-03-06T12:00:00Z')
+  );
+  assert.equal(alert.severity, 'moderate');
+});
+
 test('buildRemediationCandidates sorts by severity then age', () => {
   const candidates = buildRemediationCandidates([
     { number: 5, severity: 'moderate', ageDays: 3 },
@@ -177,6 +191,64 @@ test('evaluateOverride enforces metadata and expiration', () => {
   assert.equal(invalid.active, false);
   assert.ok(invalid.validationErrors.includes('reason-missing'));
   assert.ok(invalid.validationErrors.includes('expires-at-not-future'));
+});
+
+test('parseNextLinkFromHeader extracts the next cursor URL from Link headers', () => {
+  const header = '<https://api.github.com/repos/example/repo/dependabot/alerts?state=open&per_page=100&after=opaque>; rel="next", <https://api.github.com/repos/example/repo/dependabot/alerts?state=open&per_page=100&after=last>; rel="last"';
+  assert.equal(
+    parseNextLinkFromHeader(header),
+    'https://api.github.com/repos/example/repo/dependabot/alerts?state=open&per_page=100&after=opaque'
+  );
+  assert.equal(parseNextLinkFromHeader(null), null);
+});
+
+test('listDependabotAlerts uses cursor pagination instead of page parameters', async () => {
+  const requestedUrls = [];
+  const responses = [
+    {
+      payload: [sampleAlert({ number: 1 })],
+      link: '<https://api.github.com/repos/example/repo/dependabot/alerts?state=open&per_page=100&after=cursor-1>; rel="next"'
+    },
+    {
+      payload: [sampleAlert({ number: 2 })],
+      link: null
+    }
+  ];
+  let index = 0;
+  const alerts = await listDependabotAlerts({
+    repo: 'example/repo',
+    token: 'token',
+    state: 'open',
+    fetchImpl: async (url) => {
+      requestedUrls.push(String(url));
+      const current = responses[index++];
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get(name) {
+            return name.toLowerCase() === 'link' ? current.link : null;
+          }
+        },
+        async text() {
+          return JSON.stringify(current.payload);
+        }
+      };
+    }
+  });
+
+  assert.deepEqual(
+    requestedUrls,
+    [
+      'https://api.github.com/repos/example/repo/dependabot/alerts?state=open&per_page=100',
+      'https://api.github.com/repos/example/repo/dependabot/alerts?state=open&per_page=100&after=cursor-1'
+    ]
+  );
+  assert.ok(requestedUrls.every((entry) => !/[?&]page=/.test(entry)));
+  assert.deepEqual(
+    alerts.map((entry) => entry.number),
+    [1, 2]
+  );
 });
 
 test('runSecurityIntake writes deterministic report and routes on breach', async () => {
@@ -289,3 +361,29 @@ test('runSecurityIntake supports skip semantics and override bypass', async () =
   assert.equal(overridden.report.override.active, true);
 });
 
+test('runSecurityIntake treats 404 dependabot access failures as skip semantics', async () => {
+  const now = new Date('2026-03-06T12:00:00Z');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'security-intake-'));
+
+  const result = await runSecurityIntake(
+    {
+      outputPath: path.join(tmpDir, 'auth-skip.json'),
+      failOnSkip: false
+    },
+    {
+      now,
+      resolveRepositorySlugFn: () => 'example/repo',
+      resolveTokenFn: () => 'token',
+      listDependabotAlertsFn: async () => {
+        const error = new Error('GitHub API GET https://api.github.com/repos/example/repo/dependabot/alerts failed (404).');
+        error.status = 404;
+        error.url = 'https://api.github.com/repos/example/repo/dependabot/alerts';
+        throw error;
+      }
+    }
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.status, 'skip');
+  assert.equal(result.report.errors[0].code, 'auth-or-permission-unavailable');
+});

--- a/tools/priority/security-intake.mjs
+++ b/tools/priority/security-intake.mjs
@@ -211,6 +211,7 @@ function round(value) {
 
 function severity(raw) {
   const normalized = String(raw || '').toLowerCase().trim();
+  if (normalized === 'medium') return 'moderate';
   return ['critical', 'high', 'moderate', 'low'].includes(normalized) ? normalized : 'unknown';
 }
 
@@ -267,17 +268,34 @@ export async function requestGitHubJson(url, { token, method = 'GET', body = nul
     error.url = url;
     throw error;
   }
-  return payload;
+  return {
+    payload,
+    headers: {
+      link: response.headers?.get?.('link') ?? null
+    }
+  };
+}
+
+export function parseNextLinkFromHeader(linkHeader) {
+  const normalized = asOptional(linkHeader);
+  if (!normalized) return null;
+  for (const segment of normalized.split(',')) {
+    const match = segment.match(/<([^>]+)>\s*;\s*rel=\"([^\"]+)\"/i);
+    if (!match) continue;
+    if (String(match[2]).trim().toLowerCase() !== 'next') continue;
+    return match[1];
+  }
+  return null;
 }
 
 export async function listDependabotAlerts({ repo, token, state, maxPages = DEFAULT_MAX_PAGES, perPage = 100, fetchImpl = globalThis.fetch }) {
   const alerts = [];
-  for (let page = 1; page <= maxPages; page += 1) {
-    const url = `https://api.github.com/repos/${repo}/dependabot/alerts?state=${encodeURIComponent(state)}&per_page=${perPage}&page=${page}`;
-    const payload = await requestGitHubJson(url, { token, fetchImpl });
+  let url = `https://api.github.com/repos/${repo}/dependabot/alerts?state=${encodeURIComponent(state)}&per_page=${perPage}`;
+  for (let pageIndex = 0; pageIndex < maxPages && url; pageIndex += 1) {
+    const { payload, headers } = await requestGitHubJson(url, { token, fetchImpl });
     if (!Array.isArray(payload)) throw new Error(`Unexpected Dependabot response for state=${state}.`);
     alerts.push(...payload);
-    if (payload.length < perPage) break;
+    url = parseNextLinkFromHeader(headers?.link);
   }
   return alerts;
 }
@@ -385,7 +403,7 @@ function isAuthError(error) {
 export async function upsertRemediationIssue({ repo, token, report, titlePrefix = DEFAULT_ROUTE_TITLE_PREFIX, labels = DEFAULT_ROUTE_LABELS, fetchImpl = globalThis.fetch }) {
   const routeLabels = normalizeLabels(labels.join(','));
   const listUrl = `https://api.github.com/repos/${repo}/issues?state=open&labels=${encodeURIComponent(routeLabels.join(','))}&per_page=100`;
-  const openIssues = await requestGitHubJson(listUrl, { token, fetchImpl });
+  const { payload: openIssues } = await requestGitHubJson(listUrl, { token, fetchImpl });
   const existing = Array.isArray(openIssues) ? openIssues.find((issue) => String(issue.title || '').trim() === titlePrefix) : null;
   const bodyLines = [
     '## Security intake breach',
@@ -406,7 +424,7 @@ export async function upsertRemediationIssue({ repo, token, report, titlePrefix 
   ];
   const body = bodyLines.join('\n');
   if (existing) {
-    const updated = await requestGitHubJson(`https://api.github.com/repos/${repo}/issues/${existing.number}`, {
+    const { payload: updated } = await requestGitHubJson(`https://api.github.com/repos/${repo}/issues/${existing.number}`, {
       token,
       method: 'PATCH',
       body: { title: titlePrefix, body, labels: routeLabels },
@@ -414,7 +432,7 @@ export async function upsertRemediationIssue({ repo, token, report, titlePrefix 
     });
     return { action: 'updated', issueNumber: updated?.number || existing.number, issueUrl: updated?.html_url || existing.html_url || null, title: titlePrefix, labels: routeLabels };
   }
-  const created = await requestGitHubJson(`https://api.github.com/repos/${repo}/issues`, {
+  const { payload: created } = await requestGitHubJson(`https://api.github.com/repos/${repo}/issues`, {
     token,
     method: 'POST',
     body: { title: titlePrefix, body, labels: routeLabels },


### PR DESCRIPTION
# Summary

Fixes `priority:security:intake` so it uses the Dependabot alerts endpoint correctly instead of sending unsupported `page=` parameters that forced a synthetic HTTP 400. With the pagination bug removed, the helper now surfaces the real security state and routed the newly visible stale-alert breach into tracked issue `#1423`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
  - Closes `#1420`
- Files, tools, workflows, or policies touched:
  - `tools/priority/security-intake.mjs`
  - `tools/priority/__tests__/security-intake.test.mjs`
- Cross-repo or external-consumer impact:
  - the repo security-intake helper now reaches the real Dependabot alerts surface instead of failing on self-generated pagination errors
- Required checks, merge-queue behavior, or approval flows affected:
  - no workflow-policy change; this is a tooling correctness fix with test coverage

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/security-intake.test.mjs tools/priority/__tests__/security-intake-schema.test.mjs`
  - `node tools/npm/run-script.mjs priority:security:intake`
  - `node tools/npm/run-script.mjs priority:security:intake -- --route-on-breach`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/security/security-intake-report.json`
  - routed security issue: `#1423`
  - `tests/results/_agent/pre-push-ni-image/known-flag-scenario-report.json`
  - `tests/results/_agent/pre-push-ni-image/post-results-rendering-certification-report.json`
  - `tests/results/_agent/pre-push-ni-image/vi-history-smoke-report.json`
- Risk-based checks not run:
  - none

## Risks and Follow-ups

- Residual risks:
  - the helper now reveals a real stale-alert breach instead of masking it; that debt is tracked separately in `#1423`
- Follow-up issues or deferred work:
  - `#1423` `[Security Intake] Vulnerability remediation required`
- Deployment, approval, or rollback notes:
  - rollback is a standard revert of the helper/test pair; no release-plane artifact changes are involved

## Reviewer Focus

- Please verify:
  - cursor/link pagination is the right long-term contract for Dependabot alerts
  - mapping GitHub `medium` severity to repo `moderate` is the correct normalization boundary
  - routing `#1423` from the fixed helper is the intended behavior now that the underlying breach is visible
- Areas where the reasoning is subtle:
  - this PR intentionally changes the observed live outcome from `status=error` to a real `status=breach`; that is the desired behavior because the 400 was hiding actual stale alerts
- Manual spot checks requested:
  - inspect the live `security-intake-report.json` receipt if you want to confirm the helper is now reporting the real alert inventory
