### PR TITLE
Add host-RAM-aware NI Linux review-suite budgeting

### DIFF
--- a/docs/schemas/host-ram-budget-v1.schema.json
+++ b/docs/schemas/host-ram-budget-v1.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/host-ram-budget-v1.schema.json",
+  "title": "Host RAM Budget Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "host",
+    "policy",
+    "profiles",
+    "selectedProfile"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/host-ram-budget@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "arch",
+        "detectionSource",
+        "totalBytes",
+        "freeBytes",
+        "cpuParallelism"
+      ],
+      "properties": {
+        "platform": { "type": "string", "minLength": 1 },
+        "arch": { "type": "string", "minLength": 1 },
+        "detectionSource": { "type": "string", "minLength": 1 },
+        "totalBytes": { "type": "integer", "minimum": 0 },
+        "freeBytes": { "type": "integer", "minimum": 0 },
+        "cpuParallelism": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minimumParallelism",
+        "systemReserveBytes",
+        "freeReserveBytes",
+        "usableByTotalBytes",
+        "usableByFreeBytes",
+        "effectiveUsableBytes"
+      ],
+      "properties": {
+        "minimumParallelism": { "type": "integer", "minimum": 1 },
+        "systemReserveBytes": { "type": "integer", "minimum": 0 },
+        "freeReserveBytes": { "type": "integer", "minimum": 0 },
+        "usableByTotalBytes": { "type": "integer", "minimum": 0 },
+        "usableByFreeBytes": { "type": "integer", "minimum": 0 },
+        "effectiveUsableBytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/profile" }
+    },
+    "selectedProfile": {
+      "$ref": "#/$defs/profile"
+    }
+  },
+  "$defs": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "laneClass",
+        "perWorkerBytes",
+        "maxParallelism",
+        "memoryBoundCeiling",
+        "cpuBoundCeiling",
+        "recommendedParallelism",
+        "floorApplied",
+        "degradedByPressure",
+        "reasons"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "laneClass": { "type": "string", "minLength": 1 },
+        "perWorkerBytes": { "type": "integer", "minimum": 1 },
+        "maxParallelism": { "type": "integer", "minimum": 1 },
+        "memoryBoundCeiling": { "type": "integer", "minimum": 1 },
+        "cpuBoundCeiling": { "type": "integer", "minimum": 1 },
+        "recommendedParallelism": { "type": "integer", "minimum": 1 },
+        "floorApplied": { "type": "boolean" },
+        "degradedByPressure": { "type": "boolean" },
+        "reasons": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "priority:codex:state:hygiene": "node --no-warnings tools/priority/codex-state-hygiene.mjs",
     "priority:codex:state:hygiene:apply": "node --no-warnings tools/priority/codex-state-hygiene.mjs --apply",
     "priority:runtime:worktrees:repair": "node tools/priority/repair-runtime-worktrees.mjs",
+    "priority:runtime:ram-budget": "node tools/priority/host-ram-budget.mjs",
     "priority:runtime:daemon": "node tools/npm/run-local-typescript.mjs --project tsconfig.json --entry tools/priority/runtime-daemon.ts --fallback-dist dist/tools/priority/runtime-daemon.js",
     "priority:runtime:daemon:docker": "pwsh -NoLogo -NoProfile -File tools/priority/Manage-RuntimeDaemonInDocker.ps1 -Action start",
     "priority:runtime:daemon:docker:logs": "pwsh -NoLogo -NoProfile -File tools/priority/Manage-RuntimeDaemonInDocker.ps1 -Action logs",

--- a/tests/NILinuxReviewSuiteCertification.Tests.ps1
+++ b/tests/NILinuxReviewSuiteCertification.Tests.ps1
@@ -96,7 +96,12 @@ Describe 'NI Linux review-suite flag certification artifacts' -Tag 'Unit' {
     $artifacts = Write-FlagCombinationCertificationArtifacts `
       -ResultsRoot $resultsRoot `
       -Image 'nationalinstruments/labview:2026q1-linux' `
-      -ScenarioResults $scenarioResults
+      -ScenarioResults $scenarioResults `
+      -ParallelBudget ([pscustomobject]@{
+        requestedParallelism = 0
+        actualParallelism = 2
+        decisionSource = 'host-ram-budget'
+      })
 
     Test-Path -LiteralPath $artifacts.jsonPath | Should -BeTrue
     Test-Path -LiteralPath $artifacts.markdownPath | Should -BeTrue
@@ -112,10 +117,13 @@ Describe 'NI Linux review-suite flag certification artifacts' -Tag 'Unit' {
     $report.summary.totalScenarios | Should -Be 2
     $report.summary.passingScenarios | Should -Be 2
     $report.summary.failingScenarios | Should -Be 0
+    $report.parallelBudget.actualParallelism | Should -Be 2
+    $report.parallelBudget.decisionSource | Should -Be 'host-ram-budget'
     @($report.scenarios | ForEach-Object { $_.name }) | Should -Be @('baseline', 'noattr')
 
     $markdown = Get-Content -LiteralPath $artifacts.markdownPath -Raw
     $markdown | Should -Match 'NI Linux flag-combination certification'
+    $markdown | Should -Match 'Parallelism'
     $markdown | Should -Match 'baseline'
     $markdown | Should -Match 'noattr'
 

--- a/tests/NILinuxReviewSuiteRamBudget.Tests.ps1
+++ b/tests/NILinuxReviewSuiteRamBudget.Tests.ps1
@@ -1,0 +1,140 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'NI Linux review-suite RAM budget planning' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ReviewSuiteScriptPath = Join-Path $repoRoot 'tools' 'Invoke-NILinuxReviewSuite.ps1'
+
+    function script:Get-ScriptFunctionDefinition {
+      param(
+        [string]$ScriptPath,
+        [string]$FunctionName
+      )
+
+      $tokens = $null
+      $parseErrors = $null
+      $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+      if ($parseErrors.Count -gt 0) {
+        throw ("Failed to parse {0}: {1}" -f $ScriptPath, ($parseErrors | ForEach-Object { $_.Message } | Join-String -Separator '; '))
+      }
+
+      $functionAst = $ast.Find(
+        {
+          param($node)
+          $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+          $node.Name -eq $FunctionName
+        },
+        $true
+      )
+      if ($null -eq $functionAst) {
+        throw ("Function {0} not found in {1}" -f $FunctionName, $ScriptPath)
+      }
+
+      return $functionAst.Extent.Text
+    }
+
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Resolve-AbsolutePath')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Get-DefaultHostRamBudgetPath')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Resolve-FlagScenarioParallelBudget')
+  }
+
+  BeforeEach {
+    $script:NodeCalls = @()
+  }
+
+  AfterEach {
+    Remove-Item Function:\global:node -ErrorAction SilentlyContinue
+  }
+
+  It 'defaults the host RAM budget path under the results root' {
+    $resultsRoot = Join-Path $TestDrive 'results'
+    $resolved = Get-DefaultHostRamBudgetPath -ResultsRoot $resultsRoot
+
+    $resolved | Should -Be (Join-Path $resultsRoot 'host-ram-budget.json')
+  }
+
+  It 'uses the explicit parallelism override without invoking the node helper' {
+    $repoRoot = Join-Path $TestDrive 'repo'
+    $resultsRoot = Join-Path $repoRoot 'tests' 'results'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+    function global:node {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+      throw 'node should not be called for explicit parallelism overrides'
+    }
+
+    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 3 -HostRamBudgetPath ''
+
+    $plan.requestedParallelism | Should -Be 3
+    $plan.recommendedParallelism | Should -Be 3
+    $plan.actualParallelism | Should -Be 3
+    $plan.decisionSource | Should -Be 'explicit-override'
+  }
+
+  It 'hydrates the budget from the node helper when no override is provided' {
+    $repoRoot = Join-Path $TestDrive 'repo'
+    $resultsRoot = Join-Path $repoRoot 'tests' 'results'
+    $helperPath = Join-Path $repoRoot 'tools' 'priority'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $helperPath -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $helperPath 'host-ram-budget.mjs') -Value '' -Encoding utf8
+
+    function global:node {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+
+      $script:NodeCalls += ,@($Args)
+      $outputIndex = [Array]::IndexOf($Args, '--output')
+      if ($outputIndex -lt 0) {
+        throw 'Missing --output for host-ram-budget helper'
+      }
+      $outputPath = $Args[$outputIndex + 1]
+      New-Item -ItemType Directory -Path (Split-Path -Parent $outputPath) -Force | Out-Null
+      @{
+        schema = 'priority/host-ram-budget@v1'
+        generatedAt = '2026-03-20T05:20:00Z'
+        host = @{
+          platform = 'win32'
+          arch = 'x64'
+          detectionSource = 'node-os'
+          totalBytes = 17179869184
+          freeBytes = 10737418240
+          cpuParallelism = 12
+        }
+        policy = @{
+          minimumParallelism = 1
+          systemReserveBytes = 4294967296
+          freeReserveBytes = 1717986918
+          usableByTotalBytes = 12884901888
+          usableByFreeBytes = 9019431322
+          effectiveUsableBytes = 9019431322
+        }
+        profiles = @()
+        selectedProfile = @{
+          id = 'ni-linux-flag-combination'
+          laneClass = 'ram-bound'
+          perWorkerBytes = 3221225472
+          maxParallelism = 3
+          memoryBoundCeiling = 2
+          cpuBoundCeiling = 12
+          recommendedParallelism = 2
+          floorApplied = $false
+          degradedByPressure = $true
+          reasons = @('free-memory-pressure', 'memory-cap')
+        }
+      } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $outputPath -Encoding utf8
+      $global:LASTEXITCODE = 0
+    }
+
+    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 0 -HostRamBudgetPath ''
+
+    $script:NodeCalls.Count | Should -Be 1
+    $plan.recommendedParallelism | Should -Be 2
+    $plan.actualParallelism | Should -Be 2
+    $plan.decisionSource | Should -Be 'host-ram-budget'
+    $plan.reason | Should -Match 'free-memory-pressure'
+    Test-Path -LiteralPath $plan.path | Should -BeTrue
+  }
+}

