### PR TITLE
Track custom print payload provenance in the headless sample corpus

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-20T00:15:00Z",
+  "updated": "2026-03-20T12:50:00Z",
   "entries": [
     {
       "name": "Root Entry Points",
@@ -64,6 +64,7 @@
         "docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md",
         "docs/knowledgebase/GitHub-Wiki-Portal.md",
         "docs/knowledgebase/Headless-SampleVI-Corpus.md",
+        "docs/knowledgebase/PrintToSingleFileHtml-Provenance.md",
         "docs/knowledgebase/Offline-RealHistory-Corpus.md",
         "docs/knowledgebase/DOCKER_TOOLS_PARITY.md",
         "docs/LABVIEW_GATING.md",
@@ -210,9 +211,10 @@
       "name": "Headless Sample Corpus Contracts",
       "category": "supporting",
       "status": "reference",
-      "description": "Checked-in catalog, schemas, evaluator, and focused tests for the evidence-backed public sample VI corpus used by headless certification lanes.",
+      "description": "Checked-in catalog, schemas, evaluator, focused tests, and operation-payload provenance guidance for the evidence-backed public sample VI corpus used by headless certification lanes.",
       "files": [
         "docs/knowledgebase/Headless-SampleVI-Corpus.md",
+        "docs/knowledgebase/PrintToSingleFileHtml-Provenance.md",
         "docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json",
         "docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json",
         "fixtures/headless-corpus/sample-vi-corpus.targets.json",

--- a/docs/knowledgebase/Headless-SampleVI-Corpus.md
+++ b/docs/knowledgebase/Headless-SampleVI-Corpus.md
@@ -88,6 +88,18 @@ The corpus keeps change kind and rendering intent explicit.
 This keeps the sample corpus aligned with the change-kind-aware rendering work
 tracked in `#1406` and `#1408`.
 
+## Operation payload provenance
+
+For `print-single-file` targets, sample provenance alone is not enough.
+
+The catalog now tracks `operationPayload` separately so the evaluator can
+distinguish:
+
+- a licensed public sample repository
+- from an unlicensed or research-only custom rendering payload
+
+See `docs/knowledgebase/PrintToSingleFileHtml-Provenance.md`.
+
 ## Evaluation
 
 Run the evaluator locally:

--- a/docs/knowledgebase/PrintToSingleFileHtml-Provenance.md
+++ b/docs/knowledgebase/PrintToSingleFileHtml-Provenance.md
@@ -1,0 +1,51 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# PrintToSingleFileHtml Provenance
+
+`PrintToSingleFileHtml` is currently a support-lane surface, not a baseline
+pre-push requirement.
+
+The reason is provenance, not usefulness.
+
+## Current finding
+
+The best public added/deleted VI example we have today is
+`aphill93/linuxContainerDemo#7`.
+
+That proof uses a custom `AdditionalOperationDirectory` payload under
+`VICompareTooling/PrintToSingleFileHtml`. The sample is technically useful, but
+the repository does not currently declare a license, so the payload cannot be
+treated as promotable certification input.
+
+## Repo policy
+
+- Do not vendor or mirror unlicensed `AdditionalOperationDirectory` payloads.
+- Do not promote a `print-single-file` target to `accepted` unless both of
+  these provenance planes are clean:
+  - the sample VI repository
+  - the custom operation payload repository
+- Keep unlicensed or otherwise ambiguous custom payloads in `research-only`
+  status.
+
+## Promotion ladder
+
+1. `research-only`
+- public run exists
+- rendering behavior is informative
+- payload license or reuse rights are not yet promotable
+
+2. `accepted`
+- sample repository is public and licensed
+- payload provenance is public and licensed
+- payload metadata is tracked in the sample corpus catalog
+- at least one successful public workflow run exists
+
+## Why this is separate from sample provenance
+
+A sample repository can be clean while the rendering payload is not.
+
+That distinction matters for added/deleted VI rendering because the current
+`PrintToSingleFileHtml` proof depends on a custom operation surface rather than
+the default compare path.
+
+The headless sample corpus therefore tracks `operationPayload` separately from
+the target repository metadata.

--- a/docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json
+++ b/docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json
@@ -72,7 +72,11 @@
         "pinnedCommit",
         "successfulWorkflowEvidence",
         "renderStrategyAligned",
-        "localFixturePathsResolved"
+        "localFixturePathsResolved",
+        "operationPayloadTracked",
+        "operationPayloadSourceValid",
+        "operationPayloadLicenseDeclared",
+        "operationPayloadPromotable"
       ],
       "properties": {
         "publicRepo": { "type": "boolean" },
@@ -81,7 +85,11 @@
         "pinnedCommit": { "type": "boolean" },
         "successfulWorkflowEvidence": { "type": "boolean" },
         "renderStrategyAligned": { "type": "boolean" },
-        "localFixturePathsResolved": { "type": "boolean" }
+        "localFixturePathsResolved": { "type": "boolean" },
+        "operationPayloadTracked": { "type": "boolean" },
+        "operationPayloadSourceValid": { "type": "boolean" },
+        "operationPayloadLicenseDeclared": { "type": "boolean" },
+        "operationPayloadPromotable": { "type": "boolean" }
       }
     },
     "target": {
@@ -96,6 +104,8 @@
         "changeKind",
         "certificationSurface",
         "operation",
+        "operationPayloadMode",
+        "operationPayloadProvenanceState",
         "planeApplicability",
         "publicEvidenceCount",
         "successfulWorkflowEvidenceCount",
@@ -146,6 +156,23 @@
             "Compare-VIHistory",
             "CreateComparisonReport",
             "PrintToSingleFileHtml"
+          ]
+        },
+        "operationPayloadMode": {
+          "type": "string",
+          "enum": [
+            "not-applicable",
+            "builtin",
+            "additional-operation-directory"
+          ]
+        },
+        "operationPayloadProvenanceState": {
+          "type": "string",
+          "enum": [
+            "not-applicable",
+            "accepted",
+            "research-only",
+            "forbidden"
           ]
         },
         "planeApplicability": {

--- a/docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json
+++ b/docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json
@@ -57,6 +57,7 @@
         "acceptedTargetsRequirePublicGithubEvidence",
         "acceptedTargetsRequireLicense",
         "acceptedTargetsRequirePinnedCommit",
+        "acceptedTargetsRequirePromotableOperationPayload",
         "provisionalTargetsAllowed"
       ],
       "properties": {
@@ -67,6 +68,9 @@
           "type": "boolean"
         },
         "acceptedTargetsRequirePinnedCommit": {
+          "type": "boolean"
+        },
+        "acceptedTargetsRequirePromotableOperationPayload": {
           "type": "boolean"
         },
         "provisionalTargetsAllowed": {
@@ -113,6 +117,21 @@
         "Compare-VIHistory",
         "CreateComparisonReport",
         "PrintToSingleFileHtml"
+      ]
+    },
+    "operationPayloadMode": {
+      "type": "string",
+      "enum": [
+        "builtin",
+        "additional-operation-directory"
+      ]
+    },
+    "operationPayloadProvenanceState": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "research-only",
+        "forbidden"
       ]
     },
     "planeApplicability": {
@@ -268,6 +287,45 @@
         }
       }
     },
