### PR TITLE
Update for standing priority #1396

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Keep it short, stable, and helper-oriented. Deep runbooks belong in checked-in d
 - Keep bulky diagnostics out of source; prefer issue attachments or generated artifact folders.
 - Use vendor resolvers from `tools/VendorTools.psm1` rather than ad-hoc PATH lookups.
 - For multiline GitHub bodies in mixed Windows/WSL shells, use `--body-file`.
+  For issue comments, prefer `pwsh -File tools/Post-IssueComment.ps1 -Issue <number> -BodyFile <path>`
+  over inline `gh issue comment --body "..."`.
 
 ## Handoff And Live State
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -168,6 +168,9 @@ Quick reference for building, testing, and releasing the LVCompare composite act
 - `node tools/priority/github-helper.mjs sanitize --input issue-body.md --output issue-body.gh.txt`  
   Doubles backslashes and normalises line endings so literal sequences (for example `\t`, `\tools`) survive
   `gh issue create/edit`. Omit `--output` to print to STDOUT.
+- `pwsh -NoLogo -NoProfile -File tools/Post-IssueComment.ps1 -Issue <number> -BodyFile issue-comment.md`
+  Posts GitHub issue comments through `--body-file` by default so multiline Markdown survives PowerShell and mixed
+  Windows/WSL shells without backtick-escape drift.
 - `node tools/priority/github-helper.mjs snippet --issue 531 --prefix Fixes`  
   Emits an auto-link snippet (defaults to `Fixes #531`) you can drop into PR descriptions so GitHub auto-closes the issue.
 - `node tools/npm/run-script.mjs priority:project:portfolio:apply -- --url <issue-or-pr-url> --use-config`  
@@ -506,6 +509,10 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   `gh issue create` / `node tools/npm/run-script.mjs priority:pr`. For PR scenarios, the helper can hydrate
   issue title/URL and standing-priority state from the existing issue snapshot
   under `tests/results/_agent/issue/`.
+- For issue comments with multiline Markdown, use
+  `pwsh -File tools/Post-IssueComment.ps1 -Issue <number> -BodyFile issue-comment.md`
+  (or `-Body <text>` when the caller already has the rendered markdown in memory) instead of inline
+  `gh issue comment --body "..."`.
 - For a machine-readable execution planner and explicit apply helper, use
   `pwsh -File tools/Invoke-GitHubIntakeScenario.ps1 -Scenario <name> -AsJson`.
   This stays in dry-run mode by default, emits the structured execution plan,

--- a/docs/knowledgebase/GitHub-Intake-Layer.md
+++ b/docs/knowledgebase/GitHub-Intake-Layer.md
@@ -126,6 +126,13 @@ instead of inferring the correct path from prose alone.
   gh issue create --title "<title>" --body-file issue-body.md
   ```
 
+- Issue comments:
+
+  ```powershell
+  pwsh -File tools/Post-IssueComment.ps1 -Issue 875 -BodyFile issue-comment.md
+  gh issue comment 875 --body-file issue-comment.md
+  ```
+
 - PR bodies:
 
   ```powershell
@@ -213,5 +220,7 @@ Human-authored PRs should use the `human-change` template so they do not acciden
 
 ## Mixed-Shell Guidance
 
-For issue and PR creation in mixed WSL/Windows shells, prefer `--body-file` over inline multiline `--body` strings.
-That keeps quoting deterministic and aligns with the guidance in `AGENTS.md`.
+For issue creation, issue comments, and PR creation in mixed WSL/Windows shells, prefer `--body-file` over inline
+multiline `--body` strings. For issue comments, prefer `tools/Post-IssueComment.ps1` so PowerShell lanes always route
+through a temporary or explicit body file. That keeps quoting deterministic and aligns with the guidance in
+`AGENTS.md`.

--- a/tests/GitHubIntake.Tests.ps1
+++ b/tests/GitHubIntake.Tests.ps1
@@ -89,6 +89,18 @@ Describe 'GitHubIntake.psm1' {
     $catalog.routes.scenario | Should -Contain 'human-pr'
   }
 