--- a/tests/RunNonLVChecksInDockerReviewReceipt.Tests.ps1
+++ b/tests/RunNonLVChecksInDockerReviewReceipt.Tests.ps1
@@ -1,0 +1,98 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Docker review-loop receipt host RAM budget projection' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:RunNonLVChecksScriptPath = Join-Path $repoRoot 'tools' 'Run-NonLVChecksInDocker.ps1'
+
+    function script:Get-ScriptFunctionDefinition {
+      param(
+        [string]$ScriptPath,
+        [string]$FunctionName
+      )
+
+      $tokens = $null
+      $parseErrors = $null
+      $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+      if ($parseErrors.Count -gt 0) {
+        throw ("Failed to parse {0}: {1}" -f $ScriptPath, ($parseErrors | ForEach-Object { $_.Message } | Join-String -Separator '; '))
+      }
+
+      $functionAst = $ast.Find(
+        {
+          param($node)
+          $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+          $node.Name -eq $FunctionName
+        },
+        $true
+      )
+      if ($null -eq $functionAst) {
+        throw ("Function {0} not found in {1}" -f $FunctionName, $ScriptPath)
+      }
+
+      return $functionAst.Extent.Text
+    }
+
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Get-RepoRelativePath')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Read-JsonHashtable')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:RunNonLVChecksScriptPath -FunctionName 'Write-DockerParityReviewLoopReceipt')
+  }
+
+  BeforeEach {
+    function global:Get-GitReviewLoopMetadata {
+      param([string]$RepoRoot)
+      return @{
+        headSha = 'abc123'
+        branch = 'issue/origin-1400-host-ram-aware-parallel-budgeting'
+        upstreamDevelopMergeBase = 'def456'
+        dirtyTracked = $false
+      }
+    }
+  }
+
+  AfterEach {
+    Remove-Item Function:\global:Get-GitReviewLoopMetadata -ErrorAction SilentlyContinue
+  }
+
+  It 'includes the NI Linux host RAM budget artifact in the receipt and recommended review order' {
+    $repoRoot = Join-Path $TestDrive 'repo'
+    $niRoot = Join-Path $repoRoot 'tests/results/docker-tools-parity/ni-linux-review-suite'
+    $reqRoot = Join-Path $repoRoot 'tests/results/docker-tools-parity/requirements-verification'
+    New-Item -ItemType Directory -Path $niRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $reqRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $repoRoot 'tests/results/_agent/verification') -Force | Out-Null
+
+    '{}' | Set-Content -LiteralPath (Join-Path $niRoot 'review-suite-summary.json') -Encoding utf8
+    '<html></html>' | Set-Content -LiteralPath (Join-Path $niRoot 'review-suite-summary.html') -Encoding utf8
+    @{
+      artifacts = @{
+        historyReportMarkdownPath = 'vi-history-report/results/history-report.md'
+        historyReportHtmlPath = 'vi-history-report/results/history-report.html'
+        historySummaryPath = 'vi-history-report/results/history-summary.json'
+        historyInspectionHtmlPath = 'vi-history-report/results/history-suite-inspection.html'
+        historyInspectionJsonPath = 'vi-history-report/results/history-suite-inspection.json'
+      }
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $niRoot 'vi-history-review-loop-receipt.json') -Encoding utf8
+    '{}' | Set-Content -LiteralPath (Join-Path $niRoot 'host-ram-budget.json') -Encoding utf8
+    '{}' | Set-Content -LiteralPath (Join-Path $reqRoot 'verification-summary.json') -Encoding utf8
+    '{}' | Set-Content -LiteralPath (Join-Path $reqRoot 'trace-matrix.json') -Encoding utf8
+    '<html></html>' | Set-Content -LiteralPath (Join-Path $reqRoot 'trace-matrix.html') -Encoding utf8
+    '{}' | Set-Content -LiteralPath (Join-Path $repoRoot 'tests/results/_agent/verification/docker-review-loop-summary.json') -Encoding utf8
+
+    $receiptPath = Join-Path $repoRoot 'tests/results/docker-tools-parity/review-loop-receipt.json'
+    Write-DockerParityReviewLoopReceipt `
+      -RepoRoot $repoRoot `
+      -ReceiptPath $receiptPath `
+      -Checks @{} `
+      -RunRecord @{ status = 'passed'; exitCode = 0 } `
+      -NILinuxResultsRoot 'tests/results/docker-tools-parity/ni-linux-review-suite' `
+      -RequirementsResultsRoot 'tests/results/docker-tools-parity/requirements-verification'
+
+    $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json -Depth 20
+    $receipt.artifacts.hostRamBudgetPath | Should -Be 'tests/results/docker-tools-parity/ni-linux-review-suite/host-ram-budget.json'
+    @($receipt.recommendedReviewOrder) | Should -Contain 'tests/results/docker-tools-parity/ni-linux-review-suite/host-ram-budget.json'
+  }
+}

