### PR TITLE
#1474 prove AddTwoNumbers on the Windows container plane

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-20T14:40:00Z",
+  "updated": "2026-03-20T15:58:00Z",
   "entries": [
     {
       "name": "Root Entry Points",
@@ -238,13 +238,15 @@
       "name": "LabVIEW CLI Custom Operation Proof Contracts",
       "category": "supporting",
       "status": "reference",
-      "description": "Fail-closed AddTwoNumbers host-proof helper, analysis module, receipt schema, focused tests, and guidance for investigating LabVIEWCLI custom-operation hangs and path drift on the LabVIEW 2026 host plane.",
+      "description": "Fail-closed AddTwoNumbers proof helpers, analysis module, receipt schema, focused tests, and guidance for investigating LabVIEWCLI custom-operation hangs and path drift across the LabVIEW 2026 host plane and the pinned Windows container mirror plane.",
       "files": [
         "docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md",
         "docs/schemas/labview-cli-custom-operation-proof-v1.schema.json",
         "tools/LabVIEWCLICustomOperationProof.psm1",
+        "tools/Run-NIWindowsContainerCustomOperation.ps1",
         "tools/Test-LabVIEWCLICustomOperationProof.ps1",
-        "tests/LabVIEWCLICustomOperationProof.Tests.ps1"
+        "tests/LabVIEWCLICustomOperationProof.Tests.ps1",
+        "tests/Run-NIWindowsContainerCustomOperation.Tests.ps1"
       ]
     },
     {

--- a/docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md
+++ b/docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md
@@ -1,9 +1,10 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # LabVIEW CLI Custom Operation Proof
 
-This note defines the fail-closed proof helper used to investigate
+This note defines the fail-closed proof helpers used to investigate
 `LabVIEWCLI` custom-operation execution on the official NI `AddTwoNumbers`
-example.
+example across both the native host plane and the pinned Windows container
+mirror plane.
 
 ## Purpose
 
@@ -11,8 +12,11 @@ Use the proof helper when you need deterministic evidence for:
 
 - implicit `LabVIEWCLI` path drift
 - explicit `-LabVIEWPath` behavior on the LabVIEW 2026 host plane
+- explicit `-LabVIEWPath` behavior inside `nationalinstruments/labview:2026q1-windows`
 - `GetHelp.vi` vs headless `RunOperation.vi` behavior
 - lingering `LabVIEW` / `LabVIEWCLI` residue after a hang
+- whether a failure is host-native-specific or reproducible on the Windows
+  container mirror
 
 The helper always writes a machine-readable receipt and summary, even when the
 proof ends blocked.
@@ -20,11 +24,14 @@ proof ends blocked.
 ## Entry points
 
 - Helper: `tools/Test-LabVIEWCLICustomOperationProof.ps1`
+- Windows container runner: `tools/Run-NIWindowsContainerCustomOperation.ps1`
 - Analysis module: `tools/LabVIEWCLICustomOperationProof.psm1`
 - Receipt schema:
   `docs/schemas/labview-cli-custom-operation-proof-v1.schema.json`
 - Focused test:
   `tests/LabVIEWCLICustomOperationProof.Tests.ps1`
+- Focused Windows runner test:
+  `tests/Run-NIWindowsContainerCustomOperation.Tests.ps1`
 
 ## Default behavior
 
@@ -47,6 +54,14 @@ abstraction:
 
 When `-LabVIEWPath` is omitted, the helper prefers the LabVIEW 2026 32-bit host
 plane when one is installed and falls back to the next available candidate.
+
+When `-ExecutionPlane windows-container` is selected, the helper keeps both help
+scenarios headless because LabVIEW 2026 Windows containers require `-Headless`
+CLI execution.
+
+The Windows container runner also assumes native `powershell` inside
+`nationalinstruments/labview:2026q1-windows`; it must not assume `pwsh` exists
+in that image.
 
 ## Residue policy
 
@@ -74,12 +89,25 @@ The final receipt computes root-cause candidates for:
 - `headless-interactive-mismatch`
 - `host-plane-32bit-startup`
 
+For Windows container runs, the receipt also records:
+
+- `executionPlane = windows-container`
+- `containerImage = nationalinstruments/labview:2026q1-windows`
+- `preflightPath` from the Windows Docker Desktop host-plane preflight
+- per-scenario `containerCapturePath`
+
 ## Usage
 
 Run the live host proof:
 
 ```powershell
 node tools/npm/run-script.mjs history:custom-operation:proof
+```
+
+Run the live Windows container mirror proof:
+
+```powershell
+node tools/npm/run-script.mjs history:custom-operation:proof:windows
 ```
 
 Preview the disposable plan without executing LabVIEW:
@@ -97,12 +125,22 @@ pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1 `
   -LabVIEWPath "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe"
 ```
 
+Run the Windows container proof against an explicit in-container LabVIEW path:
+
+```powershell
+pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1 `
+  -ExecutionPlane windows-container `
+  -WindowsContainerLabVIEWPath "C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe"
+```
+
 ## Receipt
 
 Successful or blocked runs emit `labview-cli-custom-operation-proof@v1` with:
 
 - proof status
+- execution plane (`host` or `windows-container`)
 - explicit LabVIEW path used for forced scenarios
+- container image and preflight path when the Windows mirror plane is used
 - scaffold receipt path when applicable
 - per-scenario preview/invocation results
 - copied log inventory
@@ -112,9 +150,27 @@ Successful or blocked runs emit `labview-cli-custom-operation-proof@v1` with:
 
 ## Boundary
 
-This helper proves the host-plane behavior of the official NI example.
+These helpers prove the host plane and the Windows container mirror plane for
+the official NI example.
 
 - It does not make repo-owned custom operation payloads promotable by itself.
 - It does not replace the scaffold helper from `#1471`.
-- It exists so `#1472` can be closed with deterministic evidence instead of ad
-  hoc terminal transcripts.
+- The host plane and Windows container plane should be compared before blaming
+  native 32-bit host behavior.
+- The Windows mirror plane is pinned to
+  `nationalinstruments/labview:2026q1-windows`; do not drift that image without
+  a deliberate contract change.
+
+## Current conclusion
+
+As of March 20, 2026, this repo has deterministic evidence that:
+
+- the native LabVIEW 2026 x86 host plane can hang on the official
+  `AddTwoNumbers` custom operation helper scenarios
+- the Windows 64-bit container mirror plane succeeds on the same host against
+  `nationalinstruments/labview:2026q1-windows`
+
+That means the remaining suspicion is narrower than "LabVIEWCLI is broken" or
+"the NI example is invalid". The current evidence points back toward native
+host-plane behavior, especially the 32-bit host surface, rather than a general
+container-plane failure.

--- a/docs/schemas/labview-cli-custom-operation-proof-v1.schema.json
+++ b/docs/schemas/labview-cli-custom-operation-proof-v1.schema.json
@@ -33,6 +33,13 @@
         "blocked"
       ]
     },
