### PR TITLE
Align hosted Windows runner-label helper defaults

### DIFF
--- a/tests/Assert-RunnerLabelContract.Tests.ps1
+++ b/tests/Assert-RunnerLabelContract.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
           runner_id = 42
           status = 'in_progress'
           started_at = '2026-03-02T00:00:00Z'
-          labels = @('self-hosted', 'windows', 'self-hosted-docker-windows')
+          labels = @('self-hosted', 'windows', 'hosted-docker-windows')
         }
       )
     }
@@ -39,7 +39,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
         -Repository 'owner/repo' `
         -RunId '100' `
         -RunnerName 'host-a' `
-        -RequiredLabel 'self-hosted-docker-windows' `
+        -RequiredLabel 'hosted-docker-windows' `
         -JobsPayloadPath $jobsPayloadPath `
         -OutputJsonPath $outputJsonPath `
         -GitHubOutputPath $githubOutputPath `
@@ -52,7 +52,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
     $json.failureClass | Should -Be 'none'
     $json.hasRequiredLabel | Should -BeTrue
     $json.runnerId | Should -Be '42'
-    @($json.labels) | Should -Contain 'self-hosted-docker-windows'
+    @($json.labels) | Should -Contain 'hosted-docker-windows'
 
     $ghOutput = Get-Content -LiteralPath $githubOutputPath -Raw
     $ghOutput | Should -Match 'has_required_label=true'
@@ -89,7 +89,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
         -Repository 'owner/repo' `
         -RunId '101' `
         -RunnerName 'host-b' `
-        -RequiredLabel 'self-hosted-docker-windows' `
+        -RequiredLabel 'hosted-docker-windows' `
         -JobsPayloadPath $jobsPayloadPath `
         -OutputJsonPath $outputJsonPath
     } | Should -Throw
@@ -119,7 +119,7 @@ Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
         -Repository 'owner/repo' `
         -RunId '102' `
         -RunnerName 'host-c' `
-        -RequiredLabel 'self-hosted-docker-windows' `
+        -RequiredLabel 'hosted-docker-windows' `
         -JobsPayloadPath $jobsPayloadPath `
         -OutputJsonPath $outputJsonPath
     } | Should -Throw

--- a/tests/Update-FixtureDriftSessionIndex.Tests.ps1
+++ b/tests/Update-FixtureDriftSessionIndex.Tests.ps1
@@ -39,9 +39,9 @@ Describe 'Update-FixtureDriftSessionIndex.ps1' -Tag 'Unit' {
       -ResultsDir $resultsDir `
       -ContextPath $contextPath `
       -RuntimeSnapshotPath $runtimeSnapshotPath `
-      -RequiredLabel 'self-hosted-docker-windows' `
+      -RequiredLabel 'hosted-docker-windows' `
       -HasRequiredLabel:$true `
-      -RunnerLabelsCsv 'self-hosted,windows,self-hosted-docker-windows' `
+      -RunnerLabelsCsv 'self-hosted,windows,hosted-docker-windows' `
       -ManagerStatus 'success' `
       -ManagerSummaryPath 'results/fixture-drift/docker-runtime-manager.json' `
       -WindowsImageDigest 'sha256:windows' `
@@ -56,9 +56,9 @@ Describe 'Update-FixtureDriftSessionIndex.ps1' -Tag 'Unit' {
     $updated.runContext.dockerRuntimeManager.windowsImageDigest | Should -Be 'sha256:windows'
     $updated.runContext.dockerRuntimeManager.contextArtifactPath | Should -Be $contextPath
     $updated.runContext.dockerRuntimeManager.runtimeSnapshotPath | Should -Be $runtimeSnapshotPath
-    $updated.runContext.runnerLabelContract.requiredLabel | Should -Be 'self-hosted-docker-windows'
+    $updated.runContext.runnerLabelContract.requiredLabel | Should -Be 'hosted-docker-windows'
     $updated.runContext.runnerLabelContract.hasRequiredLabel | Should -BeTrue
-    @($updated.runContext.runnerLabelContract.labels) | Should -Contain 'self-hosted-docker-windows'
+    @($updated.runContext.runnerLabelContract.labels) | Should -Contain 'hosted-docker-windows'
   }
 
   It 'does not throw when session-index is missing and IgnoreMissingSessionIndex is enabled' {

--- a/tools/Assert-RunnerLabelContract.ps1
+++ b/tools/Assert-RunnerLabelContract.ps1
@@ -14,7 +14,7 @@ param(
   [string]$Repository = $env:GITHUB_REPOSITORY,
   [string]$RunId = $env:GITHUB_RUN_ID,
   [string]$RunnerName = $env:RUNNER_NAME,
-  [string]$RequiredLabel = 'self-hosted-docker-windows',
+  [string]$RequiredLabel = 'hosted-docker-windows',
   [string]$Token = $env:GITHUB_TOKEN,
   [string]$OutputJsonPath = 'results/fixture-drift/runner-label-contract.json',
   [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,

--- a/tools/Update-FixtureDriftSessionIndex.ps1
+++ b/tools/Update-FixtureDriftSessionIndex.ps1
@@ -9,7 +9,7 @@ param(
   [string]$SessionIndexPath = '',
   [string]$ContextPath = '',
   [string]$RuntimeSnapshotPath = '',
-  [string]$RequiredLabel = 'self-hosted-docker-windows',
+  [string]$RequiredLabel = 'hosted-docker-windows',
   [bool]$HasRequiredLabel = $false,
   [string]$RunnerLabelsCsv = '',
   [string]$ManagerStatus = '',


### PR DESCRIPTION
## Summary
- align the remaining runner-label helper defaults with `hosted-docker-windows`
- keep fixture-drift/session metadata from drifting back to the legacy label when callers omit `-RequiredLabel`
- record that the live runner label rollout is now done, while runner uptime remains the final blocker for hosted proof

## Testing
- `pwsh -NoLogo -NoProfile -File tests/Assert-RunnerLabelContract.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Update-FixtureDriftSessionIndex.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`

## Remaining blocker
- runner `GHOST-comparevi-org-main` now advertises `hosted-docker-windows`
- hosted Windows execution is still blocked because that runner remains offline
- `#1480` stays open until a hosted `vi-history-scenarios-windows` run completes end to end