+  It 'documents safe body-file issue comment guidance in the agent and intake docs' {
+    $agentGuide = Get-Content (Join-Path $PSScriptRoot '..' 'AGENTS.md') -Raw
+    $intakeGuide = Get-Content (Join-Path $PSScriptRoot '..' 'docs' 'knowledgebase' 'GitHub-Intake-Layer.md') -Raw
+    $developerGuide = Get-Content (Join-Path $PSScriptRoot '..' 'docs' 'DEVELOPER_GUIDE.md') -Raw
+
+    $agentGuide | Should -Match 'Post-IssueComment\.ps1'
+    $agentGuide | Should -Match 'gh issue comment'
+    $intakeGuide | Should -Match 'pwsh -File tools/Post-IssueComment\.ps1 -Issue 875 -BodyFile issue-comment\.md'
+    $intakeGuide | Should -Match 'gh issue comment 875 --body-file issue-comment\.md'
+    $developerGuide | Should -Match 'tools/Post-IssueComment\.ps1'
+  }
+
   It 'resolves workflow-policy intake to the workflow-policy issue template' {
     $route = Resolve-GitHubIntakeRoute -Scenario 'workflow-policy'
 

--- a/tests/Post-IssueComment.Tests.ps1
+++ b/tests/Post-IssueComment.Tests.ps1
@@ -1,0 +1,85 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Post-IssueComment.ps1' {
+  BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'tools' 'Post-IssueComment.ps1'
+  }
+
+  BeforeEach {
+    $script:ghShimPath = Join-Path $TestDrive 'gh.ps1'
+    $script:capturePath = Join-Path $TestDrive 'gh-capture.json'
+
+    @'
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$RemainingArgs
+)
+
+$bodyFileIndex = [Array]::IndexOf($RemainingArgs, '--body-file')
+$bodyPath = if ($bodyFileIndex -ge 0 -and ($bodyFileIndex + 1) -lt $RemainingArgs.Count) {
+  $RemainingArgs[$bodyFileIndex + 1]
+} else {
+  $null
+}
+
+$payload = [pscustomobject]@{
+  args        = @($RemainingArgs)
+  bodyPath    = $bodyPath
+  bodyContent = if ($bodyPath) { Get-Content -LiteralPath $bodyPath -Raw } else { $null }
+}
+
+$payload | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $env:GH_CAPTURE_PATH -Encoding utf8
+'@ | Set-Content -LiteralPath $script:ghShimPath -Encoding utf8
+
+    Set-Alias -Name gh -Value $script:ghShimPath -Scope Global
+    $env:GH_CAPTURE_PATH = $script:capturePath
+  }
+
+  AfterEach {
+    Remove-Item Alias:gh -ErrorAction SilentlyContinue
+    Remove-Item Env:GH_CAPTURE_PATH -ErrorAction SilentlyContinue
+  }
+
+  It 'uses --body-file when an explicit body file is supplied' {
+    $bodyPath = Join-Path $TestDrive 'comment.md'
+    $bodyText = "Comment from file`n"
+    [System.IO.File]::WriteAllText($bodyPath, $bodyText)
+
+    & $scriptPath -Issue 1396 -BodyFile $bodyPath -Quiet
+
+    $capture = Get-Content -LiteralPath $script:capturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $capture.args[0] | Should -Be 'issue'
+    $capture.args[1] | Should -Be 'comment'
+    $capture.args[2] | Should -Be '1396'
+    $capture.args | Should -Contain '--body-file'
+    $capture.bodyPath | Should -Be (Resolve-Path -LiteralPath $bodyPath).Path
+    $capture.bodyContent | Should -BeExactly $bodyText
+  }
+
+  It 'routes inline body text through a temporary body file' {
+    $bodyText = @'
+Continuity line
+`upstream/develop...HEAD`
+'@.TrimEnd("`r", "`n")
+
+    & $scriptPath -Issue 1396 -Body $bodyText -Quiet
+
+    $capture = Get-Content -LiteralPath $script:capturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $capture.args | Should -Contain '--body-file'
+    $capture.args | Should -Not -Contain $bodyText
+    [string]::IsNullOrWhiteSpace($capture.bodyPath) | Should -BeFalse
+    $capture.bodyContent.TrimEnd("`r", "`n") | Should -BeExactly $bodyText
+  }
+
+  It 'preserves edit-last mode while still using body-file transport' {
+    $bodyPath = Join-Path $TestDrive 'edit-last.md'
+    Set-Content -LiteralPath $bodyPath -Value 'Edit last comment' -Encoding utf8
+
+    & $scriptPath -Issue 1396 -BodyFile $bodyPath -EditLast -Quiet
+
+    $capture = Get-Content -LiteralPath $script:capturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $capture.args | Should -Contain '--edit-last'
+    $capture.args | Should -Contain '--body-file'
+  }
+}