+    "executionPlane": {
+      "type": "string",
+      "enum": [
+        "host",
+        "windows-container"
+      ]
+    },
     "operationName": {
       "type": "string",
       "minLength": 1
@@ -51,6 +58,18 @@
       ]
     },
     "labviewCliPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "containerImage": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "preflightPath": {
       "type": [
         "string",
         "null"
@@ -197,6 +216,12 @@
           "labviewPidTracker": {
             "type": [
               "object",
+              "null"
+            ]
+          },
+          "containerCapturePath": {
+            "type": [
+              "string",
               "null"
             ]
           }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "history:corpus:evaluate": "pwsh -NoLogo -NoProfile -File tools/Invoke-OfflineRealHistoryCorpusEvaluation.ps1",
     "history:corpus:samples:evaluate": "pwsh -NoLogo -NoProfile -File tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1",
     "history:custom-operation:proof": "pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1",
+    "history:custom-operation:proof:windows": "pwsh -NoLogo -NoProfile -File tools/Test-LabVIEWCLICustomOperationProof.ps1 -ExecutionPlane windows-container",
     "history:custom-operation:scaffold": "pwsh -NoLogo -NoProfile -File tools/New-LabVIEWCLICustomOperationWorkspace.ps1",
     "history:corpus:normalize": "pwsh -NoLogo -NoProfile -File tools/Normalize-OfflineRealHistoryCorpus.ps1",
     "history:diagnostics:show": "pwsh -NoLogo -NoProfile -File tools/Show-DockerFastLoopDiagnostics.ps1",

--- a/tests/LabVIEWCLICustomOperationProof.Tests.ps1
+++ b/tests/LabVIEWCLICustomOperationProof.Tests.ps1
@@ -144,6 +144,7 @@ Using LabVIEW: "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW
     $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 12
     $report.schema | Should -Be 'labview-cli-custom-operation-proof@v1'
     $report.status | Should -Be 'planned'
+    $report.executionPlane | Should -Be 'host'
     $report.operationName | Should -Be 'AddTwoNumbers'
     $report.explicitLabVIEWPath | Should -Be $labviewPath
     @($report.scenarios).Count | Should -Be 3
@@ -154,6 +155,32 @@ Using LabVIEW: "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW
     $summary | Should -Match '- Final status: `planned`'
     $summary | Should -Match '`default-help`'
     $summary | Should -Match '`explicit-headless-run`'
+  }
+
+  It 'writes a planned windows-container proof that keeps help scenarios headless' {
+    $sourcePath = New-SyntheticCustomOperationExample -RootPath (Join-Path $TestDrive 'source-example-container')
+    $resultsRoot = Join-Path $TestDrive 'results-root-container'
+    $containerLabVIEWPath = 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ProofScript `
+      -ExecutionPlane windows-container `
+      -SourceExamplePath $sourcePath `
+      -ResultsRoot $resultsRoot `
+      -WindowsContainerLabVIEWPath $containerLabVIEWPath `
+      -DryRun `
+      -SkipSchemaValidation *>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $reportPath = Join-Path $resultsRoot 'labview-cli-custom-operation-proof.json'
+    $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 12
+
+    $report.executionPlane | Should -Be 'windows-container'
+    $report.containerImage | Should -Be 'nationalinstruments/labview:2026q1-windows'
+    $report.explicitLabVIEWPath | Should -Be $containerLabVIEWPath
+    @($report.scenarios).Count | Should -Be 3
+    ($report.scenarios | Where-Object { $_.name -eq 'default-help' } | Select-Object -First 1).preview.args | Should -Contain '-Headless'
+    ($report.scenarios | Where-Object { $_.name -eq 'explicit-help' } | Select-Object -First 1).preview.args | Should -Contain '-Headless'
+    ($report.scenarios | Where-Object { $_.name -eq 'explicit-help' } | Select-Object -First 1).preview.args | Should -Contain $containerLabVIEWPath
   }
 
   It 'fails closed when the installed example source is missing' {

--- a/tests/Run-NIWindowsContainerCustomOperation.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCustomOperation.Tests.ps1
@@ -1,0 +1,68 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Run-NIWindowsContainerCustomOperation.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:RunnerScript = Join-Path $script:RepoRoot 'tools' 'Run-NIWindowsContainerCustomOperation.ps1'
+    if (-not (Test-Path -LiteralPath $script:RunnerScript -PathType Leaf)) {
+      throw "Run-NIWindowsContainerCustomOperation.ps1 not found at $script:RunnerScript"
+    }
+  }
+
+  It 'writes a probe-ok capture from a stub preflight contract' {
+    $resultsRoot = Join-Path $TestDrive 'results-root'
+    $preflightScript = Join-Path $TestDrive 'Stub-WindowsPreflight.ps1'
+    Set-Content -LiteralPath $preflightScript -Encoding utf8 -Value @'
+param(
+  [string]$Image,
+  [string]$ResultsDir
+)
+$resolvedResultsDir = [System.IO.Path]::GetFullPath($ResultsDir)
+if (-not (Test-Path -LiteralPath $resolvedResultsDir -PathType Container)) {
+  New-Item -ItemType Directory -Path $resolvedResultsDir -Force | Out-Null
+}
+$reportPath = Join-Path $resolvedResultsDir 'windows-ni-2026q1-host-preflight.json'
+[ordered]@{
+  schema = 'docker-runtime-manager@v1'
+  contexts = [ordered]@{
+    final = 'desktop-windows'
+    finalOsType = 'windows'
+  }
+  probes = [ordered]@{
+    windows = [ordered]@{
+      status = 'success'
+      image = $Image
+    }
+  }
+} | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $reportPath -Encoding utf8
+Write-Output $reportPath
+'@
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -Probe `
+      -ResultsRoot $resultsRoot `
+      -PreflightScriptPath $preflightScript *>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $capturePath = Join-Path $resultsRoot 'ni-windows-custom-operation-capture.json'
+    $capturePath | Should -Exist
+    $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
+    $capture.schema | Should -Be 'ni-windows-container-custom-operation/v1'
+    $capture.status | Should -Be 'probe-ok'
+    $capture.image | Should -Be 'nationalinstruments/labview:2026q1-windows'
+    $capture.dockerServerOs | Should -Be 'windows'
+    $capture.dockerContext | Should -Be 'desktop-windows'
+    $capture.preflightPath | Should -Match 'windows-ni-2026q1-host-preflight\.json$'
+  }
+
+  It 'keeps the in-container command on native powershell instead of pwsh' {
+    $scriptText = Get-Content -LiteralPath $script:RunnerScript -Raw
+
+    $scriptText | Should -Match 'powershell -NoLogo -NoProfile -EncodedCommand'
+    $scriptText | Should -Match '\$dockerArgs \+= @\(\s*\$Image,\s*''powershell'',\s*''-NoLogo'',\s*''-NoProfile'',\s*''-EncodedCommand'''
+    $scriptText | Should -Not -Match '\$dockerArgs \+= @\(\s*\$Image,\s*''pwsh'''
+  }
+}