+    "operationPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "provenanceState",
+        "notes"
+      ],
+      "properties": {
+        "mode": {
+          "$ref": "#/$defs/operationPayloadMode"
+        },
+        "provenanceState": {
+          "$ref": "#/$defs/operationPayloadProvenanceState"
+        },
+        "sourceRepositorySlug": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "sourceRepositoryUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "sourceLicenseSpdx": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "target": {
       "type": "object",
       "additionalProperties": false,
@@ -297,6 +355,9 @@
         },
         "renderStrategy": {
           "$ref": "#/$defs/renderStrategy"
+        },
+        "operationPayload": {
+          "$ref": "#/$defs/operationPayload"
         },
         "localEvidence": {
           "$ref": "#/$defs/localEvidence"

--- a/fixtures/headless-corpus/sample-vi-corpus.targets.json
+++ b/fixtures/headless-corpus/sample-vi-corpus.targets.json
@@ -12,6 +12,7 @@
     "acceptedTargetsRequirePublicGithubEvidence": true,
     "acceptedTargetsRequireLicense": true,
     "acceptedTargetsRequirePinnedCommit": true,
+    "acceptedTargetsRequirePromotableOperationPayload": true,
     "provisionalTargetsAllowed": true
   },
   "targets": [
@@ -152,6 +153,17 @@
           "linux-proof"
         ],
         "evidenceClass": "change-kind-print"
