### PR TITLE
Leverage content-based LabVIEW file detection and artifact-first report linking patterns from gregr-ni/labview-ci-cd#1 (#1401)

### DIFF
--- a/tests/Find-VIComparisonCandidates.Tests.ps1
+++ b/tests/Find-VIComparisonCandidates.Tests.ps1
@@ -5,6 +5,33 @@ Describe 'Find-VIComparisonCandidates.ps1' -Tag 'Compare','Analysis','Unit' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
         Set-Variable -Scope Script -Name scriptPath -Value (Join-Path $repoRoot 'tools/compare/Find-VIComparisonCandidates.ps1')
         Test-Path -LiteralPath $script:scriptPath | Should -BeTrue "Candidate discovery script not found."
+
+        function Set-LabVIEWBinaryFixture {
+            param(
+                [Parameter(Mandatory)][string]$Path,
+                [Parameter(Mandatory)][ValidateSet('LVIN', 'LVCC')][string]$Signature,
+                [string]$Payload = ''
+            )
+
+            $directory = Split-Path -Parent $Path
+            if ($directory -and -not (Test-Path -LiteralPath $directory -PathType Container)) {
+                New-Item -ItemType Directory -Path $directory -Force | Out-Null
+            }
+
+            $payloadBytes = if ([string]::IsNullOrWhiteSpace($Payload)) {
+                [byte[]]@()
+            } else {
+                [System.Text.Encoding]::UTF8.GetBytes($Payload)
+            }
+
+            $minimumLength = 12 + $payloadBytes.Length
+            $bytes = New-Object byte[] ([Math]::Max(16, $minimumLength))
+            [System.Text.Encoding]::ASCII.GetBytes($Signature).CopyTo($bytes, 8)
+            if ($payloadBytes.Length -gt 0) {
+                [Array]::Copy($payloadBytes, 0, $bytes, 12, $payloadBytes.Length)
+            }
+            [System.IO.File]::WriteAllBytes($Path, $bytes)
+        }
     }
 
     BeforeEach {
@@ -16,22 +43,27 @@ Describe 'Find-VIComparisonCandidates.ps1' -Tag 'Compare','Analysis','Unit' {
         git config user.email "tester@example.com" | Out-Null
         git config user.name "Tester" | Out-Null
 
-        $script:viPath = 'resource/plugins/NIIconEditor/Miscellaneous/User Events/Initialization_UserEvents.vi'
-        $script:renameSource = 'resource/plugins/NIIconEditor/Support/ApplyLibIconOverlayToVIIcon.vi'
-        $script:renameTarget = 'resource/plugins/NIIconEditor/Support/ApplyLibIconOverlayToVIIcon_Renamed.vi'
+        $script:viPath = 'resource/plugins/NIIconEditor/Miscellaneous/User Events/Initialization_UserEvents.bin'
+        $script:renameSource = 'resource/plugins/NIIconEditor/Support/ApplyLibIconOverlayToVIIcon.source'
+        $script:renameTarget = 'resource/plugins/NIIconEditor/Support/ApplyLibIconOverlayToVIIcon_Renamed.target'
         $script:ignoredPath = 'docs/readme.txt'
+        $script:textViPath = 'resource/plugins/NIIconEditor/Support/TextOnly.vi'
 
-        foreach ($path in @($script:viPath, $script:renameSource, $script:ignoredPath)) {
+        foreach ($path in @($script:ignoredPath)) {
             $dir = Split-Path -Parent (Join-Path $script:testRoot $path)
             New-Item -ItemType Directory -Path $dir -Force | Out-Null
             Set-Content -LiteralPath (Join-Path $script:testRoot $path) -Value "content for $path" -NoNewline
         }
+        Set-LabVIEWBinaryFixture -Path (Join-Path $script:testRoot $script:viPath) -Signature 'LVIN' -Payload 'vi-v1'
+        Set-LabVIEWBinaryFixture -Path (Join-Path $script:testRoot $script:renameSource) -Signature 'LVCC' -Payload 'rename-v1'
+        Set-Content -LiteralPath (Join-Path $script:testRoot $script:textViPath) -Value 'text only' -NoNewline
 
         git add . | Out-Null
         git commit -m 'initial baseline' --quiet | Out-Null
         $script:baseline = (git rev-parse HEAD).Trim()
 
-        Set-Content -LiteralPath (Join-Path $script:testRoot $script:viPath) -Value 'modified vi content' -NoNewline
+        Set-LabVIEWBinaryFixture -Path (Join-Path $script:testRoot $script:viPath) -Signature 'LVIN' -Payload 'vi-v2'
+        Set-Content -LiteralPath (Join-Path $script:testRoot $script:textViPath) -Value 'still text only' -NoNewline
         git commit -am 'modify vi payload' --quiet | Out-Null
         $script:modifyCommit = (git rev-parse HEAD).Trim()
 
@@ -69,6 +101,9 @@ Describe 'Find-VIComparisonCandidates.ps1' -Tag 'Compare','Analysis','Unit' {
         $rename.files[0].status | Should -Match '^R'
         $rename.files[0].path | Should -Be $script:renameTarget
         $rename.files[0].oldPath | Should -Be $script:renameSource
+        @($result.commits | ForEach-Object { @($_.files) } | Where-Object {
+            $_.path -eq $script:textViPath -or $_.oldPath -eq $script:textViPath
+        }).Count | Should -Be 0
     }
 
     It 'honors overrides for max commits and output path' {

--- a/tests/Get-PRVIDiffManifest.Tests.ps1
+++ b/tests/Get-PRVIDiffManifest.Tests.ps1
@@ -5,6 +5,39 @@ Set-StrictMode -Version Latest
 Describe 'Get-PRVIDiffManifest.ps1' {
     BeforeAll {
         $scriptPath = Resolve-Path (Join-Path $PSScriptRoot '..' 'tools' 'Get-PRVIDiffManifest.ps1')
+
+        function Set-LabVIEWBinaryFixture {
+            param(
+                [Parameter(Mandatory)][string]$Path,
+                [Parameter(Mandatory)][ValidateSet('LVIN', 'LVCC')][string]$Signature,
+                [string]$Payload = ''
+            )
+
+            $directory = Split-Path -Parent $Path
+            $resolvedPath = if ([System.IO.Path]::IsPathRooted($Path)) {
+                [System.IO.Path]::GetFullPath($Path)
+            } else {
+                [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+            }
+            $directory = Split-Path -Parent $resolvedPath
+            if ($directory -and -not (Test-Path -LiteralPath $directory -PathType Container)) {
+                New-Item -ItemType Directory -Path $directory -Force | Out-Null
+            }
+
+            $payloadBytes = if ([string]::IsNullOrWhiteSpace($Payload)) {
+                [byte[]]@()
+            } else {
+                [System.Text.Encoding]::UTF8.GetBytes($Payload)
+            }
+
+            $minimumLength = 12 + $payloadBytes.Length
+            $bytes = New-Object byte[] ([Math]::Max(16, $minimumLength))
+            [System.Text.Encoding]::ASCII.GetBytes($Signature).CopyTo($bytes, 8)
+            if ($payloadBytes.Length -gt 0) {
+                [Array]::Copy($payloadBytes, 0, $bytes, 12, $payloadBytes.Length)
+            }
+            [System.IO.File]::WriteAllBytes($resolvedPath, $bytes)
+        }
     }
 
     It 'emits a manifest for modified, renamed, added, and deleted VIs' {
@@ -18,20 +51,21 @@ Describe 'Get-PRVIDiffManifest.ps1' {
             git config user.email 'bot@example.com' | Out-Null
 
             # Base commit
-            Set-Content -Path 'Keep.vi' -Value 'keep-v1'
-            Set-Content -Path 'Remove.vi' -Value 'remove-v1'
-            Set-Content -Path 'Original.vi' -Value 'original-v1'
+            Set-LabVIEWBinaryFixture -Path 'Keep.vi' -Signature 'LVIN' -Payload 'keep-v1'
+            Set-LabVIEWBinaryFixture -Path 'Remove.vi' -Signature 'LVCC' -Payload 'remove-v1'
+            Set-LabVIEWBinaryFixture -Path 'Original.weird' -Signature 'LVIN' -Payload 'original-v1'
             git add . | Out-Null
             git commit --quiet -m 'base commit' | Out-Null
             $baseCommit = (git rev-parse HEAD).Trim()
 
             # Head commit with assorted changes
-            git mv Original.vi Renamed.vi | Out-Null
-            Set-Content -Path 'Keep.vi' -Value 'keep-v2'
+            git mv Original.weird Renamed.custom | Out-Null
+            Set-LabVIEWBinaryFixture -Path 'Keep.vi' -Signature 'LVIN' -Payload 'keep-v2'
             git rm Remove.vi --quiet | Out-Null
-            Set-Content -Path 'New.vi' -Value 'new-file'   # added VI
+            Set-LabVIEWBinaryFixture -Path 'NewArtifact' -Signature 'LVCC' -Payload 'new-file'
+            Set-Content -Path 'PlainText.vi' -Value 'not-a-labview-binary'
             New-Item -ItemType Directory -Path 'ignore' | Out-Null
-            Set-Content -Path (Join-Path 'ignore' 'Skip.vi') -Value 'ignored'
+            Set-LabVIEWBinaryFixture -Path (Join-Path 'ignore' 'Skip.bin') -Signature 'LVIN' -Payload 'ignored'
             Set-Content -Path 'notes.txt' -Value 'non-vi'
             git add -A | Out-Null
             git commit --quiet -m 'head commit' | Out-Null
@@ -62,19 +96,21 @@ Describe 'Get-PRVIDiffManifest.ps1' {
         $modified.headPath | Should -Be 'Keep.vi'
 
         $renamed = $manifest.pairs | Where-Object { $_.changeType -eq 'renamed' }
-        $renamed.basePath | Should -Be 'Original.vi'
-        $renamed.headPath | Should -Be 'Renamed.vi'
+        $renamed.basePath | Should -Be 'Original.weird'
+        $renamed.headPath | Should -Be 'Renamed.custom'
         [int]$renamed.renameScore | Should -BeGreaterThan 0
 
         $added = $manifest.pairs | Where-Object { $_.changeType -eq 'added' }
         $added.basePath | Should -BeNullOrEmpty
-        $added.headPath | Should -Be 'New.vi'
+        $added.headPath | Should -Be 'NewArtifact'
 
         $deleted = $manifest.pairs | Where-Object { $_.changeType -eq 'deleted' }
         $deleted.basePath | Should -Be 'Remove.vi'
         $deleted.headPath | Should -BeNullOrEmpty
 
         ($manifest.pairs | Where-Object { $_.headPath -like 'ignore/*' -or $_.basePath -like 'ignore/*' }) |
+            Should -BeNullOrEmpty
+        ($manifest.pairs | Where-Object { $_.headPath -eq 'PlainText.vi' -or $_.basePath -eq 'PlainText.vi' }) |
             Should -BeNullOrEmpty
     }
 }

--- a/tests/Run-StagedLVCompare.Tests.ps1
+++ b/tests/Run-StagedLVCompare.Tests.ps1
@@ -165,6 +165,77 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
         $outputMap['skip_count'] | Should -Be '0'
     }
 
+    It 'resolves custom report artifact paths from capture metadata when the invoke result omits ReportPath' {
+        $resultsPath = Join-Path $TestDrive 'vi-staging-results-custom-report.json'
+        $artifactsDir = Join-Path $TestDrive 'artifacts-custom-report'
+        New-Item -ItemType Directory -Path (Split-Path $resultsPath -Parent) -Force | Out-Null
+        New-Item -ItemType Directory -Path $artifactsDir -Force | Out-Null
+
+        $stagedBase = Join-Path $TestDrive 'staged-custom\Base.vi'
+        $stagedHead = Join-Path $TestDrive 'staged-custom\Head.vi'
+        New-Item -ItemType Directory -Path (Split-Path $stagedBase -Parent) -Force | Out-Null
+        Set-Content -LiteralPath $stagedBase -Value 'base'
+        Set-Content -LiteralPath $stagedHead -Value 'head'
+
+        @(
+            [ordered]@{
+                changeType = 'modify'
+                basePath   = 'resource/plugins/NIIconEditor/Miscellaneous/User Events/Initialization_UserEvents.vi'
+                headPath   = 'resource/plugins/NIIconEditor/Miscellaneous/User Events/Initialization_UserEvents.vi'
+                staged     = [ordered]@{
+                    Base         = $stagedBase
+                    Head         = $stagedHead
+                    AllowSameLeaf= $false
+                }
+            }
+        ) | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $resultsPath -Encoding utf8
+
+        $invoke = {
+            param(
+                [string]$BaseVi,
+                [string]$HeadVi,
+                [string]$OutputDir,
+                [switch]$AllowSameLeaf,
+                [switch]$RenderReport,
+                [string[]]$Flags,
+                [switch]$ReplaceFlags,
+                [switch]$LeakCheck,
+                [Nullable[int]]$TimeoutSeconds,
+                [Nullable[double]]$LeakGraceSeconds,
+                [string]$NoiseProfile
+            )
+            New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+            $capturePath = Join-Path $OutputDir 'lvcompare-capture.json'
+            $reportPath  = Join-Path $OutputDir 'diff-report-Initialization_UserEvents.vi.html'
+            @'
+{
+  "schema": "lvcompare-capture-v1",
+  "out": {
+    "reportHtml": "./diff-report-Initialization_UserEvents.vi.html"
+  },
+  "cli": {
+    "reportPath": "./diff-report-Initialization_UserEvents.vi.html"
+  }
+}
+'@ | Set-Content -LiteralPath $capturePath -Encoding utf8
+            '<html><body>custom report</body></html>' | Set-Content -LiteralPath $reportPath -Encoding utf8
+            return [pscustomobject]@{
+                ExitCode    = 0
+                CapturePath = $capturePath
+            }
+        }.GetNewClosure()
+
+        & $script:scriptPath -ResultsPath $resultsPath -ArtifactsDir $artifactsDir -RenderReport -InvokeLVCompare $invoke
+
+        $updated = @(Get-Content -LiteralPath $resultsPath -Raw | ConvertFrom-Json)
+        $entry = $updated[0]
+        $entry.compare.reportPath | Should -Match 'diff-report-Initialization_UserEvents\.vi\.html$'
+
+        $summaryPath = Join-Path $artifactsDir 'vi-staging-compare.json'
+        $compareSummary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json
+        $compareSummary[0].reportPath | Should -Match 'diff-report-Initialization_UserEvents\.vi\.html$'
+    }
+
     It 'treats exit 0 with diff headings as diff' {
         $resultsPath = Join-Path $TestDrive 'vi-staging-results-diff.json'
         $artifactsDir = Join-Path $TestDrive 'artifacts-diff'
@@ -1057,6 +1128,5 @@ Describe 'Run-StagedLVCompare.ps1' -Tag 'Unit' {
         }
     }
 }
-
 
 

--- a/tests/Summarize-VIStaging.Tests.ps1
+++ b/tests/Summarize-VIStaging.Tests.ps1
@@ -290,6 +290,65 @@ Describe 'Summarize-VIStaging.ps1' -Tag 'Unit' {
         $result.pairs[0].diffCategoryDetails[0].slug | Should -Be 'block-diagram-functional'
     }
 
+    It 'prefers capture-derived custom report artifacts over fixed compare-report leaf guesses' {
+        $compareRoot = Join-Path $TestDrive 'compare-custom'
+        $pairDir = Join-Path $compareRoot 'pair-01'
+        New-Item -ItemType Directory -Path $pairDir -Force | Out-Null
+
+        $reportPath = Join-Path $pairDir 'diff-report-Initialization_UserEvents.vi.html'
+        @'
+<!DOCTYPE html>
+<html>
+<body>
+<details open>
+  <summary class="difference-heading">1. VI Attribute - Miscellaneous</summary>
+  <ol class="detailed-description-list">
+    <li class="diff-detail">Difference Type: VI icon</li>
+  </ol>
+</details>
+</body>
+</html>
+'@ | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+        $capturePath = Join-Path $pairDir 'lvcompare-capture.json'
+        @'
+{
+  "schema": "lvcompare-capture-v1",
+  "out": {
+    "reportHtml": "./diff-report-Initialization_UserEvents.vi.html"
+  },
+  "cli": {
+    "reportPath": "./diff-report-Initialization_UserEvents.vi.html"
+  }
+}
+'@ | Set-Content -LiteralPath $capturePath -Encoding utf8
+
+        $compareEntry = @(
+            [ordered]@{
+                index      = 1
+                changeType = 'modify'
+                basePath   = 'resource/plugins/NIIconEditor/Miscellaneous/User Events/Initialization_UserEvents.vi'
+                headPath   = 'resource/plugins/NIIconEditor/Miscellaneous/User Events/Initialization_UserEvents.vi'
+                outputDir  = $pairDir
+                status     = 'diff'
+                exitCode   = 1
+                reportPath = $null
+                capturePath= $null
+            }
+        )
+
+        $compareJson = Join-Path $TestDrive 'vi-staging-compare-custom-report.json'
+        $compareEntry | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $compareJson -Encoding utf8
+
+        $result = & $script:scriptPath -CompareJson $compareJson
+
+        $result | Should -Not -BeNullOrEmpty
+        $result.pairs.Count | Should -Be 1
+        $result.pairs[0].reportPath | Should -Be $reportPath
+        ($result.pairs[0].reportRelative.Replace('\','/')) | Should -Be 'pair-01/diff-report-Initialization_UserEvents.vi.html'
+        $result.pairs[0].diffCategories | Should -Contain 'VI Attribute'
+    }
+
     It 'renders consolidated html with valid local artifact links' {
         $compareRoot = Join-Path $TestDrive 'compare-html'
         $pairDir = Join-Path $compareRoot 'pair-01'

--- a/tools/Get-PRVIDiffManifest.ps1
+++ b/tools/Get-PRVIDiffManifest.ps1
@@ -5,7 +5,8 @@ Generates a manifest of VI path pairs for pull-request comparisons.
 
 .DESCRIPTION
 This is the initial scaffold for issue #324. The script will eventually detect
-`.vi` changes between two git refs and emit a `vi-diff-manifest@v1` JSON file.
+LabVIEW binary changes between two git refs and emit a `vi-diff-manifest@v1`
+JSON file.
 Implementation is intentionally stubbed out while the spike design is finalized.
 
 .PARAMETER BaseRef
@@ -40,6 +41,12 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+$binaryToolsModule = Join-Path (Split-Path -Parent $PSCommandPath) 'LabVIEWBinaryTools.psm1'
+if (-not (Test-Path -LiteralPath $binaryToolsModule -PathType Leaf)) {
+    throw ("LabVIEWBinaryTools.psm1 not found: {0}" -f $binaryToolsModule)
+}
+Import-Module $binaryToolsModule -Force
 
 Write-Verbose "Base ref: $BaseRef"
 Write-Verbose "Head ref: $HeadRef"
@@ -93,20 +100,33 @@ function Should-IgnorePath {
     return $false
 }
 
-function Test-IsViPath {
+function Test-IsLabVIEWChange {
     param(
-        [string]$Path
+        [string]$BasePath,
+        [string]$HeadPath,
+        [string]$ChangeType,
+        [string]$BaseRefValue,
+        [string]$HeadRefValue,
+        [string]$RepoPath
     )
 
-    if ([string]::IsNullOrWhiteSpace($Path)) {
-        return $false
+    switch ($ChangeType) {
+        'added' {
+            return (Test-IsLabVIEWBinaryAtGitPath -RepoPath $RepoPath -Ref $HeadRefValue -Path $HeadPath)
+        }
+        'deleted' {
+            return (Test-IsLabVIEWBinaryAtGitPath -RepoPath $RepoPath -Ref $BaseRefValue -Path $BasePath)
+        }
+        default {
+            if (-not [string]::IsNullOrWhiteSpace($HeadPath) -and (Test-IsLabVIEWBinaryAtGitPath -RepoPath $RepoPath -Ref $HeadRefValue -Path $HeadPath)) {
+                return $true
+            }
+            if (-not [string]::IsNullOrWhiteSpace($BasePath) -and (Test-IsLabVIEWBinaryAtGitPath -RepoPath $RepoPath -Ref $BaseRefValue -Path $BasePath)) {
+                return $true
+            }
+            return $false
+        }
     }
-
-    return [System.String]::Equals(
-        [System.IO.Path]::GetExtension($Path),
-        '.vi',
-        [System.StringComparison]::OrdinalIgnoreCase
-    )
 }
 
 function Get-SortKey {
@@ -235,16 +255,15 @@ try {
             $headPath = $headPath.Replace('\', '/')
         }
 
-        if ($basePath -and -not (Test-IsViPath -Path $basePath)) {
-            if (-not ($headPath -and (Test-IsViPath -Path $headPath))) {
-                Write-Verbose "Skipping non-VI change: $line"
-                continue
-            }
-        } elseif ($headPath -and -not (Test-IsViPath -Path $headPath)) {
-            if (-not ($basePath -and (Test-IsViPath -Path $basePath))) {
-                Write-Verbose "Skipping non-VI change: $line"
-                continue
-            }
+        if (-not (Test-IsLabVIEWChange `
+            -BasePath $basePath `
+            -HeadPath $headPath `
+            -ChangeType $changeType `
+            -BaseRefValue $BaseRef `
+            -HeadRefValue $HeadRef `
+            -RepoPath $repoRoot)) {
+            Write-Verbose "Skipping non-LabVIEW-binary change: $line"
+            continue
         }
 
         if ((Should-IgnorePath -Path $basePath) -or (Should-IgnorePath -Path $headPath)) {

--- a/tools/LabVIEWBinaryTools.psm1
+++ b/tools/LabVIEWBinaryTools.psm1
@@ -1,0 +1,139 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:KnownLabVIEWBinarySignatures = @('LVIN', 'LVCC')
+$script:KnownLabVIEWBinaryExtensions = @(
+  '.vi',
+  '.vim',
+  '.vit',
+  '.ctl',
+  '.ctt',
+  '.lvclass',
+  '.lvlib',
+  '.lvproj',
+  '.lvsc',
+  '.lvlibp'
+)
+$script:LabVIEWBinarySignatureOffset = 8
+$script:LabVIEWBinarySignatureLength = 4
+$script:LabVIEWBinaryMinimumLength = $script:LabVIEWBinarySignatureOffset + $script:LabVIEWBinarySignatureLength
+
+function Get-LabVIEWKnownFileExtensions {
+  return @($script:KnownLabVIEWBinaryExtensions)
+}
+
+function Test-IsLabVIEWBinaryBytes {
+  param(
+    [byte[]]$Bytes
+  )
+
+  if ($null -eq $Bytes -or $Bytes.Length -lt $script:LabVIEWBinaryMinimumLength) {
+    return $false
+  }
+
+  $signature = [System.Text.Encoding]::ASCII.GetString(
+    $Bytes,
+    $script:LabVIEWBinarySignatureOffset,
+    $script:LabVIEWBinarySignatureLength
+  )
+
+  return $script:KnownLabVIEWBinarySignatures -contains $signature
+}
+
+function Test-IsLabVIEWBinaryFile {
+  param(
+    [Parameter(Mandatory)][string]$Path
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $false
+  }
+
+  $stream = [System.IO.File]::OpenRead($Path)
+  try {
+    $buffer = New-Object byte[] $script:LabVIEWBinaryMinimumLength
+    $readCount = $stream.Read($buffer, 0, $buffer.Length)
+    if ($readCount -lt $script:LabVIEWBinaryMinimumLength) {
+      return $false
+    }
+    return Test-IsLabVIEWBinaryBytes -Bytes $buffer
+  } finally {
+    $stream.Dispose()
+  }
+}
+
+function Invoke-GitBinaryContent {
+  param(
+    [Parameter(Mandatory)][string]$RepoPath,
+    [Parameter(Mandatory)][string[]]$Arguments
+  )
+
+  $psi = New-Object System.Diagnostics.ProcessStartInfo 'git'
+  foreach ($arg in $Arguments) {
+    [void]$psi.ArgumentList.Add($arg)
+  }
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  $psi.UseShellExecute = $false
+  $psi.CreateNoWindow = $true
+
+  $process = [System.Diagnostics.Process]::Start($psi)
+  $stdoutStream = New-Object System.IO.MemoryStream
+  try {
+    $process.StandardOutput.BaseStream.CopyTo($stdoutStream)
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+    if ($process.ExitCode -ne 0) {
+      throw "git $($Arguments -join ' ') failed: $stderr"
+    }
+    return $stdoutStream.ToArray()
+  } finally {
+    $stdoutStream.Dispose()
+    if ($null -ne $process) {
+      $process.Dispose()
+    }
+  }
+}
+
+function Get-GitBlobBytes {
+  param(
+    [Parameter(Mandatory)][string]$RepoPath,
+    [Parameter(Mandatory)][string]$Ref,
+    [Parameter(Mandatory)][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Ref) -or [string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  $normalizedRepoPath = [System.IO.Path]::GetFullPath($RepoPath)
+  $normalizedGitPath = $Path.Replace('\', '/')
+  return Invoke-GitBinaryContent -RepoPath $normalizedRepoPath -Arguments @(
+    '-C',
+    $normalizedRepoPath,
+    'show',
+    '--no-textconv',
+    ("{0}:{1}" -f $Ref, $normalizedGitPath)
+  )
+}
+
+function Test-IsLabVIEWBinaryAtGitPath {
+  param(
+    [Parameter(Mandatory)][string]$RepoPath,
+    [Parameter(Mandatory)][string]$Ref,
+    [Parameter(Mandatory)][string]$Path
+  )
+
+  try {
+    $bytes = Get-GitBlobBytes -RepoPath $RepoPath -Ref $Ref -Path $Path
+    if ($null -eq $bytes) {
+      return $false
+    }
+    return Test-IsLabVIEWBinaryBytes -Bytes $bytes
+  } catch {
+    return $false
+  }
+}
+
+Export-ModuleMember -Function Get-LabVIEWKnownFileExtensions, Test-IsLabVIEWBinaryBytes, Test-IsLabVIEWBinaryFile, Get-GitBlobBytes, Test-IsLabVIEWBinaryAtGitPath

--- a/tools/Run-StagedLVCompare.ps1
+++ b/tools/Run-StagedLVCompare.ps1
@@ -42,6 +42,12 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+$artifactModulePath = Join-Path (Split-Path -Parent $PSCommandPath) 'VICompareArtifacts.psm1'
+if (-not (Test-Path -LiteralPath $artifactModulePath -PathType Leaf)) {
+    throw "VICompareArtifacts.psm1 not found at $artifactModulePath"
+}
+Import-Module $artifactModulePath -Force
+
 $flagsProvided = $PSBoundParameters.ContainsKey('Flags')
 $effectiveFlags = $Flags
 $effectiveReplace = $ReplaceFlags.IsPresent
@@ -423,15 +429,6 @@ foreach ($entry in $results) {
             if ($profile.flags) { $modeInfo.flags = @($profile.flags) }
             if ($allowSameLeafRequested) { $modeInfo.allowSameLeaf = $true }
 
-            $reportCandidates = @('compare-report.html', 'compare-report.xml', 'compare-report.txt')
-            foreach ($candidate in $reportCandidates) {
-                $candidatePath = Join-Path $modeOutputDir $candidate
-                if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
-                    $modeInfo.reportPath = $candidatePath
-                    break
-                }
-            }
-
             if ($invokeResult -and $invokeResult.PSObject.Properties['CapturePath'] -and $invokeResult.CapturePath) {
                 $modeInfo.capturePath = $invokeResult.CapturePath
             } else {
@@ -443,6 +440,11 @@ foreach ($entry in $results) {
             if ($invokeResult -and $invokeResult.PSObject.Properties['ReportPath'] -and $invokeResult.ReportPath) {
                 $modeInfo.reportPath = $invokeResult.ReportPath
             }
+            $modeInfo.reportPath = Find-VICompareReportArtifact `
+                -ExplicitReportPath $modeInfo.reportPath `
+                -CapturePath $modeInfo.capturePath `
+                -SearchDirectories @($modeOutputDir) `
+                -Recursive
 
             $diffDetected = Test-ReportHasDiff -Path $modeInfo.reportPath
 

--- a/tools/Summarize-VIStaging.ps1
+++ b/tools/Summarize-VIStaging.ps1
@@ -45,6 +45,12 @@ try {
         Import-Module $categoryModule -Force
     }
 } catch {}
+try {
+    $artifactModule = Join-Path (Split-Path -Parent $PSCommandPath) 'VICompareArtifacts.psm1'
+    if (Test-Path -LiteralPath $artifactModule -PathType Leaf) {
+        Import-Module $artifactModule -Force
+    }
+} catch {}
 
 function Resolve-ExistingFile {
     param([string]$Path)
@@ -238,21 +244,9 @@ function Infer-DiffCategoriesFromDetails {
 function Find-ReportPath {
     param(
         [pscustomobject]$Entry,
-        [string]$CompareDir
+        [string]$CompareDir,
+        [string]$CapturePath
     )
-
-    $candidateFiles = New-Object System.Collections.Generic.List[string]
-    if ($Entry -and $Entry.PSObject.Properties['reportPath'] -and $Entry.reportPath) {
-        $candidateFiles.Add([string]$Entry.reportPath) | Out-Null
-    }
-    if ($Entry -and $Entry.PSObject.Properties['modes'] -and $Entry.modes) {
-        foreach ($mode in $Entry.modes) {
-            if (-not $mode) { continue }
-            if ($mode.PSObject.Properties['reportPath'] -and $mode.reportPath) {
-                $candidateFiles.Add([string]$mode.reportPath) | Out-Null
-            }
-        }
-    }
 
     $directories = New-Object System.Collections.Generic.List[string]
     if ($Entry -and $Entry.PSObject.Properties['outputDir'] -and $Entry.outputDir) {
@@ -273,58 +267,21 @@ function Find-ReportPath {
     if ($CompareDir -and $pairIndex -gt 0) {
         $directories.Add((Join-Path $CompareDir ("pair-{0:D2}" -f $pairIndex))) | Out-Null
     }
-
-    foreach ($candidate in $candidateFiles) {
-        $resolved = Resolve-ExistingFile -Path $candidate
-        if ($resolved) { return $resolved }
+    $explicitReportPath = $null
+    if ($Entry -and $Entry.PSObject.Properties['reportPath'] -and $Entry.reportPath) {
+        $explicitReportPath = [string]$Entry.reportPath
     }
-
-    $reportNames = @('compare-report.html','compare-report.xml','compare-report.txt')
-    foreach ($dirCandidate in $directories) {
-        $resolvedDir = Resolve-ExistingDirectory -Path $dirCandidate
-        if (-not $resolvedDir) { continue }
-        foreach ($name in $reportNames) {
-            $joined = Join-Path $resolvedDir $name
-            $resolved = Resolve-ExistingFile -Path $joined
-            if ($resolved) { return $resolved }
+    if (-not [string]::IsNullOrWhiteSpace($explicitReportPath)) {
+        $resolvedExplicit = Resolve-ExistingFile -Path $explicitReportPath
+        if ($resolvedExplicit) {
+            return $resolvedExplicit
         }
-        # search common mode subdirectories (mode-*)
-        try {
-            $modeDirs = Get-ChildItem -LiteralPath $resolvedDir -Directory -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -like 'mode-*' }
-            foreach ($modeDir in $modeDirs) {
-                foreach ($name in $reportNames) {
-                    $joined = Join-Path $modeDir.FullName $name
-                    $resolved = Resolve-ExistingFile -Path $joined
-                    if ($resolved) { return $resolved }
-                }
-            }
-        } catch {}
     }
-
-    # last resort: shallow recursive search (depth 2)
-    foreach ($dirCandidate in $directories) {
-        $resolvedDir = Resolve-ExistingDirectory -Path $dirCandidate
-        if (-not $resolvedDir) { continue }
-        try {
-            $found = Get-ChildItem -LiteralPath $resolvedDir -Recurse -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -in $reportNames } |
-                Select-Object -First 1
-            if ($found) { return $found.FullName }
-        } catch {}
-    }
-
-    if ($CompareDir) {
-        try {
-            $fallback = Get-ChildItem -LiteralPath $CompareDir -Recurse -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -in $reportNames } |
-                Sort-Object FullName |
-                Select-Object -First 1
-            if ($fallback) { return $fallback.FullName }
-        } catch {}
-    }
-
-    return $null
+    return (Find-VICompareReportArtifact `
+        -ExplicitReportPath $explicitReportPath `
+        -CapturePath $CapturePath `
+        -SearchDirectories @($directories.ToArray()) `
+        -Recursive)
 }
 
 function Find-CapturePath {
@@ -819,17 +776,6 @@ foreach ($entry in $entries) {
 foreach ($entry in $entries) {
     $status = $entry.status
 
-    $reportPath = $null
-    if ($entry.PSObject.Properties['reportPath']) {
-        $reportPath = Resolve-ExistingFile -Path $entry.reportPath
-    }
-    if (-not $reportPath) {
-        $reportPath = Find-ReportPath -Entry $entry -CompareDir $compareRoot
-        if ($reportPath) {
-            try { $entry | Add-Member -NotePropertyName reportPath -NotePropertyValue $reportPath -Force } catch {}
-        }
-    }
-
     $capturePath = $null
     if ($entry.PSObject.Properties['capturePath']) {
         $capturePath = Resolve-ExistingFile -Path $entry.capturePath
@@ -838,6 +784,17 @@ foreach ($entry in $entries) {
         $capturePath = Find-CapturePath -Entry $entry -CompareDir $compareRoot
         if ($capturePath) {
             try { $entry | Add-Member -NotePropertyName capturePath -NotePropertyValue $capturePath -Force } catch {}
+        }
+    }
+
+    $reportPath = $null
+    if ($entry.PSObject.Properties['reportPath']) {
+        $reportPath = Resolve-ExistingFile -Path $entry.reportPath
+    }
+    if (-not $reportPath) {
+        $reportPath = Find-ReportPath -Entry $entry -CompareDir $compareRoot -CapturePath $capturePath
+        if ($reportPath) {
+            try { $entry | Add-Member -NotePropertyName reportPath -NotePropertyValue $reportPath -Force } catch {}
         }
     }
 

--- a/tools/VICompareArtifacts.psm1
+++ b/tools/VICompareArtifacts.psm1
@@ -1,0 +1,176 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:KnownVICompareReportLeafNames = @(
+  'compare-report.html',
+  'compare-report.xml',
+  'compare-report.txt',
+  'cli-compare-report.html',
+  'cli-compare-report.xml',
+  'cli-compare-report.txt',
+  'linux-compare-report.html',
+  'linux-compare-report.xml',
+  'linux-compare-report.txt',
+  'windows-compare-report.html',
+  'windows-compare-report.xml',
+  'windows-compare-report.txt'
+)
+
+function Resolve-VICompareArtifactPath {
+  param(
+    [AllowEmptyString()][string]$PathValue,
+    [string[]]$BaseDirectories = @()
+  )
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $null
+  }
+
+  $candidates = New-Object System.Collections.Generic.List[string]
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    $candidates.Add([System.IO.Path]::GetFullPath($PathValue)) | Out-Null
+  } else {
+    foreach ($baseDirectory in @($BaseDirectories)) {
+      if ([string]::IsNullOrWhiteSpace($baseDirectory)) { continue }
+      $candidates.Add([System.IO.Path]::GetFullPath((Join-Path $baseDirectory $PathValue))) | Out-Null
+    }
+  }
+
+  foreach ($candidate in ($candidates | Select-Object -Unique)) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      return $candidate
+    }
+  }
+
+  return $null
+}
+
+function Test-IsVICompareReportArtifactName {
+  param(
+    [AllowEmptyString()][string]$Name
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Name)) {
+    return $false
+  }
+
+  $leafName = [System.IO.Path]::GetFileName($Name)
+  if ([string]::IsNullOrWhiteSpace($leafName)) {
+    return $false
+  }
+
+  if ($script:KnownVICompareReportLeafNames -contains $leafName) {
+    return $true
+  }
+
+  if ($leafName -match '^(?:(?:compare|diff|print|cli-compare|linux-compare|windows-compare)-report(?:-.+)?)\.(?:html|xml|txt)$') {
+    return $true
+  }
+
+  return $false
+}
+
+function Get-VICompareReportCandidatesFromCapture {
+  param(
+    [AllowEmptyString()][string]$CapturePath,
+    [string[]]$BaseDirectories = @()
+  )
+
+  if ([string]::IsNullOrWhiteSpace($CapturePath) -or -not (Test-Path -LiteralPath $CapturePath -PathType Leaf)) {
+    return @()
+  }
+
+  $captureDirectory = Split-Path -Parent $CapturePath
+  $resolutionBases = @($captureDirectory) + @($BaseDirectories)
+
+  try {
+    $capture = Get-Content -LiteralPath $CapturePath -Raw -ErrorAction Stop | ConvertFrom-Json -Depth 12
+  } catch {
+    return @()
+  }
+
+  $candidateValues = New-Object System.Collections.Generic.List[string]
+  foreach ($nodeName in @('out', 'cli')) {
+    if (-not $capture.PSObject.Properties[$nodeName]) { continue }
+    $node = $capture.$nodeName
+    if (-not $node) { continue }
+    foreach ($propertyName in @('reportHtml', 'reportPath')) {
+      if ($node.PSObject.Properties[$propertyName] -and $node.$propertyName) {
+        $candidateValues.Add([string]$node.$propertyName) | Out-Null
+      }
+    }
+  }
+  if ($capture.PSObject.Properties['reportPath'] -and $capture.reportPath) {
+    $candidateValues.Add([string]$capture.reportPath) | Out-Null
+  }
+
+  $resolved = New-Object System.Collections.Generic.List[string]
+  foreach ($candidateValue in ($candidateValues | Select-Object -Unique)) {
+    $candidatePath = Resolve-VICompareArtifactPath -PathValue $candidateValue -BaseDirectories $resolutionBases
+    if ($candidatePath -and -not $resolved.Contains($candidatePath)) {
+      $resolved.Add($candidatePath) | Out-Null
+    }
+  }
+
+  return @($resolved.ToArray())
+}
+
+function Find-VICompareReportArtifact {
+  param(
+    [AllowEmptyString()][string]$ExplicitReportPath,
+    [AllowEmptyString()][string]$CapturePath,
+    [string[]]$SearchDirectories = @(),
+    [switch]$Recursive
+  )
+
+  $existingDirectories = @(
+    $SearchDirectories |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+      ForEach-Object { [System.IO.Path]::GetFullPath($_) } |
+      Where-Object { Test-Path -LiteralPath $_ -PathType Container } |
+      Select-Object -Unique
+  )
+
+  $explicitPath = Resolve-VICompareArtifactPath -PathValue $ExplicitReportPath -BaseDirectories $existingDirectories
+  if ($explicitPath) {
+    return $explicitPath
+  }
+
+  $captureCandidates = @(Get-VICompareReportCandidatesFromCapture -CapturePath $CapturePath -BaseDirectories $existingDirectories)
+  if ($captureCandidates.Count -gt 0) {
+    return $captureCandidates[0]
+  }
+
+  foreach ($directory in $existingDirectories) {
+    foreach ($leafName in $script:KnownVICompareReportLeafNames) {
+      $candidatePath = Join-Path $directory $leafName
+      if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+        return [System.IO.Path]::GetFullPath($candidatePath)
+      }
+    }
+  }
+
+  foreach ($directory in $existingDirectories) {
+    try {
+      $candidateFiles = if ($Recursive) {
+        Get-ChildItem -LiteralPath $directory -Recurse -File -ErrorAction SilentlyContinue
+      } else {
+        Get-ChildItem -LiteralPath $directory -File -ErrorAction SilentlyContinue
+      }
+      $matchedFile = @(
+        $candidateFiles |
+          Where-Object { Test-IsVICompareReportArtifactName -Name $_.Name } |
+          Sort-Object FullName |
+          Select-Object -First 1
+      )
+      if ($matchedFile.Count -gt 0) {
+        return [System.IO.Path]::GetFullPath([string]$matchedFile[0].FullName)
+      }
+    } catch {}
+  }
+
+  return $null
+}
+
+Export-ModuleMember -Function Resolve-VICompareArtifactPath, Test-IsVICompareReportArtifactName, Get-VICompareReportCandidatesFromCapture, Find-VICompareReportArtifact

--- a/tools/compare/Find-VIComparisonCandidates.ps1
+++ b/tools/compare/Find-VIComparisonCandidates.ps1
@@ -16,6 +16,12 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $InformationPreference = 'Continue'
 
+$binaryToolsModule = Join-Path (Split-Path -Parent (Split-Path -Parent $PSCommandPath)) 'LabVIEWBinaryTools.psm1'
+if (-not (Test-Path -LiteralPath $binaryToolsModule -PathType Leaf)) {
+  throw ("LabVIEWBinaryTools.psm1 not found: {0}" -f $binaryToolsModule)
+}
+Import-Module $binaryToolsModule -Force
+
 function Resolve-RepoRoot {
   param([string]$StartPath = (Get-Location).Path)
   try {
@@ -74,7 +80,7 @@ if (-not $repoResolved -or -not (Test-Path -LiteralPath $repoResolved -PathType 
 
 $knownKinds = @{
   vi = @{
-    Extensions      = @('.vi', '.vim', '.vit', '.ctl', '.ctt', '.lvclass', '.lvlib', '.lvproj', '.lvsc', '.lvlibp')
+    Extensions      = @(Get-LabVIEWKnownFileExtensions)
     IncludePatterns = @('resource/', 'Resource/', 'Test/', 'tests/', 'compare/', 'Support/', 'support/', 'LVCompare/')
   }
 }
@@ -104,6 +110,70 @@ if ($Extensions) {
     if ($ext) {
       $normalized = $ext.StartsWith('.') ? $ext : ".$ext"
       [void]$resolvedExtensions.Add($normalized)
+    }
+  }
+}
+
+$explicitExtensionsProvided = [bool]$Extensions
+
+function Test-IsCandidateLabVIEWBinaryChange {
+  param(
+    [Parameter(Mandatory)][string]$RepoPath,
+    [AllowEmptyString()][string]$BaseRefValue,
+    [Parameter(Mandatory)][string]$HeadRefValue,
+    [AllowEmptyString()][string]$StatusCode,
+    [AllowEmptyString()][string]$PathValue,
+    [AllowEmptyString()][string]$OldPathValue,
+    [string[]]$KnownExtensions = @()
+  )
+
+  $normalizedStatus = if ([string]::IsNullOrWhiteSpace($StatusCode)) { '' } else { $StatusCode.Substring(0, 1).ToUpperInvariant() }
+  $knownExtensionSet = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($extension in @($KnownExtensions)) {
+    if (-not [string]::IsNullOrWhiteSpace([string]$extension)) {
+      [void]$knownExtensionSet.Add([string]$extension)
+    }
+  }
+
+  $testPathAtRef = {
+    param(
+      [string]$RefValue,
+      [string]$CandidatePath,
+      [bool]$AllowExtensionFallback
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RefValue) -or [string]::IsNullOrWhiteSpace($CandidatePath)) {
+      return $false
+    }
+
+    if (Test-IsLabVIEWBinaryAtGitPath -RepoPath $RepoPath -Ref $RefValue -Path $CandidatePath) {
+      return $true
+    }
+
+    if ($AllowExtensionFallback) {
+      $candidateExtension = [System.IO.Path]::GetExtension($CandidatePath)
+      if (-not [string]::IsNullOrWhiteSpace($candidateExtension) -and $knownExtensionSet.Contains($candidateExtension)) {
+        return $true
+      }
+    }
+
+    return $false
+  }
+
+  switch ($normalizedStatus) {
+    'A' { return (& $testPathAtRef $HeadRefValue $PathValue $false) }
+    'M' {
+      if (& $testPathAtRef $HeadRefValue $PathValue $false) { return $true }
+      return (& $testPathAtRef $BaseRefValue $PathValue ([string]::IsNullOrWhiteSpace($BaseRefValue)))
+    }
+    'D' { return (& $testPathAtRef $BaseRefValue $PathValue $true) }
+    'R' {
+      if (& $testPathAtRef $HeadRefValue $PathValue $false) { return $true }
+      return (& $testPathAtRef $BaseRefValue $OldPathValue $true)
+    }
+    default {
+      if (& $testPathAtRef $HeadRefValue $PathValue $false) { return $true }
+      return (& $testPathAtRef $BaseRefValue $OldPathValue $true)
     }
   }
 }
@@ -185,8 +255,22 @@ foreach ($line in $lines) {
   if (-not $matchesPattern) { continue }
 
   $extension = [System.IO.Path]::GetExtension($path)
-  if ($resolvedExtensions.Count -gt 0 -and -not $resolvedExtensions.Contains($extension)) {
-    continue
+  if ($explicitExtensionsProvided) {
+    if ($resolvedExtensions.Count -gt 0 -and -not $resolvedExtensions.Contains($extension)) {
+      continue
+    }
+  } else {
+    $oldPathForDetection = if ([string]::IsNullOrWhiteSpace($oldPath)) { $path } else { $oldPath }
+    if (-not (Test-IsCandidateLabVIEWBinaryChange `
+      -RepoPath $repoResolved `
+      -BaseRefValue $BaseRef `
+      -HeadRefValue $headRefResolved `
+      -StatusCode $statusCode `
+      -PathValue $path `
+      -OldPathValue $oldPathForDetection `
+      -KnownExtensions $knownKinds['vi'].Extensions)) {
+      continue
+    }
   }
 
   $fileInfo = [pscustomobject]@{


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1401
- Issue title: Leverage content-based LabVIEW file detection and artifact-first report linking patterns from gregr-ni/labview-ci-cd#1
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1401
- Standing priority at PR creation: Yes (#1401)
- Base branch: `develop`
- Head branch: `issue/origin-1401-labview-binary-detection`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
