### PR TITLE
#1492 Define a portable hosted Windows NI proof lane

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1448,13 +1448,15 @@ jobs:
     if: needs.smoke-gate.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
     outputs:
       available: ${{ steps.plan.outputs.available }}
       status: ${{ steps.plan.outputs.status }}
       skip_reason: ${{ steps.plan.outputs.skip_reason }}
       summary_path: ${{ steps.plan.outputs.summary_path }}
+      execution_model: ${{ steps.plan.outputs.execution_model }}
+      runner_image: ${{ steps.plan.outputs.runner_image }}
+      expected_context: ${{ steps.plan.outputs.expected_context }}
     steps:
     - uses: actions/checkout@v5
       with:
@@ -1472,19 +1474,18 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - name: Resolve hosted Windows runner availability
+    - name: Resolve portable hosted Windows lane
       id: plan
       shell: pwsh
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         $resultsRoot = 'tests/results/_agent/vi-history-dispatch'
         New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
-        $planPath = Join-Path $resultsRoot 'validate-vi-history-windows-runner-plan.json'
-        pwsh -NoLogo -NoProfile -File tools/Resolve-RunnerAvailability.ps1 `
-          -Repository '${{ github.repository }}' `
-          -RequiredLabel 'hosted-docker-windows' `
-          -RequiredOs 'Windows' `
+        $planPath = Join-Path $resultsRoot 'validate-vi-history-windows-hosted-plan.json'
+        pwsh -NoLogo -NoProfile -File tools/Resolve-HostedWindowsLanePlan.ps1 `
+          -RunnerImage 'windows-2022' `
+          -ContainerImage 'nationalinstruments/labview:2026q1-windows' `
+          -ExpectedContext 'default' `
+          -ExpectedOs 'windows' `
           -OutputJsonPath $planPath `
           -GitHubOutputPath $env:GITHUB_OUTPUT `
           -StepSummaryPath $env:GITHUB_STEP_SUMMARY
@@ -1497,10 +1498,12 @@ jobs:
             '### VI History Scenarios (Windows hosted plan)',
             '',
             ('- execute_lanes: `{0}`' -f '${{ needs.vi-history-scenarios-plan.outputs.execute_lanes }}'),
-            ('- runner_available: `{0}`' -f '${{ steps.plan.outputs.available }}'),
-            ('- runner_status: `{0}`' -f '${{ steps.plan.outputs.status }}'),
+            ('- lane_available: `{0}`' -f '${{ steps.plan.outputs.available }}'),
+            ('- lane_status: `{0}`' -f '${{ steps.plan.outputs.status }}'),
             ('- skip_reason: `{0}`' -f '${{ steps.plan.outputs.skip_reason }}'),
-            '- hosted model: agents can dispatch this hosted Windows lane while continuing on local Linux or Windows Docker Desktop lanes.'
+            ('- hosted_model: `{0}`' -f '${{ steps.plan.outputs.execution_model }}'),
+            ('- runner_image: `{0}`' -f '${{ steps.plan.outputs.runner_image }}'),
+            '- hosted model: agents can dispatch this portable hosted Windows lane while continuing on local Linux or Windows Docker Desktop lanes.'
           )
           $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
         }
@@ -1509,17 +1512,16 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: validate-vi-history-windows-runner-plan
-        path: tests/results/_agent/vi-history-dispatch/validate-vi-history-windows-runner-plan.json
+        name: validate-vi-history-windows-hosted-plan
+        path: tests/results/_agent/vi-history-dispatch/validate-vi-history-windows-hosted-plan.json
         if-no-files-found: error
 
   vi-history-scenarios-windows:
     needs: [smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan, vi-history-scenarios-windows-plan]
     if: needs.smoke-gate.outputs.skip != 'true' && needs.vi-history-scenarios-plan.outputs.execute_lanes == 'true' && needs.vi-history-scenarios-windows-plan.outputs.available == 'true'
-    runs-on: [self-hosted, Windows, X64, hosted-docker-windows]
+    runs-on: windows-2022
     timeout-minutes: 50
     permissions:
-      actions: read
       contents: read
     env:
       NI_WINDOWS_IMAGE: nationalinstruments/labview:2026q1-windows
@@ -1535,8 +1537,9 @@ jobs:
             '### VI History Scenarios (Windows lane)',
             '',
             ('- execute_lanes: `{0}`' -f '${{ needs.vi-history-scenarios-plan.outputs.execute_lanes }}'),
-            ('- runner_status: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.status }}'),
-            ('- runner_skip_reason: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.skip_reason }}'),
+            ('- hosted_status: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.status }}'),
+            ('- runner_image: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.runner_image }}'),
+            ('- expected_context: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.expected_context }}'),
             '- image pull budget: Windows image hydration is materially slower than the Linux lane, so keep local lanes active while hosted proof runs.'
           )
           $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
@@ -1559,20 +1562,6 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - name: Assert hosted Windows runner label contract
-      shell: pwsh
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        $resultsRoot = 'tests/results/local-parity/windows'
-        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
-        $summaryPath = Join-Path $resultsRoot 'runner-label-contract.json'
-        pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 `
-          -RequiredLabel 'hosted-docker-windows' `
-          -OutputJsonPath $summaryPath `
-          -GitHubOutputPath $env:GITHUB_OUTPUT `
-          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
-
     - name: Prepare NI Windows image and runtime
       shell: pwsh
       run: |
@@ -1582,6 +1571,7 @@ jobs:
         pwsh -NoLogo -NoProfile -File tools/Test-WindowsNI2026q1HostPreflight.ps1 `
           -Image $env:NI_WINDOWS_IMAGE `
           -ResultsDir $resultsRoot `