--- a/tools/Invoke-NILinuxReviewSuite.ps1
+++ b/tools/Invoke-NILinuxReviewSuite.ps1
@@ -19,6 +19,9 @@ param(
   [ValidateRange(1, 4096)]
   [int]$HistoryMaxCommitCount = 64,
   [string]$HistoryReviewReceiptPath = '',
+  [ValidateRange(0, 8)]
+  [int]$FlagScenarioParallelism = 0,
+  [string]$HostRamBudgetPath = '',
   [ValidateRange(30, 900)]
   [int]$TimeoutSeconds = 240,
   [ValidateRange(5, 120)]
@@ -86,7 +89,8 @@ function Write-FlagCombinationCertificationArtifacts {
   param(
     [Parameter(Mandatory = $true)][string]$ResultsRoot,
     [Parameter(Mandatory = $true)][string]$Image,
-    [AllowNull()][object[]]$ScenarioResults
+    [AllowNull()][object[]]$ScenarioResults,
+    [AllowNull()]$ParallelBudget
   )
 
   $flagCombinationResults = @(
@@ -135,6 +139,7 @@ function Write-FlagCombinationCertificationArtifacts {
       passingScenarios = @($normalizedScenarios | Where-Object { [string]::Equals([string]$_.gateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase) }).Count
       failingScenarios = @($normalizedScenarios | Where-Object { -not [string]::Equals([string]$_.gateOutcome, 'pass', [System.StringComparison]::OrdinalIgnoreCase) }).Count
     }
+    parallelBudget = $ParallelBudget
     scenarios = @($normalizedScenarios)
   }
   $payload | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $jsonPath -Encoding utf8
@@ -147,6 +152,10 @@ function Write-FlagCombinationCertificationArtifacts {
     ('- Image: `{0}`' -f $Image),
     ('- Plane applicability: `{0}`' -f ([string]::Join(', ', @($payload.planeApplicability)))),
     ('- Future parity planes: `{0}`' -f ([string]::Join(', ', @($payload.futureParityPlanes)))),
+    ('- Parallelism: `requested={0}; actual={1}; source={2}`' -f
+      $(if ($ParallelBudget -and $ParallelBudget.PSObject.Properties['requestedParallelism']) { [string]$ParallelBudget.requestedParallelism } else { '0' }),
+      $(if ($ParallelBudget -and $ParallelBudget.PSObject.Properties['actualParallelism']) { [string]$ParallelBudget.actualParallelism } else { '1' }),
+      $(if ($ParallelBudget -and $ParallelBudget.PSObject.Properties['decisionSource']) { [string]$ParallelBudget.decisionSource } else { 'serial-default' })),
     ('- Total scenarios: `{0}`' -f $payload.summary.totalScenarios),
     ('- Passing scenarios: `{0}`' -f $payload.summary.passingScenarios),
     ('- Failing scenarios: `{0}`' -f $payload.summary.failingScenarios),
@@ -173,6 +182,10 @@ function Write-FlagCombinationCertificationArtifacts {
       $Image,
       [string]::Join(', ', @($payload.planeApplicability)),
       [string]::Join(', ', @($payload.futureParityPlanes))),
+    ('<p>Parallelism: <code>requested={0}; actual={1}; source={2}</code></p>' -f
+      $(if ($ParallelBudget -and $ParallelBudget.PSObject.Properties['requestedParallelism']) { [string]$ParallelBudget.requestedParallelism } else { '0' }),
+      $(if ($ParallelBudget -and $ParallelBudget.PSObject.Properties['actualParallelism']) { [string]$ParallelBudget.actualParallelism } else { '1' }),
+      $(if ($ParallelBudget -and $ParallelBudget.PSObject.Properties['decisionSource']) { [string]$ParallelBudget.decisionSource } else { 'serial-default' })),
     ('<p>Total scenarios: <code>{0}</code><br/>Passing scenarios: <code>{1}</code><br/>Failing scenarios: <code>{2}</code></p>' -f
       $payload.summary.totalScenarios,
       $payload.summary.passingScenarios,
@@ -285,6 +298,253 @@ function New-FlagScenarioDefinitions {
   }
 
   return @($scenarioBuffer | Sort-Object @{ Expression = { $_.flags.Count } }, @{ Expression = { $_.orderKey } })
+}
+
+function Get-DefaultHostRamBudgetPath {
+  param([Parameter(Mandatory = $true)][string]$ResultsRoot)
+
+  return (Join-Path $ResultsRoot 'host-ram-budget.json')
+}
+
+function Resolve-FlagScenarioParallelBudget {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$ResultsRoot,
+    [Parameter(Mandatory = $true)][int]$RequestedParallelism,
+    [AllowEmptyString()][string]$HostRamBudgetPath
+  )
+
+  $budgetPathResolved = if ([string]::IsNullOrWhiteSpace($HostRamBudgetPath)) {
+    Get-DefaultHostRamBudgetPath -ResultsRoot $ResultsRoot
+  } else {
+    Resolve-AbsolutePath -Path $HostRamBudgetPath -BasePath $RepoRoot
+  }
+
+  $threadJobAvailable = $null -ne (Get-Command -Name Start-ThreadJob -ErrorAction SilentlyContinue)
+  $targetProfile = 'ni-linux-flag-combination'
+  $budgetReport = $null
+  $recommendedParallelism = 1
+  $decisionSource = 'serial-default'
+  $reason = 'deterministic-floor'
+
+  if ($RequestedParallelism -gt 0) {
+    $recommendedParallelism = [int]$RequestedParallelism
+    $decisionSource = 'explicit-override'
+    $reason = 'explicit-override'
+  } else {
+    $budgetScriptPath = Join-Path $RepoRoot 'tools' 'priority' 'host-ram-budget.mjs'
+    if (-not (Test-Path -LiteralPath $budgetScriptPath -PathType Leaf)) {
+      throw ("Host RAM budget helper not found: {0}" -f $budgetScriptPath)
+    }
+
+    Push-Location $RepoRoot
+    try {
+      & node $budgetScriptPath `
+        --target-profile $targetProfile `
+        --output $budgetPathResolved | Out-Host
+      if ($LASTEXITCODE -ne 0) {
+        throw ("host-ram-budget helper exited with code {0}" -f $LASTEXITCODE)
+      }
+    } finally {
+      Pop-Location | Out-Null
+    }
+
+    if (-not (Test-Path -LiteralPath $budgetPathResolved -PathType Leaf)) {
+      throw ("Host RAM budget helper did not emit a report: {0}" -f $budgetPathResolved)
+    }
+
+    $budgetReport = Get-Content -LiteralPath $budgetPathResolved -Raw | ConvertFrom-Json -Depth 20
+    if (-not $budgetReport.selectedProfile -or -not $budgetReport.selectedProfile.PSObject.Properties['recommendedParallelism']) {
+      throw ("Host RAM budget report missing selected profile recommendation: {0}" -f $budgetPathResolved)
+    }
+    $recommendedParallelism = [int]$budgetReport.selectedProfile.recommendedParallelism
+    $decisionSource = 'host-ram-budget'
+    $reason = if ($budgetReport.selectedProfile.PSObject.Properties['reasons'] -and @($budgetReport.selectedProfile.reasons).Count -gt 0) {
+      [string]::Join(', ', @($budgetReport.selectedProfile.reasons | ForEach-Object { [string]$_ }))
+    } else {
+      'host-ram-budget'
+    }
+  }
+
+  $actualParallelism = [int]$recommendedParallelism
+  if ($actualParallelism -lt 1) {
+    $actualParallelism = 1
+  }
+  if (-not $threadJobAvailable -and $actualParallelism -gt 1) {
+    $actualParallelism = 1
+    $reason = 'threadjob-unavailable'
+  }
+
+  return [pscustomobject]@{
+    targetProfile = $targetProfile
+    path = $budgetPathResolved
+    requestedParallelism = [int]$RequestedParallelism
+    recommendedParallelism = [int]$recommendedParallelism
+    actualParallelism = [int]$actualParallelism
+    decisionSource = $decisionSource
+    reason = $reason
+    threadJobAvailable = [bool]$threadJobAvailable
+    report = $budgetReport
+  }
+}
+
+function Invoke-FlagScenarioCompares {
+  param(
+    [Parameter(Mandatory = $true)][object[]]$ScenarioDefinitions,
+    [Parameter(Mandatory = $true)][int]$Parallelism,
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$FlagScenarioRoot,
+    [Parameter(Mandatory = $true)][string]$CompareScriptPath,
+    [Parameter(Mandatory = $true)][string]$BaseVi,
+    [Parameter(Mandatory = $true)][string]$HeadVi,
+    [Parameter(Mandatory = $true)][string]$Image,
+    [Parameter(Mandatory = $true)][string]$LabVIEWPath,
+    [Parameter(Mandatory = $true)][int]$TimeoutSeconds,
+    [Parameter(Mandatory = $true)][int]$HeartbeatSeconds,
+    [Parameter(Mandatory = $true)][int]$RuntimeEngineReadyTimeoutSeconds,
+    [Parameter(Mandatory = $true)][int]$RuntimeEngineReadyPollSeconds,
+    [AllowEmptyString()][string]$ReuseContainerName,
+    [Parameter(Mandatory = $true)][string]$ReuseRepoHostPath,
+    [Parameter(Mandatory = $true)][string]$ReuseRepoContainerPath,
+    [Parameter(Mandatory = $true)][string]$ReuseResultsHostPath,
+    [Parameter(Mandatory = $true)][string]$ReuseResultsContainerPath,
+    [string[]]$RuntimeInjectionMount = @()
+  )
+
+  $worker = {
+    param(
+      [int]$Sequence,
+      [object]$ScenarioDefinition,
+      [string]$RepoRootValue,
+      [string]$FlagScenarioRootValue,
+      [string]$CompareScriptPathValue,
+      [string]$BaseViValue,
+      [string]$HeadViValue,
+      [string]$ImageValue,
+      [string]$LabVIEWPathValue,
+      [int]$TimeoutSecondsValue,
+      [int]$HeartbeatSecondsValue,
+      [int]$RuntimeEngineReadyTimeoutSecondsValue,
+      [int]$RuntimeEngineReadyPollSecondsValue,
+      [string]$ReuseContainerNameValue,
+      [string]$ReuseRepoHostPathValue,
+      [string]$ReuseRepoContainerPathValue,
+      [string]$ReuseResultsHostPathValue,
+      [string]$ReuseResultsContainerPathValue,
+      [string[]]$RuntimeInjectionMountValue
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    $scenarioName = [string]$ScenarioDefinition.name
+    $scenarioDir = Join-Path $FlagScenarioRootValue $scenarioName
+    New-Item -ItemType Directory -Path $scenarioDir -Force | Out-Null
+    $reportPath = Join-Path $scenarioDir 'compare-report.html'
+    $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
+    $capturePath = Join-Path $scenarioDir 'ni-linux-container-capture.json'
+
+    try {
+      Push-Location $RepoRootValue
+      try {
+        & $CompareScriptPathValue `
+          -BaseVi $BaseViValue `
+          -HeadVi $HeadViValue `
+          -Image $ImageValue `
+          -ReportPath $reportPath `
+          -LabVIEWPath $LabVIEWPathValue `
+          -ContainerNameLabel $scenarioName `
+          -Flags @($ScenarioDefinition.flags) `
+          -TimeoutSeconds $TimeoutSecondsValue `
+          -HeartbeatSeconds $HeartbeatSecondsValue `
+          -AutoRepairRuntime:$true `
+          -RuntimeEngineReadyTimeoutSeconds $RuntimeEngineReadyTimeoutSecondsValue `
+          -RuntimeEngineReadyPollSeconds $RuntimeEngineReadyPollSecondsValue `
+          -RuntimeSnapshotPath $runtimeSnapshotPath `
+          -ReuseContainerName $ReuseContainerNameValue `
+          -ReuseRepoHostPath $ReuseRepoHostPathValue `
+          -ReuseRepoContainerPath $ReuseRepoContainerPathValue `
+          -ReuseResultsHostPath $ReuseResultsHostPathValue `
+          -ReuseResultsContainerPath $ReuseResultsContainerPathValue `
+          -RuntimeInjectionMount $RuntimeInjectionMountValue
+        $compareExit = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+      } finally {
+        Pop-Location | Out-Null
+      }
+
+      if ($compareExit -notin @(0, 1)) {
+        throw ("NI Linux review suite scenario '{0}' compare failed (exit={1})." -f $scenarioName, $compareExit)
+      }
+
+      return [pscustomobject]@{
+        sequence = [int]$Sequence
+        name = $scenarioName
+        requestedFlagsLabel = [string]$ScenarioDefinition.requestedFlagsLabel
+        requestedFlags = @($ScenarioDefinition.flags | ForEach-Object { [string]$_ })
+        scenarioDir = $scenarioDir
+        reportPath = $reportPath
+        runtimeSnapshotPath = $runtimeSnapshotPath
+        capturePath = $capturePath
+        compareExit = [int]$compareExit
+        errorMessage = ''
+      }
+    } catch {
+      return [pscustomobject]@{
+        sequence = [int]$Sequence
+        name = $scenarioName
+        requestedFlagsLabel = [string]$ScenarioDefinition.requestedFlagsLabel
+        requestedFlags = @($ScenarioDefinition.flags | ForEach-Object { [string]$_ })
+        scenarioDir = $scenarioDir
+        reportPath = $reportPath
+        runtimeSnapshotPath = $runtimeSnapshotPath
+        capturePath = $capturePath
+        compareExit = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+        errorMessage = [string]$_.Exception.Message
+      }
+    }
+  }
+
+  $resultBuffer = New-Object System.Collections.Generic.List[object]
+  if ($Parallelism -le 1) {
+    for ($i = 0; $i -lt $ScenarioDefinitions.Count; $i++) {
+      $resultBuffer.Add((& $worker $i $ScenarioDefinitions[$i] $RepoRoot $FlagScenarioRoot $CompareScriptPath $BaseVi $HeadVi $Image $LabVIEWPath $TimeoutSeconds $HeartbeatSeconds $RuntimeEngineReadyTimeoutSeconds $RuntimeEngineReadyPollSeconds $ReuseContainerName $ReuseRepoHostPath $ReuseRepoContainerPath $ReuseResultsHostPath $ReuseResultsContainerPath $RuntimeInjectionMount)) | Out-Null
+    }
+    return @($resultBuffer.ToArray() | Sort-Object sequence)
+  }
+
+  $activeJobs = New-Object System.Collections.Generic.List[object]
+  for ($i = 0; $i -lt $ScenarioDefinitions.Count; $i++) {
+    while ($activeJobs.Count -ge $Parallelism) {
+      $completedJob = Wait-Job -Job $activeJobs.ToArray() -Any
+      if ($null -eq $completedJob) {
+        continue
+      }
+      $jobResult = @(Receive-Job -Job $completedJob -ErrorAction SilentlyContinue) | Select-Object -Last 1
+      if ($jobResult) {
+        $resultBuffer.Add($jobResult) | Out-Null
+      }
+      Remove-Job -Job $completedJob -Force -ErrorAction SilentlyContinue | Out-Null
+      [void]$activeJobs.Remove($completedJob)
+    }
+
+    $job = Start-ThreadJob -ScriptBlock $worker -ArgumentList $i, $ScenarioDefinitions[$i], $RepoRoot, $FlagScenarioRoot, $CompareScriptPath, $BaseVi, $HeadVi, $Image, $LabVIEWPath, $TimeoutSeconds, $HeartbeatSeconds, $RuntimeEngineReadyTimeoutSeconds, $RuntimeEngineReadyPollSeconds, $ReuseContainerName, $ReuseRepoHostPath, $ReuseRepoContainerPath, $ReuseResultsHostPath, $ReuseResultsContainerPath, $RuntimeInjectionMount
+    $activeJobs.Add($job) | Out-Null
+  }
+
+  while ($activeJobs.Count -gt 0) {
+    $completedJob = Wait-Job -Job $activeJobs.ToArray() -Any
+    if ($null -eq $completedJob) {
+      continue
+    }
+    $jobResult = @(Receive-Job -Job $completedJob -ErrorAction SilentlyContinue) | Select-Object -Last 1
+    if ($jobResult) {
+      $resultBuffer.Add($jobResult) | Out-Null
+    }
+    Remove-Job -Job $completedJob -Force -ErrorAction SilentlyContinue | Out-Null
+    [void]$activeJobs.Remove($completedJob)
+  }
+
+  return @($resultBuffer.ToArray() | Sort-Object sequence)
 }
 
 function Assert-CompareScenarioArtifacts {
@@ -482,51 +742,56 @@ $historyScenarioRoot = Join-Path $resultsRootResolved 'vi-history-report'
 $summaryJsonPath = Join-Path $resultsRootResolved 'review-suite-summary.json'
 $summaryMarkdownPath = Join-Path $resultsRootResolved 'review-suite-summary.md'
 $summaryHtmlPath = Join-Path $resultsRootResolved 'review-suite-summary.html'
+$hostRamBudgetPathResolved = if ([string]::IsNullOrWhiteSpace($HostRamBudgetPath)) {
+  Get-DefaultHostRamBudgetPath -ResultsRoot $resultsRootResolved
+} else {
+  Resolve-AbsolutePath -Path $HostRamBudgetPath -BasePath $repoRootResolved
+}
 $scenarioResults = @()
 $knownFlagScenarios = New-FlagScenarioDefinitions
+$flagScenarioParallelBudget = Resolve-FlagScenarioParallelBudget `
+  -RepoRoot $repoRootResolved `
+  -ResultsRoot $resultsRootResolved `
+  -RequestedParallelism $FlagScenarioParallelism `
+  -HostRamBudgetPath $hostRamBudgetPathResolved
 $historyRefSelection = Resolve-HistoryRefSelection -RequestedBranchRef $HistoryBranchRef -RequestedBaselineRef $HistoryBaselineRef
 
 Write-Host ("[ni-linux-review-suite] resultsRoot={0}" -f $resultsRootResolved) -ForegroundColor Cyan
 Write-Host ("[ni-linux-review-suite] historyRefSource={0} requestedBranchRef={1} requestedBaselineRef={2} effectiveBranchRef={3} effectiveBaselineRef={4} maxCommitCount={5}" -f $historyRefSelection.source, ($(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBranchRef)) { '(default)' } else { $historyRefSelection.requestedBranchRef })), ($(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBaselineRef)) { '(default)' } else { $historyRefSelection.requestedBaselineRef })), $historyRefSelection.effectiveBranchRef, ($(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef })), $HistoryMaxCommitCount) -ForegroundColor DarkCyan
+Write-Host ("[ni-linux-review-suite] flag-scenario-parallelism requested={0} actual={1} source={2} reason={3}" -f $flagScenarioParallelBudget.requestedParallelism, $flagScenarioParallelBudget.actualParallelism, $flagScenarioParallelBudget.decisionSource, $flagScenarioParallelBudget.reason) -ForegroundColor DarkCyan
 
-foreach ($scenario in $knownFlagScenarios) {
-  $scenarioName = [string]$scenario.name
-  $scenarioDir = Join-Path $flagScenarioRoot $scenarioName
-  New-Item -ItemType Directory -Path $scenarioDir -Force | Out-Null
-  $reportPath = Join-Path $scenarioDir 'compare-report.html'
-  $runtimeSnapshotPath = Join-Path $scenarioDir 'runtime-determinism.json'
-  $capturePath = Join-Path $scenarioDir 'ni-linux-container-capture.json'
+$flagScenarioOutputs = Invoke-FlagScenarioCompares `
+  -ScenarioDefinitions $knownFlagScenarios `
+  -Parallelism $flagScenarioParallelBudget.actualParallelism `
+  -RepoRoot $repoRootResolved `
+  -FlagScenarioRoot $flagScenarioRoot `
+  -CompareScriptPath $compareScriptPath `
+  -BaseVi $baseViComparePath `
+  -HeadVi $headViComparePath `
+  -Image $Image `
+  -LabVIEWPath $LabVIEWPath `
+  -TimeoutSeconds $TimeoutSeconds `
+  -HeartbeatSeconds $HeartbeatSeconds `
+  -RuntimeEngineReadyTimeoutSeconds $RuntimeEngineReadyTimeoutSeconds `
+  -RuntimeEngineReadyPollSeconds $RuntimeEngineReadyPollSeconds `
+  -ReuseContainerName $ReuseContainerName `
+  -ReuseRepoHostPath $reuseRepoHostPathResolved `
+  -ReuseRepoContainerPath $ReuseRepoContainerPath `
+  -ReuseResultsHostPath $reuseResultsHostPathResolved `
+  -ReuseResultsContainerPath $ReuseResultsContainerPath `
+  -RuntimeInjectionMount $RuntimeInjectionMount
 
-  Write-Host ("[ni-linux-review-suite] scenario={0} requestedFlags={1}" -f $scenarioName, [string]$scenario.requestedFlagsLabel) -ForegroundColor Cyan
-  Push-Location $repoRootResolved
-  try {
-    & $compareScriptPath `
-      -BaseVi $baseViComparePath `
-      -HeadVi $headViComparePath `
-      -Image $Image `
-      -ReportPath $reportPath `
-      -LabVIEWPath $LabVIEWPath `
-      -ContainerNameLabel $scenarioName `
-      -Flags @($scenario.flags) `
-      -TimeoutSeconds $TimeoutSeconds `
-      -HeartbeatSeconds $HeartbeatSeconds `
-      -AutoRepairRuntime:$true `
-      -RuntimeEngineReadyTimeoutSeconds $RuntimeEngineReadyTimeoutSeconds `
-      -RuntimeEngineReadyPollSeconds $RuntimeEngineReadyPollSeconds `
-      -RuntimeSnapshotPath $runtimeSnapshotPath `
-      -ReuseContainerName $ReuseContainerName `
-      -ReuseRepoHostPath $reuseRepoHostPathResolved `
-      -ReuseRepoContainerPath $ReuseRepoContainerPath `
-      -ReuseResultsHostPath $reuseResultsHostPathResolved `
-      -ReuseResultsContainerPath $ReuseResultsContainerPath `
-      -RuntimeInjectionMount $RuntimeInjectionMount
-    $compareExit = $LASTEXITCODE
-    if ($compareExit -notin @(0, 1)) {
-      throw ("NI Linux review suite scenario '{0}' compare failed (exit={1})." -f $scenarioName, $compareExit)
-    }
-  } finally {
-    Pop-Location | Out-Null
+foreach ($scenarioOutput in @($flagScenarioOutputs)) {
+  if (-not [string]::IsNullOrWhiteSpace([string]$scenarioOutput.errorMessage)) {
+    throw ([string]$scenarioOutput.errorMessage)
   }
+
+  $scenarioName = [string]$scenarioOutput.name
+  $scenarioDir = [string]$scenarioOutput.scenarioDir
+  $reportPath = [string]$scenarioOutput.reportPath
+  $runtimeSnapshotPath = [string]$scenarioOutput.runtimeSnapshotPath
+  $capturePath = [string]$scenarioOutput.capturePath
+  $requestedFlags = @($scenarioOutput.requestedFlags | ForEach-Object { [string]$_ })
 
   $scenarioCheck = Assert-CompareScenarioArtifacts `
     -ScenarioName $scenarioName `
@@ -534,7 +799,7 @@ foreach ($scenario in $knownFlagScenarios) {
     -ReportPath $reportPath `
     -RuntimeSnapshotPath $runtimeSnapshotPath `
     -ExpectedImage $Image `
-    -RequestedFlags @($scenario.flags)
+    -RequestedFlags $requestedFlags
 
   if ([string]::Equals($scenarioName, 'baseline', [System.StringComparison]::OrdinalIgnoreCase)) {
     Copy-ArtifactIfPresent -SourcePath $reportPath -DestinationPath (Join-Path $resultsRootResolved 'compare-report.html')
@@ -548,8 +813,8 @@ foreach ($scenario in $knownFlagScenarios) {
   $scenarioResults += [pscustomobject]@{
     kind = 'flag-combination'
     name = $scenarioName
-    requestedFlagsLabel = [string]$scenario.requestedFlagsLabel
-    requestedFlags = @($scenario.flags)
+    requestedFlagsLabel = [string]$scenarioOutput.requestedFlagsLabel
+    requestedFlags = @($requestedFlags)
     flagsUsed = @($scenarioCheck.flagsUsed)
     executionMode = [string]$scenarioCheck.executionMode
     gateOutcome = [string]$scenarioCheck.gateOutcome
@@ -738,7 +1003,8 @@ $scenarioResults += [pscustomobject]@{
 $flagCombinationCertification = Write-FlagCombinationCertificationArtifacts `
   -ResultsRoot $resultsRootResolved `
   -Image $Image `
-  -ScenarioResults @($scenarioResults)
+  -ScenarioResults @($scenarioResults) `
+  -ParallelBudget $flagScenarioParallelBudget
 
 $baselineTopLevelReportPath = Join-Path $resultsRootResolved 'compare-report.html'
 $summaryRows = foreach ($entry in @($scenarioResults)) {
@@ -807,6 +1073,15 @@ $summaryPayload = [ordered]@{
     markdownPath = Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.markdownPath)
     htmlPath = Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.htmlPath)
   }
+  flagScenarioBudget = [ordered]@{
+    path = Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path $hostRamBudgetPathResolved
+    targetProfile = [string]$flagScenarioParallelBudget.targetProfile
+    requestedParallelism = [int]$flagScenarioParallelBudget.requestedParallelism
+    recommendedParallelism = [int]$flagScenarioParallelBudget.recommendedParallelism
+    actualParallelism = [int]$flagScenarioParallelBudget.actualParallelism
+    decisionSource = [string]$flagScenarioParallelBudget.decisionSource
+    reason = [string]$flagScenarioParallelBudget.reason
+  }
   scenarios = @($summaryRows)
 }
 $summaryPayload | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $summaryJsonPath -Encoding utf8
@@ -823,6 +1098,7 @@ $markdownLines = @(
   ('- History effective branch ref: `{0}`' -f $historyRefSelection.effectiveBranchRef),
   ('- History effective baseline ref: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef })),
   ('- History max commit count: `{0}`' -f $HistoryMaxCommitCount),
+  ('- Flag scenario budget: `requested={0}; recommended={1}; actual={2}; source={3}` ([json](./{4}))' -f $summaryPayload.flagScenarioBudget.requestedParallelism, $summaryPayload.flagScenarioBudget.recommendedParallelism, $summaryPayload.flagScenarioBudget.actualParallelism, $summaryPayload.flagScenarioBudget.decisionSource, $summaryPayload.flagScenarioBudget.path),
   ('- Flag certification: [flag-combination-certification.html](./{0}) ([json](./{1}), [md](./{2}))' -f $summaryPayload.flagCombinationCertification.htmlPath, $summaryPayload.flagCombinationCertification.jsonPath, $summaryPayload.flagCombinationCertification.markdownPath),
   '',
   '| Scenario | Kind | Requested Flags | Result | Report | Extra |',
@@ -840,7 +1116,7 @@ $markdownLines -join "`n" | Set-Content -LiteralPath $summaryMarkdownPath -Encod
 
 $htmlLines = @(
   '<html><body><h1>NI Linux review suite</h1>',
-  ('<p>Image: <code>{0}</code><br/>LabVIEW path: <code>{1}</code><br/>History ref source: <code>{2}</code><br/>History requested branch ref: <code>{3}</code><br/>History requested baseline ref: <code>{4}</code><br/>History effective branch ref: <code>{5}</code><br/>History effective baseline ref: <code>{6}</code><br/>History max commit count: <code>{7}</code><br/>Flag certification: <a href="./{8}">html</a>, <a href="./{9}">json</a>, <a href="./{10}">md</a></p>' -f $Image, $LabVIEWPath, $historyRefSelection.source, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBranchRef)) { '(default)' } else { $historyRefSelection.requestedBranchRef }), $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBaselineRef)) { '(default)' } else { $historyRefSelection.requestedBaselineRef }), $historyRefSelection.effectiveBranchRef, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef }), $HistoryMaxCommitCount, $summaryPayload.flagCombinationCertification.htmlPath, $summaryPayload.flagCombinationCertification.jsonPath, $summaryPayload.flagCombinationCertification.markdownPath),
+  ('<p>Image: <code>{0}</code><br/>LabVIEW path: <code>{1}</code><br/>History ref source: <code>{2}</code><br/>History requested branch ref: <code>{3}</code><br/>History requested baseline ref: <code>{4}</code><br/>History effective branch ref: <code>{5}</code><br/>History effective baseline ref: <code>{6}</code><br/>History max commit count: <code>{7}</code><br/>Flag scenario budget: <code>requested={8}; recommended={9}; actual={10}; source={11}</code> (<a href=\"./{12}\">json</a>)<br/>Flag certification: <a href=\"./{13}\">html</a>, <a href=\"./{14}\">json</a>, <a href=\"./{15}\">md</a></p>' -f $Image, $LabVIEWPath, $historyRefSelection.source, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBranchRef)) { '(default)' } else { $historyRefSelection.requestedBranchRef }), $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.requestedBaselineRef)) { '(default)' } else { $historyRefSelection.requestedBaselineRef }), $historyRefSelection.effectiveBranchRef, $(if ([string]::IsNullOrWhiteSpace($historyRefSelection.effectiveBaselineRef)) { '(default)' } else { $historyRefSelection.effectiveBaselineRef }), $HistoryMaxCommitCount, $summaryPayload.flagScenarioBudget.requestedParallelism, $summaryPayload.flagScenarioBudget.recommendedParallelism, $summaryPayload.flagScenarioBudget.actualParallelism, $summaryPayload.flagScenarioBudget.decisionSource, $summaryPayload.flagScenarioBudget.path, $summaryPayload.flagCombinationCertification.htmlPath, $summaryPayload.flagCombinationCertification.jsonPath, $summaryPayload.flagCombinationCertification.markdownPath),
   '<table border="1" cellspacing="0" cellpadding="4">',
   '<thead><tr><th>Scenario</th><th>Kind</th><th>Requested Flags</th><th>Result</th><th>Report</th><th>Extra</th></tr></thead>',
   '<tbody>'
