### PR TITLE
Update for standing priority #1472

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-20T12:50:00Z",
+  "updated": "2026-03-20T14:40:00Z",
   "entries": [
     {
       "name": "Root Entry Points",
@@ -232,6 +232,19 @@
         "docs/schemas/labview-cli-custom-operation-scaffold-v1.schema.json",
         "tools/New-LabVIEWCLICustomOperationWorkspace.ps1",
         "tests/New-LabVIEWCLICustomOperationWorkspace.Tests.ps1"
+      ]
+    },
+    {
+      "name": "LabVIEW CLI Custom Operation Proof Contracts",
+      "category": "supporting",
+      "status": "reference",
+      "description": "Fail-closed AddTwoNumbers host-proof helper, analysis module, receipt schema, focused tests, and guidance for investigating LabVIEWCLI custom-operation hangs and path drift on the LabVIEW 2026 host plane.",
+      "files": [
+        "docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md",
+        "docs/schemas/labview-cli-custom-operation-proof-v1.schema.json",
+        "tools/LabVIEWCLICustomOperationProof.psm1",
+        "tools/Test-LabVIEWCLICustomOperationProof.ps1",
+        "tests/LabVIEWCLICustomOperationProof.Tests.ps1"
       ]
     },
     {

--- a/docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md
+++ b/docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md
@@ -1,0 +1,120 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# LabVIEW CLI Custom Operation Proof
+
+This note defines the fail-closed proof helper used to investigate
+`LabVIEWCLI` custom-operation execution on the official NI `AddTwoNumbers`
+example.
+
+## Purpose
+
+Use the proof helper when you need deterministic evidence for:
+
+- implicit `LabVIEWCLI` path drift
+- explicit `-LabVIEWPath` behavior on the LabVIEW 2026 host plane
+- `GetHelp.vi` vs headless `RunOperation.vi` behavior
+- lingering `LabVIEW` / `LabVIEWCLI` residue after a hang
+
+The helper always writes a machine-readable receipt and summary, even when the
+proof ends blocked.
+
+## Entry points
+
+- Helper: `tools/Test-LabVIEWCLICustomOperationProof.ps1`
+- Analysis module: `tools/LabVIEWCLICustomOperationProof.psm1`
+- Receipt schema:
+  `docs/schemas/labview-cli-custom-operation-proof-v1.schema.json`
+- Focused test:
+  `tests/LabVIEWCLICustomOperationProof.Tests.ps1`
+
+## Default behavior
+
+Unless `-OperationDirectory` is supplied, the helper first scaffolds a
+disposable workspace from the installed NI example under
+`tests/results/_agent/custom-operation-proofs/<Operation>-<timestamp>/workspace`.
+
+It then runs this scenario pack through the shared `Invoke-LVCustomOperation`
+abstraction:
+
+1. `default-help`
+   - omit `-LabVIEWPath`
+   - probe the implicit LabVIEW selection used by `LabVIEWCLI`
+2. `explicit-help`
+   - force the preferred LabVIEW 2026 path
+   - run `GetHelp.vi`
+3. `explicit-headless-run`
+   - force the same LabVIEW 2026 path
+   - run `RunOperation.vi` with `-x 1 -y 2 -LogToConsole true -Headless true`
+
+When `-LabVIEWPath` is omitted, the helper prefers the LabVIEW 2026 32-bit host
+plane when one is installed and falls back to the next available candidate.
+
+## Residue policy
+
+The helper records `LabVIEW` and `LabVIEWCLI` processes before and after each
+scenario.
+
+- It only force-cleans newly spawned residue.
+- It does not kill pre-existing human-owned LabVIEW processes.
+- A blocked proof still fails closed if newly spawned processes remain after
+  cleanup.
+
+## Logs and analysis
+
+For each scenario, the helper copies matching temp logs into the per-run results
+root and projects:
+
+- observed `Using LabVIEW: "<path>"` values
+- whether launch reached `LabVIEW launched successfully`
+- whether completion text was observed
+
+The final receipt computes root-cause candidates for:
+
+- `default-path-drift`
+- `custom-operation-loading`
+- `headless-interactive-mismatch`
+- `host-plane-32bit-startup`
+
+## Usage
+
+Run the live host proof:
+
+```powershell
+node tools/npm/run-script.mjs history:custom-operation:proof
+```
+
+Preview the disposable plan without executing LabVIEW:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1 `
+  -DryRun
+```
+
+Use an explicit custom operation workspace instead of the scaffolded NI example:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1 `
+  -OperationDirectory tests/results/_agent/custom-operation-scaffolds/manual-authoring `
+  -LabVIEWPath "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe"
+```
+
+## Receipt
+
+Successful or blocked runs emit `labview-cli-custom-operation-proof@v1` with:
+
+- proof status
+- explicit LabVIEW path used for forced scenarios
+- scaffold receipt path when applicable
+- per-scenario preview/invocation results
+- copied log inventory
+- PID tracker payload
+- lingering-process cleanup outcomes
+- projected root-cause candidates
+
+## Boundary
+
+This helper proves the host-plane behavior of the official NI example.
+
+- It does not make repo-owned custom operation payloads promotable by itself.
+- It does not replace the scaffold helper from `#1471`.
+- It exists so `#1472` can be closed with deterministic evidence instead of ad
+  hoc terminal transcripts.

--- a/docs/schemas/labview-cli-custom-operation-proof-v1.schema.json
+++ b/docs/schemas/labview-cli-custom-operation-proof-v1.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/labview-cli-custom-operation-proof-v1.schema.json",
+  "title": "LabVIEW CLI Custom Operation Proof v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "generatedAt",
+    "status",
+    "operationName",
+    "operationDirectory",
+    "dryRun",
+    "resultsRoot",
+    "reportPath",
+    "summaryPath",
+    "analysis",
+    "scenarios"
+  ],
+  "properties": {
+    "schema": {
+      "const": "labview-cli-custom-operation-proof@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "planned",
+        "succeeded",
+        "blocked"
+      ]
+    },
+    "operationName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourceExamplePath": {
+      "type": "string"
+    },
+    "operationDirectory": {
+      "type": "string",
+      "minLength": 1
+    },
+    "explicitLabVIEWPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "labviewCliPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "timeoutSeconds": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "dryRun": {
+      "type": "boolean"
+    },
+    "resultsRoot": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reportPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summaryPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scaffoldReceiptPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "analysis": {
+      "type": "object",
+      "required": [
+        "defaultPathDriftObserved",
+        "explicitHelpTimedOut",
+        "explicitHeadlessTimedOut",
+        "headlessInteractiveMismatchObserved",
+        "customOperationLoadingObserved",
+        "hostPlane32BitConcernObserved",
+        "cleanupRequired",
+        "cleanupSucceeded",
+        "rootCauseCandidates",
+        "notes"
+      ],
+      "properties": {
+        "defaultPathDriftObserved": { "type": "boolean" },
+        "defaultObservedLabVIEWPath": { "type": [ "string", "null" ] },
+        "explicitObservedLabVIEWPath": { "type": [ "string", "null" ] },
+        "explicitHelpTimedOut": { "type": "boolean" },
+        "explicitHeadlessTimedOut": { "type": "boolean" },
+        "headlessInteractiveMismatchObserved": { "type": "boolean" },
+        "customOperationLoadingObserved": { "type": "boolean" },
+        "hostPlane32BitConcernObserved": { "type": "boolean" },
+        "cleanupRequired": { "type": "boolean" },
+        "cleanupSucceeded": { "type": "boolean" },
+        "rootCauseCandidates": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "status",
+          "timedOut",
+          "preview",
+          "cleanup",
+          "lingeringProcesses",
+          "logCapture",
+          "logInsights"
+        ],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": [
+              "planned",
+              "succeeded",
+              "failed",
+              "timed-out"
+            ]
+          },
+          "timedOut": { "type": "boolean" },
+          "requestedLabVIEWPath": { "type": [ "string", "null" ] },
+          "preview": { "type": "object" },
+          "result": { "type": [ "object", "null" ] },
+          "error": { "type": [ "string", "null" ] },
+          "processBefore": { "type": "array", "items": { "type": "object" } },
+          "processAfter": { "type": "array", "items": { "type": "object" } },
+          "processFinal": { "type": "array", "items": { "type": "object" } },
+          "cleanup": {
+            "type": "object",
+            "required": [ "killedPids", "errors" ],
+            "properties": {
+              "killedPids": {
+                "type": "array",
+                "items": { "type": "integer" }
+              },
+              "errors": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          },
+          "lingeringProcesses": { "type": "array", "items": { "type": "object" } },
+          "logCapture": {
+            "type": "object",
+            "required": [ "count", "files" ],
+            "properties": {
+              "count": { "type": "integer", "minimum": 0 },
+              "files": { "type": "array", "items": { "type": "object" } }
+            }
+          },
+          "logInsights": {
+            "type": "object",
+            "required": [
+              "observedLabVIEWPaths",
+              "observedLabVIEWPath",
+              "launchSucceeded",
+              "operationCompleted",
+              "logLineCount"
+            ],
+            "properties": {
+              "observedLabVIEWPaths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "observedLabVIEWPath": { "type": [ "string", "null" ] },
+              "launchSucceeded": { "type": "boolean" },
+              "operationCompleted": { "type": "boolean" },
+              "logLineCount": { "type": "integer", "minimum": 0 }
+            }
+          },
+          "labviewPidTracker": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "history:corpus:offline": "pwsh -NoLogo -NoProfile -File tools/Invoke-OfflineRealHistoryCorpus.ps1",
     "history:corpus:evaluate": "pwsh -NoLogo -NoProfile -File tools/Invoke-OfflineRealHistoryCorpusEvaluation.ps1",
     "history:corpus:samples:evaluate": "pwsh -NoLogo -NoProfile -File tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1",
+    "history:custom-operation:proof": "pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1",
     "history:custom-operation:scaffold": "pwsh -NoLogo -NoProfile -File tools/New-LabVIEWCLICustomOperationWorkspace.ps1",
     "history:corpus:normalize": "pwsh -NoLogo -NoProfile -File tools/Normalize-OfflineRealHistoryCorpus.ps1",
     "history:diagnostics:show": "pwsh -NoLogo -NoProfile -File tools/Show-DockerFastLoopDiagnostics.ps1",

--- a/tests/LabVIEWCLICustomOperationProof.Tests.ps1
+++ b/tests/LabVIEWCLICustomOperationProof.Tests.ps1
@@ -1,0 +1,171 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'LabVIEW CLI custom operation proof contracts' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ProofModule = Join-Path $script:RepoRoot 'tools' 'LabVIEWCLICustomOperationProof.psm1'
+    $script:ProofScript = Join-Path $script:RepoRoot 'tools' 'Test-LabVIEWCLICustomOperationProof.ps1'
+    if (-not (Test-Path -LiteralPath $script:ProofModule -PathType Leaf)) {
+      throw "LabVIEWCLICustomOperationProof.psm1 not found at $script:ProofModule"
+    }
+    if (-not (Test-Path -LiteralPath $script:ProofScript -PathType Leaf)) {
+      throw "Test-LabVIEWCLICustomOperationProof.ps1 not found at $script:ProofScript"
+    }
+
+    Import-Module $script:ProofModule -Force | Out-Null
+
+    function script:New-SyntheticCustomOperationExample {
+      param([Parameter(Mandatory)][string]$RootPath)
+
+      New-Item -ItemType Directory -Path $RootPath -Force | Out-Null
+      foreach ($relativePath in @(
+        'AddTwoNumbers.lvclass',
+        'AddTwoNumbers.vi',
+        'GetHelp.vi',
+        'RunOperation.vi'
+      )) {
+        $filePath = Join-Path $RootPath $relativePath
+        $parent = Split-Path -Parent $filePath
+        if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+          New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+        Set-Content -LiteralPath $filePath -Value 'placeholder' -Encoding utf8
+      }
+
+      return $RootPath
+    }
+  }
+
+  It 'classifies default-path drift and custom-operation loading when both explicit scenarios time out' {
+    $analysis = Resolve-LabVIEWCustomOperationProofAnalysis -ScenarioResults @(
+      [pscustomobject]@{
+        name = 'default-help'
+        status = 'timed-out'
+        timedOut = $true
+        cleanup = [pscustomobject]@{ killedPids = @(); errors = @() }
+        lingeringProcesses = @()
+        logInsights = [pscustomobject]@{ observedLabVIEWPath = 'C:\Program Files\National Instruments\LabVIEW 2025\LabVIEW.exe' }
+      },
+      [pscustomobject]@{
+        name = 'explicit-help'
+        status = 'timed-out'
+        timedOut = $true
+        cleanup = [pscustomobject]@{ killedPids = @(4100); errors = @() }
+        lingeringProcesses = @()
+        logInsights = [pscustomobject]@{ observedLabVIEWPath = 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe' }
+      },
+      [pscustomobject]@{
+        name = 'explicit-headless-run'
+        status = 'timed-out'
+        timedOut = $true
+        cleanup = [pscustomobject]@{ killedPids = @(4200); errors = @() }
+        lingeringProcesses = @()
+        logInsights = [pscustomobject]@{ observedLabVIEWPath = 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe' }
+      }
+    ) -RequestedLabVIEWPath 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe'
+
+    $analysis.defaultPathDriftObserved | Should -BeTrue
+    @($analysis.rootCauseCandidates) | Should -Contain 'default-path-drift'
+    @($analysis.rootCauseCandidates) | Should -Contain 'custom-operation-loading'
+    @($analysis.rootCauseCandidates) | Should -Contain 'host-plane-32bit-startup'
+    $analysis.headlessInteractiveMismatchObserved | Should -BeFalse
+    $analysis.cleanupRequired | Should -BeTrue
+    $analysis.cleanupSucceeded | Should -BeTrue
+  }
+
+  It 'parses both direct and last-used LabVIEW log lines' {
+    $insights = Get-LabVIEWCustomOperationLogInsights -Text @'
+Using last used LabVIEW: "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe"
+Using LabVIEW: "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe"
+'@
+
+    @($insights.observedLabVIEWPaths).Count | Should -Be 1
+    $insights.observedLabVIEWPath | Should -Be 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe'
+  }
+
+  It 'classifies headless mismatch when GetHelp succeeds but the headless run times out' {
+    $analysis = Resolve-LabVIEWCustomOperationProofAnalysis -ScenarioResults @(
+      [pscustomobject]@{
+        name = 'default-help'
+        status = 'succeeded'
+        timedOut = $false
+        cleanup = [pscustomobject]@{ killedPids = @(); errors = @() }
+        lingeringProcesses = @()
+        logInsights = [pscustomobject]@{ observedLabVIEWPath = 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe' }
+      },
+      [pscustomobject]@{
+        name = 'explicit-help'
+        status = 'succeeded'
+        timedOut = $false
+        cleanup = [pscustomobject]@{ killedPids = @(); errors = @() }
+        lingeringProcesses = @()
+        logInsights = [pscustomobject]@{ observedLabVIEWPath = 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe' }
+      },
+      [pscustomobject]@{
+        name = 'explicit-headless-run'
+        status = 'timed-out'
+        timedOut = $true
+        cleanup = [pscustomobject]@{ killedPids = @(); errors = @() }
+        lingeringProcesses = @()
+        logInsights = [pscustomobject]@{ observedLabVIEWPath = 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe' }
+      }
+    ) -RequestedLabVIEWPath 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe'
+
+    $analysis.defaultPathDriftObserved | Should -BeFalse
+    $analysis.headlessInteractiveMismatchObserved | Should -BeTrue
+    @($analysis.rootCauseCandidates) | Should -Contain 'headless-interactive-mismatch'
+    @($analysis.rootCauseCandidates) | Should -Not -Contain 'custom-operation-loading'
+  }
+
+  It 'writes a planned proof receipt and summary from a synthetic AddTwoNumbers example' {
+    $sourcePath = New-SyntheticCustomOperationExample -RootPath (Join-Path $TestDrive 'source-example')
+    $resultsRoot = Join-Path $TestDrive 'results-root'
+    $labviewPath = 'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ProofScript `
+      -SourceExamplePath $sourcePath `
+      -ResultsRoot $resultsRoot `
+      -LabVIEWPath $labviewPath `
+      -DryRun `
+      -SkipSchemaValidation *>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $reportPath = Join-Path $resultsRoot 'labview-cli-custom-operation-proof.json'
+    $summaryPath = Join-Path $resultsRoot 'labview-cli-custom-operation-proof.md'
+    $scaffoldReceiptPath = Join-Path $resultsRoot 'custom-operation-scaffold.json'
+
+    $reportPath | Should -Exist
+    $summaryPath | Should -Exist
+    $scaffoldReceiptPath | Should -Exist
+
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 12
+    $report.schema | Should -Be 'labview-cli-custom-operation-proof@v1'
+    $report.status | Should -Be 'planned'
+    $report.operationName | Should -Be 'AddTwoNumbers'
+    $report.explicitLabVIEWPath | Should -Be $labviewPath
+    @($report.scenarios).Count | Should -Be 3
+    (@($report.scenarios | ForEach-Object { $_.status } | Select-Object -Unique)) | Should -Be @('planned')
+
+    $summary = Get-Content -LiteralPath $summaryPath -Raw
+    $summary | Should -Match '# LabVIEW CLI Custom Operation Proof'
+    $summary | Should -Match '- Final status: `planned`'
+    $summary | Should -Match '`default-help`'
+    $summary | Should -Match '`explicit-headless-run`'
+  }
+
+  It 'fails closed when the installed example source is missing' {
+    $missingSource = Join-Path $TestDrive 'missing-example'
+    $resultsRoot = Join-Path $TestDrive 'results-root'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ProofScript `
+      -SourceExamplePath $missingSource `
+      -ResultsRoot $resultsRoot `
+      -DryRun `
+      -SkipSchemaValidation *>&1
+    $LASTEXITCODE | Should -Not -Be 0
+    (($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'example source was not found'
+  }
+}

--- a/tests/LabVIEWCli.CustomOperation.Tests.ps1
+++ b/tests/LabVIEWCli.CustomOperation.Tests.ps1
@@ -1,0 +1,46 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Invoke-LVCustomOperation' -Tag 'Unit' {
+  BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' 'tools' 'LabVIEWCli.psm1'
+    Import-Module $modulePath -Force
+  }
+
+  It 'returns a preview command for a custom operation through the shared abstraction' {
+    $previousCli = $env:LABVIEWCLI_PATH
+    $cliPath = Join-Path $TestDrive 'LabVIEWCLI.exe'
+    $labviewPath = Join-Path $TestDrive 'LabVIEW.exe'
+    $operationRoot = Join-Path $TestDrive 'AddTwoNumbers'
+    Set-Content -LiteralPath $cliPath -Value '' -Encoding utf8
+    Set-Content -LiteralPath $labviewPath -Value '' -Encoding utf8
+    New-Item -ItemType Directory -Path $operationRoot -Force | Out-Null
+    Set-Item Env:LABVIEWCLI_PATH $cliPath
+
+    try {
+      $preview = Invoke-LVCustomOperation `
+        -CustomOperationName 'AddTwoNumbers' `
+        -AdditionalOperationDirectory $operationRoot `
+        -Arguments @('-x', '1', '-y', '2') `
+        -Headless `
+        -LogToConsole `
+        -LabVIEWPath $labviewPath `
+        -Provider 'labviewcli' `
+        -Preview
+
+      $preview | Should -Not -BeNullOrEmpty
+      $preview.operation | Should -Be 'RunCustomOperation'
+      $preview.provider | Should -Be 'labviewcli'
+      $preview.args | Should -Contain '-AdditionalOperationDirectory'
+      $preview.args | Should -Contain '-Headless'
+      $preview.args | Should -Contain '-LogToConsole'
+      $preview.args | Should -Contain '-x'
+    } finally {
+      if ($previousCli) {
+        Set-Item Env:LABVIEWCLI_PATH $previousCli
+      } else {
+        Remove-Item Env:LABVIEWCLI_PATH -ErrorAction SilentlyContinue
+      }
+    }
+  }
+}

--- a/tests/LabVIEWCli.Provider.Tests.ps1
+++ b/tests/LabVIEWCli.Provider.Tests.ps1
@@ -103,4 +103,53 @@ Describe 'LabVIEW CLI provider' -Tag 'Unit' {
       }
     } | Should -Throw "*headless*"
   }
+
+  It 'builds custom operation arguments with additional-operation-directory, help, and explicit LabVIEW path' {
+    $labviewPath = Join-Path $TestDrive 'LabVIEW.exe'
+    Set-Content -LiteralPath $labviewPath -Value '' -Encoding utf8
+    $customOperationRoot = Join-Path $TestDrive 'AddTwoNumbers'
+    New-Item -ItemType Directory -Path $customOperationRoot -Force | Out-Null
+
+    $resolvedPath = (Resolve-Path -LiteralPath $labviewPath).Path
+    $args = InModuleScope $script:providerModule.Name {
+      param($operationRoot, $lvPath)
+      Get-LabVIEWCliArgs -Operation 'RunCustomOperation' -Params @{
+        customOperationName = 'AddTwoNumbers'
+        additionalOperationDirectory = $operationRoot
+        help = $true
+        labviewPath = $lvPath
+      }
+    } -ArgumentList $customOperationRoot, $resolvedPath
+
+    $args[0] | Should -Be '-OperationName'
+    $args[1] | Should -Be 'AddTwoNumbers'
+    $args | Should -Contain '-AdditionalOperationDirectory'
+    $args | Should -Contain '-Help'
+    $labviewIndex = [Array]::IndexOf($args, '-LabVIEWPath')
+    $labviewIndex | Should -BeGreaterThan 0
+    $args[$labviewIndex + 1] | Should -Be $resolvedPath
+  }
+
+  It 'builds custom operation arguments without injecting LabVIEWPath when omitted' {
+    $customOperationRoot = Join-Path $TestDrive 'AddTwoNumbers'
+    New-Item -ItemType Directory -Path $customOperationRoot -Force | Out-Null
+    Set-Item Env:LABVIEW_PATH (Join-Path $TestDrive 'ignored-LabVIEW.exe')
+
+    $args = InModuleScope $script:providerModule.Name {
+      param($operationRoot)
+      Get-LabVIEWCliArgs -Operation 'RunCustomOperation' -Params @{
+        customOperationName = 'AddTwoNumbers'
+        additionalOperationDirectory = $operationRoot
+        arguments = @('-x', '1', '-y', '2')
+        headless = 'true'
+        logToConsole = '1'
+      }
+    } -ArgumentList $customOperationRoot
+
+    $args | Should -Contain '-Headless'
+    $args | Should -Contain '-LogToConsole'
+    $args | Should -Not -Contain '-LabVIEWPath'
+    $args | Should -Contain '-x'
+    $args | Should -Contain '2'
+  }
 }

--- a/tools/LabVIEWCLICustomOperationProof.psm1
+++ b/tools/LabVIEWCLICustomOperationProof.psm1
@@ -1,0 +1,150 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-LabVIEWCustomOperationLogInsights {
+  [CmdletBinding(DefaultParameterSetName = 'Path')]
+  param(
+    [Parameter(ParameterSetName = 'Path')]
+    [string[]]$LogPaths,
+    [Parameter(ParameterSetName = 'Text')]
+    [AllowNull()][string]$Text
+  )
+
+  $combinedText = if ($PSCmdlet.ParameterSetName -eq 'Text') {
+    [string]($Text ?? '')
+  } else {
+    $chunks = New-Object System.Collections.Generic.List[string]
+    foreach ($pathValue in @($LogPaths)) {
+      if ([string]::IsNullOrWhiteSpace($pathValue)) { continue }
+      try {
+        if (Test-Path -LiteralPath $pathValue -PathType Leaf) {
+          $chunks.Add((Get-Content -LiteralPath $pathValue -Raw -ErrorAction Stop)) | Out-Null
+        }
+      } catch {}
+    }
+    ($chunks -join [Environment]::NewLine)
+  }
+
+  $observedLabVIEWPaths = New-Object System.Collections.Generic.List[string]
+  foreach ($match in [System.Text.RegularExpressions.Regex]::Matches($combinedText, 'Using(?:\s+last\s+used)?\s+LabVIEW:\s*"([^"]+)"')) {
+    $pathValue = [string]$match.Groups[1].Value
+    if ([string]::IsNullOrWhiteSpace($pathValue)) { continue }
+    if (-not ($observedLabVIEWPaths.Contains($pathValue))) {
+      $observedLabVIEWPaths.Add($pathValue) | Out-Null
+    }
+  }
+
+  $launchSucceeded = $combinedText -match 'LabVIEW launched successfully'
+  $operationCompleted = $combinedText -match 'Operation completed successfully' -or
+    $combinedText -match 'completed successfully' -or
+    $combinedText -match 'Operation output:'
+
+  return [pscustomobject]@{
+    observedLabVIEWPaths = @($observedLabVIEWPaths.ToArray())
+    observedLabVIEWPath = if ($observedLabVIEWPaths.Count -gt 0) { $observedLabVIEWPaths[0] } else { $null }
+    launchSucceeded = [bool]$launchSucceeded
+    operationCompleted = [bool]$operationCompleted
+    logLineCount = if ([string]::IsNullOrWhiteSpace($combinedText)) { 0 } else { ($combinedText -split "`r?`n").Count }
+  }
+}
+
+function Resolve-LabVIEWCustomOperationProofAnalysis {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][object[]]$ScenarioResults,
+    [AllowNull()][string]$RequestedLabVIEWPath
+  )
+
+  $scenarioMap = @{}
+  foreach ($scenario in @($ScenarioResults)) {
+    if ($null -eq $scenario) { continue }
+    $name = [string]$scenario.name
+    if ([string]::IsNullOrWhiteSpace($name)) { continue }
+    $scenarioMap[$name] = $scenario
+  }
+
+  $defaultHelp = $scenarioMap['default-help']
+  $explicitHelp = $scenarioMap['explicit-help']
+  $explicitHeadless = $scenarioMap['explicit-headless-run']
+
+  $defaultObserved = if ($defaultHelp -and $defaultHelp.logInsights) { [string]$defaultHelp.logInsights.observedLabVIEWPath } else { $null }
+  $explicitObserved = if ($explicitHelp -and $explicitHelp.logInsights) { [string]$explicitHelp.logInsights.observedLabVIEWPath } else { $null }
+  if ([string]::IsNullOrWhiteSpace($explicitObserved)) {
+    $explicitObserved = [string]$RequestedLabVIEWPath
+  }
+
+  $defaultPathDriftObserved = $false
+  if (-not [string]::IsNullOrWhiteSpace($defaultObserved) -and -not [string]::IsNullOrWhiteSpace($explicitObserved)) {
+    $defaultPathDriftObserved = -not [string]::Equals(
+      [System.IO.Path]::GetFullPath($defaultObserved),
+      [System.IO.Path]::GetFullPath($explicitObserved),
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  }
+
+  $explicitHelpSucceeded = $explicitHelp -and ([string]$explicitHelp.status -eq 'succeeded')
+  $explicitHelpTimedOut = $explicitHelp -and [bool]$explicitHelp.timedOut
+  $explicitHeadlessTimedOut = $explicitHeadless -and [bool]$explicitHeadless.timedOut
+  $headlessInteractiveMismatchObserved = [bool]($explicitHelpSucceeded -and $explicitHeadlessTimedOut)
+  $customOperationLoadingObserved = [bool]($explicitHelpTimedOut -and $explicitHeadlessTimedOut)
+  $hostPlane32BitConcernObserved = [bool](
+    -not [string]::IsNullOrWhiteSpace($RequestedLabVIEWPath) -and
+    $RequestedLabVIEWPath -match '(?i)Program Files \(x86\)' -and
+    ($explicitHelpTimedOut -or $explicitHeadlessTimedOut)
+  )
+
+  $cleanupRequired = $false
+  $cleanupSucceeded = $true
+  foreach ($scenario in @($ScenarioResults)) {
+    if ($null -eq $scenario) { continue }
+    $lingeringCount = @($scenario.lingeringProcesses).Count
+    $killedCount = @($scenario.cleanup.killedPids).Count
+    if ($lingeringCount -gt 0 -or $killedCount -gt 0) {
+      $cleanupRequired = $true
+    }
+    if ($lingeringCount -gt 0) {
+      $cleanupSucceeded = $false
+    }
+  }
+
+  $rootCauseCandidates = New-Object System.Collections.Generic.List[string]
+  if ($defaultPathDriftObserved) { $rootCauseCandidates.Add('default-path-drift') | Out-Null }
+  if ($customOperationLoadingObserved) { $rootCauseCandidates.Add('custom-operation-loading') | Out-Null }
+  if ($headlessInteractiveMismatchObserved) { $rootCauseCandidates.Add('headless-interactive-mismatch') | Out-Null }
+  if ($hostPlane32BitConcernObserved) { $rootCauseCandidates.Add('host-plane-32bit-startup') | Out-Null }
+
+  $notes = New-Object System.Collections.Generic.List[string]
+  if ($defaultPathDriftObserved) {
+    $notes.Add(("Default LabVIEW resolution drifted to '{0}' instead of '{1}'." -f $defaultObserved, $explicitObserved)) | Out-Null
+  }
+  if ($customOperationLoadingObserved) {
+    $notes.Add('Both explicit GetHelp and explicit headless execution timed out, which points to custom-operation loading or host-plane startup rather than a headless-only mismatch.') | Out-Null
+  } elseif ($headlessInteractiveMismatchObserved) {
+    $notes.Add('Explicit GetHelp succeeded while explicit headless execution timed out, which points to a headless/interactive mismatch.') | Out-Null
+  }
+  if ($hostPlane32BitConcernObserved) {
+    $notes.Add('The explicit proof path used the LabVIEW 2026 32-bit host plane and still timed out, so 32-bit host startup remains a live suspect.') | Out-Null
+  }
+  if ($cleanupRequired -and $cleanupSucceeded) {
+    $notes.Add('The proof required residue cleanup, but the helper removed all newly spawned LabVIEW/LabVIEWCLI processes before exit.') | Out-Null
+  } elseif ($cleanupRequired) {
+    $notes.Add('The proof required residue cleanup and still left newly spawned LabVIEW/LabVIEWCLI processes running.') | Out-Null
+  }
+
+  return [pscustomobject]@{
+    defaultPathDriftObserved = [bool]$defaultPathDriftObserved
+    defaultObservedLabVIEWPath = $defaultObserved
+    explicitObservedLabVIEWPath = $explicitObserved
+    explicitHelpTimedOut = [bool]$explicitHelpTimedOut
+    explicitHeadlessTimedOut = [bool]$explicitHeadlessTimedOut
+    headlessInteractiveMismatchObserved = [bool]$headlessInteractiveMismatchObserved
+    customOperationLoadingObserved = [bool]$customOperationLoadingObserved
+    hostPlane32BitConcernObserved = [bool]$hostPlane32BitConcernObserved
+    cleanupRequired = [bool]$cleanupRequired
+    cleanupSucceeded = [bool]$cleanupSucceeded
+    rootCauseCandidates = @($rootCauseCandidates.ToArray())
+    notes = @($notes.ToArray())
+  }
+}
+
+Export-ModuleMember -Function Get-LabVIEWCustomOperationLogInsights, Resolve-LabVIEWCustomOperationProofAnalysis

