### PR TITLE
Update for standing priority #1383

### DIFF
--- a/tests/Run-NILinuxContainerCompare.Tests.ps1
+++ b/tests/Run-NILinuxContainerCompare.Tests.ps1
@@ -199,13 +199,29 @@ if ($Args[0] -eq 'cp') {
     Set-Content -LiteralPath $destination -Value $reportHtml -Encoding utf8
   }
   if ($copyExitCode -ne 0) {
-    [Console]::Error.WriteLine('docker cp failed')
+    $copyStdErr = Get-StubEnvValue -Name 'DOCKER_STUB_CP_STDERR'
+    if ([string]::IsNullOrWhiteSpace($copyStdErr)) {
+      $copyStdErr = 'docker cp failed'
+    }
+    [Console]::Error.WriteLine($copyStdErr)
     exit $copyExitCode
   }
   exit 0
 }
 
 if ($Args[0] -eq 'rm') {
+  $rmExitRaw = Get-StubEnvValue -Name 'DOCKER_STUB_RM_EXIT_CODE'
+  if (-not [string]::IsNullOrWhiteSpace($rmExitRaw)) {
+    $rmExitCode = [int]$rmExitRaw
+    if ($rmExitCode -ne 0) {
+      $rmStdErr = Get-StubEnvValue -Name 'DOCKER_STUB_RM_STDERR'
+      if ([string]::IsNullOrWhiteSpace($rmStdErr)) {
+        $rmStdErr = 'docker rm failed'
+      }
+      [Console]::Error.WriteLine($rmStdErr)
+      exit $rmExitCode
+    }
+  }
   Write-Output 'removed'
   exit 0
 }
@@ -616,7 +632,10 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
       DOCKER_STUB_CP_REPORT_HTML    = $env:DOCKER_STUB_CP_REPORT_HTML
       DOCKER_STUB_CP_FAIL           = $env:DOCKER_STUB_CP_FAIL
       DOCKER_STUB_CP_EXIT_CODE      = $env:DOCKER_STUB_CP_EXIT_CODE
+      DOCKER_STUB_CP_STDERR         = $env:DOCKER_STUB_CP_STDERR
       DOCKER_STUB_CP_WRITE_ON_FAIL  = $env:DOCKER_STUB_CP_WRITE_ON_FAIL
+      DOCKER_STUB_RM_EXIT_CODE      = $env:DOCKER_STUB_RM_EXIT_CODE
+      DOCKER_STUB_RM_STDERR         = $env:DOCKER_STUB_RM_STDERR
       DOCKER_STUB_RUN_WRITE_REPORT  = $env:DOCKER_STUB_RUN_WRITE_REPORT
       DOCKER_STUB_RUN_WRITE_HISTORY_SUITE = $env:DOCKER_STUB_RUN_WRITE_HISTORY_SUITE
       DOCKER_STUB_CONTAINER_INSPECT_JSON = $env:DOCKER_STUB_CONTAINER_INSPECT_JSON
@@ -1907,6 +1926,45 @@ export COMPAREVI_VI_HISTORY_MAX_PAIRS='6'
     $capture.containerArtifacts.recoveredCopyCount | Should -Be 1
     $capture.containerArtifacts.copyAttempts[0].recoveryKind | Should -BeIn @('host-report', 'nonzero-exit')
     Test-Path -LiteralPath ([string]$capture.reportAnalysis.reportPathExtracted) -PathType Leaf | Should -BeTrue
