### PR TITLE
#1423 Distinguish platform-stale security intake alerts

### DIFF
--- a/.github/workflows/security-intake.yml
+++ b/.github/workflows/security-intake.yml
@@ -42,7 +42,9 @@ jobs:
             '## Security Intake',
             `- status: \`${report.status}\``,
             `- breaches: \`${Array.isArray(report.breaches) ? report.breaches.length : 0}\``,
-            `- open alerts: \`${report.summary?.open?.total ?? 0}\``,
+            `- source open alerts: \`${report.source?.dependabot?.openCount ?? 0}\``,
+            `- gated open alerts: \`${report.summary?.open?.total ?? 0}\``,
+            `- platform stale: \`${report.verification?.platformStale ?? false}\``,
             `- route action: \`${report.route?.action ?? 'none'}\``
           ];
           if (process.env.GITHUB_STEP_SUMMARY) {
@@ -58,4 +60,3 @@ jobs:
           name: security-intake-report
           path: tests/results/_agent/security/security-intake-report.json
           if-no-files-found: warn
-

--- a/docs/schemas/security-intake-report-v1.schema.json
+++ b/docs/schemas/security-intake-report-v1.schema.json
@@ -12,6 +12,7 @@
     "thresholds",
     "override",
     "source",
+    "verification",
     "summary",
     "breaches",
     "remediation",
@@ -111,6 +112,66 @@
             },
             "openCount": { "type": "integer", "minimum": 0 },
             "resolvedCount": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repoRoot",
+        "rawOpenCount",
+        "verifiedRemediationCount",
+        "unresolvedCount",
+        "unsupportedCount",
+        "platformStale",
+        "verifiedAlertNumbers",
+        "unresolvedAlertNumbers",
+        "entries"
+      ],
+      "properties": {
+        "repoRoot": { "type": "string" },
+        "rawOpenCount": { "type": "integer", "minimum": 0 },
+        "verifiedRemediationCount": { "type": "integer", "minimum": 0 },
+        "unresolvedCount": { "type": "integer", "minimum": 0 },
+        "unsupportedCount": { "type": "integer", "minimum": 0 },
+        "platformStale": { "type": "boolean" },
+        "verifiedAlertNumbers": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 }
+        },
+        "unresolvedAlertNumbers": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 }
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "number",
+              "packageName",
+              "ecosystem",
+              "manifestPath",
+              "firstPatchedVersion",
+              "detectedVersion",
+              "supported",
+              "remediated",
+              "reason"
+            ],
+            "properties": {
+              "number": { "type": ["integer", "null"] },
+              "packageName": { "type": ["string", "null"] },
+              "ecosystem": { "type": ["string", "null"] },
+              "manifestPath": { "type": ["string", "null"] },
+              "firstPatchedVersion": { "type": ["string", "null"] },
+              "detectedVersion": { "type": ["string", "null"] },
+              "supported": { "type": "boolean" },
+              "remediated": { "type": "boolean" },
+              "reason": { "type": "string" }
+            }
           }
         }
       }
@@ -231,7 +292,7 @@
       }
     },
     "status": {
-      "enum": ["pass", "breach", "overridden", "skip", "error"]
+      "enum": ["pass", "breach", "overridden", "platform-stale", "skip", "error"]
     },
     "errors": {
       "type": "array",
@@ -247,4 +308,3 @@
     }
   }
 }
-