--- a/tools/LabVIEWCli.psm1
+++ b/tools/LabVIEWCli.psm1
@@ -946,6 +946,54 @@ function Invoke-LVRunVI {
   Invoke-LVOperation -Operation 'RunVI' -Params $params -Provider $Provider -Preview:$Preview
 }
 
+function Invoke-LVCustomOperation {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$CustomOperationName,
+    [Parameter(Mandatory)][string]$AdditionalOperationDirectory,
+    [object[]]$Arguments,
+    [switch]$Help,
+    [switch]$Headless,
+    [switch]$LogToConsole,
+    [string]$LabVIEWPath,
+    [string]$Provider = 'auto',
+    [switch]$Preview,
+    [Nullable[int]]$TimeoutSeconds
+  )
+
+  $params = @{
+    customOperationName = $CustomOperationName
+    additionalOperationDirectory = $AdditionalOperationDirectory
+  }
+  if ($PSBoundParameters.ContainsKey('Arguments') -and $Arguments) {
+    $params.arguments = @($Arguments | ForEach-Object { [string]$_ })
+  }
+  if ($PSBoundParameters.ContainsKey('Help')) {
+    $params.help = $Help.IsPresent
+  }
+  if ($PSBoundParameters.ContainsKey('Headless')) {
+    $params.headless = $Headless.IsPresent
+  }
+  if ($PSBoundParameters.ContainsKey('LogToConsole')) {
+    $params.logToConsole = $LogToConsole.IsPresent
+  }
+  if ($PSBoundParameters.ContainsKey('LabVIEWPath') -and $LabVIEWPath) {
+    $params.labviewPath = $LabVIEWPath
+  }
+
+  $invokeArgs = @{
+    Operation = 'RunCustomOperation'
+    Params = $params
+    Provider = $Provider
+    Preview = $Preview.IsPresent
+  }
+  if ($PSBoundParameters.ContainsKey('TimeoutSeconds') -and $TimeoutSeconds -gt 0) {
+    $invokeArgs.TimeoutSeconds = [int]$TimeoutSeconds
+  }
+
+  Invoke-LVOperation @invokeArgs
+}
+
 function Invoke-LVRunVIAnalyzer {
   [CmdletBinding()]
   param(
@@ -1026,6 +1074,7 @@ function Invoke-LVExecuteBuildSpec {
 
 Export-ModuleMember -Function `
   Invoke-LVCreateComparisonReport, `
+  Invoke-LVCustomOperation, `
   Invoke-LVRunVI, `
   Invoke-LVRunVIAnalyzer, `
   Invoke-LVRunUnitTests, `

--- a/tools/Test-LabVIEWCLICustomOperationProof.ps1
+++ b/tools/Test-LabVIEWCLICustomOperationProof.ps1
@@ -1,0 +1,679 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+  [string]$OperationName = 'AddTwoNumbers',
+  [string]$SourceExamplePath = 'C:\Users\Public\Documents\National Instruments\LabVIEW CLI\Examples\AddTwoNumbers',
+  [string]$OperationDirectory = '',
+  [string]$LabVIEWPath = '',
+  [int]$TimeoutSeconds = 90,
+  [string]$ResultsRoot = '',
+  [string]$ReportPath = '',
+  [string]$SummaryPath = '',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [switch]$DryRun,
+  [switch]$SkipSchemaValidation,
+  [switch]$PassThru
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+  return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory)][string]$BasePath,
+    [Parameter(Mandatory)][string]$PathValue
+  )
+
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $PathValue))
+}
+
+function Ensure-Directory {
+  param([Parameter(Mandatory)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+
+  return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Convert-ToRepoRelativePath {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$PathValue
+  )
+
+  $resolved = [System.IO.Path]::GetFullPath($PathValue)
+  $relative = [System.IO.Path]::GetRelativePath($RepoRoot, $resolved)
+  if ($relative -eq '.') {
+    return '.'
+  }
+
+  if ($relative -eq '..' -or
+      $relative.StartsWith('..' + [System.IO.Path]::DirectorySeparatorChar) -or
+      $relative.StartsWith('..' + [System.IO.Path]::AltDirectorySeparatorChar)) {
+    return ($resolved -replace '\\', '/')
+  }
+
+  return ($relative -replace '\\', '/')
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return
+  }
+
+  $directory = Split-Path -Parent $Path
+  if ($directory) {
+    Ensure-Directory -Path $directory | Out-Null
+  }
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    New-Item -ItemType File -Path $Path -Force | Out-Null
+  }
+
+  Add-Content -LiteralPath $Path -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function Invoke-SchemaValidation {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$SchemaPath,
+    [Parameter(Mandatory)][string]$DataPath
+  )
+
+  $runner = Join-Path $RepoRoot 'tools' 'npm' 'run-script.mjs'
+  if (-not (Test-Path -LiteralPath $runner -PathType Leaf)) {
+    throw "Schema validation runner not found at '$runner'."
+  }
+
+  $output = & node $runner 'schema:validate' '--' '--schema' $SchemaPath '--data' $DataPath 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $message = ($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    throw "Schema validation failed for '$DataPath': $message"
+  }
+}
+
+function Get-PreferredLabVIEWHint {
+  param([Parameter(Mandatory)][string]$RepoRoot)
+
+  $candidates = New-Object System.Collections.Generic.List[string]
+  foreach ($candidate in @(
+    'C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe',
+    'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe'
+  )) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      $candidates.Add($candidate) | Out-Null
+    }
+  }
+  foreach ($rootPath in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+    if ([string]::IsNullOrWhiteSpace($rootPath)) { continue }
+    foreach ($candidate in @(Get-ChildItem -Path (Join-Path $rootPath 'National Instruments') -Filter 'LabVIEW.exe' -File -Recurse -ErrorAction SilentlyContinue)) {
+      $resolved = $candidate.FullName
+      if (-not ($candidates.Contains($resolved))) {
+        $candidates.Add($resolved) | Out-Null
+      }
+    }
+  }
+  $candidateList = @($candidates.ToArray())
+  if ($candidateList.Count -eq 0) {
+    return $null
+  }
+
+  $preferred32Bit2026 = @(
+    $candidateList |
+      Where-Object {
+        ($_ -match 'LabVIEW\s+2026') -and
+        ($_ -match '(?i)(Program Files \(x86\)|\(32-bit\))')
+      } |
+      Select-Object -First 1
+  )
+  if ($preferred32Bit2026.Count -gt 0) {
+    return $preferred32Bit2026[0]
+  }
+
+  $preferred2026 = @($candidateList | Where-Object { $_ -match 'LabVIEW\s+2026' } | Select-Object -First 1)
+  if ($preferred2026.Count -gt 0) {
+    return $preferred2026[0]
+  }
+
+  return $candidateList[0]
+}
+
+function Get-TrackedProcessSnapshot {
+  $records = New-Object System.Collections.Generic.List[object]
+  foreach ($processName in @('LabVIEW.exe', 'LabVIEWCLI.exe')) {
+    $escapedName = $processName.Replace("'", "''")
+    $processes = @(Get-CimInstance -ClassName Win32_Process -Filter "Name = '$escapedName'" -ErrorAction SilentlyContinue)
+    foreach ($process in $processes) {
+      if ($null -eq $process) { continue }
+      $created = $null
+      if ($process.CreationDate) {
+        try {
+          $created = [System.Management.ManagementDateTimeConverter]::ToDateTime($process.CreationDate).ToString('o')
+        } catch {}
+      }
+      $records.Add([pscustomobject]@{
+          pid = [int]$process.ProcessId
+          name = [string]$process.Name
+          commandLine = [string]$process.CommandLine
+          executablePath = [string]$process.ExecutablePath
+          createdAt = $created
+        }) | Out-Null
+    }
+  }
+  $snapshot = @($records.ToArray())
+  if ($snapshot.Count -eq 0) {
+    return @()
+  }
+  return @($snapshot | Sort-Object name, pid)
+}
+
+function Get-NewTrackedProcesses {
+  param(
+    [AllowNull()][object[]]$Before,
+    [AllowNull()][object[]]$After
+  )
+
+  $beforeIds = @{}
+  foreach ($item in @($Before)) {
+    if ($null -eq $item) { continue }
+    $beforeIds["$([int]$item.pid)"] = $true
+  }
+
+  return @(
+    @($After) | Where-Object {
+      $null -ne $_ -and
+      $_.PSObject.Properties['pid'] -and
+      -not $beforeIds.ContainsKey("$([int]$_.pid)")
+    }
+  )
+}
+
+function Invoke-TrackedProcessCleanup {
+  param([object[]]$Processes)
+
+  $killedPids = New-Object System.Collections.Generic.List[int]
+  $errors = New-Object System.Collections.Generic.List[string]
+  foreach ($processInfo in @($Processes | Sort-Object pid -Descending)) {
+    if ($null -eq $processInfo) { continue }
+    $pid = 0
+    try { $pid = [int]$processInfo.pid } catch { $pid = 0 }
+    if ($pid -le 0) { continue }
+    try {
+      $cleanupOutput = & taskkill.exe /PID $pid /T /F 2>&1
+      if ($LASTEXITCODE -ne 0) {
+        $message = (($cleanupOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine).Trim()
+        if ($message) {
+          $errors.Add(("PID {0}: {1}" -f $pid, $message)) | Out-Null
+        } else {
+          $errors.Add(("PID {0}: taskkill exited with code {1}" -f $pid, $LASTEXITCODE)) | Out-Null
+        }
+        continue
+      }
+      $killedPids.Add($pid) | Out-Null
+    } catch {
+      $errors.Add(("PID {0}: {1}" -f $pid, $_.Exception.Message)) | Out-Null
+    }
+  }
+
+  return [pscustomobject]@{
+    killedPids = @($killedPids.ToArray())
+    errors = @($errors.ToArray())
+  }
+}
+
+function Get-RelevantLogFiles {
+  param(
+    [datetime]$StartedAtUtc,
+    [datetime]$FinishedAtUtc
+  )
+
+  $roots = @()
+  foreach ($rootCandidate in @([System.IO.Path]::GetTempPath(), $env:TEMP, $env:TMP, (Join-Path $env:LOCALAPPDATA 'Temp'))) {
+    if ([string]::IsNullOrWhiteSpace($rootCandidate)) { continue }
+    try {
+      $resolved = [System.IO.Path]::GetFullPath($rootCandidate)
+      if (Test-Path -LiteralPath $resolved -PathType Container) {
+        $roots += $resolved
+      }
+    } catch {}
+  }
+  $roots = @($roots | Select-Object -Unique)
+
+  $lowerBound = $StartedAtUtc.AddSeconds(-5)
+  $upperBound = $FinishedAtUtc.AddSeconds(5)
+  $files = @()
+  foreach ($rootPath in $roots) {
+    foreach ($pattern in @('lvtemporary_*.log', 'LabVIEWCLI*.txt')) {
+      foreach ($file in @(Get-ChildItem -LiteralPath $rootPath -Filter $pattern -File -ErrorAction SilentlyContinue)) {
+        try {
+          $lastWriteUtc = $file.LastWriteTimeUtc
+          if ($lastWriteUtc -lt $lowerBound -or $lastWriteUtc -gt $upperBound) {
+            continue
+          }
+          $files += $file
+        } catch {}
+      }
+    }
+  }
+
+  return @($files | Sort-Object LastWriteTimeUtc, FullName -Unique)
+}
+
+function Copy-ScenarioLogs {
+  param(
+    [Parameter(Mandatory)][string]$ScenarioRoot,
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][datetime]$StartedAtUtc,
+    [Parameter(Mandatory)][datetime]$FinishedAtUtc
+  )
+
+  $logRoot = Ensure-Directory -Path (Join-Path $ScenarioRoot 'logs')
+  $captured = @()
+  foreach ($file in @(Get-RelevantLogFiles -StartedAtUtc $StartedAtUtc -FinishedAtUtc $FinishedAtUtc)) {
+    $destinationName = "{0}-{1}" -f $file.LastWriteTimeUtc.ToString('yyyyMMddTHHmmssfffZ'), $file.Name
+    $destinationPath = Join-Path $logRoot $destinationName
+    Copy-Item -LiteralPath $file.FullName -Destination $destinationPath -Force
+    $captured += [pscustomobject]@{
+      sourcePath = $file.FullName
+      copiedPath = $destinationPath
+      copiedPathRelative = Convert-ToRepoRelativePath -RepoRoot $RepoRoot -PathValue $destinationPath
+    }
+  }
+
+  $insights = Get-LabVIEWCustomOperationLogInsights -LogPaths (@($captured | ForEach-Object { $_.copiedPath }))
+  return [pscustomobject]@{
+    count = @($captured).Count
+    files = @($captured)
+    insights = $insights
+  }
+}
+
+function Get-ScenarioCatalog {
+  param([AllowNull()][string]$ExplicitLabVIEWPath)
+
+  $scenarios = New-Object System.Collections.Generic.List[object]
+  $scenarios.Add([pscustomobject]@{
+      name = 'default-help'
+      description = 'Probe the implicit LabVIEW selection used by LabVIEWCLI when -LabVIEWPath is omitted.'
+      help = $true
+      headless = $false
+      logToConsole = $false
+      arguments = @()
+      requestedLabVIEWPath = $null
+    }) | Out-Null
+
+  if (-not [string]::IsNullOrWhiteSpace($ExplicitLabVIEWPath)) {
+    $scenarios.Add([pscustomobject]@{
+        name = 'explicit-help'
+        description = 'Run GetHelp.vi against the explicit LabVIEW 2026 host plane.'
+        help = $true
+        headless = $false
+        logToConsole = $false
+        arguments = @()
+        requestedLabVIEWPath = $ExplicitLabVIEWPath
+      }) | Out-Null
+    $scenarios.Add([pscustomobject]@{
+        name = 'explicit-headless-run'
+        description = 'Run RunOperation.vi headless with explicit LabVIEW 2026 and trivial AddTwoNumbers inputs.'
+        help = $false
+        headless = $true
+        logToConsole = $true
+        arguments = @('-x', '1', '-y', '2')
+        requestedLabVIEWPath = $ExplicitLabVIEWPath
+      }) | Out-Null
+  }
+
+  return @($scenarios.ToArray())
+}
+
+function Invoke-CustomOperationScenario {
+  param(
+    [Parameter(Mandatory)]$Scenario,
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$ResultsRoot,
+    [Parameter(Mandatory)][string]$OperationName,
+    [Parameter(Mandatory)][string]$AdditionalOperationDirectory,
+    [Parameter(Mandatory)][int]$TimeoutSeconds,
+    [switch]$DryRun
+  )
+
+  $scenarioRoot = Ensure-Directory -Path (Join-Path $ResultsRoot $Scenario.name)
+  $previewArgs = @{
+    CustomOperationName = $OperationName
+    AdditionalOperationDirectory = $AdditionalOperationDirectory
+    Provider = 'labviewcli'
+    Preview = $true
+  }
+  if ($Scenario.help) { $previewArgs.Help = $true }
+  if ($Scenario.headless) { $previewArgs.Headless = $true }
+  if ($Scenario.logToConsole) { $previewArgs.LogToConsole = $true }
+  if ($Scenario.arguments.Count -gt 0) { $previewArgs.Arguments = @($Scenario.arguments) }
+  if ($Scenario.requestedLabVIEWPath) { $previewArgs.LabVIEWPath = $Scenario.requestedLabVIEWPath }
+  $preview = Invoke-LVCustomOperation @previewArgs
+
+  if ($DryRun) {
+    return [pscustomobject]@{
+      name = $Scenario.name
+      description = $Scenario.description
+      status = 'planned'
+      timedOut = $false
+      requestedLabVIEWPath = $Scenario.requestedLabVIEWPath
+      preview = $preview
+      result = $null
+      error = $null
+      processBefore = @()
+      processAfter = @()
+      cleanup = [ordered]@{
+        killedPids = @()
+        errors = @()
+      }
+      lingeringProcesses = @()
+      logCapture = [ordered]@{
+        count = 0
+        files = @()
+      }
+      logInsights = [ordered]@{
+        observedLabVIEWPaths = @()
+        observedLabVIEWPath = $null
+        launchSucceeded = $false
+        operationCompleted = $false
+        logLineCount = 0
+      }
+    }
+  }
+
+  $invokeArgs = @{
+    CustomOperationName = $OperationName
+    AdditionalOperationDirectory = $AdditionalOperationDirectory
+    Provider = 'labviewcli'
+    TimeoutSeconds = $TimeoutSeconds
+  }
+  if ($Scenario.help) { $invokeArgs.Help = $true }
+  if ($Scenario.headless) { $invokeArgs.Headless = $true }
+  if ($Scenario.logToConsole) { $invokeArgs.LogToConsole = $true }
+  if ($Scenario.arguments.Count -gt 0) { $invokeArgs.Arguments = @($Scenario.arguments) }
+  if ($Scenario.requestedLabVIEWPath) { $invokeArgs.LabVIEWPath = $Scenario.requestedLabVIEWPath }
+
+  $before = Get-TrackedProcessSnapshot
+  $startedAtUtc = (Get-Date).ToUniversalTime()
+  $result = $null
+  $errorMessage = $null
+  $timedOut = $false
+  $status = 'failed'
+  try {
+    $result = Invoke-LVCustomOperation @invokeArgs
+    $status = if ($result.ok) { 'succeeded' } else { 'failed' }
+  } catch {
+    $errorMessage = $_.Exception.Message
+    if ($errorMessage -match 'timed out') {
+      $timedOut = $true
+      $status = 'timed-out'
+    } else {
+      $status = 'failed'
+    }
+  }
+
+  $after = Get-TrackedProcessSnapshot
+  $spawned = @(Get-NewTrackedProcesses -Before $before -After $after)
+  $cleanup = Invoke-TrackedProcessCleanup -Processes $spawned
+  Start-Sleep -Seconds 1
+  $finalAfter = Get-TrackedProcessSnapshot
+  $lingering = @(Get-NewTrackedProcesses -Before $before -After $finalAfter)
+  $finishedAtUtc = (Get-Date).ToUniversalTime()
+  $logCapture = Copy-ScenarioLogs -ScenarioRoot $scenarioRoot -RepoRoot $RepoRoot -StartedAtUtc $startedAtUtc -FinishedAtUtc $finishedAtUtc
+  $tracker = $null
+  try { $tracker = Get-LabVIEWCliPidTracker } catch {}
+
+  return [pscustomobject]@{
+    name = $Scenario.name
+    description = $Scenario.description
+    status = $status
+    timedOut = [bool]$timedOut
+    requestedLabVIEWPath = $Scenario.requestedLabVIEWPath
+    preview = $preview
+    result = $result
+    error = $errorMessage
+    processBefore = @($before)
+    processAfter = @($after)
+    processFinal = @($finalAfter)
+    cleanup = [ordered]@{
+      killedPids = @($cleanup.killedPids)
+      errors = @($cleanup.errors)
+    }
+    lingeringProcesses = @($lingering)
+    logCapture = [ordered]@{
+      count = [int]$logCapture.count
+      files = @($logCapture.files)
+    }
+    logInsights = $logCapture.insights
+    labviewPidTracker = $tracker
+  }
+}
+
+function New-ProofMarkdown {
+  param(
+    [Parameter(Mandatory)]$Report,
+    [Parameter(Mandatory)][string]$ReportPath
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('# LabVIEW CLI Custom Operation Proof') | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add(('- Report: `{0}`' -f $ReportPath)) | Out-Null
+  $lines.Add(('- Final status: `{0}`' -f $Report.status)) | Out-Null
+  $lines.Add(('- Operation: `{0}`' -f $Report.operationName)) | Out-Null
+  $lines.Add(('- Operation directory: `{0}`' -f $Report.operationDirectory)) | Out-Null
+  if ($Report.explicitLabVIEWPath) {
+    $lines.Add(('- Explicit LabVIEW path: `{0}`' -f $Report.explicitLabVIEWPath)) | Out-Null
+  }
+  $rootCauseText = if (@($Report.analysis.rootCauseCandidates).Count -gt 0) {
+    (@($Report.analysis.rootCauseCandidates) -join ', ')
+  } else {
+    'none'
+  }
+  $lines.Add(("- Root-cause candidates: {0}" -f $rootCauseText)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add('## Scenarios') | Out-Null
+  $lines.Add('') | Out-Null
+
+  foreach ($scenario in @($Report.scenarios)) {
+    $lines.Add(('- `{0}`: status=`{1}` timedOut={2}' -f $scenario.name, $scenario.status, ([string][bool]$scenario.timedOut))) | Out-Null
+    if ($scenario.requestedLabVIEWPath) {
+      $lines.Add(('  requestedLabVIEWPath=`{0}`' -f $scenario.requestedLabVIEWPath)) | Out-Null
+    }
+    if ($scenario.logInsights.observedLabVIEWPath) {
+      $lines.Add(('  observedLabVIEWPath=`{0}`' -f $scenario.logInsights.observedLabVIEWPath)) | Out-Null
+    }
+    if ($scenario.error) {
+      $lines.Add(('  error=`{0}`' -f $scenario.error.Replace('`', "'"))) | Out-Null
+    }
+    if (@($scenario.cleanup.killedPids).Count -gt 0) {
+      $lines.Add(("  cleanedPids={0}" -f ((@($scenario.cleanup.killedPids)) -join ','))) | Out-Null
+    }
+    if (@($scenario.lingeringProcesses).Count -gt 0) {
+      $lines.Add(("  lingeringPids={0}" -f ((@($scenario.lingeringProcesses | ForEach-Object { $_.pid })) -join ','))) | Out-Null
+    }
+    if ($scenario.preview.command) {
+      $lines.Add(('  command=`{0}`' -f $scenario.preview.command.Replace('`', "'"))) | Out-Null
+    }
+  }
+
+  if (@($Report.analysis.notes).Count -gt 0) {
+    $lines.Add('') | Out-Null
+    $lines.Add('## Analysis') | Out-Null
+    $lines.Add('') | Out-Null
+    foreach ($note in @($Report.analysis.notes)) {
+      $lines.Add(("- {0}" -f $note)) | Out-Null
+    }
+  }
+
+  return ($lines -join "`n")
+}
+
+$repoRoot = Resolve-RepoRoot
+Import-Module (Join-Path $repoRoot 'tools' 'LabVIEWCli.psm1') -Force | Out-Null
+Import-Module (Join-Path $repoRoot 'tools' 'LabVIEWCLICustomOperationProof.psm1') -Force | Out-Null
+
+$timestamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
+$resultsRootResolved = if ([string]::IsNullOrWhiteSpace($ResultsRoot)) {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue (Join-Path 'tests/results/_agent/custom-operation-proofs' ("{0}-{1}" -f $OperationName, $timestamp))
+} else {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue $ResultsRoot
+}
+Ensure-Directory -Path $resultsRootResolved | Out-Null
+
+$reportResolved = if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+  Join-Path $resultsRootResolved 'labview-cli-custom-operation-proof.json'
+} else {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue $ReportPath
+}
+$summaryResolved = if ([string]::IsNullOrWhiteSpace($SummaryPath)) {
+  Join-Path $resultsRootResolved 'labview-cli-custom-operation-proof.md'
+} else {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue $SummaryPath
+}
+
+$explicitLabVIEWPath = if ([string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+  Get-PreferredLabVIEWHint -RepoRoot $repoRoot
+} else {
+  Resolve-AbsolutePath -BasePath $repoRoot -PathValue $LabVIEWPath
+}
+
+$operationDirectoryResolved = $null
+$scaffoldReceiptResolved = $null
+$sourceExampleResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $SourceExamplePath
+if ([string]::IsNullOrWhiteSpace($OperationDirectory)) {
+  $workspaceRoot = if ($resultsRootResolved.StartsWith($repoRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+    Join-Path $repoRoot 'tests/results/_agent/custom-operation-scaffolds' ("{0}-{1}-workspace" -f $OperationName, $timestamp)
+  } else {
+    Join-Path $resultsRootResolved 'workspace'
+  }
+  $scaffoldReceiptResolved = Join-Path $resultsRootResolved 'custom-operation-scaffold.json'
+  $scaffoldScript = Join-Path $repoRoot 'tools' 'New-LabVIEWCLICustomOperationWorkspace.ps1'
+  $scaffoldArgs = @{
+    SourceExamplePath = $sourceExampleResolved
+    DestinationPath = $workspaceRoot
+    ReceiptPath = $scaffoldReceiptResolved
+    Force = $true
+  }
+  if ($explicitLabVIEWPath) {
+    $scaffoldArgs.LabVIEWPathHint = $explicitLabVIEWPath
+  }
+  if ($SkipSchemaValidation) {
+    $scaffoldArgs.SkipSchemaValidation = $true
+  }
+  & $scaffoldScript @scaffoldArgs | Out-Null
+  $operationDirectoryResolved = $workspaceRoot
+} else {
+  $operationDirectoryResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $OperationDirectory
+}
+
+if (-not (Test-Path -LiteralPath $operationDirectoryResolved -PathType Container)) {
+  throw "Custom operation directory was not found at '$operationDirectoryResolved'."
+}
+foreach ($requiredFile in @('GetHelp.vi', 'RunOperation.vi')) {
+  $requiredPath = Join-Path $operationDirectoryResolved $requiredFile
+  if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+    throw "Custom operation directory '$operationDirectoryResolved' is missing '$requiredFile'."
+  }
+}
+
+$scenarioCatalog = Get-ScenarioCatalog -ExplicitLabVIEWPath $explicitLabVIEWPath
+$scenarioResults = New-Object System.Collections.Generic.List[object]
+foreach ($scenario in $scenarioCatalog) {
+  $scenarioResults.Add(
+    (Invoke-CustomOperationScenario `
+      -Scenario $scenario `
+      -RepoRoot $repoRoot `
+      -ResultsRoot $resultsRootResolved `
+      -OperationName $OperationName `
+      -AdditionalOperationDirectory $operationDirectoryResolved `
+      -TimeoutSeconds $TimeoutSeconds `
+      -DryRun:$DryRun)
+  ) | Out-Null
+}
+$labviewCliPath = $null
+foreach ($scenarioResult in @($scenarioResults.ToArray())) {
+  if ($scenarioResult.preview -and $scenarioResult.preview.cliPath) {
+    $labviewCliPath = [string]$scenarioResult.preview.cliPath
+    break
+  }
+}
+
+$analysis = Resolve-LabVIEWCustomOperationProofAnalysis -ScenarioResults (@($scenarioResults.ToArray())) -RequestedLabVIEWPath $explicitLabVIEWPath
+$status = if ($DryRun) {
+  'planned'
+} elseif (
+  @($scenarioResults | Where-Object { $_.status -ne 'succeeded' }).Count -eq 0 -and
+  -not $analysis.cleanupRequired
+) {
+  'succeeded'
+} elseif (
+  @($scenarioResults | Where-Object { $_.status -ne 'succeeded' }).Count -eq 0 -and
+  $analysis.cleanupRequired -and
+  $analysis.cleanupSucceeded
+) {
+  'succeeded'
+} else {
+  'blocked'
+}
+
+$report = [ordered]@{
+  schema = 'labview-cli-custom-operation-proof@v1'
+  generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  status = $status
+  operationName = $OperationName
+  sourceExamplePath = $sourceExampleResolved
+  operationDirectory = $operationDirectoryResolved
+  explicitLabVIEWPath = $explicitLabVIEWPath
+  labviewCliPath = $labviewCliPath
+  timeoutSeconds = [int]$TimeoutSeconds
+  dryRun = [bool]$DryRun
+  resultsRoot = $resultsRootResolved
+  reportPath = $reportResolved
+  summaryPath = $summaryResolved
+  scaffoldReceiptPath = $scaffoldReceiptResolved
+  analysis = $analysis
+  scenarios = @($scenarioResults.ToArray())
+}
+
+$report | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $reportResolved -Encoding utf8
+New-ProofMarkdown -Report $report -ReportPath (Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $reportResolved) |
+  Set-Content -LiteralPath $summaryResolved -Encoding utf8
+
+if (-not $SkipSchemaValidation) {
+  Invoke-SchemaValidation `
+    -RepoRoot $repoRoot `
+    -SchemaPath (Join-Path $repoRoot 'docs' 'schemas' 'labview-cli-custom-operation-proof-v1.schema.json') `
+    -DataPath $reportResolved
+}
+
+Write-Host ("LabVIEW CLI custom operation proof report: {0}" -f (Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $reportResolved))
+Write-Host ("LabVIEW CLI custom operation proof summary: {0}" -f (Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $summaryResolved))
+Write-GitHubOutput -Key 'labview-cli-custom-operation-proof-report' -Value $reportResolved -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'labview-cli-custom-operation-proof-summary' -Value $summaryResolved -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'labview-cli-custom-operation-proof-status' -Value $status -Path $GitHubOutputPath
+
+if ($PassThru) {
+  Write-Output ([pscustomobject]$report)
+}
+
+if (-not $DryRun -and $status -ne 'succeeded') {
+  throw "LabVIEW CLI custom operation proof ended with status '$status'. Review '$reportResolved'."
+}

--- a/tools/providers/labviewcli/Provider.psm1
+++ b/tools/providers/labviewcli/Provider.psm1
@@ -169,6 +169,32 @@ function Get-LabVIEWCliArgs {
       }
       return $args
     }
+    'RunCustomOperation' {
+      $args = @(
+        '-OperationName', $Params.customOperationName,
+        '-AdditionalOperationDirectory', $Params.additionalOperationDirectory
+      )
+      if ($Params.ContainsKey('help') -and $Params.help) {
+        $args += '-Help'
+      }
+      if ($Params.ContainsKey('arguments') -and $Params.arguments) {
+        foreach ($arg in $Params.arguments) {
+          if (-not [string]::IsNullOrWhiteSpace([string]$arg)) {
+            $args += [string]$arg
+          }
+        }
+      }
+      if ($Params.ContainsKey('labviewPath') -and $Params.labviewPath) {
+        $args += @('-LabVIEWPath', $Params.labviewPath)
+      }
+      if ($Params.ContainsKey('logToConsole')) {
+        $args += @('-LogToConsole', (Convert-ToCliBoolString -Value $Params.logToConsole -ParameterName 'logToConsole'))
+      }
+      if ($Params.ContainsKey('headless')) {
+        $args += @('-Headless', (Convert-ToCliBoolString -Value $Params.headless -ParameterName 'headless'))
+      }
+      return $args
+    }
     'RunVI' {
       $args = @(
         '-OperationName','RunVI',
@@ -255,7 +281,7 @@ function New-LVProvider {
   $provider | Add-Member ScriptMethod ResolveBinaryPath { Resolve-LabVIEWCliBinaryPath }
   $provider | Add-Member ScriptMethod Supports {
     param($Operation)
-    return @('CloseLabVIEW','CreateComparisonReport','RunVI','RunVIAnalyzer','RunUnitTests','MassCompile','ExecuteBuildSpec') -contains $Operation
+    return @('CloseLabVIEW','CreateComparisonReport','RunCustomOperation','RunVI','RunVIAnalyzer','RunUnitTests','MassCompile','ExecuteBuildSpec') -contains $Operation
   }
   $provider | Add-Member ScriptMethod BuildArgs {
     param($Operation,$Params)
@@ -279,4 +305,3 @@ function Get-ProviderRepoRoot {
   $script:ProviderRepoRoot = (Resolve-Path -LiteralPath $start).Path
   return $script:ProviderRepoRoot
 }
-

--- a/tools/providers/spec/operations.json
+++ b/tools/providers/spec/operations.json
@@ -113,6 +113,53 @@
       ]
     },
     {
+      "name": "RunCustomOperation",
+      "parameters": [
+        {
+          "id": "customOperationName",
+          "type": "string",
+          "required": true,
+          "description": "Custom LabVIEW CLI operation name to execute."
+        },
+        {
+          "id": "additionalOperationDirectory",
+          "type": "path",
+          "required": true,
+          "description": "Directory that contains the custom operation payload."
+        },
+        {
+          "id": "arguments",
+          "type": "array",
+          "required": false,
+          "description": "Additional arguments passed positionally to the custom operation."
+        },
+        {
+          "id": "labviewPath",
+          "type": "path",
+          "required": false,
+          "description": "Optional LabVIEW.exe path supplied to LabVIEW CLI."
+        },
+        {
+          "id": "headless",
+          "type": "bool",
+          "required": false,
+          "description": "When true, requests headless execution for compatible CLI versions."
+        },
+        {
+          "id": "logToConsole",
+          "type": "bool",
+          "required": false,
+          "description": "When true, enables LabVIEW CLI console logging."
+        },
+        {
+          "id": "help",
+          "type": "bool",
+          "required": false,
+          "description": "When true, appends -Help so GetHelp.vi is invoked for the custom operation."
+        }
+      ]
+    },
+    {
       "name": "RunVI",
       "parameters": [
         {


### PR DESCRIPTION
## Summary
- add shared `RunCustomOperation` support to the LabVIEW CLI provider/module surface
- add a fail-closed AddTwoNumbers proof helper with receipt, summary, schema, and focused tests
- document the proof flow and narrow the remaining remediation to the Windows container follow-up in `#1474`

## Validation
- `pwsh -NoLogo -NoProfile -File tests/LabVIEWCli.Provider.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/LabVIEWCli.CustomOperation.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/LabVIEWCLICustomOperationProof.Tests.ps1`
- `node tools/npm/run-script.mjs history:custom-operation:proof -- --DryRun --SkipSchemaValidation`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs hooks:pre-commit`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `git diff --check`

## Live proof
- `default-help`, `explicit-help`, and `explicit-headless-run` now all time out deterministically against LabVIEW 2026 x86 on this host
- copied logs record the observed LabVIEW path and allow root-cause classification
- proof cleanup leaves no lingering `LabVIEW` or `LabVIEWCLI` processes behind

## Follow-up
- `#1474` will prove the same AddTwoNumbers scenarios on `nationalinstruments/labview:2026q1-windows` via this host's Docker Desktop to distinguish native x86 host behavior from the Windows 64-bit mirror plane