@@ -862,6 +1138,7 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubStepSummaryPath)) {
     '',
     ('- artifact root: `{0}`' -f $resultsRootResolved),
     ('- compare scenarios: `{0}`' -f $knownFlagScenarios.Count),
+    ('- flag scenario budget: `{0}`' -f $summaryPayload.flagScenarioBudget.path),
     ('- vi history report: `enabled`'),
     ('- summary: `{0}`' -f (Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path $summaryMarkdownPath)),
     ('- flag certification: `{0}`' -f (Get-RelativeArtifactPath -RootPath $resultsRootResolved -Path ([string]$flagCombinationCertification.markdownPath)))
@@ -872,6 +1149,7 @@ Write-GitHubOutput -Key 'results_root' -Value $resultsRootResolved -Path $GitHub
 Write-GitHubOutput -Key 'summary_json_path' -Value $summaryJsonPath -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'summary_markdown_path' -Value $summaryMarkdownPath -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'summary_html_path' -Value $summaryHtmlPath -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'host_ram_budget_path' -Value $hostRamBudgetPathResolved -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'baseline_report_path' -Value $baselineTopLevelReportPath -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'flag_combination_certification_json_path' -Value ([string]$flagCombinationCertification.jsonPath) -Path $GitHubOutputPath
 Write-GitHubOutput -Key 'flag_combination_certification_markdown_path' -Value ([string]$flagCombinationCertification.markdownPath) -Path $GitHubOutputPath

--- a/tools/Run-NonLVChecksInDocker.ps1
+++ b/tools/Run-NonLVChecksInDocker.ps1
@@ -608,6 +608,7 @@ function Write-DockerParityReviewLoopReceipt {
 
   $reviewSuiteSummaryJsonPath = Join-Path $niResultsRootResolved 'review-suite-summary.json'
   $reviewSuiteSummaryHtmlPath = Join-Path $niResultsRootResolved 'review-suite-summary.html'
+  $hostRamBudgetPath = Join-Path $niResultsRootResolved 'host-ram-budget.json'
   $historyReviewReceiptPath = Join-Path $niResultsRootResolved 'vi-history-review-loop-receipt.json'
   $requirementsSummaryPath = Join-Path $requirementsResultsRootResolved 'verification-summary.json'
   $traceMatrixJsonPath = Join-Path $requirementsResultsRootResolved 'trace-matrix.json'
@@ -623,6 +624,7 @@ function Write-DockerParityReviewLoopReceipt {
     agentVerificationSummaryPath = Get-RepoRelativePath -RepoRoot $RepoRoot -Path $agentVerificationSummaryPath
     reviewSuiteSummaryJsonPath = if (Test-Path -LiteralPath $reviewSuiteSummaryJsonPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $reviewSuiteSummaryJsonPath } else { '' }
     reviewSuiteSummaryHtmlPath = if (Test-Path -LiteralPath $reviewSuiteSummaryHtmlPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $reviewSuiteSummaryHtmlPath } else { '' }
+    hostRamBudgetPath = if (Test-Path -LiteralPath $hostRamBudgetPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $hostRamBudgetPath } else { '' }
     historyReviewReceiptPath = if (Test-Path -LiteralPath $historyReviewReceiptPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $historyReviewReceiptPath } else { '' }
     requirementsSummaryPath = if (Test-Path -LiteralPath $requirementsSummaryPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $requirementsSummaryPath } else { '' }
     traceMatrixJsonPath = if (Test-Path -LiteralPath $traceMatrixJsonPath -PathType Leaf) { Get-RepoRelativePath -RepoRoot $RepoRoot -Path $traceMatrixJsonPath } else { '' }
@@ -634,6 +636,9 @@ function Write-DockerParityReviewLoopReceipt {
   $recommendedReviewOrder.Add($artifacts.agentVerificationSummaryPath)
   if ($artifacts.reviewSuiteSummaryHtmlPath) {
     $recommendedReviewOrder.Add($artifacts.reviewSuiteSummaryHtmlPath)
+  }
+  if ($artifacts.hostRamBudgetPath) {
+    $recommendedReviewOrder.Add($artifacts.hostRamBudgetPath)
   }
   if ($historyReceipt -and $historyReceipt.ContainsKey('artifacts')) {
     foreach ($artifactKey in @(
@@ -942,6 +947,7 @@ if ($checkStates.niLinuxReviewSuite.enabled) {
     $resultsRootResolved = [System.IO.Path]::GetFullPath((Join-Path $repoRootResolved $NILinuxReviewSuiteResultsRoot))
     $reviewSuiteSummaryHtmlPath = Join-Path $resultsRootResolved 'review-suite-summary.html'
     $reviewSuiteSummaryJsonPath = Join-Path $resultsRootResolved 'review-suite-summary.json'
+    $hostRamBudgetPath = Join-Path $resultsRootResolved 'host-ram-budget.json'
     $flagCombinationCertificationJsonPath = Join-Path $resultsRootResolved 'flag-combination-certification.json'
     $flagCombinationCertificationHtmlPath = Join-Path $resultsRootResolved 'flag-combination-certification.html'
     $historyMarkdownPath = Join-Path $resultsRootResolved 'vi-history-report/results/history-report.md'
@@ -990,6 +996,7 @@ if ($checkStates.niLinuxReviewSuite.enabled) {
     foreach ($artifactPath in @(
         $reviewSuiteSummaryHtmlPath,
         $reviewSuiteSummaryJsonPath,
+        $hostRamBudgetPath,
         $flagCombinationCertificationJsonPath,
         $flagCombinationCertificationHtmlPath,
         $historyMarkdownPath,
@@ -1006,6 +1013,7 @@ if ($checkStates.niLinuxReviewSuite.enabled) {
     $checkStates.niLinuxReviewSuite.artifacts.resultsRoot = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $resultsRootResolved
     $checkStates.niLinuxReviewSuite.artifacts.reviewSuiteSummaryJsonPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $reviewSuiteSummaryJsonPath
     $checkStates.niLinuxReviewSuite.artifacts.reviewSuiteSummaryHtmlPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $reviewSuiteSummaryHtmlPath
+    $checkStates.niLinuxReviewSuite.artifacts.hostRamBudgetPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $hostRamBudgetPath
     $checkStates.niLinuxReviewSuite.artifacts.flagCombinationCertificationJsonPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $flagCombinationCertificationJsonPath
     $checkStates.niLinuxReviewSuite.artifacts.flagCombinationCertificationHtmlPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $flagCombinationCertificationHtmlPath
     $checkStates.niLinuxReviewSuite.artifacts.historyReportHtmlPath = Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $historyHtmlPath

--- a/tools/priority/__tests__/host-ram-budget-schema.test.mjs
+++ b/tools/priority/__tests__/host-ram-budget-schema.test.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { buildHostRamBudgetReport } from '../host-ram-budget.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('host RAM budget schema validates the generated report', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'host-ram-budget-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const report = buildHostRamBudgetReport(
+    {
+      targetProfile: 'ni-linux-flag-combination',
+      minimumParallelism: 1,
+    },
+    {
+      totalmemFn: () => 16 * 1024 * 1024 * 1024,
+      freememFn: () => 10 * 1024 * 1024 * 1024,
+      availableParallelismFn: () => 12,
+    },
+  );
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/host-ram-budget.test.mjs
+++ b/tools/priority/__tests__/host-ram-budget.test.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_OUTPUT_PATH,
+  DEFAULT_TARGET_PROFILE,
+  PROFILE_CATALOG,
+  buildHostRamBudgetReport,
+  parseArgs,
+} from '../host-ram-budget.mjs';
+
+test('parseArgs supports explicit resource overrides and target profile', () => {
+  const parsed = parseArgs([
+    'node',
+    'host-ram-budget.mjs',
+    '--output',
+    'custom-budget.json',
+    '--target-profile',
+    'heavy',
+    '--total-bytes',
+    '17179869184',
+    '--free-bytes',
+    '10737418240',
+    '--cpu-parallelism',
+    '12',
+    '--minimum-parallelism',
+    '1',
+  ]);
+
+  assert.equal(parsed.outputPath, 'custom-budget.json');
+  assert.equal(parsed.targetProfile, 'heavy');
+  assert.equal(parsed.totalBytes, 17179869184);
+  assert.equal(parsed.freeBytes, 10737418240);
+  assert.equal(parsed.cpuParallelism, 12);
+  assert.equal(parsed.minimumParallelism, 1);
+});
+
+test('buildHostRamBudgetReport recommends parallel heavy scenarios on roomy hosts', () => {
+  const report = buildHostRamBudgetReport(
+    {
+      targetProfile: 'ni-linux-flag-combination',
+      minimumParallelism: 1,
+    },
+    {
+      totalmemFn: () => 16 * 1024 * 1024 * 1024,
+      freememFn: () => 10 * 1024 * 1024 * 1024,
+      availableParallelismFn: () => 12,
+    },
+  );
+
+  assert.equal(report.schema, 'priority/host-ram-budget@v1');
+  assert.equal(report.selectedProfile.id, 'ni-linux-flag-combination');
+  assert.equal(report.selectedProfile.recommendedParallelism, 2);
+  assert.equal(report.selectedProfile.floorApplied, false);
+  assert.equal(report.selectedProfile.degradedByPressure, true);
+});
+
+test('buildHostRamBudgetReport keeps a deterministic floor under memory pressure', () => {
+  const report = buildHostRamBudgetReport(
+    {
+      targetProfile: 'windows-mirror-heavy',
+      minimumParallelism: 1,
+    },
+    {
+      totalmemFn: () => 8 * 1024 * 1024 * 1024,
+      freememFn: () => 768 * 1024 * 1024,
+      availableParallelismFn: () => 8,
+    },
+  );
+
+  assert.equal(report.selectedProfile.id, 'windows-mirror-heavy');
+  assert.equal(report.selectedProfile.recommendedParallelism, 1);
+  assert.equal(report.selectedProfile.floorApplied, true);
+  assert.ok(report.selectedProfile.reasons.includes('deterministic-floor'));
+});
+
+test('defaults stay aligned with the contract surface', () => {
+  const parsed = parseArgs(['node', 'host-ram-budget.mjs']);
+  assert.equal(parsed.outputPath, DEFAULT_OUTPUT_PATH);
+  assert.equal(parsed.targetProfile, DEFAULT_TARGET_PROFILE);
+  assert.equal(parsed.minimumParallelism, 1);
+  assert.ok(PROFILE_CATALOG.heavy);
+});

--- a/tools/priority/host-ram-budget.mjs
+++ b/tools/priority/host-ram-budget.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const REPORT_SCHEMA = 'priority/host-ram-budget@v1';
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'runtime', 'host-ram-budget.json');
+export const DEFAULT_TARGET_PROFILE = 'ni-linux-flag-combination';
+export const PROFILE_CATALOG = Object.freeze({
+  light: Object.freeze({ perWorkerBytes: 768 * 1024 * 1024, maxParallelism: 8, laneClass: 'cpu-mixed' }),
+  medium: Object.freeze({ perWorkerBytes: 1536 * 1024 * 1024, maxParallelism: 4, laneClass: 'mixed' }),
+  heavy: Object.freeze({ perWorkerBytes: 3072 * 1024 * 1024, maxParallelism: 3, laneClass: 'ram-bound' }),
+  'ni-linux-flag-combination': Object.freeze({ perWorkerBytes: 3072 * 1024 * 1024, maxParallelism: 3, laneClass: 'ram-bound' }),
+  'windows-mirror-heavy': Object.freeze({ perWorkerBytes: 6144 * 1024 * 1024, maxParallelism: 2, laneClass: 'ram-bound' }),
+});
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function asOptional(value) {
+  const text = normalizeText(value);
+  return text || null;
+}
+
+function parsePositiveInteger(value, flag) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid value for ${flag}: ${value}`);
+  }
+  return parsed;
+}
+
+function parseByteValue(value, flag) {
+  const parsed = Number(String(value));
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid byte value for ${flag}: ${value}`);
+  }
+  return Math.trunc(parsed);
+}
+
+function ensureProfile(profileId) {
+  const profile = PROFILE_CATALOG[profileId];
+  if (!profile) {
+    throw new Error(`Unknown --target-profile '${profileId}'.`);
+  }
+  return profile;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    outputPath: DEFAULT_OUTPUT_PATH,
+    targetProfile: DEFAULT_TARGET_PROFILE,
+    totalBytes: null,
+    freeBytes: null,
+    cpuParallelism: null,
+    minimumParallelism: 1,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (
+      token === '--output' ||
+      token === '--target-profile' ||
+      token === '--total-bytes' ||
+      token === '--free-bytes' ||
+      token === '--cpu-parallelism' ||
+      token === '--minimum-parallelism'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--target-profile') options.targetProfile = normalizeText(next);
+      if (token === '--total-bytes') options.totalBytes = parseByteValue(next, token);
+      if (token === '--free-bytes') options.freeBytes = parseByteValue(next, token);
+      if (token === '--cpu-parallelism') options.cpuParallelism = parsePositiveInteger(next, token);
+      if (token === '--minimum-parallelism') options.minimumParallelism = parsePositiveInteger(next, token);
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  ensureProfile(options.targetProfile);
+  return options;
+}
+
+function detectHostResources({
+  totalmemFn = os.totalmem,
+  freememFn = os.freemem,
+  availableParallelismFn = os.availableParallelism,
+} = {}) {
+  return {
+    totalBytes: Math.trunc(totalmemFn()),
+    freeBytes: Math.trunc(freememFn()),
+    cpuParallelism: Math.max(1, Math.trunc(availableParallelismFn())),
+    platform: process.platform,
+    arch: process.arch,
+    detectionSource: 'node-os',
+  };
+}
+
+function buildProfileBudget({ profileId, profile, effectiveUsableBytes, cpuParallelism, minimumParallelism, degradedByPressure }) {
+  const rawMemoryCeiling = Math.floor(effectiveUsableBytes / profile.perWorkerBytes);
+  const floorApplied = rawMemoryCeiling < minimumParallelism;
+  const memoryBoundCeiling = Math.max(minimumParallelism, rawMemoryCeiling);
+  const cpuBoundCeiling = Math.max(minimumParallelism, cpuParallelism);
+  const recommendedParallelism = Math.max(
+    minimumParallelism,
+    Math.min(profile.maxParallelism, memoryBoundCeiling, cpuBoundCeiling),
+  );
+
+  const reasons = [];
+  if (degradedByPressure) reasons.push('free-memory-pressure');
+  if (floorApplied) reasons.push('deterministic-floor');
+  if (recommendedParallelism === profile.maxParallelism && recommendedParallelism < memoryBoundCeiling && recommendedParallelism < cpuBoundCeiling) {
+    reasons.push('profile-max-cap');
+  }
+  if (recommendedParallelism === cpuBoundCeiling && cpuBoundCeiling <= memoryBoundCeiling && cpuBoundCeiling <= profile.maxParallelism) {
+    reasons.push('cpu-cap');
+  }
+  if (recommendedParallelism === memoryBoundCeiling && memoryBoundCeiling <= cpuBoundCeiling && memoryBoundCeiling <= profile.maxParallelism) {
+    reasons.push('memory-cap');
+  }
+  if (reasons.length === 0) {
+    reasons.push('balanced');
+  }
+
+  return {
+    id: profileId,
+    laneClass: profile.laneClass,
+    perWorkerBytes: profile.perWorkerBytes,
+    maxParallelism: profile.maxParallelism,
+    memoryBoundCeiling,
+    cpuBoundCeiling,
+    recommendedParallelism,
+    floorApplied,
+    degradedByPressure,
+    reasons,
+  };
+}
+
+export function buildHostRamBudgetReport(
+  {
+    targetProfile = DEFAULT_TARGET_PROFILE,
+    minimumParallelism = 1,
+    totalBytes = null,
+    freeBytes = null,
+    cpuParallelism = null,
+    now = new Date(),
+  },
+  detectionOverrides = {},
+) {
+  const detected = detectHostResources(detectionOverrides);
+  const total = totalBytes ?? detected.totalBytes;
+  const free = freeBytes ?? detected.freeBytes;
+  const cpu = cpuParallelism ?? detected.cpuParallelism;
+  const systemReserveBytes = Math.max(2 * 1024 * 1024 * 1024, Math.floor(total * 0.25));
+  const freeReserveBytes = Math.max(1 * 1024 * 1024 * 1024, Math.floor(total * 0.10));
+  const usableByTotalBytes = Math.max(0, total - systemReserveBytes);
+  const usableByFreeBytes = Math.max(0, free - freeReserveBytes);
+  const effectiveUsableBytes = Math.max(
+    0,
+    Math.min(usableByTotalBytes, usableByFreeBytes),
+  );
+  const degradedByPressure = usableByFreeBytes < usableByTotalBytes;
+
+  const profiles = Object.entries(PROFILE_CATALOG).map(([profileId, profile]) =>
+    buildProfileBudget({
+      profileId,
+      profile,
+      effectiveUsableBytes,
+      cpuParallelism: cpu,
+      minimumParallelism,
+      degradedByPressure,
+    }),
+  );
+
+  const selectedProfile = profiles.find((entry) => entry.id === targetProfile);
+  if (!selectedProfile) {
+    throw new Error(`Target profile not found in computed report: ${targetProfile}`);
+  }
+
+  return {
+    schema: REPORT_SCHEMA,
+    generatedAt: now.toISOString(),
+    host: {
+      platform: detected.platform,
+      arch: detected.arch,
+      detectionSource: detected.detectionSource,
+      totalBytes: total,
+      freeBytes: free,
+      cpuParallelism: cpu,
+    },
+    policy: {
+      minimumParallelism,
+      systemReserveBytes,
+      freeReserveBytes,
+      usableByTotalBytes,
+      usableByFreeBytes,
+      effectiveUsableBytes,
+    },
+    profiles,
+    selectedProfile,
+  };
+}
+
+async function writeReport(outputPath, report) {
+  const resolved = path.resolve(process.cwd(), outputPath);
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.writeFile(resolved, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  return resolved;
+}
+
+function printUsage() {
+  console.log('Usage: node tools/priority/host-ram-budget.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(`  --output <path>                Output report path (default: ${DEFAULT_OUTPUT_PATH})`);
+  console.log(`  --target-profile <id>          Target profile id (default: ${DEFAULT_TARGET_PROFILE})`);
+  console.log('  --total-bytes <n>              Override detected total host RAM.');
+  console.log('  --free-bytes <n>               Override detected free host RAM.');
+  console.log('  --cpu-parallelism <n>          Override detected CPU parallelism.');
+  console.log('  --minimum-parallelism <n>      Deterministic floor (default: 1).');
+  console.log('  -h, --help                     Show help.');
+}
+
+export async function main(argv = process.argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+
+  const report = buildHostRamBudgetReport(options);
+  const reportPath = await writeReport(options.outputPath, report);
+  console.log(`[host-ram-budget] report: ${reportPath}`);
+  console.log(`[host-ram-budget] target=${report.selectedProfile.id} recommendedParallelism=${report.selectedProfile.recommendedParallelism}`);
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv).then(
+    (exitCode) => process.exit(exitCode),
+    (error) => {
+      process.stderr.write(`${error?.message || String(error)}\n`);
+      process.exit(1);
+    },
+  );
+}


### PR DESCRIPTION
# Summary

Adds a canonical host-RAM budget contract and uses it to choose NI Linux review-suite flag-scenario parallelism instead of assuming a fixed fan-out. The review-suite and Docker parity receipts now expose the selected budget so local and CI runs can explain serial versus parallel behavior on the active host.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
  - `#1400`
- Files, tools, workflows, or policies touched:
  - `tools/priority/host-ram-budget.mjs`
  - `tools/Invoke-NILinuxReviewSuite.ps1`
  - `tools/Run-NonLVChecksInDocker.ps1`
  - `docs/schemas/host-ram-budget-v1.schema.json`
  - focused Node/Pester tests for the new budget contract
- Cross-repo or external-consumer impact:
  - none yet; this is the first substrate slice in this repo
- Required checks, merge-queue behavior, or approval flows affected:
  - no branch-protection changes
  - pre-push now emits host RAM budget evidence through the NI Linux review-suite artifacts

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/host-ram-budget.test.mjs tools/priority/__tests__/host-ram-budget-schema.test.mjs`
  - `Invoke-Pester -Path tests/NILinuxReviewSuiteCertification.Tests.ps1, tests/NILinuxReviewSuiteRamBudget.Tests.ps1, tests/RunNonLVChecksInDockerReviewReceipt.Tests.ps1 -CI`
  - `pwsh -NoLogo -NoProfile -File tools/Invoke-NILinuxReviewSuite.ps1 -BaseVi fixtures/vi-attr/Base.vi -HeadVi fixtures/vi-attr/Head.vi -ResultsRoot tests/results/local-host-ram-budget-review-suite`
  - `pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -NILinuxReviewSuite -SkipActionlint -SkipMarkdown -SkipDocs -SkipWorkflow -SkipDotnetCliBuild`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - `tests/results/local-host-ram-budget-review-suite/host-ram-budget.json`
  - `tests/results/local-host-ram-budget-review-suite/review-suite-summary.json`
  - `tests/results/docker-tools-parity/ni-linux-review-suite/host-ram-budget.json`
  - `tests/results/docker-tools-parity/review-loop-receipt.json`
- Risk-based checks not run:
  - none

## Risks and Follow-ups

- Residual risks:
  - `#1400` only lands the NI Linux review-suite first slice; other heavy orchestration surfaces still use existing concurrency behavior
- Follow-up issues or deferred work:
  - `#1446` extend RAM budgeting into Docker Desktop fast-loop orchestration
  - `#1447` extend RAM budgeting into operator-session and warm-runtime orchestration
  - `#1448` adopt RAM budgeting for Windows mirror heavy lanes
- Deployment, approval, or rollback notes:
  - rollback is isolated to the new host-RAM budget helper and NI Linux review-suite scheduling path

## Reviewer Focus

- Please verify:
  - the host-RAM budget contract is explicit and deterministic under pressure
  - NI Linux review-suite parallel fan-out still preserves result ordering and receipt shape
  - Docker parity receipt wiring exposes the new budget artifact cleanly
- Areas where the reasoning is subtle:
  - PowerShell pipeline isolation around the Node helper call (`Out-Host`) is required to keep strict-mode property access deterministic
  - thread-job availability must collapse to serial without losing the budget receipt
- Manual spot checks requested:
  - inspect `review-suite-summary.md/html` and `review-loop-receipt.json` for the new budget links