--- a/tools/priority/__tests__/security-intake.test.mjs
+++ b/tools/priority/__tests__/security-intake.test.mjs
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import {
   DEFAULT_ROUTE_LABELS,
   DEFAULT_THRESHOLDS,
+  analyzeLocalAlertVerification,
   buildRemediationCandidates,
   evaluateOverride,
   evaluateSecurityBreaches,
@@ -16,7 +17,8 @@ import {
   parseNextLinkFromHeader,
   parseArgs,
   runSecurityIntake,
-  summarizeDependabotAlerts
+  summarizeDependabotAlerts,
+  verifyLocalRemediationForAlert
 } from '../security-intake.mjs';
 
 function sampleAlert(overrides = {}) {
@@ -30,6 +32,17 @@ function sampleAlert(overrides = {}) {
     html_url: 'https://example.test/alerts/10',
     security_advisory: {
       severity: 'moderate'
+    },
+    security_vulnerability: {
+      package: {
+        ecosystem: 'npm',
+        name: 'brace-expansion'
+      },
+      severity: 'moderate',
+      vulnerable_version_range: '< 2.0.0',
+      first_patched_version: {
+        identifier: '2.0.0'
+      }
     },
     dependency: {
       package: {
@@ -151,6 +164,143 @@ test('normalizeDependabotAlert maps GitHub medium severity to moderate', () => {
     new Date('2026-03-06T12:00:00Z')
   );
   assert.equal(alert.severity, 'moderate');
+  assert.equal(alert.firstPatchedVersion, '2.0.0');
+});
+
+test('verifyLocalRemediationForAlert recognizes remediated direct npm manifests and locks', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'security-intake-verify-'));
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    `${JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      devDependencies: {
+        'brace-expansion': '2.0.1'
+      }
+    }, null, 2)}\n`
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'package-lock.json'),
+    `${JSON.stringify({
+      name: 'fixture',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          name: 'fixture',
+          version: '1.0.0',
+          devDependencies: {
+            'brace-expansion': '2.0.1'
+          }
+        },
+        'node_modules/brace-expansion': {
+          version: '2.0.1'
+        }
+      }
+    }, null, 2)}\n`
+  );
+
+  const manifestAlert = normalizeDependabotAlert(
+    sampleAlert({
+      number: 11,
+      dependency: {
+        package: {
+          ecosystem: 'npm',
+          name: 'brace-expansion'
+        },
+        manifest_path: 'package.json',
+        relationship: 'direct'
+      }
+    }),
+    new Date('2026-03-06T12:00:00Z')
+  );
+  const lockAlert = normalizeDependabotAlert(
+    sampleAlert({
+      number: 12,
+      dependency: {
+        package: {
+          ecosystem: 'npm',
+          name: 'brace-expansion'
+        },
+        manifest_path: 'package-lock.json',
+        relationship: 'direct'
+      }
+    }),
+    new Date('2026-03-06T12:00:00Z')
+  );
+
+  const manifestVerification = verifyLocalRemediationForAlert(manifestAlert, { repoRoot: tmpDir });
+  const lockVerification = verifyLocalRemediationForAlert(lockAlert, { repoRoot: tmpDir });
+
+  assert.equal(manifestVerification.supported, true);
+  assert.equal(manifestVerification.remediated, true);
+  assert.equal(manifestVerification.detectedVersion, '2.0.1');
+  assert.equal(lockVerification.supported, true);
+  assert.equal(lockVerification.remediated, true);
+  assert.equal(lockVerification.detectedVersion, '2.0.1');
+});
+
+test('analyzeLocalAlertVerification flags platform-stale when every open npm alert is remediated locally', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'security-intake-analyze-'));
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    `${JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      devDependencies: {
+        'brace-expansion': '2.0.1'
+      }
+    }, null, 2)}\n`
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'package-lock.json'),
+    `${JSON.stringify({
+      name: 'fixture',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          name: 'fixture',
+          version: '1.0.0',
+          devDependencies: {
+            'brace-expansion': '2.0.1'
+          }
+        },
+        'node_modules/brace-expansion': {
+          version: '2.0.1'
+        }
+      }
+    }, null, 2)}\n`
+  );
+
+  const alerts = [
+    normalizeDependabotAlert(
+      sampleAlert({
+        number: 21,
+        dependency: {
+          package: { ecosystem: 'npm', name: 'brace-expansion' },
+          manifest_path: 'package.json',
+          relationship: 'direct'
+        }
+      }),
+      new Date('2026-03-06T12:00:00Z')
+    ),
+    normalizeDependabotAlert(
+      sampleAlert({
+        number: 22,
+        dependency: {
+          package: { ecosystem: 'npm', name: 'brace-expansion' },
+          manifest_path: 'package-lock.json',
+          relationship: 'direct'
+        }
+      }),
+      new Date('2026-03-06T12:00:00Z')
+    )
+  ];
+
+  const verification = analyzeLocalAlertVerification(alerts, { repoRoot: tmpDir });
+  assert.equal(verification.platformStale, true);
+  assert.equal(verification.verifiedRemediationCount, 2);
+  assert.equal(verification.unresolvedCount, 0);
+  assert.deepEqual(verification.verifiedAlertNumbers, [21, 22]);
 });
 
 test('buildRemediationCandidates sorts by severity then age', () => {
@@ -296,6 +446,93 @@ test('runSecurityIntake writes deterministic report and routes on breach', async
   assert.equal(persisted.schema, 'priority/security-intake@v1');
   assert.equal(persisted.route.issueNumber, 123);
   assert.deepEqual(persisted.route.labels, DEFAULT_ROUTE_LABELS);
+  assert.equal(persisted.verification.platformStale, false);
+});
+
+test('runSecurityIntake classifies locally remediated open alerts as platform-stale', async () => {
+  const now = new Date('2026-03-06T12:00:00Z');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'security-intake-platform-stale-'));
+  const outputPath = path.join(tmpDir, 'report.json');
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    `${JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      devDependencies: {
+        'brace-expansion': '2.0.1'
+      }
+    }, null, 2)}\n`
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'package-lock.json'),
+    `${JSON.stringify({
+      name: 'fixture',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          name: 'fixture',
+          version: '1.0.0',
+          devDependencies: {
+            'brace-expansion': '2.0.1'
+          }
+        },
+        'node_modules/brace-expansion': {
+          version: '2.0.1'
+        }
+      }
+    }, null, 2)}\n`
+  );
+
+  const result = await runSecurityIntake(
+    {
+      outputPath,
+      routeOnBreach: true,
+      failOnBreach: true,
+      thresholds: {
+        ...DEFAULT_THRESHOLDS,
+        openModerateMax: 0
+      }
+    },
+    {
+      now,
+      repoRoot: tmpDir,
+      resolveRepositorySlugFn: () => 'example/repo',
+      resolveTokenFn: () => 'token',
+      listDependabotAlertsFn: async ({ state }) => {
+        if (state !== 'open') return [];
+        return [
+          sampleAlert({
+            number: 31,
+            dependency: {
+              package: { ecosystem: 'npm', name: 'brace-expansion' },
+              manifest_path: 'package.json',
+              relationship: 'direct'
+            }
+          }),
+          sampleAlert({
+            number: 32,
+            dependency: {
+              package: { ecosystem: 'npm', name: 'brace-expansion' },
+              manifest_path: 'package-lock.json',
+              relationship: 'direct'
+            }
+          })
+        ];
+      },
+      upsertRemediationIssueFn: async () => {
+        throw new Error('routeIssue should not run for platform-stale reports');
+      }
+    }
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.status, 'platform-stale');
+  assert.deepEqual(result.report.breaches, []);
+  assert.equal(result.report.summary.open.total, 0);
+  assert.equal(result.report.source.dependabot.openCount, 2);
+  assert.equal(result.report.verification.platformStale, true);
+  assert.deepEqual(result.report.verification.verifiedAlertNumbers, [31, 32]);
+  assert.equal(result.report.route.action, 'none');
 });
 
 test('runSecurityIntake supports skip semantics and override bypass', async () => {

--- a/tools/priority/security-intake.mjs
+++ b/tools/priority/security-intake.mjs
@@ -209,6 +209,44 @@ function round(value) {
   return Math.round(value * 100) / 100;
 }
 
+function readJsonIfPresent(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function normalizeVersionCandidate(raw) {
+  const normalized = asOptional(raw);
+  if (!normalized) return null;
+  const match = normalized.match(/(\d+(?:\.\d+){0,3})(?:[-+][0-9A-Za-z.-]+)?/);
+  return match ? match[0] : null;
+}
+
+function compareComparableVersions(left, right) {
+  const normalizedLeft = normalizeVersionCandidate(left);
+  const normalizedRight = normalizeVersionCandidate(right);
+  if (!normalizedLeft || !normalizedRight) return null;
+  const leftCore = normalizedLeft.split(/[-+]/, 1)[0];
+  const rightCore = normalizedRight.split(/[-+]/, 1)[0];
+  const leftParts = leftCore.split('.').map((entry) => Number.parseInt(entry, 10));
+  const rightParts = rightCore.split('.').map((entry) => Number.parseInt(entry, 10));
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = Number.isFinite(leftParts[index]) ? leftParts[index] : 0;
+    const rightValue = Number.isFinite(rightParts[index]) ? rightParts[index] : 0;
+    if (leftValue > rightValue) return 1;
+    if (leftValue < rightValue) return -1;
+  }
+  const leftHasPrerelease = normalizedLeft.includes('-');
+  const rightHasPrerelease = normalizedRight.includes('-');
+  if (leftHasPrerelease && !rightHasPrerelease) return -1;
+  if (!leftHasPrerelease && rightHasPrerelease) return 1;
+  return 0;
+}
+
 function severity(raw) {
   const normalized = String(raw || '').toLowerCase().trim();
   if (normalized === 'medium') return 'moderate';
@@ -239,11 +277,117 @@ export function normalizeDependabotAlert(alert, now = new Date()) {
     packageName: asOptional(alert?.dependency?.package?.name),
     ecosystem: asOptional(alert?.dependency?.package?.ecosystem),
     manifestPath: asOptional(alert?.dependency?.manifest_path),
+    dependencyScope: asOptional(alert?.dependency?.scope),
+    dependencyRelationship: asOptional(alert?.dependency?.relationship),
+    firstPatchedVersion: asOptional(alert?.security_vulnerability?.first_patched_version?.identifier),
+    vulnerableVersionRange: asOptional(alert?.security_vulnerability?.vulnerable_version_range),
     createdAt,
     resolvedAt,
     ageDays: createdMs != null && nowMs >= createdMs ? round((nowMs - createdMs) / MS_DAY) : null,
     mttrDays: createdMs != null && resolvedMs != null && resolvedMs >= createdMs ? round((resolvedMs - createdMs) / MS_DAY) : null,
     url: alert?.html_url || null
+  };
+}
+
+function resolvePackageJsonVersion(packageJson, packageName) {
+  if (!packageJson || typeof packageJson !== 'object' || !packageName) return null;
+  for (const section of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+    const value = packageJson?.[section]?.[packageName];
+    if (asOptional(value)) return { section, version: String(value).trim() };
+  }
+  return null;
+}
+
+function resolvePackageLockVersion(packageLock, packageName) {
+  if (!packageLock || typeof packageLock !== 'object' || !packageName) return null;
+  const rootDependencies = packageLock?.packages?.[''] ?? {};
+  for (const section of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+    const value = rootDependencies?.[section]?.[packageName];
+    if (asOptional(value)) {
+      const installed = asOptional(packageLock?.packages?.[`node_modules/${packageName}`]?.version);
+      return { section, version: installed || String(value).trim(), declaredVersion: String(value).trim() };
+    }
+  }
+  const installed = asOptional(packageLock?.packages?.[`node_modules/${packageName}`]?.version);
+  if (installed) return { section: 'packages', version: installed, declaredVersion: null };
+  return null;
+}
+
+export function verifyLocalRemediationForAlert(alert, { repoRoot = process.cwd(), readJsonFn = readJsonIfPresent } = {}) {
+  const result = {
+    number: Number.isInteger(alert?.number) ? alert.number : null,
+    packageName: asOptional(alert?.packageName),
+    ecosystem: asOptional(alert?.ecosystem),
+    manifestPath: asOptional(alert?.manifestPath),
+    firstPatchedVersion: asOptional(alert?.firstPatchedVersion),
+    detectedVersion: null,
+    supported: false,
+    remediated: false,
+    reason: 'unsupported-alert-shape'
+  };
+
+  if (String(alert?.ecosystem || '').toLowerCase() !== 'npm') {
+    result.reason = 'unsupported-ecosystem';
+    return result;
+  }
+  if (String(alert?.dependencyRelationship || '').toLowerCase() !== 'direct') {
+    result.reason = 'unsupported-relationship';
+    return result;
+  }
+  if (!result.packageName || !result.manifestPath || !result.firstPatchedVersion) {
+    result.reason = 'missing-alert-metadata';
+    return result;
+  }
+
+  const manifestFile = path.resolve(repoRoot, result.manifestPath);
+  const manifestName = path.basename(result.manifestPath).toLowerCase();
+  const payload = readJsonFn(manifestFile);
+  if (!payload) {
+    result.reason = 'manifest-unavailable';
+    return result;
+  }
+
+  let resolved = null;
+  if (manifestName === 'package.json') {
+    resolved = resolvePackageJsonVersion(payload, result.packageName);
+  } else if (manifestName === 'package-lock.json' || manifestName === 'npm-shrinkwrap.json') {
+    resolved = resolvePackageLockVersion(payload, result.packageName);
+  } else {
+    result.reason = 'unsupported-manifest';
+    return result;
+  }
+
+  if (!resolved?.version) {
+    result.reason = 'package-not-present';
+    return result;
+  }
+
+  result.supported = true;
+  result.detectedVersion = resolved.version;
+  const comparison = compareComparableVersions(resolved.version, result.firstPatchedVersion);
+  if (comparison == null) {
+    result.reason = 'version-unparseable';
+    return result;
+  }
+  result.remediated = comparison >= 0;
+  result.reason = result.remediated ? 'verified-local-remediation' : 'detected-version-below-first-patched';
+  return result;
+}
+
+export function analyzeLocalAlertVerification(openAlerts = [], { repoRoot = process.cwd(), readJsonFn = readJsonIfPresent } = {}) {
+  const entries = openAlerts.map((alert) => verifyLocalRemediationForAlert(alert, { repoRoot, readJsonFn }));
+  const verifiedEntries = entries.filter((entry) => entry.supported && entry.remediated);
+  const unresolvedEntries = entries.filter((entry) => !(entry.supported && entry.remediated));
+  return {
+    repoRoot: path.resolve(repoRoot),
+    rawOpenCount: openAlerts.length,
+    verifiedRemediationCount: verifiedEntries.length,
+    unresolvedCount: unresolvedEntries.length,
+    unsupportedCount: entries.filter((entry) => !entry.supported).length,
+    platformStale: openAlerts.length > 0 && verifiedEntries.length === openAlerts.length,
+    verifiedAlertNumbers: verifiedEntries.map((entry) => entry.number).filter((value) => Number.isInteger(value)).sort((l, r) => l - r),
+    unresolvedAlertNumbers: unresolvedEntries.map((entry) => entry.number).filter((value) => Number.isInteger(value)).sort((l, r) => l - r),
+    entries
   };
 }
 
@@ -465,6 +609,7 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
   const routeIssue = deps.upsertRemediationIssueFn || upsertRemediationIssue;
   const writeReport = deps.writeJsonFn || writeJson;
   const repository = resolveRepo(options.repo);
+  const repoRoot = path.resolve(asOptional(deps.repoRoot) || process.cwd());
   const override = evaluateOverride(options, now);
   const base = {
     schema: 'priority/security-intake@v1',
@@ -480,6 +625,17 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     thresholds: { ...options.thresholds },
     override,
     source: { dependabot: { sampledStates: ['open', 'fixed', 'dismissed', 'auto_dismissed'], openCount: 0, resolvedCount: 0 } },
+    verification: {
+      repoRoot,
+      rawOpenCount: 0,
+      verifiedRemediationCount: 0,
+      unresolvedCount: 0,
+      unsupportedCount: 0,
+      platformStale: false,
+      verifiedAlertNumbers: [],
+      unresolvedAlertNumbers: [],
+      entries: []
+    },
     summary: {
       open: { total: 0, bySeverity: { critical: 0, high: 0, moderate: 0, low: 0, unknown: 0 }, oldestOpenDays: 0, staleDaysThreshold: options.thresholds.staleOpenDays, staleCount: 0, staleAlertNumbers: [] },
       resolved: { lookbackDays: options.lookbackDays, total: 0, mttrDays: { average: null, p50: null, p90: null, max: null } }
@@ -509,18 +665,23 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     const autoDismissedRaw = await listAlerts({ repo: repository, token, state: 'auto_dismissed', maxPages: options.maxPages, fetchImpl });
     const openAlerts = openRaw.map((item) => normalizeDependabotAlert(item, now));
     const resolvedAlerts = [...fixedRaw, ...dismissedRaw, ...autoDismissedRaw].map((item) => normalizeDependabotAlert(item, now));
+    const verification = analyzeLocalAlertVerification(openAlerts, { repoRoot });
+    const effectiveOpenAlerts = verification.entries.length
+      ? openAlerts.filter((alert) => !verification.verifiedAlertNumbers.includes(alert.number))
+      : openAlerts;
     const summary = summarizeDependabotAlerts({
-      openAlerts,
+      openAlerts: effectiveOpenAlerts,
       resolvedAlerts,
       thresholds: options.thresholds,
       lookbackDays: options.lookbackDays,
       now
     });
     const breaches = evaluateSecurityBreaches(summary, options.thresholds);
-    const candidates = buildRemediationCandidates(openAlerts);
+    const candidates = buildRemediationCandidates(effectiveOpenAlerts);
     const report = {
       ...base,
       source: { dependabot: { sampledStates: ['open', 'fixed', 'dismissed', 'auto_dismissed'], openCount: openAlerts.length, resolvedCount: resolvedAlerts.length } },
+      verification,
       summary,
       breaches,
       remediation: { candidateCount: candidates.length, candidates }
@@ -553,6 +714,8 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
       } else {
         report.status = 'breach';
       }
+    } else if (verification.platformStale) {
+      report.status = 'platform-stale';
     }
     const reportPath = writeReport(options.outputPath, report);
     console.log(`[security-intake] report: ${reportPath}`);


### PR DESCRIPTION
# Summary
Distinguish GitHub-side stale Dependabot alerts from unresolved repo vulnerabilities in `priority:security:intake`. The gate now verifies direct npm alert targets against the checked-out manifests/lockfile, records the verification evidence, and reports `platform-stale` instead of routing a generic remediation breach when GitHub still shows already-remediated alerts.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1423`
- Files, tools, workflows, or policies touched:
  - `tools/priority/security-intake.mjs`
  - `tools/priority/__tests__/security-intake.test.mjs`
  - `docs/schemas/security-intake-report-v1.schema.json`
  - `.github/workflows/security-intake.yml`
- Cross-repo or external-consumer impact:
  - None; this changes only the repo-local security intake contract and summary behavior.
- Required checks, merge-queue behavior, or approval flows affected:
  - `tools/PrePush-Checks.ps1` remains the local gate.
  - The scheduled `Security Intake` workflow now surfaces `source open alerts` vs `gated open alerts` and `platform stale` explicitly.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/security-intake.test.mjs tools/priority/__tests__/security-intake-schema.test.mjs`
  - `node tools/npm/run-script.mjs priority:security:intake`
  - `node tools/npm/run-script.mjs priority:security:intake -- --route-on-breach --fail-on-breach`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/security/security-intake-report.json`
  - live report now shows `status = platform-stale`, `verifiedAlertNumbers = [3, 4]`, `breaches = []`
- Risk-based checks not run:
  - None

## Risks and Follow-ups

- Residual risks:
  - GitHub still has the stale open Dependabot alerts until the dependency graph refreshes externally.
- Follow-up issues or deferred work:
  - `#1426` tracks the remaining GitHub dependency-graph / Dependabot refresh lag.
- Deployment, approval, or rollback notes:
  - No deployment step; this is repo automation and reporting only.

## Reviewer Focus

- Please verify:
  - the direct npm manifest/lock verification is conservative and does not hide unresolved alerts
  - the new `platform-stale` status is appropriate for the current `js-yaml` state
- Areas where the reasoning is subtle:
  - `source.dependabot.openCount` remains the raw GitHub alert count while `summary.open.total` becomes the gated unresolved count after local verification
- Manual spot checks requested:
  - Compare the live `security-intake-report.json` against Dependabot alerts `#3` and `#4`
