### PR TITLE
Update for standing priority #1459

### DIFF
--- a/dist/tools/cli/project-portfolio.js
+++ b/dist/tools/cli/project-portfolio.js
@@ -126,6 +126,7 @@ const resourceQuerySchema = z.object({
             id: z.string().min(1),
             url: z.string().url(),
             title: z.string().min(1).optional(),
+            body: z.string().optional().nullable(),
             repository: z.object({
                 nameWithOwner: z.string().min(1),
             }).optional(),
@@ -168,6 +169,7 @@ const projectScopedResourceQuerySchema = z.object({
             id: z.string().min(1),
             url: z.string().url(),
             title: z.string().min(1).optional(),
+            body: z.string().optional().nullable(),
             repository: z.object({
                 nameWithOwner: z.string().min(1),
             }).optional(),
@@ -398,6 +400,64 @@ function buildConfigItemFromNormalizedItem(item) {
         portfolioTrack: item.portfolioTrack,
     };
 }
+function extractIssueUrlsFromPullRequestBody(body, repositoryNameWithOwner) {
+    if (!body || body.trim().length === 0) {
+        return [];
+    }
+    const issueUrls = new Set();
+    const issueUrlPattern = /^\s*-\s*Issue URL:\s*(https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/issues\/\d+)\s*$/gim;
+    for (const match of body.matchAll(issueUrlPattern)) {
+        const issueUrl = match[1]?.trim();
+        if (issueUrl) {
+            issueUrls.add(issueUrl);
+        }
+    }
+    if (issueUrls.size === 0 && repositoryNameWithOwner) {
+        const primaryIssuePattern = /^\s*-\s*Primary issue:\s*#(\d+)\s*$/gim;
+        for (const match of body.matchAll(primaryIssuePattern)) {
+            const issueNumber = match[1]?.trim();
+            if (issueNumber) {
+                issueUrls.add(`https://github.com/${repositoryNameWithOwner}/issues/${issueNumber}`);
+            }
+        }
+    }
+    return [...issueUrls];
+}
+function dedupeNormalizedItems(items) {
+    const seenUrls = new Set();
+    const dedupedItems = [];
+    for (const item of items) {
+        const comparableUrl = normalizeComparableUrl(item.url);
+        if (seenUrls.has(comparableUrl)) {
+            continue;
+        }
+        seenUrls.add(comparableUrl);
+        dedupedItems.push(item);
+    }
+    return dedupedItems;
+}
+function resolveBodyLinkedIssueContextItems(view, fieldNames, body, repositoryNameWithOwner) {
+    const issueUrls = extractIssueUrlsFromPullRequestBody(body, repositoryNameWithOwner);
+    if (issueUrls.length === 0) {
+        return [];
+    }
+    const linkedContextItems = [];
+    for (const issueUrl of issueUrls) {
+        try {
+            const issueTarget = resolveProjectResourceInView(view, fieldNames, issueUrl);
+            if (issueTarget.existingItem) {
+                linkedContextItems.push(issueTarget.existingItem);
+            }
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (!message.startsWith(`GitHub resource not found for ${issueUrl}.`)) {
+                throw error;
+            }
+        }
+    }
+    return linkedContextItems;
+}
 function resolveInferredConfigItem(targetUrl, normalizedItems, target) {
     const normalizedTargetUrl = normalizeComparableUrl(targetUrl);
     const linkedSnapshotItem = normalizedItems.find((item) => (item.linkedPullRequests.some((pullRequestUrl) => normalizeComparableUrl(pullRequestUrl) === normalizedTargetUrl)
@@ -518,6 +578,7 @@ function resolveProjectResource(url) {
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -526,6 +587,7 @@ function resolveProjectResource(url) {
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -547,6 +609,7 @@ function resolveProjectResourceInView(view, fieldNames, url) {
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -577,6 +640,7 @@ function resolveProjectResourceInView(view, fieldNames, url) {
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -646,11 +710,12 @@ function resolveProjectResourceInView(view, fieldNames, url) {
         id: response.data.resource.id,
         url: response.data.resource.url,
         title: response.data.resource.title,
+        body: response.data.resource.body,
         repository: response.data.resource.repository,
     };
     const existingProjectItem = response.data.resource.projectItems.nodes
         .find((item) => item.project.id === view.id) ?? null;
-    const linkedContextItems = response.data.resource.__typename === 'PullRequest'
+    const graphLinkedContextItems = response.data.resource.__typename === 'PullRequest'
         ? (response.data.resource.closingIssuesReferences?.nodes ?? [])
             .map((linkedIssue) => {
             const linkedIssueProjectItem = linkedIssue.projectItems.nodes.find((item) => item.project.id === view.id) ?? null;
@@ -668,6 +733,13 @@ function resolveProjectResourceInView(view, fieldNames, url) {
         })
             .filter((item) => item !== null)
         : [];
+    const bodyLinkedContextItems = response.data.resource.__typename === 'PullRequest'
+        ? resolveBodyLinkedIssueContextItems(view, fieldNames, response.data.resource.body, response.data.resource.repository?.nameWithOwner ?? null)
+        : [];
+    const linkedContextItems = dedupeNormalizedItems([
+        ...graphLinkedContextItems,
+        ...bodyLinkedContextItems,
+    ]);
     return {
         resource,
         existingItem: existingProjectItem

--- a/tools/cli/project-portfolio.ts
+++ b/tools/cli/project-portfolio.ts
@@ -143,6 +143,7 @@ const resourceQuerySchema = z.object({
       id: z.string().min(1),
       url: z.string().url(),
       title: z.string().min(1).optional(),
+      body: z.string().optional().nullable(),
       repository: z.object({
         nameWithOwner: z.string().min(1),
       }).optional(),
@@ -189,6 +190,7 @@ const projectScopedResourceQuerySchema = z.object({
       id: z.string().min(1),
       url: z.string().url(),
       title: z.string().min(1).optional(),
+      body: z.string().optional().nullable(),
       repository: z.object({
         nameWithOwner: z.string().min(1),
       }).optional(),
@@ -606,6 +608,79 @@ function buildConfigItemFromNormalizedItem(item: NormalizedItem): ConfigItem {
   };
 }
 
+function extractIssueUrlsFromPullRequestBody(
+  body: string | null | undefined,
+  repositoryNameWithOwner: string | null | undefined,
+): string[] {
+  if (!body || body.trim().length === 0) {
+    return [];
+  }
+
+  const issueUrls = new Set<string>();
+  const issueUrlPattern = /^\s*-\s*Issue URL:\s*(https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/issues\/\d+)\s*$/gim;
+  for (const match of body.matchAll(issueUrlPattern)) {
+    const issueUrl = match[1]?.trim();
+    if (issueUrl) {
+      issueUrls.add(issueUrl);
+    }
+  }
+
+  if (issueUrls.size === 0 && repositoryNameWithOwner) {
+    const primaryIssuePattern = /^\s*-\s*Primary issue:\s*#(\d+)\s*$/gim;
+    for (const match of body.matchAll(primaryIssuePattern)) {
+      const issueNumber = match[1]?.trim();
+      if (issueNumber) {
+        issueUrls.add(`https://github.com/${repositoryNameWithOwner}/issues/${issueNumber}`);
+      }
+    }
+  }
+
+  return [...issueUrls];
+}
+
+function dedupeNormalizedItems(items: NormalizedItem[]): NormalizedItem[] {
+  const seenUrls = new Set<string>();
+  const dedupedItems: NormalizedItem[] = [];
+  for (const item of items) {
+    const comparableUrl = normalizeComparableUrl(item.url);
+    if (seenUrls.has(comparableUrl)) {
+      continue;
+    }
+    seenUrls.add(comparableUrl);
+    dedupedItems.push(item);
+  }
+  return dedupedItems;
+}
+
+function resolveBodyLinkedIssueContextItems(
+  view: ProjectView,
+  fieldNames: FieldNameMap,
+  body: string | null | undefined,
+  repositoryNameWithOwner: string | null | undefined,
+): NormalizedItem[] {
+  const issueUrls = extractIssueUrlsFromPullRequestBody(body, repositoryNameWithOwner);
+  if (issueUrls.length === 0) {
+    return [];
+  }
+
+  const linkedContextItems: NormalizedItem[] = [];
+  for (const issueUrl of issueUrls) {
+    try {
+      const issueTarget = resolveProjectResourceInView(view, fieldNames, issueUrl);
+      if (issueTarget.existingItem) {
+        linkedContextItems.push(issueTarget.existingItem);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.startsWith(`GitHub resource not found for ${issueUrl}.`)) {
+        throw error;
+      }
+    }
+  }
+
+  return linkedContextItems;
+}
+
 function resolveInferredConfigItem(
   targetUrl: string,
   normalizedItems: NormalizedItem[],
@@ -764,6 +839,7 @@ function resolveProjectResource(url: string): IssueOrPullRequestResource {
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -772,6 +848,7 @@ function resolveProjectResource(url: string): IssueOrPullRequestResource {
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -804,6 +881,7 @@ function resolveProjectResourceInView(
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -834,6 +912,7 @@ function resolveProjectResourceInView(
             id
             url
             title
+            body
             repository {
               nameWithOwner
             }
@@ -908,11 +987,12 @@ function resolveProjectResourceInView(
     id: response.data.resource.id,
     url: response.data.resource.url,
     title: response.data.resource.title,
+    body: response.data.resource.body,
     repository: response.data.resource.repository,
   };
   const existingProjectItem = response.data.resource.projectItems.nodes
     .find((item) => item.project.id === view.id) ?? null;
-  const linkedContextItems = response.data.resource.__typename === 'PullRequest'
+  const graphLinkedContextItems = response.data.resource.__typename === 'PullRequest'
     ? (response.data.resource.closingIssuesReferences?.nodes ?? [])
       .map((linkedIssue) => {
         const linkedIssueProjectItem = linkedIssue.projectItems.nodes.find((item) => item.project.id === view.id) ?? null;
@@ -931,6 +1011,18 @@ function resolveProjectResourceInView(
       })
       .filter((item): item is NormalizedItem => item !== null)
     : [];
+  const bodyLinkedContextItems = response.data.resource.__typename === 'PullRequest'
+    ? resolveBodyLinkedIssueContextItems(
+      view,
+      fieldNames,
+      response.data.resource.body,
+      response.data.resource.repository?.nameWithOwner ?? null,
+    )
+    : [];
+  const linkedContextItems = dedupeNormalizedItems([
+    ...graphLinkedContextItems,
+    ...bodyLinkedContextItems,
+  ]);
 
   return {
     resource,

--- a/tools/priority/__tests__/project-portfolio-cli.test.mjs
+++ b/tools/priority/__tests__/project-portfolio-cli.test.mjs
@@ -135,6 +135,7 @@ function buildFakeGhState({
   targetUrl,
   resourceId,
   title,
+  body = null,
   fields,
   nextAddedItemId,
   existingItemId = null,
@@ -158,6 +159,7 @@ function buildFakeGhState({
         id: resourceId,
         url: targetUrl,
         title,
+        body,
         repository: {
           nameWithOwner: 'example/repo',
         },
@@ -286,6 +288,7 @@ if (query.includes('resource(url: $url)')) {
           id: resource.id,
           url: resource.url,
           title: resource.title,
+          body: resource.body ?? null,
           repository: resource.repository,
           projectItems: { nodes: projectItems },
           closingIssuesReferences: {
@@ -293,6 +296,7 @@ if (query.includes('resource(url: $url)')) {
               id: issue.id,
               url: issue.url,
               title: issue.title,
+              body: issue.body ?? null,
               repository: issue.repository,
               projectItems: { nodes: serializeProjectItems(issue) },
             })),
@@ -927,6 +931,93 @@ test('project portfolio CLI live apply infers fresh PR field defaults from a lin
 
   assert.equal(report.target.added, true);
   assert.equal(report.target.itemId, 'item-added-22');
+  assert.equal(report.appliedFields.length, 7);
+  assert.ok(report.appliedFields.every((field) => field.source === 'inferred-linked-issue'));
+  assert.ok(report.appliedFields.every((field) => field.sourceUrl === linkedIssueUrl));
+  assert.equal(fakeGhState.addCalls.length, 1);
+  assert.equal(fakeGhState.updateCalls.length, 7);
+});
+
+test('project portfolio CLI live apply infers fresh PR field defaults from issue metadata in the PR body', async (t) => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'project-portfolio-apply-live-pr-body-infer-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const targetUrl = 'https://github.com/example/repo/pull/23';
+  const linkedIssueUrl = 'https://github.com/example/repo/issues/23';
+  const configPath = path.join(tempRoot, 'config.json');
+  const viewPath = path.join(tempRoot, 'view.json');
+  const fieldsPath = path.join(tempRoot, 'fields.json');
+  const outPath = path.join(tempRoot, 'apply-report.json');
+  const fields = buildFields();
+
+  await writeJson(configPath, buildConfig({
+    itemUrl: linkedIssueUrl,
+    status: 'Todo',
+  }));
+  await writeJson(viewPath, buildView());
+  await writeJson(fieldsPath, fields);
+
+  const fakeGh = await writeFakeGhHarness(tempRoot, buildFakeGhState({
+    targetUrl,
+    resourceId: 'PR_23',
+    title: 'Fresh PR apply target from body metadata',
+    body: `## Issue Linkage\n- Primary issue: #23\n- Issue URL: ${linkedIssueUrl}\n`,
+    fields,
+    nextAddedItemId: 'item-added-23',
+    resourceType: 'PullRequest',
+  }));
+
+  const state = JSON.parse(await readFile(fakeGh.statePath, 'utf8'));
+  state.resources[linkedIssueUrl] = {
+    __typename: 'Issue',
+    id: 'ISSUE_23',
+    url: linkedIssueUrl,
+    title: 'Standing issue context',
+    repository: {
+      nameWithOwner: 'example/repo',
+    },
+    projectItems: [
+      {
+        id: 'item-existing-issue-23',
+        projectId: 'PVT_example',
+      },
+    ],
+    closingIssuesReferences: [],
+  };
+  state.itemFields['item-existing-issue-23'] = {
+    Status: { value: 'Todo', optionId: 'status-todo' },
+    Program: { value: 'Shared Infra', optionId: 'program-shared' },
+    Phase: { value: 'Policy', optionId: 'phase-policy' },
+    'Environment Class': { value: 'Infra', optionId: 'environment-infra' },
+    'Blocking Signal': { value: 'Scope', optionId: 'blocking-scope' },
+    'Evidence State': { value: 'Ready', optionId: 'evidence-ready' },
+    'Portfolio Track': { value: 'Agent UX', optionId: 'track-agent' },
+  };
+  await writeJson(fakeGh.statePath, state);
+
+  const result = runCli([
+    'apply',
+    '--config', configPath,
+    '--view-file', viewPath,
+    '--fields-file', fieldsPath,
+    '--out', outPath,
+    '--url', targetUrl,
+    '--use-config',
+  ], {
+    env: {
+      ...fakeGh.env,
+      COMPAREVI_PROJECT_PORTFOLIO_VERIFY_DELAY_MS: '0',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(await readFile(outPath, 'utf8'));
+  const fakeGhState = JSON.parse(await readFile(fakeGh.statePath, 'utf8'));
+
+  assert.equal(report.target.added, true);
+  assert.equal(report.target.itemId, 'item-added-23');
   assert.equal(report.appliedFields.length, 7);
   assert.ok(report.appliedFields.every((field) => field.source === 'inferred-linked-issue'));
   assert.ok(report.appliedFields.every((field) => field.sourceUrl === linkedIssueUrl));


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1459
- Issue title: Infer project-portfolio apply config for new PR URLs from linked issue context
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1459
- Standing priority at PR creation: Yes (#1459)
- Base branch: `develop`
- Head branch: `issue/origin-1459-project-portfolio-apply-context`
- Template variant: `default-agent-template`
- Auto-close intent: `Closes #1459`

Closes #1459

# Summary

Project-portfolio apply can now seed a fresh PR from the linked standing issue even when the PR URL is not yet in
`tools/priority/project-portfolio.json` and GitHub has not populated `closingIssuesReferences`. The helper now falls
back to deterministic issue metadata already present in the PR body, carries the inferred source URL into the apply
report, and the live fresh-PR path is proven on PR `#1462`.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context:
  - `#1459`
- Files, tools, workflows, or policies touched:
  - `tools/cli/project-portfolio.ts`
  - `tools/priority/__tests__/project-portfolio-cli.test.mjs`
  - `dist/tools/cli/project-portfolio.js`
- Cross-repo or external-consumer impact:
  - restores `priority:project:portfolio:apply -- --url <fresh-pr-url> --use-config`
- Required checks, merge-queue behavior, or approval flows affected:
  - none; this fixes the project-board helper path used after PR creation

## Validation Evidence

- Commands run:
  - `node node_modules\typescript\bin\tsc -p tsconfig.cli.json`
  - `node --test tools/priority/__tests__/project-portfolio-cli.test.mjs`
  - `node --test tools/priority/__tests__/project-portfolio-config.test.mjs`
  - `node tools/npm/run-script.mjs priority:project:portfolio:apply -- --url https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1462 --use-config --dry-run --out tests/results/_agent/project-portfolio-apply-pr-1462-dryrun.json`
  - `node tools/npm/run-script.mjs priority:project:portfolio:apply -- --url https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1462 --use-config --out tests/results/_agent/project-portfolio-apply-pr-1462.json`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/project-portfolio-apply-pr-1462-dryrun.json`
  - `tests/results/_agent/project-portfolio-apply-pr-1462.json`
- Risk-based checks not run:
  - none

## Risks and Follow-ups

- Residual risks:
  - PR-body metadata is deterministic only while the intake template keeps the `Issue URL` / `Primary issue` lines intact
- Follow-up issues or deferred work:
  - `#1461` tracks the Windows `run-local-typescript` `tsx.cmd` wrapper failure surfaced during local validation
- Deployment, approval, or rollback notes:
  - none

## Reviewer Focus

- Please verify:
  - the new inference order is exact-config, then linked issue board context, then PR-body issue metadata
- Areas where the reasoning is subtle:
  - avoiding false negatives when `closingIssuesReferences` is still empty on a just-created PR
- Manual spot checks requested:
  - replay `priority:project:portfolio:apply` against PR `#1462`