+          -ExecutionSurface 'github-hosted-windows' `
           -OutputJsonPath $summaryPath `
           -GitHubOutputPath $env:GITHUB_OUTPUT `
           -StepSummaryPath $env:GITHUB_STEP_SUMMARY
@@ -1685,7 +1675,6 @@ jobs:
           tests/results/local-parity/windows/ni-windows-container-stdout.txt
           tests/results/local-parity/windows/ni-windows-container-stderr.txt
           tests/results/local-parity/windows/container-export/**
-          tests/results/local-parity/windows/runner-label-contract.json
           tests/results/local-parity/windows/windows-ni-2026q1-host-preflight.json
           tests/results/local-parity/windows/runtime-manager-compare-windows.json
         if-no-files-found: warn

--- a/.github/workflows/windows-hosted-parity.yml
+++ b/.github/workflows/windows-hosted-parity.yml
@@ -1,4 +1,4 @@
-name: Windows Hosted Parity (Manual)
+name: Windows Hosted NI Proof (Manual)
 
 on:
   workflow_dispatch:
@@ -13,11 +13,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  parity:
-    runs-on: windows-latest
-    timeout-minutes: 12
+  hosted-ni-proof:
+    runs-on: windows-2022
+    timeout-minutes: 50
     permissions:
       contents: read
+    env:
+      NI_WINDOWS_IMAGE: nationalinstruments/labview:2026q1-windows
+      NI_WINDOWS_LABVIEW_PATH: C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe
+    defaults:
+      run:
+        shell: pwsh
     steps:
     - uses: actions/checkout@v5
 
@@ -30,7 +36,6 @@ jobs:
 
     - name: Runner health (notice-only)
       if: ${{ vars.RUNNER_HEALTH != '0' }}
-      shell: pwsh
       run: pwsh -File tools/Collect-RunnerHealth.ps1 -AppendSummary -EmitJson
 
     - name: Hooks preflight parity
@@ -38,26 +43,118 @@ jobs:
         node tools/npm/run-script.mjs hooks:plane
         node tools/npm/run-script.mjs hooks:preflight
 
-    - name: Write parity summary
-      shell: pwsh
+    - name: Prepare NI Windows image and hosted runtime
       run: |
-        $outDir = 'tests/results/windows-hosted-parity'
-        New-Item -ItemType Directory -Path $outDir -Force | Out-Null
-        $summary = [ordered]@{
-          schema = 'windows-hosted-parity@v1'
-          generatedAt = (Get-Date).ToUniversalTime().ToString('o')
-          workflow = '${{ github.workflow }}'
-          runId = '${{ github.run_id }}'
-          runAttempt = '${{ github.run_attempt }}'
-          runnerOs = '${{ runner.os }}'
-          note = 'Hosted Windows parity only; no Docker engine mutation and no NI Windows container compare.'
-        }
-        $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $outDir 'summary.json') -Encoding utf8
+        $resultsRoot = 'tests/results/windows-hosted-parity'
+        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+        $summaryPath = Join-Path $resultsRoot 'windows-ni-2026q1-host-preflight.json'
+        pwsh -NoLogo -NoProfile -File tools/Test-WindowsNI2026q1HostPreflight.ps1 `
+          -Image $env:NI_WINDOWS_IMAGE `
+          -ResultsDir $resultsRoot `
+          -ExecutionSurface 'github-hosted-windows' `
+          -OutputJsonPath $summaryPath `
+          -GitHubOutputPath $env:GITHUB_OUTPUT `
+          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
 
-    - name: Upload parity artifacts
+    - name: Run NI Windows create comparison report
+      id: windows-compare
+      run: |
+        $resultsRoot = 'tests/results/windows-hosted-parity'
+        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+        $reportPath = Join-Path $resultsRoot 'windows-compare-report.html'
+        "windows_compare_report=$reportPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $runtimeSnapshot = Join-Path $resultsRoot 'runtime-manager-compare-windows.json'
+        pwsh -NoLogo -NoProfile -File tools/Run-NIWindowsContainerCompare.ps1 `
+          -BaseVi 'fixtures/vi-stage/control-rename/Base.vi' `
+          -HeadVi 'fixtures/vi-stage/control-rename/Head.vi' `
+          -Image $env:NI_WINDOWS_IMAGE `
+          -LabVIEWPath $env:NI_WINDOWS_LABVIEW_PATH `
+          -ReportPath $reportPath `
+          -TimeoutSeconds 600 `
+          -RuntimeEngineReadyTimeoutSeconds 180 `
+          -RuntimeEngineReadyPollSeconds 5 `
+          -RuntimeSnapshotPath $runtimeSnapshot
+        $compareExit = $LASTEXITCODE
+
+        $capturePath = Join-Path $resultsRoot 'ni-windows-container-capture.json'
+        if (Test-Path -LiteralPath $capturePath -PathType Leaf) {
+          "windows_compare_capture=$capturePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
+          $gateOutcome = if ($capture.PSObject.Properties['gateOutcome']) { [string]$capture.gateOutcome } else { '' }
+          $resultClass = if ($capture.PSObject.Properties['resultClass']) { [string]$capture.resultClass } else { '' }
+          Write-Host ("[windows-hosted-compare] exit={0} gateOutcome={1} resultClass={2}" -f $compareExit, $gateOutcome, $resultClass)
+          if ($compareExit -ne 0 -and $gateOutcome -ne 'pass') {
+            exit $compareExit
+          }
+        } elseif ($compareExit -ne 0) {
+          throw ("Windows compare failed (exit={0}) and capture file was not found at {1}" -f $compareExit, $capturePath)
+        }
+
+    - name: Validate Windows comparison report artifact contract
+      if: always()
+      run: |
+        $resultsRoot = 'tests/results/windows-hosted-parity'
+        $reportPath = '${{ steps.windows-compare.outputs.windows_compare_report }}'
+        if ([string]::IsNullOrWhiteSpace($reportPath)) {
+          $reportPath = Join-Path $resultsRoot 'windows-compare-report.html'
+        }
+        $capturePath = '${{ steps.windows-compare.outputs.windows_compare_capture }}'
+        if ([string]::IsNullOrWhiteSpace($capturePath)) {
+          $capturePath = Join-Path $resultsRoot 'ni-windows-container-capture.json'
+        }
+        $summaryPath = Join-Path $resultsRoot 'windows-compare-artifact-summary.json'
+        $captureResultClass = ''
+        $captureGateOutcome = ''
+        $captureExists = Test-Path -LiteralPath $capturePath -PathType Leaf
+        if ($captureExists) {
+          $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
+          if ($capture.PSObject.Properties['resultClass']) {
+            $captureResultClass = [string]$capture.resultClass
+          }
+          if ($capture.PSObject.Properties['gateOutcome']) {
+            $captureGateOutcome = [string]$capture.gateOutcome
+          }
+        }
+
+        $reportExists = Test-Path -LiteralPath $reportPath -PathType Leaf
+        $compareSucceeded = '${{ steps.windows-compare.conclusion }}' -eq 'success'
+
+        $payload = [ordered]@{
+          schema = 'vi-history/windows-compare-artifact-summary@v1'
+          generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+          compareStepConclusion = '${{ steps.windows-compare.conclusion }}'
+          reportPath = $reportPath
+          reportExists = [bool]$reportExists
+          capturePath = $capturePath
+          captureExists = [bool]$captureExists
+          captureResultClass = $captureResultClass
+          captureGateOutcome = $captureGateOutcome
+        }
+        $payload | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+        $requireReport = $compareSucceeded -and [string]::Equals($captureResultClass, 'success-diff', [System.StringComparison]::OrdinalIgnoreCase)
+        if ($requireReport -and -not $reportExists) {
+          throw ("Windows compare classified success-diff but report file was not found: {0}" -f $reportPath)
+        }
+        if ($compareSucceeded -and -not $reportExists -and -not $requireReport) {
+          Write-Host ("::warning::Windows compare succeeded without diff classification ({0}); no report file was generated at {1}." -f $captureResultClass, $reportPath)
+        }
+        if (-not $reportExists) {
+          Write-Host ("::warning::Windows comparison report not found at {0}" -f $reportPath)
+        }
+
+    - name: Upload Windows hosted proof artifacts
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: windows-hosted-parity
-        path: tests/results/windows-hosted-parity/**
+        name: windows-hosted-ni-proof
+        path: |
+          tests/results/windows-hosted-parity/windows-compare-report.html
+          tests/results/windows-hosted-parity/windows-compare-artifact-summary.json
+          tests/results/windows-hosted-parity/windows-ni-2026q1-host-preflight.json
+          tests/results/windows-hosted-parity/ni-windows-container-capture.json
+          tests/results/windows-hosted-parity/ni-windows-container-stdout.txt
+          tests/results/windows-hosted-parity/ni-windows-container-stderr.txt
+          tests/results/windows-hosted-parity/container-export/**
+          tests/results/windows-hosted-parity/runtime-manager-compare-windows.json
         if-no-files-found: warn

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -400,8 +400,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   `vi-history-scenarios-*` runs for `compare-engine-history`, `docker-vi-history`, `mixed-runtime`, `unclassified`, and
   explicit manual dispatches; the final VI-history plan still honors `history_scenario_set`.
 - Hosted Windows mirror proof now lives in `Validate` as the non-required `vi-history-scenarios-windows` lane.
-  That lane only runs when a `hosted-docker-windows` runner is online, and it is expected to hydrate
-  `nationalinstruments/labview:2026q1-windows` much more slowly than the Linux lane.
+  That lane runs on GitHub-hosted `windows-2022`, hydrates
+  `nationalinstruments/labview:2026q1-windows` with no repository runner dependency, and is expected to
+  take materially longer to pull than the Linux lane.
   Agents can dispatch the hosted lane while continuing with the manual Linux or Windows Docker Desktop/WSL2 lanes locally.
 - Machine-readable routing evidence is written to
   `tests/results/_agent/validate-scope-plan/validate-scope-plan.json` and summarized in the Validate step summary so

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -89,7 +89,7 @@ Notes:
 - The `windows-mirror-proof` local VI-history profile is pinned to this same image and is proof-only in the first
   slice; it is not a warm or accelerated lane.
 - Hosted CI now has a matching non-required Windows proof lane in `Validate`:
-  `vi-history-scenarios-windows`. It runs on a `hosted-docker-windows` runner, bootstraps
+  `vi-history-scenarios-windows`. It runs on GitHub-hosted `windows-2022`, bootstraps
   `nationalinstruments/labview:2026q1-windows`, and uses the same canonical in-container LabVIEW path:
   `C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe`.
 - Expect the hosted Windows image pull to be materially slower than the Linux lane.

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Feature Branch Enforcement & Merge Queue
 
-| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` when a `hosted-docker-windows` runner is online. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
+| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
 
 ## Purpose
 
@@ -73,7 +73,7 @@ promotion behavior, not the branch-class source of truth.
 ### GitHub rulesets
 | Ruleset ID | Scope                | Highlights                                                                                   |
 |------------|----------------------|----------------------------------------------------------------------------------------------|
-| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` when a `hosted-docker-windows` runner is online. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
+| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
 | `8614140`  | `refs/heads/main`    | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`, `commit-integrity`. Required approving reviews: `0`. |
 | `8614172`  | `refs/heads/release/*` | No merge queue; protects against force-push/deletion. Required checks: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`. Required approving reviews: `0`. |
 
@@ -110,8 +110,8 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 - **Required checks**: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`,
   `Policy Guard (Upstream) / policy-guard`,
   `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`.
-- **Non-required hosted proof**: `vi-history-scenarios-windows` may run on the dedicated
-  `hosted-docker-windows` runner to validate `nationalinstruments/labview:2026q1-windows`. Agents may
+- **Non-required hosted proof**: `vi-history-scenarios-windows` may run on GitHub-hosted
+  `windows-2022` to validate `nationalinstruments/labview:2026q1-windows`. Agents may
   dispatch that hosted lane while manually running the Linux or Windows Docker Desktop/WSL2 lanes on this host.
 - **Admin bypass**: leave disabled; administrators should only intervene when `priority:policy` confirms parity.
 - **Reapply**: Use `node tools/npm/run-script.mjs priority:policy -- --apply` to push the manifest configuration when drift is detected.

--- a/docs/schemas/comparevi-windows-host-preflight-v1.schema.json
+++ b/docs/schemas/comparevi-windows-host-preflight-v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/comparevi-windows-host-preflight-v1.schema.json",
+  "title": "CompareVI Windows Host Preflight v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAtUtc",
+    "executionSurface",
+    "image",
+    "status",
+    "failureClass",
+    "failureMessage",
+    "contexts",
+    "runtimeProvider",
+    "runtimeDeterminism",
+    "bootstrap",
+    "probe",
+    "hostedContract"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi/windows-host-preflight@v1"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "executionSurface": {
+      "enum": ["desktop-local", "github-hosted-windows"]
+    },
+    "image": {
+      "type": "string"
+    },
+    "status": {
+      "enum": ["pending", "ready", "warning", "failure"]
+    },
+    "failureClass": {
+      "type": "string"
+    },
+    "failureMessage": {
+      "type": "string"
+    },
+    "runnerEnvironment": {
+      "type": "string"
+    },
+    "contexts": {
+      "type": "object",
+      "required": ["start", "startOsType", "final", "finalOsType"],
+      "properties": {
+        "start": { "type": "string" },
+        "startOsType": { "type": "string" },
+        "final": { "type": "string" },
+        "finalOsType": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "runtimeProvider": {
+      "type": "string"
+    },
+    "runtimeDeterminism": {
+      "type": "object",
+      "required": ["status", "reason", "snapshotPath", "failureClass"],
+      "properties": {
+        "status": { "type": "string" },
+        "reason": { "type": "string" },
+        "snapshotPath": { "type": "string" },
+        "failureClass": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "bootstrap": {
+      "type": "object",
+      "required": [
+        "attempted",
+        "pulled",
+        "imagePresent",
+        "localImageId",
+        "localRepoDigest",
+        "localDigest",
+        "pullDurationMs",
+        "pullError"
+      ],
+      "properties": {
+        "attempted": { "type": "boolean" },
+        "pulled": { "type": "boolean" },
+        "imagePresent": { "type": "boolean" },
+        "localImageId": { "type": "string" },
+        "localRepoDigest": { "type": "string" },
+        "localDigest": { "type": "string" },
+        "pullDurationMs": { "type": "integer", "minimum": 0 },
+        "pullError": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "probe": {
+      "type": "object",
+      "required": ["attempted", "status", "exitCode", "durationMs", "output", "command", "error"],
+      "properties": {
+        "attempted": { "type": "boolean" },
+        "status": { "type": "string" },
+        "exitCode": { "type": "integer" },
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "output": { "type": "string" },
+        "command": { "type": "string" },
+        "error": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "hostedContract": {
+      "type": "object",
+      "required": ["hostEngineMutationAllowed", "expectedContext", "expectedOs"],
+      "properties": {
+        "hostEngineMutationAllowed": { "type": "boolean" },
+        "expectedContext": { "type": "string" },
+        "expectedOs": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/Resolve-HostedWindowsLanePlan.Tests.ps1
+++ b/tests/Resolve-HostedWindowsLanePlan.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Resolve-HostedWindowsLanePlan.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Resolve-HostedWindowsLanePlan.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Resolve-HostedWindowsLanePlan.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'writes a portable hosted Windows plan artifact and GitHub outputs' {
+    $work = Join-Path $TestDrive 'hosted-plan'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $outputJsonPath = Join-Path $work 'hosted-plan.json'
+    $githubOutputPath = Join-Path $work 'github-output.txt'
+    $stepSummaryPath = Join-Path $work 'step-summary.md'
+
+    {
+      & $script:ToolPath `
+        -RunnerImage 'windows-2022' `
+        -ContainerImage 'nationalinstruments/labview:2026q1-windows' `
+        -ExpectedContext 'default' `
+        -ExpectedOs 'windows' `
+        -OutputJsonPath $outputJsonPath `
+        -GitHubOutputPath $githubOutputPath `
+        -StepSummaryPath $stepSummaryPath
+    } | Should -Not -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.schema | Should -Be 'hosted-windows-lane-plan@v1'
+    $json.status | Should -Be 'portable-hosted'
+    $json.available | Should -BeTrue
+    $json.executionModel | Should -Be 'github-hosted-windows'
+    $json.runnerImage | Should -Be 'windows-2022'
+    $json.expectedContext | Should -Be 'default'
+    $json.expectedOs | Should -Be 'windows'
+    $json.hostEngineMutationAllowed | Should -BeFalse
+
+    $ghOutput = Get-Content -LiteralPath $githubOutputPath -Raw
+    $ghOutput | Should -Match 'available=true'
+    $ghOutput | Should -Match 'execution_model=github-hosted-windows'
+    $ghOutput | Should -Match 'runner_image=windows-2022'
+
+    $summary = Get-Content -LiteralPath $stepSummaryPath -Raw
+    $summary | Should -Match '### Hosted Windows Lane Plan'
+    $summary | Should -Match 'runner_image: `windows-2022`'
+  }
+}

--- a/tests/Test-WindowsNI2026q1HostPreflight.Tests.ps1
+++ b/tests/Test-WindowsNI2026q1HostPreflight.Tests.ps1
@@ -1,0 +1,187 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Test-WindowsNI2026q1HostPreflight.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Test-WindowsNI2026q1HostPreflight.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Test-WindowsNI2026q1HostPreflight.ps1 not found: $script:ToolPath"
+    }
+
+    $script:CreateDockerHostedStubs = {
+      param([Parameter(Mandatory)][string]$WorkRoot)
+
+      $binDir = Join-Path $WorkRoot 'bin'
+      New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+      $pwshPath = (Get-Command pwsh -ErrorAction Stop).Source
+
+      $dockerStub = @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+if ($Args.Count -eq 0) { exit 0 }
+
+$requestedContext = ''
+if ($Args.Count -ge 3 -and $Args[0] -eq '--context') {
+  $requestedContext = [string]$Args[1]
+  $Args = @($Args | Select-Object -Skip 2)
+}
+
+if ($Args[0] -eq 'context' -and $Args.Count -ge 2 -and $Args[1] -eq 'show') {
+  $ctx = [Environment]::GetEnvironmentVariable('DOCKER_STUB_CONTEXT')
+  if ([string]::IsNullOrWhiteSpace($ctx)) { $ctx = 'default' }
+  Write-Output $ctx
+  exit 0
+}
+
+if ($Args[0] -eq 'context' -and $Args.Count -ge 2 -and $Args[1] -eq 'ls') {
+  $ctx = [Environment]::GetEnvironmentVariable('DOCKER_STUB_CONTEXT')
+  if ([string]::IsNullOrWhiteSpace($ctx)) { $ctx = 'default' }
+  $rows = @(
+    [ordered]@{
+      Name = 'default'
+      Current = if ($ctx -eq 'default') { 'true' } else { 'false' }
+      Description = 'Current DOCKER_HOST based configuration'
+      DockerEndpoint = 'npipe:////./pipe/docker_engine'
+      Error = ''
+    }
+  )
+  foreach ($row in $rows) {
+    ($row | ConvertTo-Json -Compress) | Write-Output
+  }
+  exit 0
+}
+
+if ($Args[0] -eq 'context' -and $Args.Count -ge 3 -and $Args[1] -eq 'use') {
+  [System.Environment]::SetEnvironmentVariable('DOCKER_STUB_CONTEXT', $Args[2], 'Process')
+  Write-Output $Args[2]
+  exit 0
+}
+
+if ($Args[0] -eq 'info') {
+  $infoJson = [Environment]::GetEnvironmentVariable('DOCKER_STUB_INFO_JSON')
+  if ($Args -contains '{{json .}}' -and -not [string]::IsNullOrWhiteSpace($infoJson)) {
+    Write-Output $infoJson
+    exit 0
+  }
+  $osType = [Environment]::GetEnvironmentVariable('DOCKER_STUB_OSTYPE')
+  if ([string]::IsNullOrWhiteSpace($osType)) { $osType = 'windows' }
+  Write-Output $osType
+  exit 0
+}
+
+if ($Args[0] -eq 'image' -and $Args.Count -ge 2 -and $Args[1] -eq 'inspect') {
+  $exists = [Environment]::GetEnvironmentVariable('DOCKER_STUB_IMAGE_EXISTS')
+  if ($exists -eq '1') {
+    Write-Output '{"Id":"sha256:synthetic","RepoDigests":["nationalinstruments/labview:2026q1-windows@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]}'
+    exit 0
+  }
+  [Console]::Error.WriteLine('Error: No such image')
+  exit 1
+}
+
+if ($Args[0] -eq 'pull') {
+  Write-Output 'pulled'
+  exit 0
+}
+
+if ($Args[0] -eq 'run') {
+  Write-Output 'ni-runtime-probe-ok'
+  exit 0
+}
+
+if ($Args[0] -eq 'ps') {
+  exit 0
+}
+
+exit 0
+'@
+      Set-Content -LiteralPath (Join-Path $binDir 'docker.ps1') -Value $dockerStub -Encoding utf8
+
+      $dockerCmd = @"
+@echo off
+"$pwshPath" -NoLogo -NoProfile -File "%~dp0docker.ps1" %*
+"@
+      Set-Content -LiteralPath (Join-Path $binDir 'docker.cmd') -Value $dockerCmd -Encoding ascii
+
+      $wslStub = @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+if ($Args.Count -ge 2 -and $Args[0] -eq '-l' -and $Args[1] -eq '-v') {
+  Write-Output '  NAME              STATE           VERSION'
+  Write-Output '* docker-desktop    Stopped         2'
+  exit 0
+}
+if ($Args.Count -ge 1 -and $Args[0] -eq '--shutdown') {
+  exit 0
+}
+exit 0
+'@
+      Set-Content -LiteralPath (Join-Path $binDir 'wsl.ps1') -Value $wslStub -Encoding utf8
+
+      $wslCmd = @"
+@echo off
+"$pwshPath" -NoLogo -NoProfile -File "%~dp0wsl.ps1" %*
+"@
+      Set-Content -LiteralPath (Join-Path $binDir 'wsl.cmd') -Value $wslCmd -Encoding ascii
+
+      $env:PATH = "{0};{1}" -f $binDir, $env:PATH
+    }
+  }
+
+  BeforeEach {
+    $script:SavedPath = $env:PATH
+    $script:SavedEnv = @{
+      DOCKER_STUB_CONTEXT = $env:DOCKER_STUB_CONTEXT
+      DOCKER_STUB_OSTYPE = $env:DOCKER_STUB_OSTYPE
+      DOCKER_STUB_IMAGE_EXISTS = $env:DOCKER_STUB_IMAGE_EXISTS
+      DOCKER_STUB_INFO_JSON = $env:DOCKER_STUB_INFO_JSON
+    }
+  }
+
+  AfterEach {
+    $env:PATH = $script:SavedPath
+    foreach ($name in $script:SavedEnv.Keys) {
+      $value = $script:SavedEnv[$name]
+      if ($null -eq $value -or $value -eq '') {
+        Remove-Item ("Env:{0}" -f $name) -ErrorAction SilentlyContinue
+      } else {
+        Set-Item ("Env:{0}" -f $name) $value
+      }
+    }
+  }
+
+  It 'writes a hosted Windows preflight receipt without Docker Desktop mutation' {
+    $work = Join-Path $TestDrive 'hosted-preflight'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerHostedStubs -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_CONTEXT 'default'
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_INFO_JSON '{"OSType":"windows","OperatingSystem":"Windows Server 2022","Name":"github-hosted","Platform":{"Name":"Docker Engine - Community"}}'
+
+    $resultsRoot = Join-Path $work 'results'
+    $outputJsonPath = Join-Path $resultsRoot 'windows-ni-2026q1-host-preflight.json'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ToolPath `
+      -Image 'nationalinstruments/labview:2026q1-windows' `
+      -ResultsDir $resultsRoot `
+      -ExecutionSurface 'github-hosted-windows' `
+      -OutputJsonPath $outputJsonPath `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.schema | Should -Be 'comparevi/windows-host-preflight@v1'
+    $json.executionSurface | Should -Be 'github-hosted-windows'
+    $json.status | Should -Be 'ready'
+    $json.runtimeProvider | Should -Be 'github-hosted-windows'
+    $json.contexts.final | Should -Be 'default'
+    $json.contexts.finalOsType | Should -Be 'windows'
+    $json.bootstrap.imagePresent | Should -BeTrue
+    $json.probe.status | Should -Be 'success'
+    $json.hostedContract.hostEngineMutationAllowed | Should -BeFalse
+  }
+}

--- a/tools/Resolve-HostedWindowsLanePlan.ps1
+++ b/tools/Resolve-HostedWindowsLanePlan.ps1
@@ -1,0 +1,103 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Resolves the portable hosted Windows execution plan for NI Windows lanes.
+
+.DESCRIPTION
+  Emits a deterministic planning artifact for GitHub-hosted Windows lanes that
+  run the pinned NI Windows container image without depending on repository
+  runner inventory or custom runner labels.
+#>
+[CmdletBinding()]
+param(
+  [string]$RunnerImage = 'windows-2022',
+  [string]$ContainerImage = 'nationalinstruments/labview:2026q1-windows',
+  [string]$ExpectedContext = 'default',
+  [ValidateSet('windows')]
+  [string]$ExpectedOs = 'windows',
+  [string]$OutputJsonPath = 'tests/results/_agent/vi-history-dispatch/validate-vi-history-windows-hosted-plan.json',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [AllowNull()][AllowEmptyString()][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  $dest = Resolve-AbsolutePath -Path $Path
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Add-Content -LiteralPath $dest -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+$outputJsonResolved = Resolve-AbsolutePath -Path $OutputJsonPath
+$outputParent = Split-Path -Parent $outputJsonResolved
+if ($outputParent -and -not (Test-Path -LiteralPath $outputParent -PathType Container)) {
+  New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
+}
+
+$summary = [ordered]@{
+  schema = 'hosted-windows-lane-plan@v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  status = 'portable-hosted'
+  available = $true
+  skipReason = ''
+  failureClass = 'none'
+  failureMessage = ''
+  executionModel = 'github-hosted-windows'
+  runnerImage = $RunnerImage
+  containerImage = $ContainerImage
+  expectedContext = $ExpectedContext
+  expectedOs = $ExpectedOs
+  hostEngineMutationAllowed = $false
+  notes = @(
+    'Portable hosted Windows lanes do not depend on repository-scoped runner registration.',
+    'The pinned NI Windows image must run on the GitHub-hosted Windows runner with no Docker Desktop engine mutation.'
+  )
+}
+
+($summary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $outputJsonResolved -Encoding utf8
+
+Write-GitHubOutput -Key 'available' -Value 'true' -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'status' -Value ([string]$summary.status) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'skip_reason' -Value '' -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'failure_class' -Value 'none' -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'summary_path' -Value $outputJsonResolved -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'execution_model' -Value ([string]$summary.executionModel) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'runner_image' -Value ([string]$summary.runnerImage) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'expected_context' -Value ([string]$summary.expectedContext) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'expected_os' -Value ([string]$summary.expectedOs) -Path $GitHubOutputPath
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  $summaryLines = @(
+    '### Hosted Windows Lane Plan',
+    '',
+    ('- status: `{0}`' -f [string]$summary.status),
+    ('- available: `{0}`' -f ([string]([bool]$summary.available)).ToLowerInvariant()),
+    ('- execution_model: `{0}`' -f [string]$summary.executionModel),
+    ('- runner_image: `{0}`' -f [string]$summary.runnerImage),
+    ('- expected_context: `{0}`' -f [string]$summary.expectedContext),
+    ('- expected_os: `{0}`' -f [string]$summary.expectedOs),
+    ('- container_image: `{0}`' -f [string]$summary.containerImage)
+  )
+  $summaryLines -join "`n" | Out-File -LiteralPath (Resolve-AbsolutePath -Path $StepSummaryPath) -Encoding utf8 -Append
+}
+
+Write-Output $outputJsonResolved

--- a/tools/Test-WindowsNI2026q1HostPreflight.ps1
+++ b/tools/Test-WindowsNI2026q1HostPreflight.ps1
@@ -1,17 +1,26 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-  Deterministic host preflight for NI LabVIEW 2026 q1 Windows container image.
+  Deterministic host preflight for the NI LabVIEW 2026 q1 Windows container image.
 
 .DESCRIPTION
-  Executes the Docker runtime manager in windows-only mode, bootstraps
-  `nationalinstruments/labview:2026q1-windows` when missing, and emits a
-  machine-readable artifact under tests/results/local-parity by default.
+  Supports two execution surfaces:
+
+  - `desktop-local`: uses the Docker runtime manager to probe a local
+    Docker Desktop Windows engine and bootstrap the pinned NI image.
+  - `github-hosted-windows`: validates a hosted Windows Docker engine without
+    any host mutation, then bootstraps and probes the pinned NI image directly.
+
+  The output is normalized into a stable `comparevi/windows-host-preflight@v1`
+  contract so local tooling, hosted workflows, and bundle consumers can share
+  one preflight artifact shape.
 #>
 [CmdletBinding()]
 param(
   [string]$Image = 'nationalinstruments/labview:2026q1-windows',
   [string]$ResultsDir = 'tests/results/local-parity',
+  [ValidateSet('desktop-local', 'github-hosted-windows')]
+  [string]$ExecutionSurface = 'desktop-local',
   [string]$OutputJsonPath = '',
   [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
   [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
@@ -28,10 +37,149 @@ function Resolve-AbsolutePath {
   return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
 }
 
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [AllowNull()][AllowEmptyString()][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  $dest = Resolve-AbsolutePath -Path $Path
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Add-Content -LiteralPath $dest -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function Resolve-PathWithinRepo {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$RelativePath
+  )
+
+  return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $RelativePath))
+}
+
+function Invoke-DockerCommand {
+  param(
+    [Parameter(Mandatory)][string[]]$Arguments,
+    [switch]$IgnoreExitCode
+  )
+
+  $raw = & docker @Arguments 2>&1
+  $exitCode = $LASTEXITCODE
+  $lines = @($raw | ForEach-Object { [string]$_ })
+  $text = ($lines -join "`n")
+
+  if (-not $IgnoreExitCode -and $exitCode -ne 0) {
+    throw ("docker {0} failed (exit={1}). Output: {2}" -f ($Arguments -join ' '), $exitCode, $text)
+  }
+
+  return [pscustomobject]@{
+    ExitCode = [int]$exitCode
+    Lines = $lines
+    Text = $text
+  }
+}
+
+function Ensure-LocalImageAvailability {
+  param(
+    [Parameter(Mandatory)][string]$Image
+  )
+
+  $result = [ordered]@{
+    attempted = $true
+    pulled = $false
+    imagePresent = $false
+    localImageId = ''
+    localRepoDigest = ''
+    localDigest = ''
+    pullDurationMs = 0
+    pullError = ''
+  }
+
+  $inspect = Invoke-DockerCommand -Arguments @('image', 'inspect', $Image, '--format', '{{json .}}') -IgnoreExitCode
+  if ($inspect.ExitCode -ne 0) {
+    $pullStart = Get-Date
+    $pull = Invoke-DockerCommand -Arguments @('pull', $Image) -IgnoreExitCode
+    $result.pullDurationMs = [int]([Math]::Round(((Get-Date) - $pullStart).TotalMilliseconds))
+    if ($pull.ExitCode -ne 0) {
+      $result.pullError = [string]$pull.Text
+      throw ("docker pull failed for '{0}' (exit={1}). Output: {2}" -f $Image, $pull.ExitCode, $pull.Text)
+    }
+    $result.pulled = $true
+    $inspect = Invoke-DockerCommand -Arguments @('image', 'inspect', $Image, '--format', '{{json .}}') -IgnoreExitCode
+  }
+
+  if ($inspect.ExitCode -ne 0) {
+    throw ("Local image inspect failed for '{0}'. Output: {1}" -f $Image, $inspect.Text)
+  }
+
+  $inspectJson = $inspect.Text.Trim() | ConvertFrom-Json -Depth 20
+  $repoDigests = @()
+  if ($inspectJson.PSObject.Properties['RepoDigests']) {
+    $repoDigests = @($inspectJson.RepoDigests | ForEach-Object { [string]$_ })
+  }
+  $repoDigest = if ($repoDigests.Count -gt 0) { [string]$repoDigests[0] } else { '' }
+  $digest = ''
+  if ($repoDigest -match '@(?<digest>sha256:[0-9a-fA-F]+)$') {
+    $digest = [string]$Matches['digest']
+  }
+
+  $result.imagePresent = $true
+  if ($inspectJson.PSObject.Properties['Id']) {
+    $result.localImageId = [string]$inspectJson.Id
+  }
+  $result.localRepoDigest = $repoDigest
+  $result.localDigest = $digest
+  return $result
+}
+
+function Invoke-ContainerRuntimeProbe {
+  param(
+    [Parameter(Mandatory)][string]$Image
+  )
+
+  $args = @(
+    'run',
+    '--rm',
+    '--entrypoint', 'powershell',
+    $Image,
+    '-NoLogo',
+    '-NoProfile',
+    '-Command',
+    "[Console]::WriteLine('ni-runtime-probe-ok')"
+  )
+
+  $start = Get-Date
+  $probe = Invoke-DockerCommand -Arguments $args -IgnoreExitCode
+  $durationMs = [int]([Math]::Round(((Get-Date) - $start).TotalMilliseconds))
+  $text = [string]$probe.Text
+  if ($text.Length -gt 2000) {
+    $text = $text.Substring(0, 2000)
+  }
+
+  return [ordered]@{
+    attempted = $true
+    status = if ($probe.ExitCode -eq 0) { 'success' } else { 'failure' }
+    exitCode = [int]$probe.ExitCode
+    durationMs = $durationMs
+    output = $text
+    command = ($args -join ' ')
+    error = if ($probe.ExitCode -eq 0) { '' } else { $text }
+  }
+}
+
 $repoRoot = Resolve-AbsolutePath -Path (Join-Path $PSScriptRoot '..')
-$managerScript = Join-Path $repoRoot 'tools' 'Invoke-DockerRuntimeManager.ps1'
-if (-not (Test-Path -LiteralPath $managerScript -PathType Leaf)) {
-  throw ("Invoke-DockerRuntimeManager.ps1 not found: {0}" -f $managerScript)
+$runtimeManagerScript = Resolve-PathWithinRepo -RepoRoot $repoRoot -RelativePath 'tools/Invoke-DockerRuntimeManager.ps1'
+$runtimeGuardScript = Resolve-PathWithinRepo -RepoRoot $repoRoot -RelativePath 'tools/Assert-DockerRuntimeDeterminism.ps1'
+if (-not (Test-Path -LiteralPath $runtimeManagerScript -PathType Leaf)) {
+  throw ("Invoke-DockerRuntimeManager.ps1 not found: {0}" -f $runtimeManagerScript)
+}
+if (-not (Test-Path -LiteralPath $runtimeGuardScript -PathType Leaf)) {
+  throw ("Assert-DockerRuntimeDeterminism.ps1 not found: {0}" -f $runtimeGuardScript)
 }
 
 $resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir
@@ -44,15 +192,178 @@ $jsonPathResolved = if ([string]::IsNullOrWhiteSpace($OutputJsonPath)) {
 } else {
   Resolve-AbsolutePath -Path $OutputJsonPath
 }
+$jsonParent = Split-Path -Parent $jsonPathResolved
+if ($jsonParent -and -not (Test-Path -LiteralPath $jsonParent -PathType Container)) {
+  New-Item -ItemType Directory -Path $jsonParent -Force | Out-Null
+}
 
-& $managerScript `
-  -ProbeScope 'windows' `
-  -WindowsImage $Image `
-  -BootstrapWindowsImage:$true `
-  -BootstrapLinuxImage:$false `
-  -RestoreContext 'desktop-windows' `
-  -OutputJsonPath $jsonPathResolved `
-  -GitHubOutputPath $GitHubOutputPath `
-  -StepSummaryPath $StepSummaryPath
+$summary = [ordered]@{
+  schema = 'comparevi/windows-host-preflight@v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  executionSurface = $ExecutionSurface
+  image = $Image
+  status = 'pending'
+  failureClass = 'none'
+  failureMessage = ''
+  runnerEnvironment = if ([string]::IsNullOrWhiteSpace($env:RUNNER_ENVIRONMENT)) { '' } else { [string]$env:RUNNER_ENVIRONMENT }
+  contexts = [ordered]@{
+    start = ''
+    startOsType = ''
+    final = ''
+    finalOsType = ''
+  }
+  runtimeProvider = ''
+  runtimeDeterminism = [ordered]@{
+    status = ''
+    reason = ''
+    snapshotPath = ''
+    failureClass = ''
+  }
+  bootstrap = [ordered]@{
+    attempted = $false
+    pulled = $false
+    imagePresent = $false
+    localImageId = ''
+    localRepoDigest = ''
+    localDigest = ''
+    pullDurationMs = 0
+    pullError = ''
+  }
+  probe = [ordered]@{
+    attempted = $false
+    status = 'not-run'
+    exitCode = -1
+    durationMs = 0
+    output = ''
+    command = ''
+    error = ''
+  }
+  hostedContract = [ordered]@{
+    hostEngineMutationAllowed = $false
+    expectedContext = if ($ExecutionSurface -eq 'github-hosted-windows') { 'default' } else { 'desktop-windows' }
+    expectedOs = 'windows'
+  }
+}
+
+try {
+  if ($ExecutionSurface -eq 'desktop-local') {
+    $summary.runtimeProvider = 'docker-desktop'
+
+    $managerOutput = @(& $runtimeManagerScript `
+      -ProbeScope 'windows' `
+      -WindowsImage $Image `
+      -BootstrapWindowsImage:$true `
+      -BootstrapLinuxImage:$false `
+      -RestoreContext 'desktop-windows' `
+      -OutputJsonPath $jsonPathResolved `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '')
+    $managerPath = @($managerOutput | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
+    if ($managerPath.Count -eq 0) {
+      throw 'Docker runtime manager did not return an output path.'
+    }
+    $managerPathResolved = Resolve-AbsolutePath -Path $managerPath[0]
+    if (-not (Test-Path -LiteralPath $managerPathResolved -PathType Leaf)) {
+      throw ("Docker runtime manager output path was not written: {0}" -f $managerPathResolved)
+    }
+
+    $manager = Get-Content -LiteralPath $managerPathResolved -Raw | ConvertFrom-Json -Depth 20
+    $summary.contexts.start = [string]$manager.contexts.start
+    $summary.contexts.startOsType = [string]$manager.contexts.startOsType
+    $summary.contexts.final = [string]$manager.contexts.final
+    $summary.contexts.finalOsType = [string]$manager.contexts.finalOsType
+    $summary.bootstrap = [ordered]@{
+      attempted = [bool]$manager.probes.windows.bootstrap.attempted
+      pulled = [bool]$manager.probes.windows.bootstrap.pulled
+      imagePresent = [bool]$manager.probes.windows.bootstrap.imagePresent
+      localImageId = [string]$manager.probes.windows.bootstrap.localImageId
+      localRepoDigest = [string]$manager.probes.windows.bootstrap.localRepoDigest
+      localDigest = [string]$manager.probes.windows.bootstrap.localDigest
+      pullDurationMs = [int]$manager.probes.windows.bootstrap.pullDurationMs
+      pullError = [string]$manager.probes.windows.bootstrap.pullError
+    }
+    $summary.probe = [ordered]@{
+      attempted = [bool]$manager.probes.windows.probe.attempted
+      status = [string]$manager.probes.windows.probe.status
+      exitCode = [int]$manager.probes.windows.probe.exitCode
+      durationMs = [int]$manager.probes.windows.probe.durationMs
+      output = [string]$manager.probes.windows.probe.output
+      command = [string]$manager.probes.windows.probe.command
+      error = [string]$manager.probes.windows.probe.error
+    }
+    $summary.runtimeDeterminism.status = 'success'
+    $summary.status = if ([string]::Equals([string]$manager.status, 'success', [System.StringComparison]::OrdinalIgnoreCase)) { 'ready' } else { 'warning' }
+  } else {
+    $summary.runtimeProvider = 'github-hosted-windows'
+    $snapshotPath = Join-Path $resultsDirResolved 'windows-hosted-runtime-determinism.json'
+    & pwsh -NoLogo -NoProfile -File $runtimeGuardScript `
+      -ExpectedOsType 'windows' `
+      -RuntimeProvider 'desktop' `
+      -ExpectedContext 'default' `
+      -AutoRepair:$true `
+      -ManageDockerEngine:$false `
+      -AllowHostEngineMutation:$false `
+      -SnapshotPath $snapshotPath `
+      -GitHubOutputPath ''
+    if ($LASTEXITCODE -ne 0) {
+      throw ("Assert-DockerRuntimeDeterminism.ps1 failed with exit code {0}." -f $LASTEXITCODE)
+    }
+
+    $snapshot = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json -Depth 20
+    $summary.contexts.start = [string]$snapshot.observed.context
+    $summary.contexts.startOsType = [string]$snapshot.observed.osType
+    $summary.contexts.final = [string]$snapshot.observed.context
+    $summary.contexts.finalOsType = [string]$snapshot.observed.osType
+    $summary.runtimeDeterminism.status = [string]$snapshot.result.status
+    $summary.runtimeDeterminism.reason = [string]$snapshot.result.reason
+    $summary.runtimeDeterminism.snapshotPath = $snapshotPath
+    $summary.runtimeDeterminism.failureClass = [string]$snapshot.result.failureClass
+
+    $bootstrap = Ensure-LocalImageAvailability -Image $Image
+    $summary.bootstrap = $bootstrap
+
+    $probe = Invoke-ContainerRuntimeProbe -Image $Image
+    $summary.probe = $probe
+    if ([string]$probe.status -ne 'success') {
+      throw ("Hosted Windows runtime probe failed for image '{0}' (exit={1})." -f $Image, [int]$probe.exitCode)
+    }
+
+    $summary.status = 'ready'
+  }
+} catch {
+  $summary.status = 'failure'
+  $summary.failureClass = 'preflight-failed'
+  $summary.failureMessage = [string]$_.Exception.Message
+  ($summary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jsonPathResolved -Encoding utf8
+  throw
+}
+
+($summary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jsonPathResolved -Encoding utf8
+
+Write-GitHubOutput -Key 'windows_host_preflight_path' -Value $jsonPathResolved -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'windows_host_preflight_status' -Value ([string]$summary.status) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'windows_host_preflight_surface' -Value ([string]$summary.executionSurface) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'windows_host_preflight_context' -Value ([string]$summary.contexts.final) -Path $GitHubOutputPath
+Write-GitHubOutput -Key 'windows_host_preflight_ostype' -Value ([string]$summary.contexts.finalOsType) -Path $GitHubOutputPath
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  $lines = @(
+    '### Windows Host Preflight',
+    '',
+    ('- execution_surface: `{0}`' -f [string]$summary.executionSurface),
+    ('- status: `{0}`' -f [string]$summary.status),
+    ('- image: `{0}`' -f [string]$summary.image),
+    ('- context: `{0}`' -f [string]$summary.contexts.final),
+    ('- docker_ostype: `{0}`' -f [string]$summary.contexts.finalOsType),
+    ('- runtime_provider: `{0}`' -f [string]$summary.runtimeProvider)
+  )
+  if ($summary.bootstrap.pulled) {
+    $lines += ('- image_pull_ms: `{0}`' -f [int]$summary.bootstrap.pullDurationMs)
+  }
+  if (-not [string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+    $lines += ('- failure: `{0}`' -f ([string]$summary.failureMessage -replace '`', "'"))
+  }
+  $lines -join "`n" | Out-File -LiteralPath (Resolve-AbsolutePath -Path $StepSummaryPath) -Encoding utf8 -Append
+}
 
 Write-Output $jsonPathResolved

--- a/tools/policy/certification-matrix.json
+++ b/tools/policy/certification-matrix.json
@@ -35,7 +35,7 @@
       "job_name": "vi-history-scenarios-windows",
       "branch": "develop",
       "event": "pull_request",
-      "runner": "hosted-docker-windows",
+      "runner": "windows-2022",
       "os": "windows",
       "image_tag": "nationalinstruments/labview:2026q1-windows",
       "required_for_stable": false,

--- a/tools/priority/__tests__/docker-labview-path-contract.test.mjs
+++ b/tools/priority/__tests__/docker-labview-path-contract.test.mjs
@@ -20,13 +20,14 @@ test('validate workflow pins explicit LabVIEW paths for hosted Linux and Windows
   assert.match(workflow, /-Image \$env:NI_LINUX_IMAGE/);
   assert.match(workflow, /-LabVIEWPath \$env:NI_LINUX_LABVIEW_PATH/);
   assert.match(workflow, /vi-history-scenarios-windows-plan:/);
-  assert.match(workflow, /Resolve-RunnerAvailability\.ps1/);
+  assert.match(workflow, /Resolve-HostedWindowsLanePlan\.ps1/);
   assert.match(workflow, /vi-history-scenarios-windows:/);
-  assert.match(workflow, /runs-on:\s*\[self-hosted, Windows, X64, hosted-docker-windows\]/);
+  assert.match(workflow, /runs-on:\s*windows-2022/);
   assert.match(workflow, /NI_WINDOWS_IMAGE:\s*nationalinstruments\/labview:2026q1-windows/);
   assert.match(workflow, /NI_WINDOWS_LABVIEW_PATH:\s*C:\\Program Files\\National Instruments\\LabVIEW 2026\\LabVIEW\.exe/);
   assert.match(workflow, /Test-WindowsNI2026q1HostPreflight\.ps1/);
   assert.match(workflow, /Run-NIWindowsContainerCompare\.ps1/);
+  assert.match(workflow, /-ExecutionSurface 'github-hosted-windows'/);
   assert.match(workflow, /-Image \$env:NI_WINDOWS_IMAGE/);
   assert.match(workflow, /-LabVIEWPath \$env:NI_WINDOWS_LABVIEW_PATH/);
   assert.match(workflow, /validate-vi-history-scenarios-windows/);
@@ -109,9 +110,12 @@ test('runbook validation no longer executes windows docker fast-loop canary job'
 test('windows hosted parity no longer includes hosted LVCompare babysitting debt', () => {
   const workflow = readRepoFile('.github/workflows/windows-hosted-parity.yml');
 
+  assert.match(workflow, /name:\s*Windows Hosted NI Proof \(Manual\)/);
+  assert.match(workflow, /runs-on:\s*windows-2022/);
   assert.doesNotMatch(workflow, /Verify LVCompare and idle LabVIEW state \(notice-only on hosted\)/);
   assert.doesNotMatch(workflow, /LVCompare\.exe not found at canonical path/);
-  assert.match(workflow, /name:\s*Hooks preflight parity/);
+  assert.match(workflow, /Prepare NI Windows image and hosted runtime/);
+  assert.match(workflow, /Run-NIWindowsContainerCompare\.ps1/);
 });
 
 test('docker desktop fast-loop only accepts lane-specific LabVIEW path contracts', () => {

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -52,21 +52,22 @@ test('validate workflow Linux VI-history lane consumes shared dispatch-plan outp
   assert.doesNotMatch(linuxSection, /pull-requests: read/);
 });
 
-test('validate workflow Windows VI-history lane is gated by shared dispatch planning and runner availability', () => {
+test('validate workflow Windows VI-history lane is gated by shared dispatch planning and portable hosted execution', () => {
   const workflow = readRepoFile('.github/workflows/validate.yml');
   const planSection = extractWorkflowJobSection(workflow, 'vi-history-scenarios-windows-plan', 'vi-history-scenarios-windows');
   const windowsSection = extractWorkflowJobSection(workflow, 'vi-history-scenarios-windows');
 
   assert.match(workflow, /vi-history-scenarios-windows-plan:\s*\r?\n\s+needs:\s*\[smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan\]\r?\n\s+if:\s+needs\.smoke-gate\.outputs\.skip != 'true'/);
-  assert.match(planSection, /permissions:\s*\r?\n\s+actions: read\r?\n\s+contents: read/);
-  assert.match(planSection, /Resolve hosted Windows runner availability/);
-  assert.match(planSection, /tools\/Resolve-RunnerAvailability\.ps1/);
-  assert.match(planSection, /-RequiredLabel 'hosted-docker-windows'/);
+  assert.match(planSection, /permissions:\s*\r?\n\s+contents: read/);
+  assert.match(planSection, /Resolve portable hosted Windows lane/);
+  assert.match(planSection, /tools\/Resolve-HostedWindowsLanePlan\.ps1/);
+  assert.match(planSection, /-RunnerImage 'windows-2022'/);
   assert.match(planSection, /outputs:\s*\r?\n\s+available:\s+\$\{\{\s*steps\.plan\.outputs\.available\s*\}\}/);
 
   assert.match(workflow, /vi-history-scenarios-windows:\s*\r?\n\s+needs:\s*\[smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan, vi-history-scenarios-windows-plan\]\r?\n\s+if:\s+needs\.smoke-gate\.outputs\.skip != 'true' && needs\.vi-history-scenarios-plan\.outputs\.execute_lanes == 'true' && needs\.vi-history-scenarios-windows-plan\.outputs\.available == 'true'/);
-  assert.match(windowsSection, /runs-on:\s*\[self-hosted, Windows, X64, hosted-docker-windows\]/);
-  assert.match(windowsSection, /Assert-RunnerLabelContract\.ps1/);
+  assert.match(windowsSection, /runs-on:\s*windows-2022/);
   assert.match(windowsSection, /Test-WindowsNI2026q1HostPreflight\.ps1/);
+  assert.match(windowsSection, /-ExecutionSurface 'github-hosted-windows'/);
   assert.match(windowsSection, /Run-NIWindowsContainerCompare\.ps1/);
+  assert.doesNotMatch(windowsSection, /Assert-RunnerLabelContract\.ps1/);
 });


### PR DESCRIPTION
## Summary
- replace the Windows VI-history validate lane's repo-runner dependency with a portable GitHub-hosted `windows-2022` plan
- teach the NI Windows host preflight to support both local Docker Desktop and GitHub-hosted Windows contracts with one normalized artifact
- upgrade the manual Windows hosted workflow into a real NI container proof lane and document the hosted model

## Validation
- `pwsh -NoLogo -NoProfile -File tests/Resolve-HostedWindowsLanePlan.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Test-WindowsNI2026q1HostPreflight.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Run-NIWindowsContainerCustomOperation.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/VIHistoryLocalAcceleration.Tests.ps1`
- `node --test tools/priority/__tests__/docker-labview-path-contract.test.mjs tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `git diff --check`

## Follow-ups
- #1493 retire leftover runner-label migration helpers once the hosted lane is stable
- #1494 add cross-OS `cookiecutter` bootstrap for hosted Linux and Windows lanes