--- a/tools/Post-IssueComment.ps1
+++ b/tools/Post-IssueComment.ps1
@@ -25,6 +25,22 @@ function Ensure-Gh {
 
 Ensure-Gh
 
+function Invoke-GhIssueComment {
+  param(
+    [Parameter(Mandatory=$true)]
+    [string[]]$Arguments
+  )
+
+  & gh @Arguments
+  if (-not $?) {
+    $exitCode = if (Test-Path variable:LASTEXITCODE) { $LASTEXITCODE } else { $null }
+    if ($null -ne $exitCode) {
+      throw "gh issue comment exited with code $exitCode."
+    }
+    throw 'gh issue comment failed.'
+  }
+}
+
 $issueArg = @('issue','comment',$Issue.ToString())
 if ($EditLast) {
   $issueArg = @('issue','comment',$Issue.ToString(),'--edit-last')
@@ -37,10 +53,7 @@ switch ($PSCmdlet.ParameterSetName) {
     if (-not $Quiet) {
       Write-Host ("Posting comment from file '{0}' to issue #{1}..." -f $resolved.Path, $Issue)
     }
-    & gh @args
-    if ($LASTEXITCODE -ne 0) {
-      throw "gh issue comment exited with code $LASTEXITCODE."
-    }
+    Invoke-GhIssueComment -Arguments $args
   }
   'Body' {
     $temp = [System.IO.Path]::GetTempFileName()
@@ -50,10 +63,7 @@ switch ($PSCmdlet.ParameterSetName) {
       if (-not $Quiet) {
         Write-Host ("Posting comment to issue #{0} using temporary body file..." -f $Issue)
       }
-      & gh @args
-      if ($LASTEXITCODE -ne 0) {
-        throw "gh issue comment exited with code $LASTEXITCODE."
-      }
+      Invoke-GhIssueComment -Arguments $args
     } finally {
       Remove-Item -LiteralPath $temp -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1396
- Issue title: Add safe body-file handling for GitHub issue comments in PowerShell lanes
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1396
- Standing priority at PR creation: Yes (#1396)
- Base branch: `develop`
- Head branch: `issue/origin-1396-safe-body-file-handling`
- Template variant: `default-agent-template`
- Auto-close intent: `Closes #1396`

Closes #1396

# Summary

GitHub issue comments in PowerShell lanes now have a tested, documented body-file path instead of relying on inline
multiline `gh issue comment --body "..."` calls that break on backticks and mixed shell quoting. The existing
`tools/Post-IssueComment.ps1` helper is hardened to work when `gh` resolves to a script or alias, and the intake/agent
docs now place issue comments beside issue create/edit as a first-class `--body-file` contract.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context:
  - `#1396`
- Files, tools, workflows, or policies touched:
  - `tools/Post-IssueComment.ps1`
  - `tests/Post-IssueComment.Tests.ps1`
  - `tests/GitHubIntake.Tests.ps1`
  - `docs/knowledgebase/GitHub-Intake-Layer.md`
  - `docs/DEVELOPER_GUIDE.md`
  - `AGENTS.md`
- Cross-repo or external-consumer impact:
  - none; this hardens local/agent GitHub issue comment flows in this repo
- Required checks, merge-queue behavior, or approval flows affected:
  - none

## Validation Evidence

- Commands run:
  - `pwsh -NoLogo -NoProfile -File tests/Post-IssueComment.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tests/GitHubIntake.Tests.ps1`
  - `node tools/npm/run-script.mjs lint:md:changed`
  - `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- Key artifacts, logs, or workflow runs:
  - `tests/Post-IssueComment.Tests.ps1`
  - `tests/GitHubIntake.Tests.ps1`
- Risk-based checks not run:
  - none

## Risks and Follow-ups

- Residual risks:
  - call sites that bypass `tools/Post-IssueComment.ps1` still need operator discipline unless later linted or wrapped
- Follow-up issues or deferred work:
  - `#1461` tracks the separate Windows `run-local-typescript` `tsx.cmd` wrapper failure surfaced during `#1459`
- Deployment, approval, or rollback notes:
  - none

## Reviewer Focus

- Please verify:
  - `Post-IssueComment.ps1` now succeeds when `gh` resolves to a script/alias without `$LASTEXITCODE`
  - the docs consistently point issue comments to body-file transport
- Areas where the reasoning is subtle:
  - PowerShell command status semantics differ for native executables vs script/alias wrappers
- Manual spot checks requested:
  - run `pwsh -NoLogo -NoProfile -File tools/Post-IssueComment.ps1 -Issue 1396 -BodyFile <path>` from PowerShell