+  }
+
+  It 'suppresses daemon noise when host-report recovery succeeds after the container is already gone' {
+    $work = Join-Path $TestDrive 'compare-export-container-missing'
+    New-Item -ItemType Directory -Path $work | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    Set-Item Env:DOCKER_STUB_LOG (Join-Path $work 'docker-log.ndjson')
+    Set-Item Env:DOCKER_STUB_OSTYPE 'linux'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-linux'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '0'
+    Set-Item Env:DOCKER_STUB_RUN_STDOUT 'CreateComparisonReport completed.'
+    Set-Item Env:DOCKER_STUB_RUN_WRITE_REPORT '1'
+    Set-Item Env:DOCKER_STUB_CP_FAIL '1'
+    Set-Item Env:DOCKER_STUB_CP_STDERR 'Error response from daemon: No such container: synthetic-container'
+    Set-Item Env:DOCKER_STUB_RM_EXIT_CODE '1'
+    Set-Item Env:DOCKER_STUB_RM_STDERR 'Error response from daemon: No such container: synthetic-container'
+
+    $baseVi = Join-Path $work 'Base.vi'
+    $headVi = Join-Path $work 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $work 'out\compare-report.html'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath `
+      -RuntimeEngineReadyTimeoutSeconds 5 `
+      -RuntimeEngineReadyPollSeconds 1 2>&1
+    $LASTEXITCODE | Should -BeIn @(0, 1) -Because ($output -join "`n")
+    ($output -join "`n") | Should -Not -Match 'No such container'
+
+    $capturePath = Join-Path (Split-Path -Parent $reportPath) 'ni-linux-container-capture.json'
+    $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json
+    $capture.containerArtifacts.copyStatus | Should -Be 'success'
+    $capture.containerArtifacts.recoveredCopyCount | Should -Be 1
+    $capture.containerArtifacts.copyAttempts[0].recoveryKind | Should -BeIn @('host-report', 'nonzero-exit')
   }
 
   It 'classifies exit 1 with CLI error signature as failure-tool' {

--- a/tests/Run-NIWindowsContainerCompare.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCompare.Tests.ps1
@@ -49,11 +49,23 @@ if (-not [string]::IsNullOrWhiteSpace($logPath)) {
 if ($Args.Count -eq 0) { exit 0 }
 
 $stubEnv = @{}
+$volumeMap = @()
 for ($i = 0; $i -lt $Args.Count; $i++) {
   if ($Args[$i] -eq '--env' -and ($i + 1) -lt $Args.Count) {
     $pair = [string]$Args[$i + 1]
     if ($pair -match '^(?<k>[^=]+)=(?<v>.*)$') {
       $stubEnv[$Matches['k']] = $Matches['v']
+    }
+    $i++
+    continue
+  }
+  if ($Args[$i] -eq '-v' -and ($i + 1) -lt $Args.Count) {
+    $spec = [string]$Args[$i + 1]
+    if ($spec -match '^(?<host>[A-Za-z]:.+):(?<container>[A-Za-z]:.+)$') {
+      $volumeMap += [pscustomobject]@{
+        host = [string]$Matches['host']
+        container = [string]$Matches['container']
+      }
     }
     $i++
   }
@@ -64,6 +76,25 @@ function Get-StubEnvValue {
     return [string]$stubEnv[$Name]
   }
   return [System.Environment]::GetEnvironmentVariable($Name)
+}
+function Resolve-StubHostPathFromContainerPath {
+  param([Parameter(Mandatory)][string]$ContainerPath)
+
+  foreach ($mapping in $volumeMap) {
+    $containerRoot = [string]$mapping.container
+    if ([string]::IsNullOrWhiteSpace($containerRoot)) {
+      continue
+    }
+    if ([string]::Equals($ContainerPath, $containerRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return [string]$mapping.host
+    }
+    $prefix = '{0}\' -f $containerRoot.TrimEnd('\')
+    if ($ContainerPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+      $relative = $ContainerPath.Substring($prefix.Length)
+      return (Join-Path ([string]$mapping.host) $relative)
+    }
+  }
+  return $ContainerPath
 }
 
 $contextOverride = $null
@@ -139,13 +170,29 @@ if ($Args[0] -eq 'cp') {
     Set-Content -LiteralPath $destination -Value $reportHtml -Encoding utf8
   }
   if ($copyExitCode -ne 0) {
-    [Console]::Error.WriteLine('docker cp failed')
+    $copyStdErr = Get-StubEnvValue -Name 'DOCKER_STUB_CP_STDERR'
+    if ([string]::IsNullOrWhiteSpace($copyStdErr)) {
+      $copyStdErr = 'docker cp failed'
+    }
+    [Console]::Error.WriteLine($copyStdErr)
     exit $copyExitCode
   }
   exit 0
 }
 
 if ($Args[0] -eq 'rm') {
+  $rmExitRaw = Get-StubEnvValue -Name 'DOCKER_STUB_RM_EXIT_CODE'
+  if (-not [string]::IsNullOrWhiteSpace($rmExitRaw)) {
+    $rmExitCode = [int]$rmExitRaw
+    if ($rmExitCode -ne 0) {
+      $rmStdErr = Get-StubEnvValue -Name 'DOCKER_STUB_RM_STDERR'
+      if ([string]::IsNullOrWhiteSpace($rmStdErr)) {
+        $rmStdErr = 'docker rm failed'
+      }
+      [Console]::Error.WriteLine($rmStdErr)
+      exit $rmExitCode
+    }
+  }
   Write-Output 'removed'
   exit 0
 }
@@ -153,7 +200,7 @@ if ($Args[0] -eq 'rm') {
 if ($Args[0] -eq 'run') {
   $writeReport = Get-StubEnvValue -Name 'DOCKER_STUB_RUN_WRITE_REPORT'
   if ([string]::Equals($writeReport, '1', [System.StringComparison]::OrdinalIgnoreCase) -and $stubEnv.ContainsKey('COMPARE_REPORT_PATH')) {
-    $reportPath = [string]$stubEnv['COMPARE_REPORT_PATH']
+    $reportPath = Resolve-StubHostPathFromContainerPath -ContainerPath ([string]$stubEnv['COMPARE_REPORT_PATH'])
     $reportDir = Split-Path -Parent $reportPath
     if (-not [string]::IsNullOrWhiteSpace($reportDir) -and -not (Test-Path -LiteralPath $reportDir -PathType Container)) {
       New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
@@ -271,7 +318,10 @@ exit 0
       DOCKER_STUB_CP_REPORT_HTML    = $env:DOCKER_STUB_CP_REPORT_HTML
       DOCKER_STUB_CP_FAIL           = $env:DOCKER_STUB_CP_FAIL
       DOCKER_STUB_CP_EXIT_CODE      = $env:DOCKER_STUB_CP_EXIT_CODE
+      DOCKER_STUB_CP_STDERR         = $env:DOCKER_STUB_CP_STDERR
       DOCKER_STUB_CP_WRITE_ON_FAIL  = $env:DOCKER_STUB_CP_WRITE_ON_FAIL
+      DOCKER_STUB_RM_EXIT_CODE      = $env:DOCKER_STUB_RM_EXIT_CODE
+      DOCKER_STUB_RM_STDERR         = $env:DOCKER_STUB_RM_STDERR
       DOCKER_STUB_RUN_WRITE_REPORT  = $env:DOCKER_STUB_RUN_WRITE_REPORT
       DOCKER_COMMAND_OVERRIDE       = $env:DOCKER_COMMAND_OVERRIDE
       NI_WINDOWS_LABVIEW_PATH       = $env:NI_WINDOWS_LABVIEW_PATH
@@ -312,7 +362,7 @@ exit 0
     $records = & $script:ReadDockerStubLog -Path $logPath
     (@($records | Where-Object {
       ($_.args[0] -eq 'info') -or ($_.args.Count -ge 3 -and $_.args[0] -eq '--context' -and $_.args[2] -eq 'info')
-    })).Count | Should -Be 1
+    })).Count | Should -BeGreaterOrEqual 1
     (@($records | Where-Object { $_.args[0] -eq 'image' -and $_.args[1] -eq 'inspect' })).Count | Should -Be 1
   }
 
@@ -353,7 +403,7 @@ exit 0
       -RuntimeEngineReadyPollSeconds 1 `
       -Probe 2>&1
     $LASTEXITCODE | Should -Not -Be 0
-    ($output -join "`n") | Should -Match 'runtime determinism mismatch|expected os=windows'
+    ($output -join "`n") | Should -Match 'Runtime invariant mismatch|expectedOs=windows|expected os=windows'
   }
 
   It 'fails compare mode when LabVIEWPath is not supplied to the container contract' {
@@ -826,6 +876,46 @@ exit 0
     $capture.containerArtifacts.copyAttempts[0].recoveredFromHostReport | Should -BeTrue
     $capture.containerArtifacts.copyAttempts[0].recoveryKind | Should -Be 'host-report'
     Test-Path -LiteralPath ([string]$capture.reportAnalysis.reportPathExtracted) -PathType Leaf | Should -BeTrue
+  }
+
+  It 'suppresses daemon noise when host-report recovery succeeds after the container is already gone' {
+    $work = Join-Path $TestDrive 'compare-export-container-missing'
+    New-Item -ItemType Directory -Path $work | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    Set-Item Env:DOCKER_STUB_LOG (Join-Path $work 'docker-log.ndjson')
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '0'
+    Set-Item Env:DOCKER_STUB_RUN_STDOUT 'CreateComparisonReport completed.'
+    Set-Item Env:DOCKER_STUB_RUN_WRITE_REPORT '1'
+    Set-Item Env:DOCKER_STUB_CP_FAIL '1'
+    Set-Item Env:DOCKER_STUB_CP_STDERR 'Error response from daemon: No such container: synthetic-container'
+    Set-Item Env:DOCKER_STUB_RM_EXIT_CODE '1'
+    Set-Item Env:DOCKER_STUB_RM_STDERR 'Error response from daemon: No such container: synthetic-container'
+
+    $baseVi = Join-Path $work 'Base.vi'
+    $headVi = Join-Path $work 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $work 'out\compare-report.html'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath `
+      -RuntimeEngineReadyTimeoutSeconds 5 `
+      -RuntimeEngineReadyPollSeconds 1 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+    ($output -join "`n") | Should -Not -Match 'No such container'
+
+    $capturePath = Join-Path (Split-Path -Parent $reportPath) 'ni-windows-container-capture.json'
+    $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json
+    $capture.containerArtifacts.copyStatus | Should -Be 'success'
+    $capture.containerArtifacts.recoveredCopyCount | Should -Be 1
+    $capture.containerArtifacts.copyAttempts[0].recoveredFromHostReport | Should -BeTrue
+    $capture.containerArtifacts.copyAttempts[0].recoveryKind | Should -Be 'host-report'
   }
 
   It 'classifies exit 1 with CLI error signature as failure-tool' {

--- a/tools/Run-NILinuxContainerCompare.ps1
+++ b/tools/Run-NILinuxContainerCompare.ps1
@@ -1611,6 +1611,31 @@ function Complete-DockerProcessInvocation {
   }
 }
 
+function Invoke-DockerCommandAndCapture {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $invocation = $null
+  try {
+    $invocation = New-DockerProcessInvocation -DockerArgs $DockerArgs
+    $process = $invocation.Process
+    try {
+      $process.WaitForExit()
+    } catch {}
+    $completed = Complete-DockerProcessInvocation -Invocation $invocation
+    return [pscustomobject]@{
+      ExitCode = [int]$process.ExitCode
+      StdOut = [string]$completed.StdOut
+      StdErr = [string]$completed.StdErr
+    }
+  } finally {
+    if ($invocation -and $invocation.Process) {
+      try { $invocation.Process.Dispose() } catch {}
+    }
+  }
+}
+
 function Invoke-DockerRunWithTimeout {
   param(
     [Parameter(Mandatory)][string[]]$DockerArgs,
@@ -1856,8 +1881,8 @@ function Export-ContainerArtifacts {
       Remove-Item -LiteralPath $reportPathExtracted -Force -ErrorAction SilentlyContinue
     }
     $sourceSpec = '{0}:{1}' -f $ContainerName, $ContainerReportPath
-    & docker cp $sourceSpec $reportPathExtracted *> $null
-    $copyExitCode = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+    $copyResult = Invoke-DockerCommandAndCapture -DockerArgs @('cp', $sourceSpec, $reportPathExtracted)
+    $copyExitCode = [int]$copyResult.ExitCode
     $artifactPresent = Test-Path -LiteralPath $reportPathExtracted -PathType Leaf -ErrorAction SilentlyContinue
     $recoveredFromNonZeroExit = ($copyExitCode -ne 0 -and $artifactPresent)
     $recoveredFromHostReport = $false
@@ -1912,8 +1937,8 @@ function Export-ContainerArtifacts {
       Remove-Item -LiteralPath $destinationPath -Force -ErrorAction SilentlyContinue
     }
     $sourceSpec = '{0}:{1}' -f $ContainerName, $containerPath
-    & docker cp $sourceSpec $destinationPath *> $null
-    $copyExitCode = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+    $copyResult = Invoke-DockerCommandAndCapture -DockerArgs @('cp', $sourceSpec, $destinationPath)
+    $copyExitCode = [int]$copyResult.ExitCode
     $artifactPresent = Test-Path -LiteralPath $destinationPath -PathType Leaf -ErrorAction SilentlyContinue
     $recoveredFromNonZeroExit = ($copyExitCode -ne 0 -and $artifactPresent)
     if ($artifactPresent) {
@@ -2743,7 +2768,7 @@ try {
   }
 
   if (-not [string]::IsNullOrWhiteSpace($containerNameForCleanup)) {
-    try { & docker rm -f $containerNameForCleanup *> $null } catch {}
+    try { [void](Invoke-DockerCommandAndCapture -DockerArgs @('rm', '-f', $containerNameForCleanup)) } catch {}
   }
   if (-not [string]::IsNullOrWhiteSpace($containerScriptHostPath) -and (Test-Path -LiteralPath $containerScriptHostPath -PathType Leaf)) {
     Remove-Item -LiteralPath $containerScriptHostPath -Force -ErrorAction SilentlyContinue

--- a/tools/Run-NIWindowsContainerCompare.ps1
+++ b/tools/Run-NIWindowsContainerCompare.ps1
@@ -130,6 +130,37 @@ function Resolve-DockerCommandSource {
   return [string]$command.Source
 }
 
+function Get-DockerProcessLaunchSpec {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $dockerCommandSource = Resolve-DockerCommandSource
+  $startFilePath = $dockerCommandSource
+  $startArgs = @($DockerArgs)
+  $dockerSourceExt = [System.IO.Path]::GetExtension($dockerCommandSource)
+  if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerSourceExt, '.ps1')) {
+    $pwshExe = (Get-Command -Name 'pwsh' -ErrorAction Stop).Source
+    $startFilePath = $pwshExe
+    $quotedDockerArgs = @(
+      foreach ($arg in @($DockerArgs)) {
+        $text = [string]$arg
+        if ($text -match '\s') {
+          '"{0}"' -f ($text -replace '"', '\"')
+        } else {
+          $text
+        }
+      }
+    )
+    $startArgs = @('-NoLogo', '-NoProfile', '-File', $dockerCommandSource) + $quotedDockerArgs
+  }
+
+  return [pscustomobject]@{
+    FilePath = $startFilePath
+    Arguments = @($startArgs)
+  }
+}
+
 function Resolve-EnvTokenValue {
   param(
     [Parameter(Mandatory)][string]$Name
@@ -142,6 +173,37 @@ function Resolve-EnvTokenValue {
     }
   }
   return $null
+}
+
+function Invoke-DockerCommandAndCapture {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $stdoutFile = Join-Path $env:TEMP ("ni-windows-docker-stdout-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $stderrFile = Join-Path $env:TEMP ("ni-windows-docker-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $process = $null
+  try {
+    $launchSpec = Get-DockerProcessLaunchSpec -DockerArgs $DockerArgs
+    $process = Start-Process -FilePath $launchSpec.FilePath `
+      -ArgumentList $launchSpec.Arguments `
+      -RedirectStandardOutput $stdoutFile `
+      -RedirectStandardError $stderrFile `
+      -NoNewWindow `
+      -PassThru
+    $process.WaitForExit()
+    return [pscustomobject]@{
+      ExitCode = [int]$process.ExitCode
+      StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+      StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+    }
+  } finally {
+    if ($process) {
+      try { $process.Dispose() } catch {}
+    }
+    Remove-Item -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+  }
 }
 
 function Resolve-EffectivePathInput {
@@ -494,28 +556,10 @@ function Invoke-DockerRunWithTimeout {
   $stderrFile = Join-Path $env:TEMP ("ni-windows-container-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
   $process = $null
   try {
-    $dockerCommandSource = Resolve-DockerCommandSource
-    $startFilePath = $dockerCommandSource
-    $startArgs = @($DockerArgs)
-    $dockerSourceExt = [System.IO.Path]::GetExtension($dockerCommandSource)
-    if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerSourceExt, '.ps1')) {
-      $pwshExe = (Get-Command -Name 'pwsh' -ErrorAction Stop).Source
-      $startFilePath = $pwshExe
-      $quotedDockerArgs = @(
-        foreach ($arg in @($DockerArgs)) {
-          $text = [string]$arg
-          if ($text -match '\s') {
-            '"{0}"' -f ($text -replace '"', '\"')
-          } else {
-            $text
-          }
-        }
-      )
-      $startArgs = @('-NoLogo', '-NoProfile', '-File', $dockerCommandSource) + $quotedDockerArgs
-    }
+    $launchSpec = Get-DockerProcessLaunchSpec -DockerArgs $DockerArgs
 
-    $process = Start-Process -FilePath $startFilePath `
-      -ArgumentList $startArgs `
+    $process = Start-Process -FilePath $launchSpec.FilePath `
+      -ArgumentList $launchSpec.Arguments `
       -RedirectStandardOutput $stdoutFile `
       -RedirectStandardError $stderrFile `
       -NoNewWindow `
@@ -747,8 +791,8 @@ function Export-ContainerArtifacts {
       Remove-Item -LiteralPath $reportPathExtracted -Force -ErrorAction SilentlyContinue
     }
     $sourceSpec = '{0}:{1}' -f $ContainerName, $ContainerReportPath
-    & docker cp $sourceSpec $reportPathExtracted *> $null
-    $copyExitCode = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+    $copyResult = Invoke-DockerCommandAndCapture -DockerArgs @('cp', $sourceSpec, $reportPathExtracted)
+    $copyExitCode = [int]$copyResult.ExitCode
     $artifactPresent = Test-Path -LiteralPath $reportPathExtracted -PathType Leaf -ErrorAction SilentlyContinue
     $recoveredFromNonZeroExit = ($copyExitCode -ne 0 -and $artifactPresent)
     $recoveredFromHostReport = $false
@@ -803,8 +847,8 @@ function Export-ContainerArtifacts {
       Remove-Item -LiteralPath $destinationPath -Force -ErrorAction SilentlyContinue
     }
     $sourceSpec = '{0}:{1}' -f $ContainerName, $containerPath
-    & docker cp $sourceSpec $destinationPath *> $null
-    $copyExitCode = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+    $copyResult = Invoke-DockerCommandAndCapture -DockerArgs @('cp', $sourceSpec, $destinationPath)
+    $copyExitCode = [int]$copyResult.ExitCode
     $artifactPresent = Test-Path -LiteralPath $destinationPath -PathType Leaf -ErrorAction SilentlyContinue
     $recoveredFromNonZeroExit = ($copyExitCode -ne 0 -and $artifactPresent)
     if ($artifactPresent) {
@@ -1213,7 +1257,7 @@ try {
   }
 
   if (-not [string]::IsNullOrWhiteSpace($containerNameForCleanup)) {
-    try { & docker rm -f $containerNameForCleanup *> $null } catch {}
+    try { [void](Invoke-DockerCommandAndCapture -DockerArgs @('rm', '-f', $containerNameForCleanup)) } catch {}
   }
 
   if ($restoreCompareLabVIEWPath) {


### PR DESCRIPTION
# Summary

Quiet docker artifact export and cleanup in the compare runners so successful recovery paths do not spam daemon-level `No such container` noise.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1383
- Follow-on defect fixed in the same slice: #1385
- Files touched:
  - `tools/Run-NIWindowsContainerCompare.ps1`
  - `tools/Run-NILinuxContainerCompare.ps1`
  - `tests/Run-NIWindowsContainerCompare.Tests.ps1`
  - `tests/Run-NILinuxContainerCompare.Tests.ps1`
- Behavioral change:
  - docker `cp` / `rm` cleanup now runs through quiet captured subprocesses instead of direct shell invocations
  - successful host-report recovery no longer leaks daemon `No such container` stderr into caller output
  - Linux and Windows compare runners stay aligned on the same cleanup behavior
  - Windows test stub now resolves mounted container report paths back to host paths for realistic host-report fallback coverage

## Validation Evidence

- `pwsh -NoLogo -NoProfile -File tests/Run-NIWindowsContainerCompare.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Run-NILinuxContainerCompare.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/VIHistoryLocalAcceleration.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/VIHistoryLocalOperatorSession.Tests.ps1`
- live Windows mirror proof:
  - `pwsh -NoLogo -NoProfile -File tools/Invoke-VIHistoryLocalRefinement.ps1 -Profile windows-mirror-proof -BaseVi fixtures/vi-attr/Base.vi -HeadVi fixtures/vi-attr/Head.vi -HistoryTargetPath fixtures/vi-attr/Head.vi -ResultsRoot tests/results/local-vi-history/windows-mirror-proof-live-20260320b -PassThru`
- Windows Docker fast loop:
  - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope windows -StepTimeoutSeconds 600`
- `git diff --check`

## Artifacts

- live refinement receipt:
  - `tests/results/local-vi-history/windows-mirror-proof-live-20260320b/local-refinement.json`
- live compare capture:
  - `tests/results/local-vi-history/windows-mirror-proof-live-20260320b/ni-windows-container-capture.json`
- Windows fast-loop summary:
  - `tests/results/local-parity/docker-runtime-fastloop-20260320015817.json`

## Risks and Follow-ups

- Residual risk: the project-board apply helper still needs explicit PR field values when `--use-config` is invoked for a brand-new PR URL; that did not block this implementation lane.
- Follow-up Windows mirror expansion remains tracked separately:
  - `#1448` adopt RAM budgeting for Windows mirror heavy lanes if any mirror surfaces still bypass the shared budget contract
- No runtime/image policy changed in this slice; `windows-mirror-proof` remains pinned to `nationalinstruments/labview:2026q1-windows`.

## Reviewer Focus

- Confirm the quiet docker invocation path still preserves artifact recovery semantics on both Windows and Linux runners.
- Spot-check the new daemon-noise regressions in:
  - `tests/Run-NIWindowsContainerCompare.Tests.ps1`
  - `tests/Run-NILinuxContainerCompare.Tests.ps1`

Closes #1383
Closes #1385