--- a/tools/Run-NIWindowsContainerCustomOperation.ps1
+++ b/tools/Run-NIWindowsContainerCustomOperation.ps1
@@ -1,0 +1,702 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Runs a LabVIEW CLI custom operation inside the pinned NI Windows container.
+
+.DESCRIPTION
+  Preflights Docker Desktop against `nationalinstruments/labview:2026q1-windows`
+  and then executes a LabVIEW CLI custom operation inside that container using a
+  mounted operation workspace and mounted capture directory on the host.
+
+  The Windows LabVIEW image uses native `powershell` inside the container.
+  This helper must not assume `pwsh` exists in that plane.
+
+  The helper is intentionally scenario-oriented:
+  - it accepts the same LabVIEW CLI custom-operation knobs exposed by
+    `Invoke-LVCustomOperation`
+  - it emits a deterministic capture JSON adjacent to the scenario artifacts
+  - it keeps Windows-container execution separate from host-plane execution so
+    `Test-LabVIEWCLICustomOperationProof.ps1` can compare both surfaces cleanly
+#>
+[CmdletBinding()]
+param(
+  [string]$OperationName = 'AddTwoNumbers',
+  [string]$AdditionalOperationDirectory,
+  [string]$Image = 'nationalinstruments/labview:2026q1-windows',
+  [string]$ResultsRoot = 'tests/results/ni-windows-custom-operation',
+  [object[]]$Arguments,
+  [string]$ArgumentsJson = '',
+  [switch]$Help,
+  [switch]$Headless,
+  [switch]$LogToConsole,
+  [string]$LabVIEWPath,
+  [int]$TimeoutSeconds = 120,
+  [int]$HeartbeatSeconds = 15,
+  [int]$PrelaunchWaitSeconds = 8,
+  [switch]$Probe,
+  [switch]$PassThru,
+  [string]$PreflightScriptPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:PreflightExitCode = 2
+$script:TimeoutExitCode = 124
+$script:ContainerOperationRoot = 'C:\custom-operation'
+$script:ContainerCaptureRoot = 'C:\capture'
+
+function Resolve-RepoRoot {
+  return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory)][string]$BasePath,
+    [Parameter(Mandatory)][string]$PathValue
+  )
+
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $PathValue))
+}
+
+function Ensure-Directory {
+  param([Parameter(Mandatory)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+
+  return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Resolve-ScriptPath {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [AllowEmptyString()][string]$PathValue,
+    [Parameter(Mandatory)][string]$DefaultRelativePath
+  )
+
+  $effective = if ([string]::IsNullOrWhiteSpace($PathValue)) { $DefaultRelativePath } else { $PathValue }
+  $resolved = Resolve-AbsolutePath -BasePath $RepoRoot -PathValue $effective
+  if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+    throw "Script path was not found: '$resolved'."
+  }
+  return $resolved
+}
+
+function Assert-Tool {
+  param([Parameter(Mandatory)][string]$Name)
+
+  if (-not (Get-Command -Name $Name -ErrorAction SilentlyContinue)) {
+    throw ("Required tool not found on PATH: {0}" -f $Name)
+  }
+}
+
+function Resolve-DockerCommandSource {
+  $override = $env:DOCKER_COMMAND_OVERRIDE
+  if (-not [string]::IsNullOrWhiteSpace($override) -and (Test-Path -LiteralPath $override -PathType Leaf)) {
+    return [System.IO.Path]::GetFullPath($override)
+  }
+
+  $commands = @(Get-Command -Name 'docker' -All -ErrorAction SilentlyContinue)
+  foreach ($command in $commands) {
+    if ([string]::IsNullOrWhiteSpace([string]$command.Source)) { continue }
+    $source = [string]$command.Source
+    if (Test-Path -LiteralPath $source -PathType Leaf) {
+      return [System.IO.Path]::GetFullPath($source)
+    }
+  }
+
+  throw 'Unable to resolve docker command source path.'
+}
+
+function Get-DockerProcessLaunchSpec {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $dockerCommandSource = Resolve-DockerCommandSource
+  $startFilePath = $dockerCommandSource
+  $startArgs = @($DockerArgs)
+  $dockerSourceExt = [System.IO.Path]::GetExtension($dockerCommandSource)
+  if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerSourceExt, '.ps1')) {
+    $pwshExe = (Get-Command -Name 'pwsh' -ErrorAction Stop).Source
+    $startFilePath = $pwshExe
+    $quotedDockerArgs = @(
+      foreach ($arg in @($DockerArgs)) {
+        $text = [string]$arg
+        if ($text -match '\s') {
+          '"{0}"' -f ($text -replace '"', '\"')
+        } else {
+          $text
+        }
+      }
+    )
+    $startArgs = @('-NoLogo', '-NoProfile', '-File', $dockerCommandSource) + $quotedDockerArgs
+  }
+
+  return [pscustomobject]@{
+    FilePath = $startFilePath
+    Arguments = @($startArgs)
+  }
+}
+
+function Invoke-DockerCommandAndCapture {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $stdoutFile = Join-Path $env:TEMP ("ni-windows-custom-op-docker-stdout-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $stderrFile = Join-Path $env:TEMP ("ni-windows-custom-op-docker-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $process = $null
+  try {
+    $launchSpec = Get-DockerProcessLaunchSpec -DockerArgs $DockerArgs
+    $process = Start-Process -FilePath $launchSpec.FilePath `
+      -ArgumentList $launchSpec.Arguments `
+      -RedirectStandardOutput $stdoutFile `
+      -RedirectStandardError $stderrFile `
+      -NoNewWindow `
+      -PassThru
+    $process.WaitForExit()
+    return [pscustomobject]@{
+      ExitCode = [int]$process.ExitCode
+      StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+      StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+    }
+  } finally {
+    if ($process) {
+      try { $process.Dispose() } catch {}
+    }
+    Remove-Item -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+  }
+}
+
+function Invoke-DockerRunWithTimeout {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs,
+    [Parameter(Mandatory)][int]$Seconds,
+    [Parameter(Mandatory)][string]$Image,
+    [int]$HeartbeatSeconds = 15
+  )
+
+  $stdoutFile = Join-Path $env:TEMP ("ni-windows-custom-op-stdout-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $stderrFile = Join-Path $env:TEMP ("ni-windows-custom-op-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $process = $null
+  try {
+    $launchSpec = Get-DockerProcessLaunchSpec -DockerArgs $DockerArgs
+    $process = Start-Process -FilePath $launchSpec.FilePath `
+      -ArgumentList $launchSpec.Arguments `
+      -RedirectStandardOutput $stdoutFile `
+      -RedirectStandardError $stderrFile `
+      -NoNewWindow `
+      -PassThru
+
+    $deadline = (Get-Date).AddSeconds([Math]::Max(1, $Seconds))
+    $lastHeartbeat = Get-Date
+    while (-not $process.HasExited) {
+      if ((Get-Date) -ge $deadline) {
+        try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
+        return [pscustomobject]@{
+          TimedOut = $true
+          ExitCode = $script:TimeoutExitCode
+          StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+          StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+        }
+      }
+
+      if (((Get-Date) - $lastHeartbeat).TotalSeconds -ge [Math]::Max(5, $HeartbeatSeconds)) {
+        Write-Host ("[ni-custom-op-container] running image={0} elapsed={1:n1}s timeout={2}s" -f $Image, ((Get-Date) - $process.StartTime).TotalSeconds, $Seconds) -ForegroundColor DarkGray
+        $lastHeartbeat = Get-Date
+      }
+      Start-Sleep -Milliseconds 500
+    }
+
+    return [pscustomobject]@{
+      TimedOut = $false
+      ExitCode = [int]$process.ExitCode
+      StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+      StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+    }
+  } finally {
+    if ($process) {
+      try { $process.Dispose() } catch {}
+    }
+    Remove-Item -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+  }
+}
+
+function Convert-ToEncodedCommand {
+  param(
+    [Parameter(Mandatory)][string]$CommandText
+  )
+
+  return [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($CommandText))
+}
+
+function Write-TextArtifact {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [AllowNull()][string]$Content
+  )
+
+  $parent = Split-Path -Parent $Path
+  if ($parent) {
+    Ensure-Directory -Path $parent | Out-Null
+  }
+  if ($null -eq $Content) {
+    $Content = ''
+  }
+  Set-Content -LiteralPath $Path -Value $Content -Encoding utf8
+}
+
+function Quote-CommandArgument {
+  param([AllowNull()][string]$Text)
+
+  if ($null -eq $Text) {
+    return '""'
+  }
+
+  if ($Text -match '[\s"]') {
+    return '"' + ($Text -replace '"', '\"') + '"'
+  }
+
+  return $Text
+}
+
+function New-InContainerPreview {
+  param(
+    [Parameter(Mandatory)][string]$OperationName,
+    [Parameter(Mandatory)][string]$ContainerOperationDirectory,
+    [AllowNull()][object[]]$Arguments,
+    [bool]$Help,
+    [bool]$Headless,
+    [bool]$LogToConsole,
+    [AllowEmptyString()][string]$LabVIEWPath
+  )
+
+  $previewArgs = @{
+    CustomOperationName = $OperationName
+    AdditionalOperationDirectory = $ContainerOperationDirectory
+    Provider = 'labviewcli'
+    Preview = $true
+  }
+  if ($Help) { $previewArgs.Help = $true }
+  if ($Headless) { $previewArgs.Headless = $true }
+  if ($LogToConsole) { $previewArgs.LogToConsole = $true }
+  if ($Arguments) { $previewArgs.Arguments = @($Arguments) }
+  if (-not [string]::IsNullOrWhiteSpace($LabVIEWPath)) { $previewArgs.LabVIEWPath = $LabVIEWPath }
+
+  $preview = Invoke-LVCustomOperation @previewArgs
+  $args = @($preview.args | ForEach-Object { [string]$_ })
+  $commandText = 'LabVIEWCLI.exe {0}' -f ((@($args | ForEach-Object { Quote-CommandArgument -Text $_ })) -join ' ')
+  return [ordered]@{
+    operation = 'RunCustomOperation'
+    provider = 'labviewcli'
+    cliPath = 'in-container'
+    args = $args
+    command = $commandText
+  }
+}
+
+function New-ContainerCommand {
+  return @'
+$ErrorActionPreference = "Stop"
+
+function Ensure-Directory {
+  param([Parameter(Mandatory)][string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+  return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Set-IniToken {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$Key,
+    [Parameter(Mandatory)][string]$Value
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return }
+  $content = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
+  if ($null -eq $content) { $content = '' }
+  if ($content -match ("(?m)^\s*{0}\s*=" -f [regex]::Escape($Key))) {
+    $updated = [regex]::Replace($content, ("(?m)^\s*{0}\s*=.*$" -f [regex]::Escape($Key)), ("{0}={1}" -f $Key, $Value))
+  } else {
+    $updated = ($content.TrimEnd() + [Environment]::NewLine + ("{0}={1}" -f $Key, $Value) + [Environment]::NewLine)
+  }
+  Set-Content -LiteralPath $Path -Value $updated -Encoding utf8
+}
+
+function Copy-RelevantLogFiles {
+  param(
+    [Parameter(Mandatory)][string]$CaptureRoot,
+    [Parameter(Mandatory)][datetime]$StartedAtUtc,
+    [Parameter(Mandatory)][datetime]$FinishedAtUtc
+  )
+
+  $logRoot = Ensure-Directory -Path (Join-Path $CaptureRoot 'logs')
+  $roots = @()
+  foreach ($rootCandidate in @([System.IO.Path]::GetTempPath(), $env:TEMP, $env:TMP, (Join-Path $env:LOCALAPPDATA 'Temp'))) {
+    if ([string]::IsNullOrWhiteSpace($rootCandidate)) { continue }
+    try {
+      $resolved = [System.IO.Path]::GetFullPath($rootCandidate)
+      if (Test-Path -LiteralPath $resolved -PathType Container) {
+        $roots += $resolved
+      }
+    } catch {}
+  }
+  $roots = @($roots | Select-Object -Unique)
+
+  $lowerBound = $StartedAtUtc.AddSeconds(-5)
+  $upperBound = $FinishedAtUtc.AddSeconds(5)
+  $captured = New-Object System.Collections.Generic.List[object]
+  foreach ($root in $roots) {
+    foreach ($file in @(Get-ChildItem -LiteralPath $root -File -ErrorAction SilentlyContinue)) {
+      if ($file.Name -notmatch '^(lvtemporary_.*\.log|LabVIEWCLI.*(?:\.log|\.txt)?)$') { continue }
+      $lastWriteUtc = $file.LastWriteTimeUtc
+      if ($lastWriteUtc -lt $lowerBound -or $lastWriteUtc -gt $upperBound) { continue }
+      $destinationPath = Join-Path $logRoot $file.Name
+      Copy-Item -LiteralPath $file.FullName -Destination $destinationPath -Force
+      $captured.Add([ordered]@{
+          name = $file.Name
+          sourcePath = $file.FullName
+          destinationPath = $destinationPath
+          lastWriteTimeUtc = $lastWriteUtc.ToString('o')
+          length = [int64]$file.Length
+        }) | Out-Null
+    }
+  }
+
+  return @($captured.ToArray())
+}
+
+$captureRoot = Ensure-Directory -Path $env:CUSTOM_OP_CAPTURE_ROOT
+$stdoutPath = Join-Path $captureRoot 'labview-cli-stdout.txt'
+$stderrPath = Join-Path $captureRoot 'labview-cli-stderr.txt'
+$resultPath = Join-Path $captureRoot 'scenario-result.json'
+$requestedLabVIEWPath = if ([string]::IsNullOrWhiteSpace($env:CUSTOM_OP_REQUESTED_LABVIEW_PATH)) { $null } else { $env:CUSTOM_OP_REQUESTED_LABVIEW_PATH }
+
+$cliCandidates = @(
+  "C:\Program Files\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.exe",
+  "C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.exe"
+)
+$cliPath = $cliCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+if (-not $cliPath) {
+  throw "LabVIEWCLI.exe not found in container. Ensure the NI image includes the LabVIEW CLI component."
+}
+
+$openTimeout = 180
+if (-not [string]::IsNullOrWhiteSpace($env:CUSTOM_OP_OPEN_APP_TIMEOUT)) {
+  [void][int]::TryParse($env:CUSTOM_OP_OPEN_APP_TIMEOUT, [ref]$openTimeout)
+}
+$afterLaunchTimeout = 180
+if (-not [string]::IsNullOrWhiteSpace($env:CUSTOM_OP_AFTER_LAUNCH_TIMEOUT)) {
+  [void][int]::TryParse($env:CUSTOM_OP_AFTER_LAUNCH_TIMEOUT, [ref]$afterLaunchTimeout)
+}
+
+$cliIniCandidates = @(
+  "C:\ProgramData\National Instruments\LabVIEW CLI\LabVIEWCLI.ini",
+  "C:\ProgramData\National Instruments\LabVIEWCLI\LabVIEWCLI.ini",
+  "C:\Program Files\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini",
+  "C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini"
+)
+$cliIni = $cliIniCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+if ($cliIni) {
+  Set-IniToken -Path $cliIni -Key 'OpenAppReferenceTimeoutInSecond' -Value ([string]$openTimeout)
+  Set-IniToken -Path $cliIni -Key 'AfterLaunchOpenAppReferenceTimeoutInSecond' -Value ([string]$afterLaunchTimeout)
+}
+
+$cliArgsJson = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($env:CUSTOM_OP_ARGS_B64))
+$cliArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($cliArgsJson)) {
+  $parsedArgs = $cliArgsJson | ConvertFrom-Json -ErrorAction Stop
+  if ($parsedArgs -is [System.Collections.IEnumerable] -and -not ($parsedArgs -is [string])) {
+    $cliArgs = @($parsedArgs | ForEach-Object { [string]$_ })
+  } elseif (-not [string]::IsNullOrWhiteSpace([string]$parsedArgs)) {
+    $cliArgs = @([string]$parsedArgs)
+  }
+}
+
+$prelaunchAttempted = $false
+$prelaunchEnabled = -not [string]::Equals($env:CUSTOM_OP_PRELAUNCH_ENABLED, '0', [System.StringComparison]::OrdinalIgnoreCase)
+if ($prelaunchEnabled) {
+  $lvCandidates = @(
+    $requestedLabVIEWPath,
+    "C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe",
+    "C:\Program Files (x86)\National Instruments\LabVIEW 2026\LabVIEW.exe"
+  ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+  $lvPath = $lvCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+  if ($lvPath) {
+    $prelaunchAttempted = $true
+    Start-Process -FilePath $lvPath -ArgumentList '--headless' -WindowStyle Hidden | Out-Null
+    $prelaunchWait = 8
+    if (-not [string]::IsNullOrWhiteSpace($env:CUSTOM_OP_PRELAUNCH_WAIT_SECONDS)) {
+      [void][int]::TryParse($env:CUSTOM_OP_PRELAUNCH_WAIT_SECONDS, [ref]$prelaunchWait)
+    }
+    if ($prelaunchWait -gt 0) {
+      Start-Sleep -Seconds $prelaunchWait
+    }
+  }
+}
+
+$startedAtUtc = (Get-Date).ToUniversalTime()
+$process = Start-Process -FilePath $cliPath -ArgumentList $cliArgs -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -NoNewWindow -PassThru
+$timedOut = $false
+$deadline = (Get-Date).AddSeconds([Math]::Max(1, [int]$env:CUSTOM_OP_TIMEOUT_SECONDS))
+while (-not $process.HasExited) {
+  if ((Get-Date) -ge $deadline) {
+    $timedOut = $true
+    try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
+    break
+  }
+  Start-Sleep -Milliseconds 500
+}
+
+$exitCode = if ($timedOut) { 124 } else { [int]$process.ExitCode }
+try {
+  Get-Process -Name 'LabVIEW', 'LabVIEWCLI' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+} catch {}
+$finishedAtUtc = (Get-Date).ToUniversalTime()
+$logFiles = Copy-RelevantLogFiles -CaptureRoot $captureRoot -StartedAtUtc $startedAtUtc -FinishedAtUtc $finishedAtUtc
+
+$result = [ordered]@{
+  schema = 'ni-windows-container-custom-operation-scenario@v1'
+  status = if ($timedOut) { 'timed-out' } elseif ($exitCode -eq 0) { 'succeeded' } else { 'failed' }
+  timedOut = [bool]$timedOut
+  exitCode = [int]$exitCode
+  cliPath = $cliPath
+  requestedLabVIEWPath = $requestedLabVIEWPath
+  stdoutPath = $stdoutPath
+  stderrPath = $stderrPath
+  logFiles = @($logFiles)
+  prelaunchAttempted = [bool]$prelaunchAttempted
+  iniPath = $cliIni
+  openTimeout = [int]$openTimeout
+  afterLaunchTimeout = [int]$afterLaunchTimeout
+  finishedAt = $finishedAtUtc.ToString('o')
+}
+
+$result | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $resultPath -Encoding utf8
+exit $exitCode
+'@
+}
+
+$repoRoot = Resolve-RepoRoot
+Import-Module (Join-Path $repoRoot 'tools' 'LabVIEWCli.psm1') -Force | Out-Null
+
+$effectiveArguments = @()
+if (-not [string]::IsNullOrWhiteSpace($ArgumentsJson)) {
+  $parsedArguments = $ArgumentsJson | ConvertFrom-Json -ErrorAction Stop
+  if ($parsedArguments -is [System.Collections.IEnumerable] -and -not ($parsedArguments -is [string])) {
+    $effectiveArguments = @($parsedArguments | ForEach-Object { [string]$_ })
+  } elseif (-not [string]::IsNullOrWhiteSpace([string]$parsedArguments)) {
+    $effectiveArguments = @([string]$parsedArguments)
+  }
+} elseif ($Arguments) {
+  $effectiveArguments = @($Arguments | ForEach-Object { [string]$_ })
+}
+
+$resultsRootResolved = Ensure-Directory -Path (Resolve-AbsolutePath -BasePath $repoRoot -PathValue $ResultsRoot)
+$capturePath = Join-Path $resultsRootResolved 'ni-windows-custom-operation-capture.json'
+$stdoutPath = Join-Path $resultsRootResolved 'ni-windows-custom-operation-run-stdout.txt'
+$stderrPath = Join-Path $resultsRootResolved 'ni-windows-custom-operation-run-stderr.txt'
+$scenarioResultPath = Join-Path $resultsRootResolved 'scenario-result.json'
+$preflightResultsRoot = Ensure-Directory -Path (Join-Path $resultsRootResolved 'preflight')
+$preflightScriptResolved = Resolve-ScriptPath -RepoRoot $repoRoot -PathValue $PreflightScriptPath -DefaultRelativePath 'tools/Test-WindowsNI2026q1HostPreflight.ps1'
+
+$capture = [ordered]@{
+  schema = 'ni-windows-container-custom-operation/v1'
+  generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  status = 'init'
+  classification = 'init'
+  image = $Image
+  operationName = $OperationName
+  resultsRoot = $resultsRootResolved
+  additionalOperationDirectory = $null
+  requestedLabVIEWPath = if ([string]::IsNullOrWhiteSpace($LabVIEWPath)) { $null } else { $LabVIEWPath }
+  timeoutSeconds = [int]$TimeoutSeconds
+  probe = [bool]$Probe
+  dockerServerOs = $null
+  dockerContext = $null
+  preflightPath = $null
+  preview = $null
+  scenarioResultPath = $scenarioResultPath
+  stdoutPath = $stdoutPath
+  stderrPath = $stderrPath
+  containerCommand = $null
+  exitCode = $null
+  timedOut = $false
+  message = $null
+  scenarioResult = $null
+}
+
+$finalExitCode = 0
+$stdoutContent = ''
+$stderrContent = ''
+$previousRequestedLabVIEWPath = $null
+$restoreRequestedLabVIEWPath = $false
+
+try {
+  Assert-Tool -Name 'docker'
+
+  $preflightOutput = @(& $preflightScriptResolved -Image $Image -ResultsDir $preflightResultsRoot)
+  $preflightPath = @($preflightOutput | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
+  if ($preflightPath.Count -eq 0) {
+    throw "Windows container preflight did not return a report path. Output: $(@($preflightOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine)"
+  }
+  $preflightPathResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $preflightPath[0]
+  $capture.preflightPath = $preflightPathResolved
+  if (-not (Test-Path -LiteralPath $preflightPathResolved -PathType Leaf)) {
+    throw "Windows container preflight did not produce a report at '$preflightPathResolved'."
+  }
+  $preflight = Get-Content -LiteralPath $preflightPathResolved -Raw | ConvertFrom-Json -Depth 12
+  $capture.dockerServerOs = $preflight.contexts.finalOsType
+  $capture.dockerContext = $preflight.contexts.final
+
+  if ($Probe) {
+    $capture.status = 'probe-ok'
+    $capture.classification = 'probe-ok'
+    $capture.exitCode = 0
+    $capture.message = ("Windows container preflight succeeded for image '{0}'." -f $Image)
+  } else {
+    if ([string]::IsNullOrWhiteSpace($AdditionalOperationDirectory)) {
+      throw '-AdditionalOperationDirectory is required unless -Probe is set.'
+    }
+
+    $operationDirectoryResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $AdditionalOperationDirectory
+    if (-not (Test-Path -LiteralPath $operationDirectoryResolved -PathType Container)) {
+      throw "Custom operation directory was not found at '$operationDirectoryResolved'."
+    }
+    $capture.additionalOperationDirectory = $operationDirectoryResolved
+
+    $preview = New-InContainerPreview `
+      -OperationName $OperationName `
+      -ContainerOperationDirectory $script:ContainerOperationRoot `
+      -Arguments $effectiveArguments `
+      -Help:$Help.IsPresent `
+      -Headless:$Headless.IsPresent `
+      -LogToConsole:$LogToConsole.IsPresent `
+      -LabVIEWPath $LabVIEWPath
+    $capture.preview = $preview
+
+    $cliArgsJson = (@($preview.args) | ConvertTo-Json -Compress)
+    if ([string]::IsNullOrWhiteSpace($cliArgsJson)) {
+      $cliArgsJson = '[]'
+    }
+    $cliArgsB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($cliArgsJson))
+    $containerCommand = New-ContainerCommand
+    $encodedCommand = Convert-ToEncodedCommand -CommandText $containerCommand
+
+    $dockerArgs = @(
+      'run',
+      '--rm',
+      '--workdir', $script:ContainerOperationRoot,
+      '-v', ('{0}:{1}' -f $operationDirectoryResolved, $script:ContainerOperationRoot),
+      '-v', ('{0}:{1}' -f $resultsRootResolved, $script:ContainerCaptureRoot),
+      '--env', ('CUSTOM_OP_CAPTURE_ROOT={0}' -f $script:ContainerCaptureRoot),
+      '--env', ('CUSTOM_OP_ARGS_B64={0}' -f $cliArgsB64),
+      '--env', ('CUSTOM_OP_TIMEOUT_SECONDS={0}' -f [Math]::Max(1, $TimeoutSeconds)),
+      '--env', ('CUSTOM_OP_PRELAUNCH_ENABLED={0}' -f 1),
+      '--env', ('CUSTOM_OP_PRELAUNCH_WAIT_SECONDS={0}' -f [Math]::Max(0, $PrelaunchWaitSeconds)),
+      '--env', 'CUSTOM_OP_OPEN_APP_TIMEOUT=180',
+      '--env', 'CUSTOM_OP_AFTER_LAUNCH_TIMEOUT=180'
+    )
+    if (-not [string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+      $previousRequestedLabVIEWPath = [Environment]::GetEnvironmentVariable('CUSTOM_OP_REQUESTED_LABVIEW_PATH', 'Process')
+      [Environment]::SetEnvironmentVariable('CUSTOM_OP_REQUESTED_LABVIEW_PATH', $LabVIEWPath, 'Process')
+      $restoreRequestedLabVIEWPath = $true
+      $dockerArgs += @('--env', 'CUSTOM_OP_REQUESTED_LABVIEW_PATH')
+    }
+    $dockerArgs += @(
+      $Image,
+      'powershell',
+      '-NoLogo',
+      '-NoProfile',
+      '-EncodedCommand',
+      $encodedCommand
+    )
+
+    $capture.containerCommand = ('docker run --rm --workdir {0} ... {1} powershell -NoLogo -NoProfile -EncodedCommand <base64-custom-operation-script>' -f $script:ContainerOperationRoot, $Image)
+    Write-Host ("[ni-custom-op-container] image={0} operation={1}" -f $Image, $OperationName) -ForegroundColor Cyan
+
+    $runResult = Invoke-DockerRunWithTimeout `
+      -DockerArgs $dockerArgs `
+      -Seconds ([Math]::Max($TimeoutSeconds + 30, $TimeoutSeconds)) `
+      -HeartbeatSeconds $HeartbeatSeconds `
+      -Image $Image
+    $stdoutContent = $runResult.StdOut
+    $stderrContent = $runResult.StdErr
+
+    if ($runResult.TimedOut) {
+      $capture.status = 'timeout'
+      $capture.classification = 'timeout'
+      $capture.timedOut = $true
+      $capture.exitCode = $script:TimeoutExitCode
+      $capture.message = ("Windows container custom operation timed out after {0} second(s)." -f $TimeoutSeconds)
+      $finalExitCode = $script:TimeoutExitCode
+    } else {
+      $capture.exitCode = [int]$runResult.ExitCode
+      $finalExitCode = [int]$runResult.ExitCode
+      if (Test-Path -LiteralPath $scenarioResultPath -PathType Leaf) {
+        $scenarioResult = Get-Content -LiteralPath $scenarioResultPath -Raw | ConvertFrom-Json -Depth 12
+        $capture.scenarioResult = $scenarioResult
+        switch ([string]$scenarioResult.status) {
+          'succeeded' {
+            $capture.status = 'ok'
+            $capture.classification = 'ok'
+          }
+          'timed-out' {
+            $capture.status = 'timeout'
+            $capture.classification = 'timeout'
+            $capture.timedOut = $true
+            if (-not $capture.message) {
+              $capture.message = ("Windows container custom operation timed out after {0} second(s)." -f $TimeoutSeconds)
+            }
+          }
+          default {
+            $capture.status = 'error'
+            $capture.classification = 'run-error'
+            $capture.message = 'Windows container custom operation did not complete successfully.'
+          }
+        }
+      } else {
+        $capture.status = 'error'
+        $capture.classification = 'missing-result'
+        $capture.message = "Container run completed without emitting '$scenarioResultPath'."
+        if ($finalExitCode -eq 0) {
+          $finalExitCode = 1
+        }
+      }
+    }
+  }
+} catch {
+  $capture.status = 'preflight-error'
+  $capture.classification = 'preflight-error'
+  $capture.exitCode = $script:PreflightExitCode
+  $capture.message = $_.Exception.Message
+  $finalExitCode = $script:PreflightExitCode
+} finally {
+  if (-not $Probe) {
+    Write-TextArtifact -Path $stdoutPath -Content $stdoutContent
+    Write-TextArtifact -Path $stderrPath -Content $stderrContent
+  }
+  if ($restoreRequestedLabVIEWPath) {
+    [Environment]::SetEnvironmentVariable('CUSTOM_OP_REQUESTED_LABVIEW_PATH', $previousRequestedLabVIEWPath, 'Process')
+  }
+  $capture.generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  $capture | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $capturePath -Encoding utf8
+  Write-Host ("[ni-custom-op-container] capture={0} status={1} exit={2}" -f $capturePath, $capture.status, $capture.exitCode) -ForegroundColor DarkGray
+}
+
+if ($PassThru) {
+  [pscustomobject]$capture
+}
+
+exit $finalExitCode

--- a/tools/Test-LabVIEWCLICustomOperationProof.ps1
+++ b/tools/Test-LabVIEWCLICustomOperationProof.ps1
@@ -5,7 +5,12 @@ param(
   [string]$OperationName = 'AddTwoNumbers',
   [string]$SourceExamplePath = 'C:\Users\Public\Documents\National Instruments\LabVIEW CLI\Examples\AddTwoNumbers',
   [string]$OperationDirectory = '',
+  [ValidateSet('host', 'windows-container')]
+  [string]$ExecutionPlane = 'host',
   [string]$LabVIEWPath = '',
+  [string]$WindowsContainerImage = 'nationalinstruments/labview:2026q1-windows',
+  [string]$WindowsContainerLabVIEWPath = 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe',
+  [string]$WindowsContainerRunnerScriptPath = '',
   [int]$TimeoutSeconds = 90,
   [string]$ResultsRoot = '',
   [string]$ReportPath = '',
@@ -44,6 +49,21 @@ function Ensure-Directory {
   }
 
   return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Resolve-ScriptPath {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [AllowEmptyString()][string]$PathValue,
+    [Parameter(Mandatory)][string]$DefaultRelativePath
+  )
+
+  $effective = if ([string]::IsNullOrWhiteSpace($PathValue)) { $DefaultRelativePath } else { $PathValue }
+  $resolved = Resolve-AbsolutePath -BasePath $RepoRoot -PathValue $effective
+  if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+    throw "Script path was not found: '$resolved'."
+  }
+  return $resolved
 }
 
 function Convert-ToRepoRelativePath {
@@ -106,6 +126,18 @@ function Invoke-SchemaValidation {
     $message = ($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
     throw "Schema validation failed for '$DataPath': $message"
   }
+}
+
+function Quote-CommandArgument {
+  param([AllowNull()][string]$Text)
+
+  if ($null -eq $Text) {
+    return '""'
+  }
+  if ($Text -match '[\s"]') {
+    return '"' + ($Text -replace '"', '\"') + '"'
+  }
+  return $Text
 }
 
 function Get-PreferredLabVIEWHint {
@@ -304,15 +336,87 @@ function Copy-ScenarioLogs {
   }
 }
 
+function New-ScenarioPreview {
+  param(
+    [Parameter(Mandatory)]$Scenario,
+    [Parameter(Mandatory)][string]$OperationName,
+    [Parameter(Mandatory)][string]$AdditionalOperationDirectory,
+    [ValidateSet('host', 'windows-container')]
+    [string]$ExecutionPlane = 'host'
+  )
+
+  $previewArgs = @{
+    CustomOperationName = $OperationName
+    AdditionalOperationDirectory = $AdditionalOperationDirectory
+    Provider = 'labviewcli'
+    Preview = $true
+  }
+  if ($Scenario.help) { $previewArgs.Help = $true }
+  if ($Scenario.headless) { $previewArgs.Headless = $true }
+  if ($Scenario.logToConsole) { $previewArgs.LogToConsole = $true }
+  if ($Scenario.arguments.Count -gt 0) { $previewArgs.Arguments = @($Scenario.arguments) }
+  if ($Scenario.requestedLabVIEWPath) { $previewArgs.LabVIEWPath = $Scenario.requestedLabVIEWPath }
+  $preview = Invoke-LVCustomOperation @previewArgs
+
+  if ($ExecutionPlane -eq 'windows-container') {
+    $args = @($preview.args | ForEach-Object { [string]$_ })
+    return [ordered]@{
+      operation = 'RunCustomOperation'
+      provider = 'labviewcli'
+      cliPath = 'in-container'
+      args = $args
+      command = ('LabVIEWCLI.exe {0}' -f ((@($args | ForEach-Object { Quote-CommandArgument -Text $_ })) -join ' '))
+    }
+  }
+
+  return $preview
+}
+
+function Get-LogInsightsFromCapturedFiles {
+  param(
+    [AllowNull()][object[]]$Files
+  )
+
+  $texts = New-Object System.Collections.Generic.List[string]
+  foreach ($file in @($Files)) {
+    if ($null -eq $file) { continue }
+    $destinationPath = if ($file.PSObject.Properties['destinationPath']) { [string]$file.destinationPath } else { [string]$file }
+    if ([string]::IsNullOrWhiteSpace($destinationPath)) { continue }
+    if (-not (Test-Path -LiteralPath $destinationPath -PathType Leaf)) { continue }
+    $texts.Add((Get-Content -LiteralPath $destinationPath -Raw -ErrorAction SilentlyContinue)) | Out-Null
+  }
+
+  if ($texts.Count -eq 0) {
+    return [ordered]@{
+      observedLabVIEWPaths = @()
+      observedLabVIEWPath = $null
+      launchSucceeded = $false
+      operationCompleted = $false
+      logLineCount = 0
+    }
+  }
+
+  return Get-LabVIEWCustomOperationLogInsights -Text (($texts.ToArray()) -join [Environment]::NewLine)
+}
+
 function Get-ScenarioCatalog {
-  param([AllowNull()][string]$ExplicitLabVIEWPath)
+  param(
+    [AllowNull()][string]$ExplicitLabVIEWPath,
+    [ValidateSet('host', 'windows-container')]
+    [string]$ExecutionPlane = 'host'
+  )
 
   $scenarios = New-Object System.Collections.Generic.List[object]
+  $containerHeadless = ($ExecutionPlane -eq 'windows-container')
   $scenarios.Add([pscustomobject]@{
       name = 'default-help'
-      description = 'Probe the implicit LabVIEW selection used by LabVIEWCLI when -LabVIEWPath is omitted.'
+      description = if ($containerHeadless) {
+        'Probe the implicit LabVIEW selection used by LabVIEWCLI when -LabVIEWPath is omitted, while honoring the Windows container headless requirement.'
+      } else {
+        'Probe the implicit LabVIEW selection used by LabVIEWCLI when -LabVIEWPath is omitted.'
+      }
       help = $true
-      headless = $false
+      headless = $containerHeadless
       logToConsole = $false
       arguments = @()
       requestedLabVIEWPath = $null
@@ -321,9 +425,13 @@ function Get-ScenarioCatalog {
   if (-not [string]::IsNullOrWhiteSpace($ExplicitLabVIEWPath)) {
     $scenarios.Add([pscustomobject]@{
         name = 'explicit-help'
-        description = 'Run GetHelp.vi against the explicit LabVIEW 2026 host plane.'
+        description = if ($containerHeadless) {
+          'Run GetHelp.vi against the explicit LabVIEW 2026 Windows-container plane with -Headless.'
+        } else {
+          'Run GetHelp.vi against the explicit LabVIEW 2026 host plane.'
+        }
         help = $true
-        headless = $false
+        headless = $containerHeadless
         logToConsole = $false
         arguments = @()
         requestedLabVIEWPath = $ExplicitLabVIEWPath
@@ -354,18 +462,11 @@ function Invoke-CustomOperationScenario {
   )
 
   $scenarioRoot = Ensure-Directory -Path (Join-Path $ResultsRoot $Scenario.name)
-  $previewArgs = @{
-    CustomOperationName = $OperationName
-    AdditionalOperationDirectory = $AdditionalOperationDirectory
-    Provider = 'labviewcli'
-    Preview = $true
-  }
-  if ($Scenario.help) { $previewArgs.Help = $true }
-  if ($Scenario.headless) { $previewArgs.Headless = $true }
-  if ($Scenario.logToConsole) { $previewArgs.LogToConsole = $true }
-  if ($Scenario.arguments.Count -gt 0) { $previewArgs.Arguments = @($Scenario.arguments) }
-  if ($Scenario.requestedLabVIEWPath) { $previewArgs.LabVIEWPath = $Scenario.requestedLabVIEWPath }
-  $preview = Invoke-LVCustomOperation @previewArgs
+  $preview = New-ScenarioPreview `
+    -Scenario $Scenario `
+    -OperationName $OperationName `
+    -AdditionalOperationDirectory $AdditionalOperationDirectory `
+    -ExecutionPlane 'host'
 
   if ($DryRun) {
     return [pscustomobject]@{
@@ -466,6 +567,148 @@ function Invoke-CustomOperationScenario {
   }
 }
 
+function Invoke-WindowsContainerCustomOperationScenario {
+  param(
+    [Parameter(Mandatory)]$Scenario,
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$ResultsRoot,
+    [Parameter(Mandatory)][string]$OperationName,
+    [Parameter(Mandatory)][string]$AdditionalOperationDirectory,
+    [Parameter(Mandatory)][int]$TimeoutSeconds,
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string]$RunnerScriptPath,
+    [switch]$DryRun
+  )
+
+  $scenarioRoot = Ensure-Directory -Path (Join-Path $ResultsRoot $Scenario.name)
+  $preview = New-ScenarioPreview `
+    -Scenario $Scenario `
+    -OperationName $OperationName `
+    -AdditionalOperationDirectory 'C:\custom-operation' `
+    -ExecutionPlane 'windows-container'
+
+  if ($DryRun) {
+    return [pscustomobject]@{
+      name = $Scenario.name
+      description = $Scenario.description
+      status = 'planned'
+      timedOut = $false
+      requestedLabVIEWPath = $Scenario.requestedLabVIEWPath
+      preview = $preview
+      result = $null
+      error = $null
+      processBefore = @()
+      processAfter = @()
+      processFinal = @()
+      cleanup = [ordered]@{
+        killedPids = @()
+        errors = @()
+      }
+      lingeringProcesses = @()
+      logCapture = [ordered]@{
+        count = 0
+        files = @()
+      }
+      logInsights = [ordered]@{
+        observedLabVIEWPaths = @()
+        observedLabVIEWPath = $null
+        launchSucceeded = $false
+        operationCompleted = $false
+        logLineCount = 0
+      }
+      containerCapturePath = $null
+    }
+  }
+
+  $capturePath = Join-Path $scenarioRoot 'ni-windows-custom-operation-capture.json'
+  $runnerArgs = @(
+    '-NoLogo',
+    '-NoProfile',
+    '-File',
+    $RunnerScriptPath,
+    '-OperationName',
+    $OperationName,
+    '-AdditionalOperationDirectory',
+    $AdditionalOperationDirectory,
+    '-ResultsRoot',
+    $scenarioRoot,
+    '-Image',
+    $Image,
+    '-TimeoutSeconds',
+    [string]$TimeoutSeconds
+  )
+  if ($Scenario.help) { $runnerArgs += '-Help' }
+  if ($Scenario.headless) { $runnerArgs += '-Headless' }
+  if ($Scenario.logToConsole) { $runnerArgs += '-LogToConsole' }
+  if ($Scenario.arguments.Count -gt 0) {
+    $runnerArgs += @('-ArgumentsJson', ((@($Scenario.arguments | ForEach-Object { [string]$_ }) | ConvertTo-Json -Compress)))
+  }
+  if ($Scenario.requestedLabVIEWPath) {
+    $runnerArgs += @('-LabVIEWPath', [string]$Scenario.requestedLabVIEWPath)
+  }
+
+  $runnerOutput = & pwsh @runnerArgs *>&1
+  $runnerExitCode = $LASTEXITCODE
+  $runnerCapture = if (Test-Path -LiteralPath $capturePath -PathType Leaf) {
+    Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
+  } else {
+    $null
+  }
+
+  $scenarioResult = if ($runnerCapture -and $runnerCapture.scenarioResult) { $runnerCapture.scenarioResult } else { $null }
+  $capturedFiles = if ($scenarioResult -and $scenarioResult.logFiles) { @($scenarioResult.logFiles) } else { @() }
+  $logInsights = Get-LogInsightsFromCapturedFiles -Files $capturedFiles
+
+  $status = 'failed'
+  $timedOut = $false
+  if ($runnerCapture) {
+    switch ([string]$runnerCapture.status) {
+      'ok' {
+        $status = 'succeeded'
+      }
+      'timeout' {
+        $status = 'timed-out'
+        $timedOut = $true
+      }
+      default {
+        $status = if ($runnerExitCode -eq 0 -and $scenarioResult -and ([string]$scenarioResult.status -eq 'succeeded')) { 'succeeded' } else { 'failed' }
+      }
+    }
+  }
+
+  if ($scenarioResult -and $scenarioResult.timedOut) {
+    $timedOut = [bool]$scenarioResult.timedOut
+    if ($timedOut) {
+      $status = 'timed-out'
+    }
+  }
+
+  return [pscustomobject]@{
+    name = $Scenario.name
+    description = $Scenario.description
+    status = $status
+    timedOut = [bool]$timedOut
+    requestedLabVIEWPath = $Scenario.requestedLabVIEWPath
+    preview = $preview
+    result = $scenarioResult
+    error = if ($runnerCapture -and $runnerCapture.message) { [string]$runnerCapture.message } elseif ($runnerExitCode -ne 0) { (($runnerOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) } else { $null }
+    processBefore = @()
+    processAfter = @()
+    processFinal = @()
+    cleanup = [ordered]@{
+      killedPids = @()
+      errors = @()
+    }
+    lingeringProcesses = @()
+    logCapture = [ordered]@{
+      count = @($capturedFiles).Count
+      files = @($capturedFiles)
+    }
+    logInsights = $logInsights
+    containerCapturePath = if ($runnerCapture) { $capturePath } else { $null }
+  }
+}
+
 function New-ProofMarkdown {
   param(
     [Parameter(Mandatory)]$Report,
@@ -477,10 +720,17 @@ function New-ProofMarkdown {
   $lines.Add('') | Out-Null
   $lines.Add(('- Report: `{0}`' -f $ReportPath)) | Out-Null
   $lines.Add(('- Final status: `{0}`' -f $Report.status)) | Out-Null
+  $lines.Add(('- Execution plane: `{0}`' -f $Report.executionPlane)) | Out-Null
   $lines.Add(('- Operation: `{0}`' -f $Report.operationName)) | Out-Null
   $lines.Add(('- Operation directory: `{0}`' -f $Report.operationDirectory)) | Out-Null
   if ($Report.explicitLabVIEWPath) {
     $lines.Add(('- Explicit LabVIEW path: `{0}`' -f $Report.explicitLabVIEWPath)) | Out-Null
+  }
+  if ($Report.containerImage) {
+    $lines.Add(('- Container image: `{0}`' -f $Report.containerImage)) | Out-Null
+  }
+  if ($Report.preflightPath) {
+    $lines.Add(('- Preflight report: `{0}`' -f $Report.preflightPath)) | Out-Null
   }
   $rootCauseText = if (@($Report.analysis.rootCauseCandidates).Count -gt 0) {
     (@($Report.analysis.rootCauseCandidates) -join ', ')
@@ -549,10 +799,21 @@ $summaryResolved = if ([string]::IsNullOrWhiteSpace($SummaryPath)) {
   Resolve-AbsolutePath -BasePath $repoRoot -PathValue $SummaryPath
 }
 
-$explicitLabVIEWPath = if ([string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+$explicitLabVIEWPath = if ($ExecutionPlane -eq 'windows-container') {
+  if ([string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+    $WindowsContainerLabVIEWPath
+  } else {
+    $LabVIEWPath
+  }
+} elseif ([string]::IsNullOrWhiteSpace($LabVIEWPath)) {
   Get-PreferredLabVIEWHint -RepoRoot $repoRoot
 } else {
   Resolve-AbsolutePath -BasePath $repoRoot -PathValue $LabVIEWPath
+}
+$windowsContainerRunnerResolved = if ($ExecutionPlane -eq 'windows-container') {
+  Resolve-ScriptPath -RepoRoot $repoRoot -PathValue $WindowsContainerRunnerScriptPath -DefaultRelativePath 'tools/Run-NIWindowsContainerCustomOperation.ps1'
+} else {
+  $null
 }
 
 $operationDirectoryResolved = $null
@@ -594,24 +855,48 @@ foreach ($requiredFile in @('GetHelp.vi', 'RunOperation.vi')) {
   }
 }
 
-$scenarioCatalog = Get-ScenarioCatalog -ExplicitLabVIEWPath $explicitLabVIEWPath
+$scenarioCatalog = Get-ScenarioCatalog -ExplicitLabVIEWPath $explicitLabVIEWPath -ExecutionPlane $ExecutionPlane
 $scenarioResults = New-Object System.Collections.Generic.List[object]
 foreach ($scenario in $scenarioCatalog) {
-  $scenarioResults.Add(
-    (Invoke-CustomOperationScenario `
-      -Scenario $scenario `
-      -RepoRoot $repoRoot `
-      -ResultsRoot $resultsRootResolved `
-      -OperationName $OperationName `
-      -AdditionalOperationDirectory $operationDirectoryResolved `
-      -TimeoutSeconds $TimeoutSeconds `
-      -DryRun:$DryRun)
-  ) | Out-Null
+  if ($ExecutionPlane -eq 'windows-container') {
+    $scenarioResults.Add(
+      (Invoke-WindowsContainerCustomOperationScenario `
+        -Scenario $scenario `
+        -RepoRoot $repoRoot `
+        -ResultsRoot $resultsRootResolved `
+        -OperationName $OperationName `
+        -AdditionalOperationDirectory $operationDirectoryResolved `
+        -TimeoutSeconds $TimeoutSeconds `
+        -Image $WindowsContainerImage `
+        -RunnerScriptPath $windowsContainerRunnerResolved `
+        -DryRun:$DryRun)
+    ) | Out-Null
+  } else {
+    $scenarioResults.Add(
+      (Invoke-CustomOperationScenario `
+        -Scenario $scenario `
+        -RepoRoot $repoRoot `
+        -ResultsRoot $resultsRootResolved `
+        -OperationName $OperationName `
+        -AdditionalOperationDirectory $operationDirectoryResolved `
+        -TimeoutSeconds $TimeoutSeconds `
+        -DryRun:$DryRun)
+    ) | Out-Null
+  }
 }
 $labviewCliPath = $null
 foreach ($scenarioResult in @($scenarioResults.ToArray())) {
+  if ($scenarioResult.result -and $scenarioResult.result.cliPath) {
+    $labviewCliPath = [string]$scenarioResult.result.cliPath
+    break
+  }
   if ($scenarioResult.preview -and $scenarioResult.preview.cliPath) {
-    $labviewCliPath = [string]$scenarioResult.preview.cliPath
+    $candidatePath = [string]$scenarioResult.preview.cliPath
+    if (-not [string]::Equals($candidatePath, 'in-container', [System.StringComparison]::OrdinalIgnoreCase)) {
+      $labviewCliPath = $candidatePath
+    } elseif (-not $labviewCliPath) {
+      $labviewCliPath = $candidatePath
+    }
     break
   }
 }
@@ -638,11 +923,28 @@ $report = [ordered]@{
   schema = 'labview-cli-custom-operation-proof@v1'
   generatedAt = (Get-Date).ToUniversalTime().ToString('o')
   status = $status
+  executionPlane = $ExecutionPlane
   operationName = $OperationName
   sourceExamplePath = $sourceExampleResolved
   operationDirectory = $operationDirectoryResolved
   explicitLabVIEWPath = $explicitLabVIEWPath
   labviewCliPath = $labviewCliPath
+  containerImage = if ($ExecutionPlane -eq 'windows-container') { $WindowsContainerImage } else { $null }
+  preflightPath = if ($ExecutionPlane -eq 'windows-container') {
+    $firstContainerScenario = @($scenarioResults | Where-Object { $_.containerCapturePath } | Select-Object -First 1)
+    if ($firstContainerScenario.Count -gt 0 -and (Test-Path -LiteralPath $firstContainerScenario[0].containerCapturePath -PathType Leaf)) {
+      try {
+        $containerCapture = Get-Content -LiteralPath $firstContainerScenario[0].containerCapturePath -Raw | ConvertFrom-Json -Depth 12
+        if ($containerCapture.preflightPath) { [string]$containerCapture.preflightPath } else { $null }
+      } catch {
+        $null
+      }
+    } else {
+      $null
+    }
+  } else {
+    $null
+  }
   timeoutSeconds = [int]$TimeoutSeconds
   dryRun = [bool]$DryRun
   resultsRoot = $resultsRootResolved


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1474
- Issue title: Prove AddTwoNumbers custom-operation behavior on the LabVIEW 2026 Q1 Windows 64-bit container plane
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1474
- Standing priority at PR creation: Yes (#1474)
- Base branch: `develop`
- Head branch: `issue/origin-1474-addtwonumbers-windows-container`
- Template variant: `agent-maintenance`
- Auto-close intent: `Closes #1474`

Closes #1474

# Summary

This adds a deterministic Windows-container proof lane for the official NI `AddTwoNumbers` LabVIEW CLI custom operation.
It proves the same scenario pack through Docker Desktop against `nationalinstruments/labview:2026q1-windows`, records the execution plane in the receipt, and documents that the Windows image uses native `powershell` rather than `pwsh`.
The live proof on March 20, 2026 succeeded for all three scenarios, which narrows the remaining suspicion from `#1472` back toward native host-plane behavior instead of a general container-plane failure.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block populated. Reviewer-routing and policy checks treat its presence as the machine-usable signal that
> the PR is agent-authored.

## Change Surface

- Standing-priority or linked issue context:
  - `#1474` proves the Windows 64-bit container mirror plane for AddTwoNumbers after `#1472` narrowed the host x86 hang.
- Repo areas touched:
  - `tools/Test-LabVIEWCLICustomOperationProof.ps1`
  - `tools/Run-NIWindowsContainerCustomOperation.ps1`
  - `tests/LabVIEWCLICustomOperationProof.Tests.ps1`
  - `tests/Run-NIWindowsContainerCustomOperation.Tests.ps1`
  - `docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md`
  - `docs/schemas/labview-cli-custom-operation-proof-v1.schema.json`
  - `docs/documentation-manifest.json`
  - `package.json`
- Workflow, policy, or tooling surfaces touched:
  - local proof tooling only; no GitHub workflow logic changed in this slice
  - new npm entrypoint: `history:custom-operation:proof:windows`
- Cross-repo or downstream impact:
  - gives the platform a reusable Windows 64-bit mirror proof surface before any host-native 32-bit promotion work

## Validation Evidence

- Commands run:
  - `pwsh -NoLogo -NoProfile -File tests/LabVIEWCLICustomOperationProof.Tests.ps1`
  - `pwsh -NoLogo -NoProfile -File tests/Run-NIWindowsContainerCustomOperation.Tests.ps1`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs lint:md:changed`
  - `node tools/npm/run-script.mjs history:custom-operation:proof:windows -- -DryRun -SkipSchemaValidation -ResultsRoot tests/results/_agent/custom-operation-proofs/windows-container-alias-dryrun`
  - `git diff --check`
- Key artifacts, logs, or workflow runs:
  - live proof receipt: `tests/results/_agent/custom-operation-proofs/windows-container-live-1474-3/labview-cli-custom-operation-proof.json`
  - live proof summary: `tests/results/_agent/custom-operation-proofs/windows-container-live-1474-3/labview-cli-custom-operation-proof.md`
  - host preflight evidence: `tests/results/_agent/windows-custom-operation-preflight/windows-ni-2026q1-host-preflight.json`
- Checks intentionally deferred:
  - no additional CI/workflow dispatch yet; this lane changes the proof surface and focused contracts, not hosted workflow behavior

## Reviewer Focus

- Please verify:
  - the new receipt fields cleanly distinguish `host` vs `windows-container`
  - the Windows mirror plane is pinned to `nationalinstruments/labview:2026q1-windows`
  - the runner keeps native `powershell` for the container plane instead of assuming `pwsh`
- Any assumptions that deserve challenge:
  - the successful Windows container proof is sufficient to narrow suspicion back toward native host-plane/x86 behavior from `#1472`
- Manual spot checks requested:
  - if desired, replay `tools/Test-LabVIEWCLICustomOperationProof.ps1 -ExecutionPlane windows-container` on a Windows-container Docker Desktop session

## Queue and Follow-up

- Merge-queue or approval notes:
  - standard approval/green-check path; no policy changes in this PR
- Residual risks:
  - successful proof receipts still duplicate copied log inventory entries per scenario
  - stale/noisy container cleanup under engine mismatch remains tracked separately
- Follow-up issues:
  - `#1476` deduplicate copied log inventory in Windows container custom-operation proof receipts
  - `#1385` stop repeated `No such container` noise in cleanup / artifact recovery
  - `#1477` define per-plane shell contracts for Windows and Linux LabVIEW container helpers
  - `#1469` payload authoring umbrella should absorb this new proof surface after merge
