### PR TITLE
Add a headless sample VI corpus for certification lanes

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-19T12:50:00Z",
+  "updated": "2026-03-20T00:15:00Z",
   "entries": [
     {
       "name": "Root Entry Points",
@@ -63,6 +63,7 @@
         "docs/knowledgebase/GitHub-Intake-Layer.md",
         "docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md",
         "docs/knowledgebase/GitHub-Wiki-Portal.md",
+        "docs/knowledgebase/Headless-SampleVI-Corpus.md",
         "docs/knowledgebase/Offline-RealHistory-Corpus.md",
         "docs/knowledgebase/DOCKER_TOOLS_PARITY.md",
         "docs/LABVIEW_GATING.md",
@@ -203,6 +204,20 @@
         "tools/priority/__tests__/render-mission-control-prompt.test.mjs",
         "tools/priority/__tests__/resolve-mission-control-profile.test.mjs",
         "tools/priority/__tests__/validate-mission-control-operator-input.test.mjs"
+      ]
+    },
+    {
+      "name": "Headless Sample Corpus Contracts",
+      "category": "supporting",
+      "status": "reference",
+      "description": "Checked-in catalog, schemas, evaluator, and focused tests for the evidence-backed public sample VI corpus used by headless certification lanes.",
+      "files": [
+        "docs/knowledgebase/Headless-SampleVI-Corpus.md",
+        "docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json",
+        "docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json",
+        "fixtures/headless-corpus/sample-vi-corpus.targets.json",
+        "tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1",
+        "tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1"
       ]
     },
     {

--- a/docs/knowledgebase/Headless-SampleVI-Corpus.md
+++ b/docs/knowledgebase/Headless-SampleVI-Corpus.md
@@ -1,0 +1,123 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Headless Sample VI Corpus
+
+This note defines the checked-in admission contract for public sample VIs used
+as a higher certification layer above the repo's minimal local fixtures.
+
+## Purpose
+
+Use externally evidenced sample VIs when you need stronger proof that headless
+compare or history rendering still works on realistic public files.
+
+This corpus is not the pre-push gate.
+
+- Pre-push stays deterministic and fixture-backed.
+- The sample corpus is a certification and research layer.
+- Admission state keeps licensed, public, reproducible seeds separate from
+  useful-but-not-yet-promotable samples.
+
+## Checked-in inputs
+
+- Target catalog: `fixtures/headless-corpus/sample-vi-corpus.targets.json`
+- Catalog schema:
+  `docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json`
+- Evaluation schema:
+  `docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json`
+- Evaluator:
+  `tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1`
+
+## Admission states
+
+- `accepted`
+  - requires public GitHub evidence
+  - requires a declared license
+  - requires a pinned commit SHA
+  - can be promoted into broader certification lanes
+- `provisional`
+  - useful for research and future replacement
+  - must stay non-blocking
+  - captures why the seed is not yet promotable
+- `rejected`
+  - recorded only when the catalog needs to remember why a prior seed cannot be
+    used anymore
+
+## Current seeds
+
+### Accepted
+
+1. `icon-editor-settings-init-history`
+- Repo: `LabVIEW-Community-CI-CD/labview-icon-editor`
+- License: `MIT`
+- Surface: `vi-history`
+- Plane: `windows-mirror`
+- Local lineage: `fixtures/cross-repo/labview-icon-editor/settings-init/`
+- Public evidence: PR VI History workflow success on the public upstream repo
+
+2. `icon-editor-demo-vip-preinstall-history`
+- Repo: `LabVIEW-Community-CI-CD/labview-icon-editor-demo`
+- License: `MIT`
+- Surface: `vi-history`
+- Plane: `linux-proof`
+- Public evidence: PR `#31` plus successful diagnostics, publish, and canary
+  runs on the real modified VI
+
+### Provisional
+
+1. `linuxcontainerdemo-newthing-print`
+- Repo: `aphill93/linuxContainerDemo`
+- Surface: `print-single-file`
+- Plane: `linux-proof`
+- Change kind: `added`
+- Public evidence: PR `#7` plus successful Linux compare/headless runs
+- Blocking gap: the repository currently declares no license
+
+That provisional seed is intentionally kept out of accepted certification until
+there is either explicit licensing or a replacement seed from a licensed public
+repository.
+
+## Render strategy rules
+
+The corpus keeps change kind and rendering intent explicit.
+
+- `modified` VIs:
+  - `vi-history` -> `Compare-VIHistory`
+  - `compare-report` -> `CreateComparisonReport`
+- `added` or `deleted` VIs:
+  - `print-single-file` -> `PrintToSingleFileHtml`
+
+This keeps the sample corpus aligned with the change-kind-aware rendering work
+tracked in `#1406` and `#1408`.
+
+## Evaluation
+
+Run the evaluator locally:
+
+```powershell
+node tools/npm/run-script.mjs history:corpus:samples:evaluate
+```
+
+Outputs land under:
+
+- `tests/results/_agent/headless-sample-corpus/headless-sample-vi-corpus-evaluation.json`
+- `tests/results/_agent/headless-sample-corpus/headless-sample-vi-corpus-evaluation.md`
+
+The evaluator fails closed when an `accepted` target loses:
+
+- public GitHub evidence
+- declared license
+- pinned commit
+- coherent change-kind/render strategy
+- declared local fixture lineage paths when present
+
+`provisional` targets can warn without failing the overall report.
+
+## Intentional boundary
+
+Do not let this corpus replace:
+
+- the local fixture-backed pre-push gate
+- the rendered reviewer semantic assertions
+- the broad NI Linux certification lane
+
+It exists to strengthen those surfaces with public, realistic, machine-tracked
+sample provenance.

--- a/docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json
+++ b/docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json",
+  "title": "Headless Sample VI Corpus Evaluation v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "catalogPath",
+    "overallStatus",
+    "summary",
+    "targets"
+  ],
+  "properties": {
+    "schema": {
+      "const": "vi-headless/sample-corpus-evaluation@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "catalogPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "overallStatus": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "drift"
+      ]
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetCount",
+        "acceptedCount",
+        "provisionalCount",
+        "rejectedCount",
+        "okCount",
+        "warningCount",
+        "driftCount"
+      ],
+      "properties": {
+        "targetCount": { "type": "integer", "minimum": 0 },
+        "acceptedCount": { "type": "integer", "minimum": 0 },
+        "provisionalCount": { "type": "integer", "minimum": 0 },
+        "rejectedCount": { "type": "integer", "minimum": 0 },
+        "okCount": { "type": "integer", "minimum": 0 },
+        "warningCount": { "type": "integer", "minimum": 0 },
+        "driftCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/target"
+      }
+    }
+  },
+  "$defs": {
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "publicRepo",
+        "githubEvidenceUrls",
+        "licenseDeclared",
+        "pinnedCommit",
+        "successfulWorkflowEvidence",
+        "renderStrategyAligned",
+        "localFixturePathsResolved"
+      ],
+      "properties": {
+        "publicRepo": { "type": "boolean" },
+        "githubEvidenceUrls": { "type": "boolean" },
+        "licenseDeclared": { "type": "boolean" },
+        "pinnedCommit": { "type": "boolean" },
+        "successfulWorkflowEvidence": { "type": "boolean" },
+        "renderStrategyAligned": { "type": "boolean" },
+        "localFixturePathsResolved": { "type": "boolean" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "admissionState",
+        "status",
+        "repoSlug",
+        "targetPath",
+        "changeKind",
+        "certificationSurface",
+        "operation",
+        "planeApplicability",
+        "publicEvidenceCount",
+        "successfulWorkflowEvidenceCount",
+        "localFixtureCount",
+        "localFixtureExistingCount",
+        "checks",
+        "notes"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "admissionState": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "provisional",
+            "rejected"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "ok",
+            "warning",
+            "drift"
+          ]
+        },
+        "repoSlug": { "type": "string", "minLength": 1 },
+        "targetPath": { "type": "string", "minLength": 1 },
+        "changeKind": {
+          "type": "string",
+          "enum": [
+            "modified",
+            "added",
+            "deleted"
+          ]
+        },
+        "certificationSurface": {
+          "type": "string",
+          "enum": [
+            "vi-history",
+            "compare-report",
+            "print-single-file"
+          ]
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "Compare-VIHistory",
+            "CreateComparisonReport",
+            "PrintToSingleFileHtml"
+          ]
+        },
+        "planeApplicability": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "linux-proof",
+              "windows-mirror",
+              "host-shadow"
+            ]
+          }
+        },
+        "publicEvidenceCount": { "type": "integer", "minimum": 0 },
+        "successfulWorkflowEvidenceCount": { "type": "integer", "minimum": 0 },
+        "localFixtureCount": { "type": "integer", "minimum": 0 },
+        "localFixtureExistingCount": { "type": "integer", "minimum": 0 },
+        "checks": { "$ref": "#/$defs/checks" },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json
+++ b/docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json
@@ -1,0 +1,322 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/headless-sample-vi-corpus-targets-v1.schema.json",
+  "title": "Headless Sample VI Corpus Targets v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema",
+    "generatedAt",
+    "description",
+    "storagePolicy",
+    "admissionPolicy",
+    "targets"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "../../docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json"
+    },
+    "schema": {
+      "const": "vi-headless/sample-targets@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "storagePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "checkedInCatalogPath",
+        "generatedRoot",
+        "rawArtifactsInGit"
+      ],
+      "properties": {
+        "checkedInCatalogPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generatedRoot": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rawArtifactsInGit": {
+          "const": false
+        }
+      }
+    },
+    "admissionPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "acceptedTargetsRequirePublicGithubEvidence",
+        "acceptedTargetsRequireLicense",
+        "acceptedTargetsRequirePinnedCommit",
+        "provisionalTargetsAllowed"
+      ],
+      "properties": {
+        "acceptedTargetsRequirePublicGithubEvidence": {
+          "type": "boolean"
+        },
+        "acceptedTargetsRequireLicense": {
+          "type": "boolean"
+        },
+        "acceptedTargetsRequirePinnedCommit": {
+          "type": "boolean"
+        },
+        "provisionalTargetsAllowed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/target"
+      }
+    }
+  },
+  "$defs": {
+    "admissionState": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "provisional",
+        "rejected"
+      ]
+    },
+    "changeKind": {
+      "type": "string",
+      "enum": [
+        "modified",
+        "added",
+        "deleted"
+      ]
+    },
+    "certificationSurface": {
+      "type": "string",
+      "enum": [
+        "vi-history",
+        "compare-report",
+        "print-single-file"
+      ]
+    },
+    "operation": {
+      "type": "string",
+      "enum": [
+        "Compare-VIHistory",
+        "CreateComparisonReport",
+        "PrintToSingleFileHtml"
+      ]
+    },
+    "planeApplicability": {
+      "type": "string",
+      "enum": [
+        "linux-proof",
+        "windows-mirror",
+        "host-shadow"
+      ]
+    },
+    "admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "reasons"
+      ],
+      "properties": {
+        "state": {
+          "$ref": "#/$defs/admissionState"
+        },
+        "reasons": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repoSlug",
+        "repoUrl",
+        "licenseSpdx",
+        "targetPath",
+        "changeKind",
+        "pinnedCommit"
+      ],
+      "properties": {
+        "repoSlug": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "repoUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "licenseSpdx": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "targetPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changeKind": {
+          "$ref": "#/$defs/changeKind"
+        },
+        "pinnedCommit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "renderStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "certificationSurface",
+        "operation",
+        "planeApplicability",
+        "evidenceClass"
+      ],
+      "properties": {
+        "certificationSurface": {
+          "$ref": "#/$defs/certificationSurface"
+        },
+        "operation": {
+          "$ref": "#/$defs/operation"
+        },
+        "planeApplicability": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/planeApplicability"
+          }
+        },
+        "evidenceClass": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "publicEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "url",
+        "status",
+        "note"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "workflow-run",
+            "pull-request",
+            "issue-comment"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "merged",
+            "open",
+            "warning",
+            "failed"
+          ]
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "localEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixturePaths"
+      ],
+      "properties": {
+        "fixturePaths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "admission",
+        "source",
+        "renderStrategy",
+        "publicEvidence",
+        "notes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "admission": {
+          "$ref": "#/$defs/admission"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "renderStrategy": {
+          "$ref": "#/$defs/renderStrategy"
+        },
+        "localEvidence": {
+          "$ref": "#/$defs/localEvidence"
+        },
+        "publicEvidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/publicEvidence"
+          }
+        },
+        "notes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/fixtures/headless-corpus/sample-vi-corpus.targets.json
+++ b/fixtures/headless-corpus/sample-vi-corpus.targets.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "../../docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json",
+  "schema": "vi-headless/sample-targets@v1",
+  "generatedAt": "2026-03-19T23:55:00Z",
+  "description": "Evidence-backed public sample VIs used to certify headless compare and history rendering lanes above the minimal local fixtures.",
+  "storagePolicy": {
+    "checkedInCatalogPath": "fixtures/headless-corpus/sample-vi-corpus.targets.json",
+    "generatedRoot": "tests/results/_agent/headless-sample-corpus",
+    "rawArtifactsInGit": false
+  },
+  "admissionPolicy": {
+    "acceptedTargetsRequirePublicGithubEvidence": true,
+    "acceptedTargetsRequireLicense": true,
+    "acceptedTargetsRequirePinnedCommit": true,
+    "provisionalTargetsAllowed": true
+  },
+  "targets": [
+    {
+      "id": "icon-editor-settings-init-history",
+      "label": "labview-icon-editor Settings Init.vi history seed",
+      "admission": {
+        "state": "accepted",
+        "reasons": [
+          "MIT-licensed upstream repository.",
+          "Checked-in history fixture lineage already exists in this repository.",
+          "Public PR VI History workflow evidence exists on the upstream repository."
+        ]
+      },
+      "source": {
+        "repoSlug": "LabVIEW-Community-CI-CD/labview-icon-editor",
+        "repoUrl": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor",
+        "licenseSpdx": "MIT",
+        "targetPath": "resource/plugins/NIIconEditor/Miscellaneous/Settings Init.vi",
+        "changeKind": "modified",
+        "pinnedCommit": "fda45ac448d4b3dcf498bac291681b1dc3bc449d"
+      },
+      "renderStrategy": {
+        "certificationSurface": "vi-history",
+        "operation": "Compare-VIHistory",
+        "planeApplicability": [
+          "windows-mirror"
+        ],
+        "evidenceClass": "history-review"
+      },
+      "localEvidence": {
+        "fixturePaths": [
+          "fixtures/cross-repo/labview-icon-editor/settings-init/manifest.json",
+          "fixtures/cross-repo/labview-icon-editor/settings-init/history-report.md",
+          "fixtures/cross-repo/labview-icon-editor/settings-init/history-report.html"
+        ]
+      },
+      "publicEvidence": [
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor/actions/runs/22530196636",
+          "status": "success",
+          "note": "Public PR VI History workflow succeeded on the upstream MIT-licensed repository."
+        },
+        {
+          "kind": "pull-request",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor/pull/20",
+          "status": "merged",
+          "note": "Org-owned PR VI History rollout kept the public workflow surface active for this repository."
+        }
+      ],
+      "notes": [
+        "Public evidence is repository-level; target-specific lineage is anchored by the checked-in fixture under fixtures/cross-repo/labview-icon-editor/settings-init.",
+        "This seed keeps the Windows-mirror VI history lane tied to a licensed public source repository."
+      ]
+    },
+    {
+      "id": "icon-editor-demo-vip-preinstall-history",
+      "label": "labview-icon-editor-demo VIP_Pre-Install Custom Action.vi proof PR",
+      "admission": {
+        "state": "accepted",
+        "reasons": [
+          "MIT-licensed downstream demo repository.",
+          "Target-specific public proof PR and workflow runs already exist.",
+          "The sample exercises changed-VI discovery and rendered review surfaces on a real VI change."
+        ]
+      },
+      "source": {
+        "repoSlug": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+        "repoUrl": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+        "licenseSpdx": "MIT",
+        "targetPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+        "changeKind": "modified",
+        "pinnedCommit": "49d1415b3c593f24e3a1bb798211caec695735f6"
+      },
+      "renderStrategy": {
+        "certificationSurface": "vi-history",
+        "operation": "Compare-VIHistory",
+        "planeApplicability": [
+          "linux-proof"
+        ],
+        "evidenceClass": "history-review"
+      },
+      "publicEvidence": [
+        {
+          "kind": "pull-request",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/pull/31",
+          "status": "open",
+          "note": "Standing proof PR carrying the real modified VI used for downstream CompareVI History validation."
+        },
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/actions/runs/23280819231",
+          "status": "success",
+          "note": "Pull request diagnostics workflow succeeded on the real modified VI change."
+        },
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/actions/runs/23280887595",
+          "status": "success",
+          "note": "Diagnostics publish workflow succeeded and rendered the reviewer surface."
+        },
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/actions/runs/23280903916",
+          "status": "success",
+          "note": "Agent canary workflow succeeded on the same proof surface."
+        }
+      ],
+      "notes": [
+        "This seed is the cleanest public target-specific proof currently available for CompareVI History reviewer rendering.",
+        "No checked-in local fixture is required because the public PR and workflow evidence are already target-specific."
+      ]
+    },
+    {
+      "id": "linuxcontainerdemo-newthing-print",
+      "label": "linuxContainerDemo NewThing.vi added-VI print path",
+      "admission": {
+        "state": "provisional",
+        "reasons": [
+          "Public successful Linux workflow evidence exists for the added-VI print path.",
+          "The repository currently declares no license, so this seed cannot be promoted to accepted status yet.",
+          "The sample still documents the best available public added-VI PrintToSingleFileHtml pattern for research and future replacement."
+        ]
+      },
+      "source": {
+        "repoSlug": "aphill93/linuxContainerDemo",
+        "repoUrl": "https://github.com/aphill93/linuxContainerDemo",
+        "licenseSpdx": null,
+        "targetPath": "Test-VIs/NewThing.vi",
+        "changeKind": "added",
+        "pinnedCommit": "0f31bc7a0c26624742101c925f58320dffece847"
+      },
+      "renderStrategy": {
+        "certificationSurface": "print-single-file",
+        "operation": "PrintToSingleFileHtml",
+        "planeApplicability": [
+          "linux-proof"
+        ],
+        "evidenceClass": "change-kind-print"
+      },
+      "publicEvidence": [
+        {
+          "kind": "pull-request",
+          "url": "https://github.com/aphill93/linuxContainerDemo/pull/7",
+          "status": "open",
+          "note": "Public PR carrying the change-kind-aware VI compare and print surface, including NewThing.vi as an added VI."
+        },
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/aphill93/linuxContainerDemo/actions/runs/22909143209",
+          "status": "success",
+          "note": "Linux VI Compare workflow succeeded on the PR head after change-kind rendering landed."
+        },
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/aphill93/linuxContainerDemo/actions/runs/22909143196",
+          "status": "success",
+          "note": "Linux headless LabVIEWCLI workflow succeeded on the same PR head."
+        }
+      ],
+      "notes": [
+        "Keep this seed provisional until licensing is explicit and a replacement accepted sample is available.",
+        "Do not use this target as a blocking accepted corpus lane while it remains license-ambiguous.",
+        "This seed currently covers Linux-only public evidence; it does not establish Windows parity."
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "history:bundle:verify": "tsc -p tsconfig.cli.json && node dist/tools/cli/verify-history-bundle-certification.js",
     "history:corpus:offline": "pwsh -NoLogo -NoProfile -File tools/Invoke-OfflineRealHistoryCorpus.ps1",
     "history:corpus:evaluate": "pwsh -NoLogo -NoProfile -File tools/Invoke-OfflineRealHistoryCorpusEvaluation.ps1",
+    "history:corpus:samples:evaluate": "pwsh -NoLogo -NoProfile -File tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1",
     "history:corpus:normalize": "pwsh -NoLogo -NoProfile -File tools/Normalize-OfflineRealHistoryCorpus.ps1",
     "history:diagnostics:show": "pwsh -NoLogo -NoProfile -File tools/Show-DockerFastLoopDiagnostics.ps1",
     "history:local:build-dev-image": "pwsh -NoLogo -NoProfile -File tools/Build-VIHistoryDevImage.ps1",

--- a/tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
+++ b/tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
@@ -1,0 +1,73 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Invoke-HeadlessSampleVICorpusEvaluation.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:EvaluateScript = Join-Path $script:RepoRoot 'tools' 'Invoke-HeadlessSampleVICorpusEvaluation.ps1'
+    if (-not (Test-Path -LiteralPath $script:EvaluateScript -PathType Leaf)) {
+      throw "Invoke-HeadlessSampleVICorpusEvaluation.ps1 not found at $script:EvaluateScript"
+    }
+
+    $script:CatalogPath = Join-Path $script:RepoRoot 'fixtures' 'headless-corpus' 'sample-vi-corpus.targets.json'
+  }
+
+  It 'passes on the checked-in headless sample corpus and records admission-state coverage' {
+    $resultsRoot = Join-Path $TestDrive 'sample-corpus-eval'
+    $runOutput = & pwsh -NoLogo -NoProfile -File $script:EvaluateScript -ResultsRoot $resultsRoot 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because (($runOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine)
+
+    $reportPath = Join-Path $resultsRoot 'headless-sample-vi-corpus-evaluation.json'
+    $markdownPath = Join-Path $resultsRoot 'headless-sample-vi-corpus-evaluation.md'
+    $reportPath | Should -Exist
+    $markdownPath | Should -Exist
+
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
+    $report.schema | Should -Be 'vi-headless/sample-corpus-evaluation@v1'
+    $report.overallStatus | Should -Be 'ok'
+    $report.summary.acceptedCount | Should -Be 2
+    $report.summary.provisionalCount | Should -Be 1
+    $report.summary.driftCount | Should -Be 0
+
+    $accepted = @($report.targets | Where-Object { [string]$_.id -eq 'icon-editor-demo-vip-preinstall-history' } | Select-Object -First 1)
+    $accepted | Should -Not -BeNullOrEmpty
+    $accepted.status | Should -Be 'ok'
+    $accepted.checks.licenseDeclared | Should -BeTrue
+    $accepted.checks.successfulWorkflowEvidence | Should -BeTrue
+
+    $provisional = @($report.targets | Where-Object { [string]$_.id -eq 'linuxcontainerdemo-newthing-print' } | Select-Object -First 1)
+    $provisional | Should -Not -BeNullOrEmpty
+    $provisional.status | Should -Be 'warning'
+    $provisional.certificationSurface | Should -Be 'print-single-file'
+    $provisional.checks.licenseDeclared | Should -BeFalse
+    (($provisional.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'No declared license'
+  }
+
+  It 'fails closed when an accepted seed loses its declared license' {
+    $catalog = Get-Content -LiteralPath $script:CatalogPath -Raw | ConvertFrom-Json -Depth 20
+    $target = @($catalog.targets | Where-Object { [string]$_.id -eq 'icon-editor-demo-vip-preinstall-history' } | Select-Object -First 1)
+    $target | Should -Not -BeNullOrEmpty
+    $target.source.licenseSpdx = $null
+
+    $driftCatalogPath = Join-Path $TestDrive 'sample-corpus.drift.json'
+    $catalog | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $driftCatalogPath -Encoding utf8
+
+    $resultsRoot = Join-Path $TestDrive 'sample-corpus-drift'
+    $runOutput = & pwsh -NoLogo -NoProfile -File $script:EvaluateScript -CatalogPath $driftCatalogPath -ResultsRoot $resultsRoot -SkipSchemaValidation 2>&1
+    $LASTEXITCODE | Should -Not -Be 0
+
+    $outputText = ($runOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    $outputText | Should -Match 'detected drift'
+
+    $reportPath = Join-Path $resultsRoot 'headless-sample-vi-corpus-evaluation.json'
+    $reportPath | Should -Exist
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
+    $report.overallStatus | Should -Be 'drift'
+
+    $targetReport = @($report.targets | Where-Object { [string]$_.id -eq 'icon-editor-demo-vip-preinstall-history' } | Select-Object -First 1)
+    $targetReport | Should -Not -BeNullOrEmpty
+    $targetReport.status | Should -Be 'drift'
+    $targetReport.checks.licenseDeclared | Should -BeFalse
+    (($targetReport.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'Accepted targets require a declared license'
+  }
+}

--- a/tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1
+++ b/tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1
@@ -1,0 +1,394 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+  [string]$CatalogPath = 'fixtures/headless-corpus/sample-vi-corpus.targets.json',
+  [string]$ResultsRoot = 'tests/results/_agent/headless-sample-corpus',
+  [string]$ReportPath,
+  [string]$MarkdownPath,
+  [switch]$SkipSchemaValidation
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+  return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory)][string]$BasePath,
+    [Parameter(Mandatory)][string]$PathValue
+  )
+
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $PathValue))
+}
+
+function Ensure-Directory {
+  param([Parameter(Mandatory)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+
+  return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Read-JsonFile {
+  param([Parameter(Mandatory)][string]$Path)
+
+  return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 32)
+}
+
+function Convert-ToRepoRelativePath {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$PathValue
+  )
+
+  $resolved = Resolve-AbsolutePath -BasePath $RepoRoot -PathValue $PathValue
+  $relative = [System.IO.Path]::GetRelativePath($RepoRoot, $resolved)
+  if ($relative -eq '.') {
+    return '.'
+  }
+
+  if ($relative.StartsWith('..' + [System.IO.Path]::DirectorySeparatorChar) -or
+      $relative.StartsWith('..' + [System.IO.Path]::AltDirectorySeparatorChar) -or
+      $relative -eq '..') {
+    return ($resolved -replace '\\', '/')
+  }
+
+  return ($relative -replace '\\', '/')
+}
+
+function Invoke-SchemaValidation {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$SchemaPath,
+    [Parameter(Mandatory)][string]$DataPath
+  )
+
+  $runner = Join-Path $RepoRoot 'tools' 'npm' 'run-script.mjs'
+  if (-not (Test-Path -LiteralPath $runner -PathType Leaf)) {
+    throw "Schema validation runner not found at '$runner'."
+  }
+
+  $output = & node $runner 'schema:validate' '--' '--schema' $SchemaPath '--data' $DataPath 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $message = ($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    throw "Schema validation failed for '$DataPath': $message"
+  }
+}
+
+function Get-StringArray {
+  param([AllowNull()][object]$Value)
+
+  $items = New-Object System.Collections.Generic.List[string]
+  foreach ($item in @($Value)) {
+    if ([string]::IsNullOrWhiteSpace([string]$item)) {
+      continue
+    }
+
+    $items.Add(([string]$item).Trim()) | Out-Null
+  }
+
+  return @($items.ToArray())
+}
+
+function Test-IsPinnedCommit {
+  param([AllowNull()][string]$Value)
+
+  return (-not [string]::IsNullOrWhiteSpace($Value)) -and ($Value -match '^[0-9a-f]{40}$')
+}
+
+function Test-IsGitHubRepoUrl {
+  param([AllowNull()][string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return $false
+  }
+
+  try {
+    $uri = [System.Uri]$Value
+    return $uri.Scheme -in @('https', 'http') -and $uri.Host -eq 'github.com'
+  } catch {
+    return $false
+  }
+}
+
+function Test-IsGitHubEvidenceUrl {
+  param([AllowNull()][string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return $false
+  }
+
+  try {
+    $uri = [System.Uri]$Value
+    return $uri.Scheme -in @('https', 'http') -and $uri.Host -eq 'github.com' -and $uri.AbsolutePath -match '/(pull|actions/runs|issues/.+#issuecomment-)'
+  } catch {
+    return $false
+  }
+}
+
+function Test-RenderStrategyAlignment {
+  param(
+    [Parameter(Mandatory)][string]$ChangeKind,
+    [Parameter(Mandatory)][string]$CertificationSurface,
+    [Parameter(Mandatory)][string]$Operation
+  )
+
+  switch ($CertificationSurface) {
+    'vi-history' {
+      return $ChangeKind -eq 'modified' -and $Operation -eq 'Compare-VIHistory'
+    }
+    'compare-report' {
+      return $ChangeKind -eq 'modified' -and $Operation -eq 'CreateComparisonReport'
+    }
+    'print-single-file' {
+      return $ChangeKind -in @('added', 'deleted') -and $Operation -eq 'PrintToSingleFileHtml'
+    }
+    default {
+      return $false
+    }
+  }
+}
+
+$repoRoot = Resolve-RepoRoot
+$catalogResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $CatalogPath
+if (-not (Test-Path -LiteralPath $catalogResolved -PathType Leaf)) {
+  throw "Headless sample VI corpus catalog not found at '$catalogResolved'."
+}
+
+$catalogSchemaPath = Join-Path $repoRoot 'docs' 'schemas' 'headless-sample-vi-corpus-targets-v1.schema.json'
+$evaluationSchemaPath = Join-Path $repoRoot 'docs' 'schemas' 'headless-sample-vi-corpus-evaluation-v1.schema.json'
+if (-not $SkipSchemaValidation.IsPresent) {
+  Invoke-SchemaValidation -RepoRoot $repoRoot -SchemaPath $catalogSchemaPath -DataPath $catalogResolved
+}
+
+$catalog = Read-JsonFile -Path $catalogResolved
+$resultsRootResolved = Ensure-Directory -Path (Resolve-AbsolutePath -BasePath $repoRoot -PathValue $ResultsRoot)
+$reportResolved = if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+  Join-Path $resultsRootResolved 'headless-sample-vi-corpus-evaluation.json'
+} else {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue $ReportPath
+}
+$markdownResolved = if ([string]::IsNullOrWhiteSpace($MarkdownPath)) {
+  Join-Path $resultsRootResolved 'headless-sample-vi-corpus-evaluation.md'
+} else {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue $MarkdownPath
+}
+Ensure-Directory -Path (Split-Path -Parent $reportResolved) | Out-Null
+Ensure-Directory -Path (Split-Path -Parent $markdownResolved) | Out-Null
+
+$policy = $catalog.admissionPolicy
+$evaluatedTargets = New-Object System.Collections.Generic.List[object]
+$driftCount = 0
+$warningCount = 0
+$okCount = 0
+$acceptedCount = 0
+$provisionalCount = 0
+$rejectedCount = 0
+
+foreach ($target in @($catalog.targets)) {
+  $notes = New-Object System.Collections.Generic.List[string]
+  $admissionState = [string]$target.admission.state
+  switch ($admissionState) {
+    'accepted' { $acceptedCount += 1 }
+    'provisional' { $provisionalCount += 1 }
+    'rejected' { $rejectedCount += 1 }
+  }
+
+  $repoSlug = [string]$target.source.repoSlug
+  $repoUrl = [string]$target.source.repoUrl
+  $license = [string]$target.source.licenseSpdx
+  $targetPath = [string]$target.source.targetPath
+  $changeKind = [string]$target.source.changeKind
+  $pinnedCommit = [string]$target.source.pinnedCommit
+  $surface = [string]$target.renderStrategy.certificationSurface
+  $operation = [string]$target.renderStrategy.operation
+  $planes = @(Get-StringArray -Value $target.renderStrategy.planeApplicability)
+  $publicEvidence = @($target.publicEvidence)
+
+  $hasPublicRepo = Test-IsGitHubRepoUrl -Value $repoUrl
+  if (-not $hasPublicRepo) {
+    $notes.Add('Repository URL must be a public GitHub repository URL.') | Out-Null
+  }
+
+  $evidenceUrlsValid = $publicEvidence.Count -gt 0
+  $successfulWorkflowEvidenceCount = 0
+  foreach ($evidence in $publicEvidence) {
+    if (-not (Test-IsGitHubEvidenceUrl -Value ([string]$evidence.url))) {
+      $evidenceUrlsValid = $false
+    }
+    if ([string]$evidence.kind -eq 'workflow-run' -and [string]$evidence.status -eq 'success') {
+      $successfulWorkflowEvidenceCount += 1
+    }
+  }
+  if (-not $evidenceUrlsValid) {
+    $notes.Add('One or more public evidence URLs are missing or not GitHub-backed workflow/PR/comment links.') | Out-Null
+  }
+
+  $hasLicense = -not [string]::IsNullOrWhiteSpace($license)
+  if (-not $hasLicense) {
+    $notes.Add('No declared license is recorded for this seed.') | Out-Null
+  }
+
+  $hasPinnedCommit = Test-IsPinnedCommit -Value $pinnedCommit
+  if (-not $hasPinnedCommit) {
+    $notes.Add('Pinned commit must be a 40-character lowercase git SHA.') | Out-Null
+  }
+
+  $renderStrategyAligned = Test-RenderStrategyAlignment -ChangeKind $changeKind -CertificationSurface $surface -Operation $operation
+  if (-not $renderStrategyAligned) {
+    $notes.Add(("Render strategy is not coherent for changeKind='{0}', surface='{1}', operation='{2}'." -f $changeKind, $surface, $operation)) | Out-Null
+  }
+
+  $fixturePaths = @()
+  if ($target.PSObject.Properties['localEvidence'] -and $target.localEvidence) {
+    $fixturePaths = @(Get-StringArray -Value $target.localEvidence.fixturePaths)
+  }
+  $existingFixtureCount = 0
+  $fixturePathsResolved = $true
+  foreach ($pathValue in $fixturePaths) {
+    $resolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $pathValue
+    if (Test-Path -LiteralPath $resolved) {
+      $existingFixtureCount += 1
+    } else {
+      $fixturePathsResolved = $false
+      $notes.Add(("Local fixture path was not found: {0}" -f $pathValue)) | Out-Null
+    }
+  }
+
+  if ($admissionState -eq 'accepted' -and $policy.acceptedTargetsRequirePublicGithubEvidence -and $successfulWorkflowEvidenceCount -lt 1) {
+    $notes.Add('Accepted targets require at least one successful workflow-run evidence URL.') | Out-Null
+  }
+  if ($admissionState -eq 'accepted' -and $policy.acceptedTargetsRequireLicense -and -not $hasLicense) {
+    $notes.Add('Accepted targets require a declared license.') | Out-Null
+  }
+  if ($admissionState -eq 'accepted' -and $policy.acceptedTargetsRequirePinnedCommit -and -not $hasPinnedCommit) {
+    $notes.Add('Accepted targets require a pinned commit.') | Out-Null
+  }
+  if ($admissionState -eq 'accepted' -and -not $hasPublicRepo) {
+    $notes.Add('Accepted targets require a public GitHub repository URL.') | Out-Null
+  }
+  if ($admissionState -eq 'accepted' -and -not $evidenceUrlsValid) {
+    $notes.Add('Accepted targets require valid GitHub evidence URLs.') | Out-Null
+  }
+  if ($admissionState -eq 'accepted' -and -not $renderStrategyAligned) {
+    $notes.Add('Accepted targets require a render strategy aligned with the change kind.') | Out-Null
+  }
+  if ($admissionState -eq 'accepted' -and -not $fixturePathsResolved -and $fixturePaths.Count -gt 0) {
+    $notes.Add('Accepted target declared local fixture lineage but one or more fixture paths were missing.') | Out-Null
+  }
+  if ($admissionState -eq 'provisional' -and -not $policy.provisionalTargetsAllowed) {
+    $notes.Add('Catalog policy currently does not allow provisional targets.') | Out-Null
+  }
+
+  $status = 'ok'
+  if ($admissionState -eq 'accepted' -and @($notes).Count -gt 0) {
+    $status = 'drift'
+    $driftCount += 1
+  } elseif ($admissionState -ne 'accepted' -and @($notes).Count -gt 0) {
+    $status = 'warning'
+    $warningCount += 1
+  } else {
+    $okCount += 1
+  }
+
+  $evaluatedTargets.Add([ordered]@{
+      id = [string]$target.id
+      admissionState = $admissionState
+      status = $status
+      repoSlug = $repoSlug
+      targetPath = $targetPath
+      changeKind = $changeKind
+      certificationSurface = $surface
+      operation = $operation
+      planeApplicability = @($planes)
+      publicEvidenceCount = $publicEvidence.Count
+      successfulWorkflowEvidenceCount = $successfulWorkflowEvidenceCount
+      localFixtureCount = $fixturePaths.Count
+      localFixtureExistingCount = $existingFixtureCount
+      checks = [ordered]@{
+        publicRepo = $hasPublicRepo
+        githubEvidenceUrls = $evidenceUrlsValid
+        licenseDeclared = $hasLicense
+        pinnedCommit = $hasPinnedCommit
+        successfulWorkflowEvidence = $successfulWorkflowEvidenceCount -gt 0
+        renderStrategyAligned = $renderStrategyAligned
+        localFixturePathsResolved = $fixturePathsResolved
+      }
+      notes = @($notes.ToArray())
+    }) | Out-Null
+}
+
+$summary = [ordered]@{
+  targetCount = @($catalog.targets).Count
+  acceptedCount = $acceptedCount
+  provisionalCount = $provisionalCount
+  rejectedCount = $rejectedCount
+  okCount = $okCount
+  warningCount = $warningCount
+  driftCount = $driftCount
+}
+
+$report = [ordered]@{
+  schema = 'vi-headless/sample-corpus-evaluation@v1'
+  generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  catalogPath = Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $catalogResolved
+  overallStatus = if ($driftCount -gt 0) { 'drift' } else { 'ok' }
+  summary = $summary
+  targets = @($evaluatedTargets.ToArray())
+}
+
+$report | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $reportResolved -Encoding utf8
+
+$markdownLines = @(
+  '# Headless Sample VI Corpus Evaluation',
+  '',
+  ('- Catalog: `{0}`' -f $report.catalogPath),
+  ('- Overall Status: `{0}`' -f $report.overallStatus),
+  ('- Accepted Targets: `{0}`' -f $summary.acceptedCount),
+  ('- Provisional Targets: `{0}`' -f $summary.provisionalCount),
+  ('- Drift Targets: `{0}`' -f $summary.driftCount),
+  ('- Warning Targets: `{0}`' -f $summary.warningCount),
+  '',
+  '| Target | Admission | Status | Surface | Planes | Evidence |',
+  '| --- | --- | --- | --- | --- | --- |'
+)
+foreach ($target in @($report.targets)) {
+  $markdownLines += ('| `{0}` | `{1}` | `{2}` | `{3}` | `{4}` | `{5}` successful workflow run(s) |' -f
+    $target.id,
+    $target.admissionState,
+    $target.status,
+    $target.certificationSurface,
+    ((@($target.planeApplicability) | ForEach-Object { [string]$_ }) -join ', '),
+    $target.successfulWorkflowEvidenceCount)
+  if (@($target.notes).Count -gt 0) {
+    $markdownLines += ''
+    $markdownLines += ('## {0}' -f $target.id)
+    foreach ($note in @($target.notes)) {
+      $markdownLines += ('- {0}' -f [string]$note)
+    }
+  }
+}
+$markdownLines += ''
+$markdownLines | Set-Content -LiteralPath $markdownResolved -Encoding utf8
+
+if (-not $SkipSchemaValidation.IsPresent) {
+  Invoke-SchemaValidation -RepoRoot $repoRoot -SchemaPath $evaluationSchemaPath -DataPath $reportResolved
+}
+
+if ($report.overallStatus -eq 'drift') {
+  $reportRelative = Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $reportResolved
+  throw "Headless sample VI corpus evaluation detected drift. See '$reportRelative'."
+}
+
+Write-Host ("Headless sample VI corpus evaluation passed. Report: {0}" -f (Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $reportResolved))
+return [pscustomobject]$report


### PR DESCRIPTION
# Summary
Adds a headless sample VI corpus contract, evaluator, and focused test coverage so public, pinned, evidence-backed sample VIs can be tracked as a certification layer above the minimal local fixtures. The first accepted seeds cover real VI history scenarios from `labview-icon-editor` and `labview-icon-editor-demo`, while the added/deleted print seed remains explicitly provisional until a licensed replacement lands.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1407`
- Files, tools, workflows, or policies touched:
  - `fixtures/headless-corpus/sample-vi-corpus.targets.json`
  - `tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1`
  - `tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1`
  - `docs/knowledgebase/Headless-SampleVI-Corpus.md`
  - `docs/schemas/headless-sample-vi-corpus-*.json`
  - `package.json`
  - `docs/documentation-manifest.json`
- Cross-repo or external-consumer impact:
  - codifies which public sample repos and runs are admissible as headless certification evidence
- Required checks, merge-queue behavior, or approval flows affected:
  - no branch protection changes; this is a documentation/contract/test lane only

## Validation Evidence

- Commands run:
  - `pwsh -NoLogo -NoProfile -File tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1`
  - `node tools/npm/run-script.mjs history:corpus:samples:evaluate`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs lint:md:changed`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/headless-sample-corpus/headless-sample-vi-corpus-evaluation.json`
  - `tests/results/_agent/headless-sample-corpus/headless-sample-vi-corpus-evaluation.md`
- Risk-based checks not run:
  - full pre-push container loop; this lane changes only the corpus catalog/evaluator layer

## Risks and Follow-ups

- Residual risks:
  - the added/deleted `PrintToSingleFileHtml` sample remains provisional because `aphill93/linuxContainerDemo` does not declare a license
- Follow-up issues or deferred work:
  - `#1467` add a licensed added/deleted sample VI seed for `PrintToSingleFileHtml` certification
  - `#1406`, `#1408` continue to track change-kind/rendering pattern leverage
- Deployment, approval, or rollback notes:
  - rollback is a normal revert of the catalog/evaluator files if the corpus admission policy needs adjustment

## Reviewer Focus

- Please verify:
  - the admission rules for `accepted` vs `provisional` targets match the intended policy
  - the two accepted seeds are the right initial public evidence set
- Areas where the reasoning is subtle:
  - `linuxContainerDemo` is intentionally preserved as `provisional`, not promoted, because evidence exists but licensing is ambiguous
- Manual spot checks requested:
  - inspect `fixtures/headless-corpus/sample-vi-corpus.targets.json` and the generated evaluation report for target-state clarity