+      },
+      "operationPayload": {
+        "mode": "additional-operation-directory",
+        "provenanceState": "research-only",
+        "sourceRepositorySlug": "aphill93/linuxContainerDemo",
+        "sourceRepositoryUrl": "https://github.com/aphill93/linuxContainerDemo",
+        "sourceLicenseSpdx": null,
+        "notes": [
+          "The public proof depends on a custom AdditionalOperationDirectory payload checked into VICompareTooling/PrintToSingleFileHtml.",
+          "That payload remains research-only here because the source repository does not currently declare a license."
+        ]
       },
       "publicEvidence": [
         {

--- a/tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
+++ b/tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
@@ -34,13 +34,20 @@ Describe 'Invoke-HeadlessSampleVICorpusEvaluation.ps1' -Tag 'Unit' {
     $accepted.status | Should -Be 'ok'
     $accepted.checks.licenseDeclared | Should -BeTrue
     $accepted.checks.successfulWorkflowEvidence | Should -BeTrue
+    $accepted.operationPayloadMode | Should -Be 'not-applicable'
+    $accepted.checks.operationPayloadPromotable | Should -BeTrue
 
     $provisional = @($report.targets | Where-Object { [string]$_.id -eq 'linuxcontainerdemo-newthing-print' } | Select-Object -First 1)
     $provisional | Should -Not -BeNullOrEmpty
     $provisional.status | Should -Be 'warning'
     $provisional.certificationSurface | Should -Be 'print-single-file'
+    $provisional.operationPayloadMode | Should -Be 'additional-operation-directory'
+    $provisional.operationPayloadProvenanceState | Should -Be 'research-only'
     $provisional.checks.licenseDeclared | Should -BeFalse
-    (($provisional.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'No declared license'
+    $provisional.checks.operationPayloadTracked | Should -BeTrue
+    $provisional.checks.operationPayloadLicenseDeclared | Should -BeFalse
+    $provisional.checks.operationPayloadPromotable | Should -BeFalse
+    (($provisional.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'Custom operation payload has no declared license'
   }
 
   It 'fails closed when an accepted seed loses its declared license' {
@@ -69,5 +76,34 @@ Describe 'Invoke-HeadlessSampleVICorpusEvaluation.ps1' -Tag 'Unit' {
     $targetReport.status | Should -Be 'drift'
     $targetReport.checks.licenseDeclared | Should -BeFalse
     (($targetReport.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'Accepted targets require a declared license'
+  }
+
+  It 'fails closed when a print-single-file target is marked accepted before its custom payload becomes promotable' {
+    $catalog = Get-Content -LiteralPath $script:CatalogPath -Raw | ConvertFrom-Json -Depth 20
+    $target = @($catalog.targets | Where-Object { [string]$_.id -eq 'linuxcontainerdemo-newthing-print' } | Select-Object -First 1)
+    $target | Should -Not -BeNullOrEmpty
+    $target.admission.state = 'accepted'
+    $target.source.licenseSpdx = 'MIT'
+
+    $driftCatalogPath = Join-Path $TestDrive 'sample-corpus.print-payload-drift.json'
+    $catalog | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $driftCatalogPath -Encoding utf8
+
+    $resultsRoot = Join-Path $TestDrive 'sample-corpus-print-payload-drift'
+    $runOutput = & pwsh -NoLogo -NoProfile -File $script:EvaluateScript -CatalogPath $driftCatalogPath -ResultsRoot $resultsRoot -SkipSchemaValidation 2>&1
+    $LASTEXITCODE | Should -Not -Be 0
+
+    $outputText = ($runOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    $outputText | Should -Match 'detected drift'
+
+    $reportPath = Join-Path $resultsRoot 'headless-sample-vi-corpus-evaluation.json'
+    $reportPath | Should -Exist
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
+    $report.overallStatus | Should -Be 'drift'
+
+    $targetReport = @($report.targets | Where-Object { [string]$_.id -eq 'linuxcontainerdemo-newthing-print' } | Select-Object -First 1)
+    $targetReport | Should -Not -BeNullOrEmpty
+    $targetReport.status | Should -Be 'drift'
+    $targetReport.checks.operationPayloadPromotable | Should -BeFalse
+    (($targetReport.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'Accepted targets require a promotable custom operation payload'
   }
 }

--- a/tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1
+++ b/tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1
@@ -136,6 +136,12 @@ function Test-IsGitHubEvidenceUrl {
   }
 }
 
+function Test-IsRepoSlug {
+  param([AllowNull()][string]$Value)
+
+  return (-not [string]::IsNullOrWhiteSpace($Value)) -and ($Value -match '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
+}
+
 function Test-RenderStrategyAlignment {
   param(
     [Parameter(Mandatory)][string]$ChangeKind,
@@ -214,6 +220,12 @@ foreach ($target in @($catalog.targets)) {
   $operation = [string]$target.renderStrategy.operation
   $planes = @(Get-StringArray -Value $target.renderStrategy.planeApplicability)
   $publicEvidence = @($target.publicEvidence)
+  $operationPayloadMode = 'not-applicable'
+  $operationPayloadProvenanceState = 'not-applicable'
+  $operationPayloadTracked = $true
+  $operationPayloadSourceValid = $true
+  $operationPayloadLicenseDeclared = $true
+  $operationPayloadPromotable = $true
 
   $hasPublicRepo = Test-IsGitHubRepoUrl -Value $repoUrl
   if (-not $hasPublicRepo) {
@@ -247,6 +259,57 @@ foreach ($target in @($catalog.targets)) {
   $renderStrategyAligned = Test-RenderStrategyAlignment -ChangeKind $changeKind -CertificationSurface $surface -Operation $operation
   if (-not $renderStrategyAligned) {
     $notes.Add(("Render strategy is not coherent for changeKind='{0}', surface='{1}', operation='{2}'." -f $changeKind, $surface, $operation)) | Out-Null
+  }
+
+  $requiresOperationPayload = $surface -eq 'print-single-file'
+  if ($requiresOperationPayload) {
+    if (-not ($target.PSObject.Properties['operationPayload'] -and $target.operationPayload)) {
+      $operationPayloadTracked = $false
+      $operationPayloadSourceValid = $false
+      $operationPayloadLicenseDeclared = $false
+      $operationPayloadPromotable = $false
+      $notes.Add('PrintToSingleFileHtml targets must declare operationPayload provenance.') | Out-Null
+    } else {
+      $operationPayloadMode = [string]$target.operationPayload.mode
+      $operationPayloadProvenanceState = [string]$target.operationPayload.provenanceState
+      $payloadSourceRepoSlug = [string]$target.operationPayload.sourceRepositorySlug
+      $payloadSourceRepoUrl = [string]$target.operationPayload.sourceRepositoryUrl
+      $payloadSourceLicense = [string]$target.operationPayload.sourceLicenseSpdx
+      $payloadNotes = @(Get-StringArray -Value $target.operationPayload.notes)
+
+      if ($operationPayloadMode -eq 'additional-operation-directory') {
+        $operationPayloadSourceValid = (Test-IsRepoSlug -Value $payloadSourceRepoSlug) -and
+          (Test-IsGitHubRepoUrl -Value $payloadSourceRepoUrl) -and
+          ($payloadNotes.Count -gt 0)
+        if (-not $operationPayloadSourceValid) {
+          $notes.Add('Custom operation payload provenance is incomplete or not GitHub-backed.') | Out-Null
+        }
+
+        $operationPayloadLicenseDeclared = -not [string]::IsNullOrWhiteSpace($payloadSourceLicense)
+        if (-not $operationPayloadLicenseDeclared) {
+          $notes.Add('Custom operation payload has no declared license.') | Out-Null
+        }
+
+        $operationPayloadPromotable = $operationPayloadProvenanceState -eq 'accepted' -and
+          $operationPayloadSourceValid -and
+          $operationPayloadLicenseDeclared
+        if (-not $operationPayloadPromotable) {
+          $notes.Add('Custom operation payload is not promotable for accepted certification use.') | Out-Null
+        }
+      } elseif ($operationPayloadMode -eq 'builtin') {
+        $operationPayloadSourceValid = $true
+        $operationPayloadLicenseDeclared = $true
+        $operationPayloadPromotable = $operationPayloadProvenanceState -eq 'accepted'
+        if (-not $operationPayloadPromotable) {
+          $notes.Add('Builtin operation payload metadata must still be marked accepted before promotion.') | Out-Null
+        }
+      } else {
+        $operationPayloadSourceValid = $false
+        $operationPayloadLicenseDeclared = $false
+        $operationPayloadPromotable = $false
+        $notes.Add(("Unsupported operation payload mode '{0}'." -f $operationPayloadMode)) | Out-Null
+      }
+    }
   }
 
   $fixturePaths = @()
@@ -283,6 +346,12 @@ foreach ($target in @($catalog.targets)) {
   if ($admissionState -eq 'accepted' -and -not $renderStrategyAligned) {
     $notes.Add('Accepted targets require a render strategy aligned with the change kind.') | Out-Null
   }
+  if ($admissionState -eq 'accepted' -and
+      $policy.acceptedTargetsRequirePromotableOperationPayload -and
+      $requiresOperationPayload -and
+      -not $operationPayloadPromotable) {
+    $notes.Add('Accepted targets require a promotable custom operation payload.') | Out-Null
+  }
   if ($admissionState -eq 'accepted' -and -not $fixturePathsResolved -and $fixturePaths.Count -gt 0) {
     $notes.Add('Accepted target declared local fixture lineage but one or more fixture paths were missing.') | Out-Null
   }
@@ -310,6 +379,8 @@ foreach ($target in @($catalog.targets)) {
       changeKind = $changeKind
       certificationSurface = $surface
       operation = $operation
+      operationPayloadMode = $operationPayloadMode
+      operationPayloadProvenanceState = $operationPayloadProvenanceState
       planeApplicability = @($planes)
       publicEvidenceCount = $publicEvidence.Count
       successfulWorkflowEvidenceCount = $successfulWorkflowEvidenceCount
@@ -323,6 +394,10 @@ foreach ($target in @($catalog.targets)) {
         successfulWorkflowEvidence = $successfulWorkflowEvidenceCount -gt 0
         renderStrategyAligned = $renderStrategyAligned
         localFixturePathsResolved = $fixturePathsResolved
+        operationPayloadTracked = $operationPayloadTracked
+        operationPayloadSourceValid = $operationPayloadSourceValid
+        operationPayloadLicenseDeclared = $operationPayloadLicenseDeclared
+        operationPayloadPromotable = $operationPayloadPromotable
       }
       notes = @($notes.ToArray())
     }) | Out-Null
@@ -359,15 +434,21 @@ $markdownLines = @(
   ('- Drift Targets: `{0}`' -f $summary.driftCount),
   ('- Warning Targets: `{0}`' -f $summary.warningCount),
   '',
-  '| Target | Admission | Status | Surface | Planes | Evidence |',
+  '| Target | Admission | Status | Surface | Payload | Planes | Evidence |',
   '| --- | --- | --- | --- | --- | --- |'
 )
 foreach ($target in @($report.targets)) {
-  $markdownLines += ('| `{0}` | `{1}` | `{2}` | `{3}` | `{4}` | `{5}` successful workflow run(s) |' -f
+  $payloadLabel = if ([string]$target.operationPayloadMode -eq 'not-applicable') {
+    'n/a'
+  } else {
+    ('{0}/{1}' -f [string]$target.operationPayloadMode, [string]$target.operationPayloadProvenanceState)
+  }
+  $markdownLines += ('| `{0}` | `{1}` | `{2}` | `{3}` | `{4}` | `{5}` | `{6}` successful workflow run(s) |' -f
     $target.id,
     $target.admissionState,
     $target.status,
     $target.certificationSurface,
+    $payloadLabel,
     ((@($target.planeApplicability) | ForEach-Object { [string]$_ }) -join ', '),
     $target.successfulWorkflowEvidenceCount)
   if (@($target.notes).Count -gt 0) {


### PR DESCRIPTION
# Summary
Closes #1408 by making custom print-operation provenance explicit in the headless sample corpus contract. `print-single-file` targets now track the operation payload separately from the sample repository so unlicensed `AdditionalOperationDirectory` payloads stay research-only instead of looking promotable by accident.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Change Surface

- Primary issue or standing-priority context: `#1408`
- Files, tools, workflows, or policies touched:
  - `fixtures/headless-corpus/sample-vi-corpus.targets.json`
  - `tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1`
  - `tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1`
  - `docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json`
  - `docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json`
  - `docs/knowledgebase/Headless-SampleVI-Corpus.md`
  - `docs/knowledgebase/PrintToSingleFileHtml-Provenance.md`
  - `docs/documentation-manifest.json`
- Cross-repo or external-consumer impact:
  - clarifies that `#1467` depends on licensed payload provenance, not just a licensed sample repository
- Required checks, merge-queue behavior, or approval flows affected:
  - no branch protection changes; focused corpus evaluator/tests only

## Validation Evidence

- Commands run:
  - `pwsh -NoLogo -NoProfile -File tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1`
  - `node tools/npm/run-script.mjs history:corpus:samples:evaluate`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs lint:md:changed`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/headless-sample-corpus/headless-sample-vi-corpus-evaluation.json`
  - `tests/results/_agent/headless-sample-corpus/headless-sample-vi-corpus-evaluation.md`
- Risk-based checks not run:
  - full container pre-push loop; this lane changes catalog/evaluator/documentation contracts only

## Risks and Follow-ups

- Residual risks:
  - no licensed public `PrintToSingleFileHtml` payload exists yet, so added/deleted print certification remains research-only
- Follow-up issues or deferred work:
  - `#1469` author a licensed `PrintToSingleFileHtml` payload
  - `#1467` promote a licensed added/deleted sample seed once the payload is promotable
- Deployment, approval, or rollback notes:
  - rollback is a normal revert of the catalog/evaluator/docs changes if the provenance split needs to be reworked

## Reviewer Focus

- Please verify:
  - the `operationPayload` contract is the right separation of concerns
  - accepted targets cannot silently bypass custom payload provenance
- Areas where the reasoning is subtle:
  - the sample repository can be public and licensed while the rendering payload is still non-promotable
- Manual spot checks requested:
  - inspect the provisional `linuxcontainerdemo-newthing-print` target and the new provenance note for policy clarity
