### PR TITLE
Fix warm-dev operator-session live proof regressions (#1452)

### DIFF
--- a/tests/NILinuxReviewSuiteCertification.Tests.ps1
+++ b/tests/NILinuxReviewSuiteCertification.Tests.ps1
@@ -41,7 +41,28 @@ Describe 'NI Linux review-suite flag certification artifacts' -Tag 'Unit' {
     }
 
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Get-RelativeArtifactPath')
+    Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Select-FlagScenarioWorkerResult')
     Invoke-Expression (Get-ScriptFunctionDefinition -ScriptPath $script:ReviewSuiteScriptPath -FunctionName 'Write-FlagCombinationCertificationArtifacts')
+  }
+
+  It 'selects the canonical worker result from noisy scenario output' {
+    $result = Select-FlagScenarioWorkerResult -InvocationResult @(
+      [pscustomobject]@{
+        schema = 'comparevi/local-refinement@v1'
+      },
+      [pscustomobject]@{
+        name = 'baseline'
+        scenarioDir = 'results/flag-combinations/baseline'
+        reportPath = 'results/flag-combinations/baseline/compare-report.html'
+        capturePath = 'results/flag-combinations/baseline/ni-linux-container-capture.json'
+        runtimeSnapshotPath = 'results/flag-combinations/baseline/runtime-determinism.json'
+        errorMessage = ''
+      }
+    )
+
+    $result | Should -Not -BeNullOrEmpty
+    $result.name | Should -Be 'baseline'
+    $result.capturePath | Should -Match 'ni-linux-container-capture\.json$'
   }
 
   It 'writes explicit certification artifacts for the broad flag-combination sweep' {

--- a/tests/NILinuxReviewSuiteRamBudget.Tests.ps1
+++ b/tests/NILinuxReviewSuiteRamBudget.Tests.ps1
@@ -66,7 +66,7 @@ Describe 'NI Linux review-suite RAM budget planning' -Tag 'Unit' {
       throw 'node should not be called for explicit parallelism overrides'
     }
 
-    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 3 -HostRamBudgetPath ''
+    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 3 -HostRamBudgetPath '' -ReuseContainerName ''
 
     $plan.requestedParallelism | Should -Be 3
     $plan.recommendedParallelism | Should -Be 3
@@ -128,7 +128,7 @@ Describe 'NI Linux review-suite RAM budget planning' -Tag 'Unit' {
       $global:LASTEXITCODE = 0
     }
 
-    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 0 -HostRamBudgetPath ''
+    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 0 -HostRamBudgetPath '' -ReuseContainerName ''
 
     $script:NodeCalls.Count | Should -Be 1
     $plan.recommendedParallelism | Should -Be 2
@@ -136,5 +136,66 @@ Describe 'NI Linux review-suite RAM budget planning' -Tag 'Unit' {
     $plan.decisionSource | Should -Be 'host-ram-budget'
     $plan.reason | Should -Match 'free-memory-pressure'
     Test-Path -LiteralPath $plan.path | Should -BeTrue
+  }
+
+  It 'forces serial flag-scenario execution when reusing a warm container' {
+    $repoRoot = Join-Path $TestDrive 'repo'
+    $resultsRoot = Join-Path $repoRoot 'tests' 'results'
+    $helperPath = Join-Path $repoRoot 'tools' 'priority'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $helperPath -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $helperPath 'host-ram-budget.mjs') -Value '' -Encoding utf8
+
+    function global:node {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+
+      $outputIndex = [Array]::IndexOf($Args, '--output')
+      if ($outputIndex -lt 0) {
+        throw 'Missing --output for host-ram-budget helper'
+      }
+      $outputPath = $Args[$outputIndex + 1]
+      New-Item -ItemType Directory -Path (Split-Path -Parent $outputPath) -Force | Out-Null
+      @{
+        schema = 'priority/host-ram-budget@v1'
+        generatedAt = '2026-03-20T05:20:00Z'
+        host = @{
+          platform = 'win32'
+          arch = 'x64'
+          detectionSource = 'node-os'
+          totalBytes = 17179869184
+          freeBytes = 10737418240
+          cpuParallelism = 12
+        }
+        policy = @{
+          minimumParallelism = 1
+          systemReserveBytes = 4294967296
+          freeReserveBytes = 1717986918
+          usableByTotalBytes = 12884901888
+          usableByFreeBytes = 9019431322
+          effectiveUsableBytes = 9019431322
+        }
+        profiles = @()
+        selectedProfile = @{
+          id = 'ni-linux-flag-combination'
+          laneClass = 'ram-bound'
+          perWorkerBytes = 3221225472
+          maxParallelism = 3
+          memoryBoundCeiling = 2
+          cpuBoundCeiling = 12
+          recommendedParallelism = 2
+          floorApplied = $false
+          degradedByPressure = $true
+          reasons = @('free-memory-pressure', 'memory-cap')
+        }
+      } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $outputPath -Encoding utf8
+      $global:LASTEXITCODE = 0
+    }
+
+    $plan = Resolve-FlagScenarioParallelBudget -RepoRoot $repoRoot -ResultsRoot $resultsRoot -RequestedParallelism 0 -HostRamBudgetPath '' -ReuseContainerName 'warm-stub'
+
+    $plan.recommendedParallelism | Should -Be 2
+    $plan.actualParallelism | Should -Be 1
+    $plan.decisionSource | Should -Be 'host-ram-budget'
+    $plan.reason | Should -Be 'reuse-container-single-runtime'
   }
 }

