### PR TITLE
Promote artifact-first VICompare report discovery to metadata and dashboard consumers (#1464)

### DIFF
--- a/.github/actions/fixture-drift/action.yml
+++ b/.github/actions/fixture-drift/action.yml
@@ -373,9 +373,31 @@ runs:
         $status = 'unknown'; $exitCode = ''
         $artifactsList = @()
         $reportPath = $null
-        if ($latest) {
-          $candidateReport = Join-Path $latest.FullName 'compare-report.html'
-          if (Test-Path $candidateReport) { $reportPath = (Resolve-Path -LiteralPath $candidateReport).Path }
+        $searchBase = '${{ steps.orchestrate.outputs.results_dir }}'
+        if (-not $searchBase) {
+          if ($latest) {
+            $searchBase = $latest.FullName
+          } else {
+            $searchBase = $root
+          }
+        }
+        $compareOutcomePath = Join-Path $searchBase 'compare-outcome.json'
+        if (Test-Path -LiteralPath $compareOutcomePath) {
+          try {
+            $compareOutcome = Get-Content -LiteralPath $compareOutcomePath -Raw | ConvertFrom-Json -Depth 8
+            if ($compareOutcome.reportPath) {
+              $reportCandidate = if ([System.IO.Path]::IsPathRooted([string]$compareOutcome.reportPath)) {
+                [string]$compareOutcome.reportPath
+              } else {
+                Join-Path $searchBase ([string]$compareOutcome.reportPath)
+              }
+              try {
+                $reportPath = (Resolve-Path -LiteralPath $reportCandidate -ErrorAction Stop).Path
+              } catch {
+                $reportPath = $reportCandidate
+              }
+            }
+          } catch {}
         }
         if ($sum -and (Test-Path $sum)) {
           $j = Get-Content -LiteralPath $sum -Raw | ConvertFrom-Json
@@ -386,7 +408,7 @@ runs:
         if (-not $reportPath -and $artifactsList.Count -gt 0) {
           foreach ($rel in $artifactsList) {
             if ([string]::IsNullOrWhiteSpace($rel)) { continue }
-            if ($rel -match 'compare-report.html$') {
+            if ($rel -match '(?i)(compare|diff|print|cli-compare|linux-compare|windows-compare)-report\.(html|xml|txt)$') {
               $resolved = if ([System.IO.Path]::IsPathRooted($rel)) { $rel } else { Join-Path (Get-Location) $rel }
               if (Test-Path -LiteralPath $resolved) { $reportPath = (Resolve-Path -LiteralPath $resolved).Path; break }
             }
@@ -504,4 +526,3 @@ runs:
           $lines += '- Fixture Drift: ./docs/FIXTURE_DRIFT.md'
           $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
         }
-

--- a/tests/DevDashboard.CLI.Tests.ps1
+++ b/tests/DevDashboard.CLI.Tests.ps1
@@ -92,4 +92,30 @@ Describe 'Dev Dashboard CLI' -Tag 'Unit' {
     $json = (($jsonOutput | Out-String) | ConvertFrom-Json)
     $json.PesterTelemetry.RuntimeEvents | Should -BeNullOrEmpty
   }
+
+  It 'surfaces custom compare report artifacts in the CLI snapshot' {
+    $resultsRoot = Join-Path $TestDrive 'samples-custom-report'
+    Copy-Item -LiteralPath $script:samplesRoot -Destination $resultsRoot -Recurse -Force
+
+    $compareDir = Join-Path $resultsRoot 'compare'
+    New-Item -ItemType Directory -Path $compareDir -Force | Out-Null
+    $reportPath = Join-Path $compareDir 'diff-report-Initialization_UserEvents.vi.html'
+    Set-Content -LiteralPath $reportPath -Value '<html></html>' -Encoding utf8
+    @'
+{
+  "schema": "lvcompare-capture-v1",
+  "exitCode": 1,
+  "seconds": 0.2,
+  "environment": {
+    "cli": {
+      "reportPath": "./diff-report-Initialization_UserEvents.vi.html"
+    }
+  }
+}
+'@ | Set-Content -LiteralPath (Join-Path $compareDir 'lvcompare-capture.json') -Encoding utf8
+
+    $jsonOutput = & $script:cliPath -Group 'pester-selfhosted' -ResultsRoot $resultsRoot -Quiet -Json
+    $json = (($jsonOutput | Out-String) | ConvertFrom-Json)
+    $json.CompareOutcome.ReportPath | Should -Be $reportPath
+  }
 }

--- a/tests/DevDashboard.Loaders.Tests.ps1
+++ b/tests/DevDashboard.Loaders.Tests.ps1
@@ -65,6 +65,32 @@ Describe 'Dev Dashboard loaders' -Tag 'Unit','REQ:WATCH_AND_QUEUE' {
     $suite.ModeManifestsJson | Should -Match '"slug":"attributes"'
   }
 
+  It 'resolves custom compare report artifacts from capture metadata' {
+    $resultsRoot = Join-Path $TestDrive 'dashboard-custom-report'
+    $compareDir = Join-Path $resultsRoot 'compare'
+    New-Item -ItemType Directory -Path $compareDir -Force | Out-Null
+
+    $reportPath = Join-Path $compareDir 'diff-report-Initialization_UserEvents.vi.html'
+    Set-Content -LiteralPath $reportPath -Value '<html></html>' -Encoding utf8
+    @'
+{
+  "schema": "lvcompare-capture-v1",
+  "exitCode": 1,
+  "seconds": 0.2,
+  "environment": {
+    "cli": {
+      "reportPath": "./diff-report-Initialization_UserEvents.vi.html"
+    }
+  }
+}
+'@ | Set-Content -LiteralPath (Join-Path $compareDir 'lvcompare-capture.json') -Encoding utf8
+
+    $compare = Get-CompareOutcomeTelemetry -ResultsRoot $resultsRoot
+    $compare | Should -Not -BeNullOrEmpty
+    $compare.ReportPath | Should -Be $reportPath
+    $compare.Diff | Should -BeTrue
+  }
+
   It 'resolves stakeholder information from configuration' {
     $info = Get-StakeholderInfo -Group 'pester-selfhosted' -StakeholderPath $script:stakeholderPath
     $info.Found | Should -BeTrue

--- a/tests/FixtureDriftAction.Contracts.Tests.ps1
+++ b/tests/FixtureDriftAction.Contracts.Tests.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+
+Describe 'fixture-drift action artifact-first contracts' -Tag 'Unit' {
+    BeforeAll {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+        $actionPath = Join-Path $repoRoot '.github' 'actions' 'fixture-drift' 'action.yml'
+        Test-Path -LiteralPath $actionPath | Should -BeTrue
+        $script:actionText = Get-Content -LiteralPath $actionPath -Raw
+    }
+
+    It 'uses compare-outcome.json when building PR comments' {
+        $script:actionText | Should -Match 'compare-outcome\.json'
+        $script:actionText | Should -Match 'compareOutcome\.reportPath'
+    }
+
+    It 'accepts custom report artifact names instead of only compare-report.html' {
+        $script:actionText | Should -Match '\(\?i\)\(compare\|diff\|print\|cli-compare\|linux-compare\|windows-compare\)-report\\\.\(html\|xml\|txt\)\$'
+        $script:actionText | Should -Not -Match "\$rel -match 'compare-report\.html\$'"
+    }
+}

--- a/tests/Get-VICompareMetadata.Tests.ps1
+++ b/tests/Get-VICompareMetadata.Tests.ps1
@@ -79,4 +79,59 @@ Describe 'Get-VICompareMetadata.ps1' -Tag 'Unit' {
         $json.status | Should -Be 'diff'
         $json.diffCategories | Should -Contain 'Block Diagram Cosmetic'
     }
+
+    It 'resolves custom report artifacts from capture metadata' {
+        $baseVi = Join-Path $TestDrive 'Base.vi'
+        $headVi = Join-Path $TestDrive 'Head.vi'
+        Set-Content -LiteralPath $baseVi -Value 'base'
+        Set-Content -LiteralPath $headVi -Value 'head'
+
+        $outputPath = Join-Path $TestDrive 'metadata-custom.json'
+
+        $invoke = {
+            param(
+                [string]$BaseVi,
+                [string]$HeadVi,
+                [string]$OutputDir,
+                [string[]]$Flags,
+                [switch]$ReplaceFlags
+            )
+            New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+            $reportPath = Join-Path $OutputDir 'diff-report-Initialization_UserEvents.vi.html'
+            $capturePath = Join-Path $OutputDir 'lvcompare-capture.json'
+            @'
+<!DOCTYPE html>
+<html>
+<body>
+<details open>
+  <summary class="difference-heading">1. VI Attribute - Miscellaneous</summary>
+  <ol class="detailed-description-list">
+    <li class="diff-detail">Difference Type: VI icon</li>
+  </ol>
+</details>
+</body>
+</html>
+'@ | Set-Content -LiteralPath $reportPath -Encoding utf8
+            @'
+{
+  "schema": "lvcompare-capture-v1",
+  "cli": {
+    "reportPath": "./diff-report-Initialization_UserEvents.vi.html"
+  },
+  "out": {
+    "reportHtml": "./diff-report-Initialization_UserEvents.vi.html"
+  }
+}
+'@ | Set-Content -LiteralPath $capturePath -Encoding utf8
+            return [pscustomobject]@{
+                ExitCode = 1
+            }
+        }.GetNewClosure()
+
+        $result = & $script:scriptPath -BaseVi $baseVi -HeadVi $headVi -OutputPath $outputPath -InvokeLVCompare $invoke
+
+        $result.reportPath | Should -Match 'diff-report-Initialization_UserEvents\.vi\.html$'
+        $result.diffCategories | Should -Contain 'VI Attribute'
+    }
 }

--- a/tests/ParseCompareExec.Tests.ps1
+++ b/tests/ParseCompareExec.Tests.ps1
@@ -72,6 +72,38 @@ Describe 'Parse-CompareExec.ps1' -Tag 'Unit' {
     $out.compareExec.path | Should -Be $execPath
   }
 
+  It 'resolves custom report artifacts from capture metadata' {
+    $work = Join-Path $TestDrive 'capture-custom-report'
+    New-Item -ItemType Directory -Path $work | Out-Null
+
+    $captureDir = Join-Path $work 'compare'
+    New-Item -ItemType Directory -Path $captureDir | Out-Null
+
+    $capture = [ordered]@{
+      schema    = 'lvcompare-capture-v1'
+      timestamp = '2025-01-02T03:04:05Z'
+      exitCode  = 1
+      seconds   = 0.42
+      environment = [ordered]@{
+        cli = [ordered]@{
+          reportPath = './diff-report-Initialization_UserEvents.vi.html'
+        }
+      }
+    }
+    $capturePath = Join-Path $captureDir 'lvcompare-capture.json'
+    $capture | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $capturePath -Encoding utf8
+    $reportPath = Join-Path $captureDir 'diff-report-Initialization_UserEvents.vi.html'
+    Set-Content -LiteralPath $reportPath -Value '<html></html>' -Encoding utf8
+
+    $outPath = Join-Path $work 'compare-outcome.json'
+    & pwsh -NoLogo -NoProfile -File $script:parseScript -SearchDir $work -OutJson $outPath
+    $LASTEXITCODE | Should -Be 0
+
+    $out = Get-Content -LiteralPath $outPath -Raw | ConvertFrom-Json -Depth 6
+    $out.source | Should -Be 'capture'
+    $out.reportPath | Should -Be $reportPath
+  }
+
   It 'falls back to compare-exec when capture is missing' {
     $work = Join-Path $TestDrive 'exec-only'
     New-Item -ItemType Directory -Path $work | Out-Null

--- a/tools/Dev-Dashboard.ps1
+++ b/tools/Dev-Dashboard.ps1
@@ -16,6 +16,10 @@ $script:toolRoot = Split-Path -Parent $PSCommandPath
 $script:repoRoot = Split-Path -Parent $toolRoot
 $modulePath = Join-Path $toolRoot 'Dev-Dashboard.psm1'
 Import-Module $modulePath -Force
+$artifactModulePath = Join-Path $toolRoot 'VICompareArtifacts.psm1'
+if (Test-Path -LiteralPath $artifactModulePath -PathType Leaf) {
+  Import-Module $artifactModulePath -Force
+}
 
 function Invoke-Git {
   param([string[]]$Arguments)
@@ -58,6 +62,41 @@ function Get-PropertyValue {
   return $null
 }
 
+function Resolve-ArtifactPathHint {
+  param(
+    [string]$ArtifactPath,
+    [string]$SessionIndexPath,
+    [string]$ResultsRoot
+  )
+
+  if ([string]::IsNullOrWhiteSpace($ArtifactPath)) { return $null }
+
+  try {
+    $resolved = Resolve-Path -LiteralPath $ArtifactPath -ErrorAction Stop
+    return $resolved.ProviderPath
+  } catch {}
+
+  $candidates = @()
+  if (-not [System.IO.Path]::IsPathRooted($ArtifactPath)) {
+    if ($SessionIndexPath) {
+      $candidates += Join-Path (Split-Path -Parent $SessionIndexPath) $ArtifactPath
+    }
+    if ($ResultsRoot) {
+      $candidates += Join-Path $ResultsRoot $ArtifactPath
+    }
+  }
+
+  foreach ($candidate in $candidates) {
+    try {
+      $resolved = Resolve-Path -LiteralPath $candidate -ErrorAction Stop
+      return $resolved.ProviderPath
+    } catch {}
+  }
+
+  if ($candidates.Count -gt 0) { return $candidates[0] }
+  return $ArtifactPath
+}
+
 function Get-CompareOutcomeTelemetry {
   param([string]$ResultsRoot)
 
@@ -80,7 +119,7 @@ function Get-CompareOutcomeTelemetry {
         Source       = if ($data.source) { $data.source } else { 'compare-outcome' }
         JsonPath     = $outcome.FullName
         CapturePath  = if ($data.captureJson) { $data.captureJson } else { $data.file }
-        ReportPath   = if ($data.reportPath) { $data.reportPath } else { $null }
+        ReportPath   = Resolve-ArtifactPathHint -ArtifactPath $data.reportPath -SessionIndexPath $outcome.FullName -ResultsRoot $resolved
         ExitCode     = if ($data.exitCode -ne $null) { [int]$data.exitCode } else { $null }
         Diff         = if ($data.diff -ne $null) { [bool]$data.diff } else { $null }
         DurationMs   = if ($data.durationMs -ne $null) { [double]$data.durationMs } else { $null }
@@ -101,12 +140,16 @@ function Get-CompareOutcomeTelemetry {
     if ($capture) {
       try {
         $cap = Get-Content -LiteralPath $capture.FullName -Raw | ConvertFrom-Json -Depth 6
-        $exitCode = if ($cap.exitCode -ne $null) { [int]$cap.exitCode } else { $null }
+        $capExitCode = Get-PropertyValue -Object $cap -Property 'exitCode'
+        $exitCode = if ($capExitCode -ne $null) { [int]$capExitCode } else { $null }
         $diff = if ($exitCode -ne $null) { $exitCode -eq 1 } else { $null }
         $durationMs = $null
-        if ($cap.seconds -ne $null) { $durationMs = [math]::Round([double]$cap.seconds * 1000, 3) }
-        $cliPath = if ($cap.cliPath) { [string]$cap.cliPath } else { $null }
-        $command = if ($cap.command) { [string]$cap.command } else { $null }
+        $capSeconds = Get-PropertyValue -Object $cap -Property 'seconds'
+        if ($capSeconds -ne $null) { $durationMs = [math]::Round([double]$capSeconds * 1000, 3) }
+        $capCliPath = Get-PropertyValue -Object $cap -Property 'cliPath'
+        $cliPath = if ($capCliPath) { [string]$capCliPath } else { $null }
+        $capCommand = Get-PropertyValue -Object $cap -Property 'command'
+        $command = if ($capCommand) { [string]$capCommand } else { $null }
 
         $artifacts = $null
         if ($cap.environment -and $cap.environment.cli -and $cap.environment.cli.PSObject.Properties.Name -contains 'artifacts') {
@@ -114,15 +157,17 @@ function Get-CompareOutcomeTelemetry {
         }
 
         $reportPath = $null
+        $explicitReportPath = $null
         if ($cap.environment -and $cap.environment.cli -and $cap.environment.cli.PSObject.Properties.Name -contains 'reportPath') {
-          $reportPath = $cap.environment.cli.reportPath
+          $explicitReportPath = [string]$cap.environment.cli.reportPath
+        } elseif ($cap.PSObject.Properties.Name -contains 'cli' -and $cap.cli -and $cap.cli.PSObject.Properties.Name -contains 'reportPath') {
+          $explicitReportPath = [string]$cap.cli.reportPath
         }
-        if (-not $reportPath) {
-          $compareHtml = Join-Path (Split-Path -Parent $capture.FullName) 'compare-report.html'
-          if (Test-Path -LiteralPath $compareHtml) { $reportPath = $compareHtml }
-          $cliHtml = Join-Path (Split-Path -Parent $capture.FullName) 'cli-report.html'
-          if (Test-Path -LiteralPath $cliHtml) { $reportPath = $cliHtml }
-        }
+        $reportPath = Find-VICompareReportArtifact `
+          -ExplicitReportPath $explicitReportPath `
+          -CapturePath $capture.FullName `
+          -SearchDirectories @((Split-Path -Parent $capture.FullName)) `
+          -Recursive
 
         $latestOutcome = [pscustomobject][ordered]@{
           Source       = 'capture'

--- a/tools/Dev-Dashboard.psm1
+++ b/tools/Dev-Dashboard.psm1
@@ -4,6 +4,10 @@ $ErrorActionPreference = 'Stop'
 $script:repoRoot = Split-Path -Parent $PSScriptRoot
 $sessionIndexReaderModule = Join-Path $PSScriptRoot 'SessionIndex-Readers.psm1'
 Import-Module $sessionIndexReaderModule -Force
+$artifactModulePath = Join-Path $PSScriptRoot 'VICompareArtifacts.psm1'
+if (Test-Path -LiteralPath $artifactModulePath -PathType Leaf) {
+  Import-Module $artifactModulePath -Force
+}
 
 function Resolve-PathSafe {
   param([string]$Path)
@@ -341,7 +345,7 @@ function Get-CompareOutcomeTelemetry {
         Source       = if ($data.source) { $data.source } else { 'compare-outcome' }
         JsonPath     = $outcome.FullName
         CapturePath  = if ($data.captureJson) { $data.captureJson } else { $data.file }
-        ReportPath   = if ($data.reportPath) { $data.reportPath } else { $null }
+        ReportPath   = Resolve-ArtifactPathHint -ArtifactPath $data.reportPath -SessionIndexPath $outcome.FullName -ResultsRoot $resolvedRoot
         ExitCode     = if ($data.exitCode -ne $null) { [int]$data.exitCode } else { $null }
         Diff         = if ($data.diff -ne $null) { [bool]$data.diff } else { $null }
         DurationMs   = if ($data.durationMs -ne $null) { [double]$data.durationMs } else { $null }
@@ -362,28 +366,33 @@ function Get-CompareOutcomeTelemetry {
     if ($capture) {
       try {
         $cap = Get-Content -LiteralPath $capture.FullName -Raw | ConvertFrom-Json -Depth 6
-        $exitCode = if ($cap.exitCode -ne $null) { [int]$cap.exitCode } else { $null }
+        $capExitCode = Get-ObjectPropertyValue -Object $cap -Name 'exitCode'
+        $exitCode = if ($capExitCode -ne $null) { [int]$capExitCode } else { $null }
         $diff = if ($exitCode -ne $null) { $exitCode -eq 1 } else { $null }
         $durationMs = $null
-        if ($cap.seconds -ne $null) { $durationMs = [math]::Round([double]$cap.seconds * 1000, 3) }
-        $cliPath = if ($cap.cliPath) { [string]$cap.cliPath } else { $null }
-        $command = if ($cap.command) { [string]$cap.command } else { $null }
+        $capSeconds = Get-ObjectPropertyValue -Object $cap -Name 'seconds'
+        if ($capSeconds -ne $null) { $durationMs = [math]::Round([double]$capSeconds * 1000, 3) }
+        $capCliPath = Get-ObjectPropertyValue -Object $cap -Name 'cliPath'
+        $cliPath = if ($capCliPath) { [string]$capCliPath } else { $null }
+        $capCommand = Get-ObjectPropertyValue -Object $cap -Name 'command'
+        $command = if ($capCommand) { [string]$capCommand } else { $null }
 
         $artifacts = $null
         if ($cap.environment -and $cap.environment.cli -and $cap.environment.cli.PSObject.Properties.Name -contains 'artifacts') {
           $artifacts = $cap.environment.cli.artifacts
         }
 
-        $reportPath = $null
+        $explicitReportPath = $null
         if ($cap.environment -and $cap.environment.cli -and $cap.environment.cli.PSObject.Properties.Name -contains 'reportPath') {
-          $reportPath = $cap.environment.cli.reportPath
+          $explicitReportPath = [string]$cap.environment.cli.reportPath
+        } elseif ($cap.PSObject.Properties.Name -contains 'cli' -and $cap.cli -and $cap.cli.PSObject.Properties.Name -contains 'reportPath') {
+          $explicitReportPath = [string]$cap.cli.reportPath
         }
-        if (-not $reportPath) {
-          $compareHtml = Join-Path (Split-Path -Parent $capture.FullName) 'compare-report.html'
-          if (Test-Path -LiteralPath $compareHtml) { $reportPath = $compareHtml }
-          $cliHtml = Join-Path (Split-Path -Parent $capture.FullName) 'cli-report.html'
-          if (Test-Path -LiteralPath $cliHtml) { $reportPath = $cliHtml }
-        }
+        $reportPath = Find-VICompareReportArtifact `
+          -ExplicitReportPath $explicitReportPath `
+          -CapturePath $capture.FullName `
+          -SearchDirectories @((Split-Path -Parent $capture.FullName)) `
+          -Recursive
 
         $latestOutcome = [pscustomobject][ordered]@{
           Source       = 'capture'

--- a/tools/Get-VICompareMetadata.ps1
+++ b/tools/Get-VICompareMetadata.ps1
@@ -58,6 +58,12 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+$artifactModulePath = Join-Path (Split-Path -Parent $PSCommandPath) 'VICompareArtifacts.psm1'
+if (-not (Test-Path -LiteralPath $artifactModulePath -PathType Leaf)) {
+    throw "VICompareArtifacts.psm1 not found at $artifactModulePath"
+}
+Import-Module $artifactModulePath -Force
+
 function Resolve-ExistingFile {
     param([string]$Path)
     if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
@@ -158,8 +164,17 @@ if ($invokeResult -is [int]) {
     $exitCode = $LASTEXITCODE
 }
 
-$reportPath = Resolve-ExistingFile -Path (Join-Path $compareDir 'compare-report.html')
 $capturePath = Resolve-ExistingFile -Path (Join-Path $compareDir 'lvcompare-capture.json')
+$explicitReportPath = if ($invokeResult -and $invokeResult.PSObject.Properties['ReportPath']) {
+    [string]$invokeResult.ReportPath
+} else {
+    $null
+}
+$reportPath = Find-VICompareReportArtifact `
+    -ExplicitReportPath $explicitReportPath `
+    -CapturePath $capturePath `
+    -SearchDirectories @($compareDir) `
+    -Recursive
 
 if (-not $reportPath) {
     throw "Compare report not found in $compareDir"

--- a/tools/Parse-CompareExec.ps1
+++ b/tools/Parse-CompareExec.ps1
@@ -6,6 +6,26 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+$artifactModulePath = Join-Path (Split-Path -Parent $PSCommandPath) 'VICompareArtifacts.psm1'
+if (-not (Test-Path -LiteralPath $artifactModulePath -PathType Leaf)) {
+  throw "VICompareArtifacts.psm1 not found at $artifactModulePath"
+}
+Import-Module $artifactModulePath -Force
+
+function Get-PropertyValue {
+  param(
+    $Object,
+    [string]$Property
+  )
+
+  if ($null -eq $Object -or [string]::IsNullOrWhiteSpace($Property)) { return $null }
+  try {
+    $member = $Object.PSObject.Properties[$Property]
+    if ($member) { return $member.Value }
+  } catch {}
+  return $null
+}
+
 try { $resolvedDir = (Resolve-Path -LiteralPath $SearchDir -ErrorAction Stop).Path } catch { $resolvedDir = $SearchDir }
 
 $capturePath = @(Get-ChildItem -Path $resolvedDir -Recurse -Include lvcompare-capture.json -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName) | Sort-Object -Descending | Select-Object -First 1
@@ -39,23 +59,42 @@ if ($capturePath -and (Test-Path -LiteralPath $capturePath)) {
     $payload.capture.reason = $null
     $payload.source = 'capture'
     $payload.file = $capturePath
-    if ($cap.exitCode -ne $null) { $payload.exitCode = [int]$cap.exitCode }
-    if ($cap.command) { $payload.command = [string]$cap.command }
-    if ($cap.cliPath) { $payload.cliPath = [string]$cap.cliPath }
-    if ($cap.seconds -ne $null) { $payload.durationMs = [math]::Round([double]$cap.seconds * 1000,3) }
+    $capExitCode = Get-PropertyValue -Object $cap -Property 'exitCode'
+    if ($capExitCode -ne $null) { $payload.exitCode = [int]$capExitCode }
+    $capCommand = Get-PropertyValue -Object $cap -Property 'command'
+    if ($capCommand) { $payload.command = [string]$capCommand }
+    $capCliPath = Get-PropertyValue -Object $cap -Property 'cliPath'
+    if ($capCliPath) { $payload.cliPath = [string]$capCliPath }
+    $capSeconds = Get-PropertyValue -Object $cap -Property 'seconds'
+    if ($capSeconds -ne $null) { $payload.durationMs = [math]::Round([double]$capSeconds * 1000,3) }
     if ($payload.exitCode -ne $null) { $payload.diff = ($payload.exitCode -eq 1) }
-    if ($cap.stdoutLen -ne $null) { $payload.stdoutLen = [int]$cap.stdoutLen }
-    if ($cap.stderrLen -ne $null) { $payload.stderrLen = [int]$cap.stderrLen }
+    $capStdoutLen = Get-PropertyValue -Object $cap -Property 'stdoutLen'
+    if ($capStdoutLen -ne $null) { $payload.stdoutLen = [int]$capStdoutLen }
+    $capStderrLen = Get-PropertyValue -Object $cap -Property 'stderrLen'
+    if ($capStderrLen -ne $null) { $payload.stderrLen = [int]$capStderrLen }
     $capDir = Split-Path -Parent $capturePath
     $stdoutCandidate = Join-Path $capDir 'lvcompare-stdout.txt'
     if (Test-Path -LiteralPath $stdoutCandidate) { $payload.stdoutPath = $stdoutCandidate }
     $stderrCandidate = Join-Path $capDir 'lvcompare-stderr.txt'
     if (Test-Path -LiteralPath $stderrCandidate) { $payload.stderrPath = $stderrCandidate }
-    $reportCandidate = Join-Path $capDir 'compare-report.html'
-    if (Test-Path -LiteralPath $reportCandidate) { $payload.reportPath = $reportCandidate }
-    $cliArtifacts = $null
+    $explicitReportPath = $null
     $capEnv = $null
     if ($cap.PSObject.Properties['environment']) { $capEnv = $cap.environment }
+    if (-not $capEnv -and $cap.PSObject.Properties['cli']) {
+      $capEnv = [pscustomobject]@{ cli = $cap.cli }
+    }
+    if ($capEnv -and $capEnv.PSObject.Properties['cli']) {
+      $capCli = $capEnv.cli
+      if ($capCli -and $capCli.PSObject.Properties['reportPath'] -and $capCli.reportPath) {
+        $explicitReportPath = [string]$capCli.reportPath
+      }
+    }
+    $payload.reportPath = Find-VICompareReportArtifact `
+      -ExplicitReportPath $explicitReportPath `
+      -CapturePath $capturePath `
+      -SearchDirectories @($capDir) `
+      -Recursive
+    $cliArtifacts = $null
     if ($capEnv -and $capEnv.PSObject.Properties['cli']) {
       $capCli = $capEnv.cli
       if ($capCli -and $capCli.PSObject.Properties['artifacts']) { $cliArtifacts = $capCli.artifacts }


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1464
- Issue title: Promote artifact-first VICompare report discovery to metadata and dashboard consumers
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1464
- Standing priority at PR creation: Yes (#1464)
- Base branch: `develop`
- Head branch: `issue/origin-1464-artifact-first-report-consumers`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
