### PR TITLE
#1424 Ignore incidental numeric suffixes in issue branches

### DIFF
--- a/tools/priority/__tests__/create-pr.test.mjs
+++ b/tools/priority/__tests__/create-pr.test.mjs
@@ -297,6 +297,7 @@ test('createPriorityPr refuses to open a priority PR when the standing queue is 
 test('parseIssueNumberFromBranch extracts issue numbers from issue/* branches', () => {
   assert.equal(parseIssueNumberFromBranch('issue/680-sync-standing-priority'), 680);
   assert.equal(parseIssueNumberFromBranch('issue/personal-680-sync-standing-priority'), 680);
+  assert.equal(parseIssueNumberFromBranch('issue/origin-1420-security-intake-dependabot-api-400'), 1420);
   assert.equal(parseIssueNumberFromBranch('feature/something'), null);
 });
 
@@ -384,7 +385,12 @@ test('createPriorityPr builds PR metadata from resolved standing issue', () => {
     getCurrentBranchFn: () => 'issue/680-sync-standing-priority',
     ensureGhCliFn: () => {},
     resolveUpstreamFn: () => ({ owner: 'upstream-owner', repo: 'repo' }),
-    ensureForkRemoteFn: (_repoRoot, _upstream, remote) => ({ owner: 'fork-owner', repo: 'repo', remoteName: remote }),
+    ensureForkRemoteFn: (_repoRoot, _upstream, remote) => ({
+      owner: 'LabVIEW-Community-CI-CD',
+      repo: 'compare-vi-cli-action-fork',
+      sameOwnerFork: true,
+      remoteName: remote
+    }),
     pushBranchFn: (_repoRoot, branch, remote) => {
       pushedBranch = `${remote}:${branch}`;
     },
@@ -516,6 +522,37 @@ test('createPriorityPr fails before PR creation when branch issue mismatches sta
     /maps to #588, but standing priority resolves to #680/i
   );
   assert.equal(prCreated, false);
+});
+
+test('createPriorityPr ignores incidental trailing numeric suffixes when matching standing issue branches', () => {
+  let prPayload = null;
+  const result = createPriorityPr({
+    env: {},
+    options: {
+      issue: 1420
+    },
+    readFileSyncFn: readDefaultPrTemplate,
+    getRepoRootFn: () => '/tmp/repo',
+    getCurrentBranchFn: () => 'issue/origin-1420-security-intake-dependabot-api-400',
+    ensureGhCliFn: () => {},
+    resolveUpstreamFn: () => ({ owner: 'upstream-owner', repo: 'repo' }),
+    ensureForkRemoteFn: (_repoRoot, _upstream, remote) => ({
+      owner: 'LabVIEW-Community-CI-CD',
+      repo: 'compare-vi-cli-action-fork',
+      sameOwnerFork: true,
+      remoteName: remote
+    }),
+    pushBranchFn: () => {},
+    runGhPrCreateFn: (payload) => {
+      prPayload = payload;
+      return { strategy: 'gh-pr-create' };
+    },
+    resolveStandingIssueNumberFn: () => ({ issueNumber: 1420, source: 'router' }),
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
+  });
+
+  assert.equal(result.issueNumber, 1420);
+  assert.equal(prPayload.branch, 'issue/origin-1420-security-intake-dependabot-api-400');
 });
 
 test('createPriorityPr uses mirror metadata for PR closing references while matching the local mirror branch', () => {

--- a/tools/priority/create-pr.mjs
+++ b/tools/priority/create-pr.mjs
@@ -330,11 +330,19 @@ export function resolveStandingIssueNumberForPr(repoRoot, { readJsonFn = readJso
 }
 
 export function parseIssueNumberFromBranch(branch) {
-  const match = String(branch || '').match(/^issue\/(?:(?<fork>[a-z0-9._-]+)-)?(?<issue>\d+)(?:-|$)/i);
-  if (!match?.groups?.issue) {
+  const normalized = normalizeText(branch);
+  if (!normalized.toLowerCase().startsWith('issue/')) {
     return null;
   }
-  return toPositiveInteger(match.groups.issue);
+  const suffix = normalized.slice('issue/'.length);
+  const tokens = suffix.split('-').map((entry) => entry.trim()).filter(Boolean);
+  for (const token of tokens) {
+    const issueNumber = toPositiveInteger(token);
+    if (issueNumber) {
+      return issueNumber;
+    }
+  }
+  return null;
 }
 
 export function assertBranchMatchesIssue(branch, issueNumber) {


### PR DESCRIPTION
# Summary
Fix the priority PR helper so it resolves the issue number from the first numeric segment after `issue/` instead of the last incidental numeric suffix in the branch slug. That restores deterministic PR creation for descriptive branch names like `issue/origin-1420-security-intake-dependabot-api-400`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1424`
- Files, tools, workflows, or policies touched:
  - `tools/priority/create-pr.mjs`
  - `tools/priority/__tests__/create-pr.test.mjs`
- Cross-repo or external-consumer impact:
  - Any automation using `priority:pr` or `assertBranchMatchesIssue` now tolerates descriptive trailing numeric suffixes in issue branches.
- Required checks, merge-queue behavior, or approval flows affected:
  - None beyond the standard local and hosted validation surfaces.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/create-pr.test.mjs`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - focused regression added for `issue/origin-1420-security-intake-dependabot-api-400`
- Risk-based checks not run:
  - None

## Risks and Follow-ups

- Residual risks:
  - This parser now prefers the first pure numeric token after `issue/`; if the branch naming contract changes materially again, the helper tests will need to move with it.
- Follow-up issues or deferred work:
  - None for this slice.
- Deployment, approval, or rollback notes:
  - No deployment step required.

## Reviewer Focus

- Please verify:
  - the new parser still preserves the normal `issue/<number>-...` and `issue/<fork>-<number>-...` contracts
  - the regression coverage is specific enough to prevent falling back to the old greedy behavior
- Areas where the reasoning is subtle:
  - The bug was in issue-number inference, not branch classification; the fix intentionally selects the first numeric token instead of relying on a greedy optional fork capture.
- Manual spot checks requested:
  - None