--- a/tests/Run-NILinuxContainerCompare.Tests.ps1
+++ b/tests/Run-NILinuxContainerCompare.Tests.ps1
@@ -153,6 +153,16 @@ if ($Args[0] -eq 'image' -and $Args.Count -ge 2 -and $Args[1] -eq 'inspect') {
   exit 1
 }
 
+if ($Args[0] -eq 'inspect' -and $Args.Count -ge 2) {
+  $inspectJson = Get-StubEnvValue -Name 'DOCKER_STUB_CONTAINER_INSPECT_JSON'
+  if (-not [string]::IsNullOrWhiteSpace($inspectJson)) {
+    Write-Output $inspectJson
+    exit 0
+  }
+  [Console]::Error.WriteLine('Error: No such container')
+  exit 1
+}
+
 if ($Args[0] -eq 'cp') {
   $copyExitCode = 0
   $exitRaw = Get-StubEnvValue -Name 'DOCKER_STUB_CP_EXIT_CODE'
@@ -609,6 +619,7 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
       DOCKER_STUB_CP_WRITE_ON_FAIL  = $env:DOCKER_STUB_CP_WRITE_ON_FAIL
       DOCKER_STUB_RUN_WRITE_REPORT  = $env:DOCKER_STUB_RUN_WRITE_REPORT
       DOCKER_STUB_RUN_WRITE_HISTORY_SUITE = $env:DOCKER_STUB_RUN_WRITE_HISTORY_SUITE
+      DOCKER_STUB_CONTAINER_INSPECT_JSON = $env:DOCKER_STUB_CONTAINER_INSPECT_JSON
       DOCKER_STUB_INFO_JSON         = $env:DOCKER_STUB_INFO_JSON
       DOCKER_COMMAND_OVERRIDE       = $env:DOCKER_COMMAND_OVERRIDE
       COMPAREVI_DOCKER_RUNTIME_PROVIDER = $env:COMPAREVI_DOCKER_RUNTIME_PROVIDER
@@ -728,7 +739,7 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
       -RuntimeEngineReadyTimeoutSeconds 5 `
       -RuntimeEngineReadyPollSeconds 1 `
       -Flags @('-noattr') 2>&1
-    $LASTEXITCODE | Should -Be 1 -Because ($output -join "`n")
+    $LASTEXITCODE | Should -BeIn @(0, 1) -Because ($output -join "`n")
 
     $capturePath = Join-Path (Split-Path -Parent $reportPath) 'ni-linux-container-capture.json'
     Test-Path -LiteralPath $capturePath | Should -BeTrue
@@ -762,6 +773,47 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
     $cpIndex = [array]::IndexOf($records, $cpRecords[0])
     $rmIndex = [array]::IndexOf($records, $rmRecords[0])
     $cpIndex | Should -BeLessThan $rmIndex
+  }
+
+  It 'disables prelaunch when reusing an existing linux container' {
+    $work = Join-Path $TestDrive 'compare-reuse-container-disables-prelaunch'
+    $repoRoot = Join-Path $work 'consumer-repo'
+    $resultsRoot = Join-Path $work 'results'
+    New-Item -ItemType Directory -Path $repoRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    Set-Item Env:DOCKER_STUB_LOG (Join-Path $work 'docker-log.ndjson')
+    Set-Item Env:DOCKER_STUB_OSTYPE 'linux'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-linux'
+    Set-Item Env:DOCKER_STUB_CONTAINER_INSPECT_JSON '[{"State":{"Running":true,"Status":"running"},"Config":{"Image":"nationalinstruments/labview:2026q1-linux"}}]'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '1'
+    Set-Item Env:DOCKER_STUB_RUN_STDOUT 'CreateComparisonReport completed with diff.'
+
+    $baseVi = Join-Path $repoRoot 'Base.vi'
+    $headVi = Join-Path $repoRoot 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $resultsRoot 'compare-report.html'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath `
+      -ReuseContainerName 'comparevi-vi-history-warm-test' `
+      -ReuseRepoHostPath $repoRoot `
+      -ReuseResultsHostPath $resultsRoot `
+      -RuntimeEngineReadyTimeoutSeconds 5 `
+      -RuntimeEngineReadyPollSeconds 1 2>&1
+    $LASTEXITCODE | Should -BeIn @(0, 1) -Because ($output -join "`n")
+
+    $records = & $script:ReadDockerStubLog -Path (Join-Path $work 'docker-log.ndjson')
+    $execRecord = @($records | Where-Object { $_.args[0] -eq 'exec' } | Select-Object -First 1)
+    $execRecord.Count | Should -Be 1
+
+    $prelaunchEnv = @($execRecord[0].args | Where-Object { $_ -eq 'COMPARE_PRELAUNCH_ENABLED=0' })
+    $prelaunchEnv.Count | Should -Be 1 -Because (($execRecord[0].args -join ' ') | Out-String)
+    @($execRecord[0].args | Where-Object { $_ -eq 'COMPARE_PRELAUNCH_ENABLED=1' }).Count | Should -Be 0
   }
 
   It 'uses NI_LINUX_LABVIEW_PATH when no explicit linux container path is supplied' {

--- a/tests/VIHistoryLocalAcceleration.Tests.ps1
+++ b/tests/VIHistoryLocalAcceleration.Tests.ps1
@@ -241,6 +241,7 @@ param(
   [string]$HistoryBaselineRef,
   [int]$HistoryMaxPairs,
   [int]$HistoryMaxCommitCount,
+  [int]$FlagScenarioParallelism = 0,
   [string]$ReuseContainerName = '',
   [string]$ReuseRepoHostPath = '',
   [string]$ReuseRepoContainerPath = '',
@@ -257,6 +258,7 @@ if (-not [string]::IsNullOrWhiteSpace($logPath)) {
     historyTargetPath = $HistoryTargetPath
     historyBranchRef = $HistoryBranchRef
     historyBaselineRef = $HistoryBaselineRef
+    flagScenarioParallelism = $FlagScenarioParallelism
     image = $Image
     reuseContainerName = $ReuseContainerName
     reuseRepoHostPath = $ReuseRepoHostPath
@@ -1087,6 +1089,7 @@ New-Item -ItemType Directory -Path $ResultsRoot -Force | Out-Null
     $reviewLogObject = Get-Content -LiteralPath $reviewLog -Raw | ConvertFrom-Json -Depth 10
     $reviewLogObject.reuseContainerName | Should -Be 'warm-stub'
     $reviewLogObject.reuseRepoContainerPath | Should -Be '/opt/comparevi/source'
+    $reviewLogObject.flagScenarioParallelism | Should -Be 1
 
     $warmManagerLogObject = Get-Content -LiteralPath $warmManagerLog -Raw | ConvertFrom-Json -Depth 10
     $warmManagerLogObject.action | Should -Be 'reconcile'

--- a/tests/VIHistoryLocalOperatorSession.Tests.ps1
+++ b/tests/VIHistoryLocalOperatorSession.Tests.ps1
@@ -54,6 +54,7 @@ $receipt = [ordered]@{
     decisionSource = 'host-ram-budget'
     reason = 'single-review-execution'
   }
+  windowsMirror = $null
   finalStatus = 'succeeded'
 }
 $receipt | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path $resolvedResultsRoot 'local-refinement.json') -Encoding utf8

--- a/tools/Invoke-NILinuxReviewSuite.ps1
+++ b/tools/Invoke-NILinuxReviewSuite.ps1
@@ -311,7 +311,8 @@ function Resolve-FlagScenarioParallelBudget {
     [Parameter(Mandatory = $true)][string]$RepoRoot,
     [Parameter(Mandatory = $true)][string]$ResultsRoot,
     [Parameter(Mandatory = $true)][int]$RequestedParallelism,
-    [AllowEmptyString()][string]$HostRamBudgetPath
+    [AllowEmptyString()][string]$HostRamBudgetPath,
+    [AllowEmptyString()][string]$ReuseContainerName
   )
 
   $budgetPathResolved = if ([string]::IsNullOrWhiteSpace($HostRamBudgetPath)) {
@@ -374,6 +375,10 @@ function Resolve-FlagScenarioParallelBudget {
     $actualParallelism = 1
     $reason = 'threadjob-unavailable'
   }
+  if (-not [string]::IsNullOrWhiteSpace($ReuseContainerName)) {
+    $actualParallelism = 1
+    $reason = 'reuse-container-single-runtime'
+  }
 
   return [pscustomobject]@{
     targetProfile = $targetProfile
@@ -386,6 +391,34 @@ function Resolve-FlagScenarioParallelBudget {
     threadJobAvailable = [bool]$threadJobAvailable
     report = $budgetReport
   }
+}
+
+function Select-FlagScenarioWorkerResult {
+  param([AllowNull()]$InvocationResult)
+
+  $canonicalResults = New-Object System.Collections.Generic.List[object]
+  foreach ($candidate in @($InvocationResult)) {
+    if ($null -eq $candidate) {
+      continue
+    }
+
+    $properties = $candidate.PSObject.Properties
+    if (
+      $properties['name'] -and
+      $properties['scenarioDir'] -and
+      $properties['reportPath'] -and
+      $properties['capturePath'] -and
+      $properties['runtimeSnapshotPath']
+    ) {
+      $canonicalResults.Add($candidate) | Out-Null
+    }
+  }
+
+  if ($canonicalResults.Count -eq 0) {
+    return $null
+  }
+
+  return $canonicalResults[$canonicalResults.Count - 1]
 }
 
 function Invoke-FlagScenarioCompares {
@@ -507,7 +540,11 @@ function Invoke-FlagScenarioCompares {
   $resultBuffer = New-Object System.Collections.Generic.List[object]
   if ($Parallelism -le 1) {
     for ($i = 0; $i -lt $ScenarioDefinitions.Count; $i++) {
-      $resultBuffer.Add((& $worker $i $ScenarioDefinitions[$i] $RepoRoot $FlagScenarioRoot $CompareScriptPath $BaseVi $HeadVi $Image $LabVIEWPath $TimeoutSeconds $HeartbeatSeconds $RuntimeEngineReadyTimeoutSeconds $RuntimeEngineReadyPollSeconds $ReuseContainerName $ReuseRepoHostPath $ReuseRepoContainerPath $ReuseResultsHostPath $ReuseResultsContainerPath $RuntimeInjectionMount)) | Out-Null
+      $workerResult = Select-FlagScenarioWorkerResult -InvocationResult (& $worker $i $ScenarioDefinitions[$i] $RepoRoot $FlagScenarioRoot $CompareScriptPath $BaseVi $HeadVi $Image $LabVIEWPath $TimeoutSeconds $HeartbeatSeconds $RuntimeEngineReadyTimeoutSeconds $RuntimeEngineReadyPollSeconds $ReuseContainerName $ReuseRepoHostPath $ReuseRepoContainerPath $ReuseResultsHostPath $ReuseResultsContainerPath $RuntimeInjectionMount)
+      if ($null -eq $workerResult) {
+        throw ("NI Linux review suite scenario '{0}' worker did not emit a canonical result." -f [string]$ScenarioDefinitions[$i].name)
+      }
+      $resultBuffer.Add($workerResult) | Out-Null
     }
     return @($resultBuffer.ToArray() | Sort-Object sequence)
   }
@@ -519,7 +556,7 @@ function Invoke-FlagScenarioCompares {
       if ($null -eq $completedJob) {
         continue
       }
-      $jobResult = @(Receive-Job -Job $completedJob -ErrorAction SilentlyContinue) | Select-Object -Last 1
+      $jobResult = Select-FlagScenarioWorkerResult -InvocationResult @(Receive-Job -Job $completedJob -ErrorAction SilentlyContinue)
       if ($jobResult) {
         $resultBuffer.Add($jobResult) | Out-Null
       }
@@ -536,7 +573,7 @@ function Invoke-FlagScenarioCompares {
     if ($null -eq $completedJob) {
       continue
     }
-    $jobResult = @(Receive-Job -Job $completedJob -ErrorAction SilentlyContinue) | Select-Object -Last 1
+    $jobResult = Select-FlagScenarioWorkerResult -InvocationResult @(Receive-Job -Job $completedJob -ErrorAction SilentlyContinue)
     if ($jobResult) {
       $resultBuffer.Add($jobResult) | Out-Null
     }
@@ -753,7 +790,8 @@ $flagScenarioParallelBudget = Resolve-FlagScenarioParallelBudget `
   -RepoRoot $repoRootResolved `
   -ResultsRoot $resultsRootResolved `
   -RequestedParallelism $FlagScenarioParallelism `
-  -HostRamBudgetPath $hostRamBudgetPathResolved
+  -HostRamBudgetPath $hostRamBudgetPathResolved `
+  -ReuseContainerName $ReuseContainerName
 $historyRefSelection = Resolve-HistoryRefSelection -RequestedBranchRef $HistoryBranchRef -RequestedBaselineRef $HistoryBaselineRef
 
 Write-Host ("[ni-linux-review-suite] resultsRoot={0}" -f $resultsRootResolved) -ForegroundColor Cyan
@@ -782,8 +820,13 @@ $flagScenarioOutputs = Invoke-FlagScenarioCompares `
   -RuntimeInjectionMount $RuntimeInjectionMount
 
 foreach ($scenarioOutput in @($flagScenarioOutputs)) {
-  if (-not [string]::IsNullOrWhiteSpace([string]$scenarioOutput.errorMessage)) {
-    throw ([string]$scenarioOutput.errorMessage)
+  $scenarioErrorMessage = if ($scenarioOutput.PSObject.Properties['errorMessage']) {
+    [string]$scenarioOutput.errorMessage
+  } else {
+    ''
+  }
+  if (-not [string]::IsNullOrWhiteSpace($scenarioErrorMessage)) {
+    throw $scenarioErrorMessage
   }
 
   $scenarioName = [string]$scenarioOutput.name

--- a/tools/Invoke-VIHistoryLocalOperatorSession.ps1
+++ b/tools/Invoke-VIHistoryLocalOperatorSession.ps1
@@ -400,6 +400,17 @@ $hostRamBudget = if ($localRefinementReceipt -and $localRefinementReceipt.PSObje
 } else {
   $null
 }
+$windowsMirrorPayload = if (
+  $localRefinementReceipt -and
+  $localRefinementReceipt.PSObject.Properties['windowsMirror'] -and
+  $localRefinementReceipt.windowsMirror
+) {
+  $localRefinementReceipt.windowsMirror
+} else {
+  $null
+}
+$windowsMirrorHostPreflight = Get-OptionalObjectValue -InputObject $windowsMirrorPayload -Name 'hostPreflight'
+$windowsMirrorCompare = Get-OptionalObjectValue -InputObject $windowsMirrorPayload -Name 'compare'
 
 $sessionReceipt = [ordered]@{
   schema = 'comparevi/local-operator-session@v1'
@@ -421,7 +432,7 @@ $sessionReceipt = [ordered]@{
       benchmarkSampleKind = [string]$localRefinementReceipt.benchmarkSampleKind
       hostRamBudget = if ($localRefinementReceipt.PSObject.Properties['hostRamBudget']) { $localRefinementReceipt.hostRamBudget } else { $null }
       timings = $localRefinementReceipt.timings
-      windowsMirror = if ($localRefinementReceipt.PSObject.Properties['windowsMirror']) { $localRefinementReceipt.windowsMirror } else { $null }
+      windowsMirror = $windowsMirrorPayload
       finalStatus = [string]$localRefinementReceipt.finalStatus
     }
   } else {
@@ -444,10 +455,10 @@ $sessionReceipt = [ordered]@{
     warmRuntimeStatePath = if ($warmRuntimeArtifacts) { [string]$warmRuntimeArtifacts.statePath } else { $null }
     warmRuntimeHealthPath = if ($warmRuntimeArtifacts) { [string]$warmRuntimeArtifacts.healthPath } else { $null }
     warmRuntimeLeasePath = if ($warmRuntimeArtifacts) { [string]$warmRuntimeArtifacts.leasePath } else { $null }
-    windowsMirrorHostPreflightPath = if ($localRefinementReceipt -and $localRefinementReceipt.PSObject.Properties['windowsMirror']) { [string]$localRefinementReceipt.windowsMirror.hostPreflight.path } else { $null }
-    windowsMirrorReportPath = if ($localRefinementReceipt -and $localRefinementReceipt.PSObject.Properties['windowsMirror']) { [string]$localRefinementReceipt.windowsMirror.compare.reportPath } else { $null }
-    windowsMirrorCapturePath = if ($localRefinementReceipt -and $localRefinementReceipt.PSObject.Properties['windowsMirror']) { [string]$localRefinementReceipt.windowsMirror.compare.capturePath } else { $null }
-    windowsMirrorRuntimeSnapshotPath = if ($localRefinementReceipt -and $localRefinementReceipt.PSObject.Properties['windowsMirror']) { [string]$localRefinementReceipt.windowsMirror.compare.runtimeSnapshotPath } else { $null }
+    windowsMirrorHostPreflightPath = [string](Get-OptionalObjectValue -InputObject $windowsMirrorHostPreflight -Name 'path')
+    windowsMirrorReportPath = [string](Get-OptionalObjectValue -InputObject $windowsMirrorCompare -Name 'reportPath')
+    windowsMirrorCapturePath = [string](Get-OptionalObjectValue -InputObject $windowsMirrorCompare -Name 'capturePath')
+    windowsMirrorRuntimeSnapshotPath = [string](Get-OptionalObjectValue -InputObject $windowsMirrorCompare -Name 'runtimeSnapshotPath')
     reviewReceiptPath = [string]$reviewOutputsPayload.receiptPath
     reviewBundlePath = [string]$reviewOutputsPayload.reviewBundlePath
     workspaceHtmlPath = [string]$reviewOutputsPayload.workspaceHtmlPath

--- a/tools/Invoke-VIHistoryLocalRefinement.ps1
+++ b/tools/Invoke-VIHistoryLocalRefinement.ps1
@@ -439,6 +439,14 @@ if ($Profile -eq 'warm-dev') {
   $reviewParams.ReuseRepoContainerPath = [string]$warmRuntimeState.mounts.repoContainerPath
   $reviewParams.ReuseResultsHostPath = [string]$warmRuntimeState.mounts.resultsHostPath
   $reviewParams.ReuseResultsContainerPath = [string]$warmRuntimeState.mounts.resultsContainerPath
+  $reviewParams.FlagScenarioParallelism = if (
+    $hostRamBudget -and
+    $hostRamBudget.PSObject.Properties['actualParallelism']
+  ) {
+    [int]$hostRamBudget.actualParallelism
+  } else {
+    1
+  }
 } else {
   $hostRamBudgetPathResolved = if ([string]::IsNullOrWhiteSpace($HostRamBudgetPath)) {
     Get-DefaultLocalRefinementHostRamBudgetPath -ProfileName $Profile -ResultsRootResolved $resultsRootResolved -WarmRuntimeDirResolved $null
@@ -457,6 +465,9 @@ if ($Profile -eq 'warm-dev') {
     -BudgetPath $hostRamBudgetReport.path `
     -RequestedParallelism $HeavyExecutionParallelism `
     -ReasonWhenParallelEligible 'single-review-execution'
+  if ($HeavyExecutionParallelism -gt 0) {
+    $reviewParams.FlagScenarioParallelism = $HeavyExecutionParallelism
+  }
 }
 
 $timer = [System.Diagnostics.Stopwatch]::StartNew()

--- a/tools/Run-NILinuxContainerCompare.ps1
+++ b/tools/Run-NILinuxContainerCompare.ps1
@@ -2625,7 +2625,8 @@ try {
     $dockerArgs += @('--env', ("COMPARE_REPORT_TYPE={0}" -f $reportInfo.CliReportType))
     $dockerArgs += @('--env', ("COMPARE_FLAGS_B64={0}" -f $flagsB64))
     $dockerArgs += @('--env', 'LV_RTE_HEADLESS=1')
-    $dockerArgs += @('--env', ("COMPARE_PRELAUNCH_ENABLED={0}" -f 1))
+    $prelaunchEnabled = if ($useExistingContainer) { 0 } else { 1 }
+    $dockerArgs += @('--env', ("COMPARE_PRELAUNCH_ENABLED={0}" -f $prelaunchEnabled))
     $dockerArgs += @('--env', ("COMPARE_PRELAUNCH_WAIT_SECONDS={0}" -f [Math]::Max(0, $PrelaunchWaitSeconds)))
     $dockerArgs += @('--env', ("COMPARE_STARTUP_RETRY_COUNT={0}" -f [Math]::Max(0, $StartupRetryCount)))
     $dockerArgs += @('--env', ("COMPARE_RETRY_DELAY_SECONDS={0}" -f [Math]::Max(0, $RetryDelaySeconds)))


### PR DESCRIPTION
# Summary
Fixes #1452 by making warm-dev operator-session proof succeed end to end on a reused warm container. This PR also closes #1454, #1455, and #1456 by serializing reused-container flag scenarios, normalizing noisy review-suite worker output, and treating Linux-side `windowsMirror` payloads as optional during operator-session receipt projection.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context:
  - `#1452` standing-priority warm-dev live proof regression
  - closes `#1454`, `#1455`, `#1456`
- Files, tools, workflows, or policies touched:
  - `tools/Run-NILinuxContainerCompare.ps1`
  - `tools/Invoke-VIHistoryLocalRefinement.ps1`
  - `tools/Invoke-NILinuxReviewSuite.ps1`
  - `tools/Invoke-VIHistoryLocalOperatorSession.ps1`
  - focused Pester coverage for compare runner, review-suite RAM planning/certification, local refinement, and operator session
- Cross-repo or external-consumer impact:
  - restores a real `warm-dev` operator-session proof surface for downstream local-first consumers
- Required checks, merge-queue behavior, or approval flows affected:
  - no policy changes; pre-push and existing CI contracts remain the gate

## Validation Evidence

- Commands run:
  - `pwsh -NoLogo -NoProfile -File tests/Run-NILinuxContainerCompare.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tests/NILinuxReviewSuiteRamBudget.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tests/NILinuxReviewSuiteCertification.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tests/VIHistoryLocalAcceleration.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tests/VIHistoryLocalOperatorSession.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
  - `pwsh -NoLogo -NoProfile -File tools/Invoke-VIHistoryLocalOperatorSession.ps1 -Profile warm-dev -ResultsRoot tests/results/local-operator-session-1452/warm-dev -WarmRuntimeDir tests/results/local-operator-session-1452/runtime/warm-dev -PassThru`
- Key artifacts, logs, or workflow runs:
  - `tests/results/local-operator-session-1452/warm-dev/local-operator-session.json`
  - `tests/results/local-operator-session-1452/warm-dev/local-refinement.json`
  - `tests/results/local-operator-session-1452/warm-dev/review-suite-summary.json`
  - `tests/results/local-operator-session-1452/warm-dev/flag-combinations/baseline/ni-linux-container-capture.json`
- Risk-based checks not run:
  - no hosted CI run yet; this PR is the dispatch surface

## Risks and Follow-ups

- Residual risks:
  - warm-dev proof is still a long-running lane and remains sensitive to Docker Desktop / NI image startup time
- Follow-up issues or deferred work:
  - none deferred from this slice
- Deployment, approval, or rollback notes:
  - rollback is limited to the four local VI history orchestration scripts and focused tests above

## Reviewer Focus

- Please verify:
  - reused-container compare execution stays serial in warm-dev
  - review-suite aggregation tolerates noisy worker output
  - operator-session receipts omit Windows mirror artifacts cleanly on Linux profiles
- Areas where the reasoning is subtle:
  - the fix is intentionally split across compare runner, refinement wrapper, review suite, and operator-session projection because the live proof surfaced sequential defects in all four seams
- Manual spot checks requested:
  - inspect `tests/results/local-operator-session-1452/warm-dev/local-operator-session.json` for `finalStatus = succeeded`
