### PR TITLE
Update for standing priority #1421

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -33,9 +33,6 @@
     // Allow a limited buffer of consecutive blank lines while legacy docs are refactored.
     "maximum": 2
   },
-  // Newer markdownlint releases add stricter table-style enforcement; keep it non-blocking
-  // until the legacy documentation corpus is normalized intentionally.
-  "MD060": false,
   "MD041": {
     // Require a top-level heading on the first content line.
     "level": 1

--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ the same summary table to a GitHub issue for stakeholders.
 
 ## Optional inputs
 
-| Input name                 | Default   | Description                                                                 |
-| -------------------------- | --------- | --------------------------------------------------------------------------- |
-| `compare_depth`            | `0`       | Maximum commit pairs to evaluate (`0` = no limit)                           |
-| `compare_modes`            | `default` | Comma/semicolon list of compare modes (`default,attributes,front-panel`) |
-| `compare_ignore_flags`     | `none`    | LVCompare ignore toggles (`none`, `default`, or comma-separated flags)      |
-| `compare_additional_flags` | _(empty)_ | Extra LVCompare switches (space-delimited)                                  |
-| `compare_fail_fast`        | `false`   | Stop after the first diff                                                   |
-| `compare_fail_on_diff`     | `false`   | Fail the workflow when any diff is detected                                 |
-| `sample_id`                | _(empty)_ | Optional concurrency key (advanced use)                                     |
-| `notify_issue`             | _(empty)_ | Issue number to receive the summary table as a comment                      |
+| Input name | Default | Description |
+| --- | --- | --- |
+| `compare_depth` | `0` | Maximum commit pairs to evaluate (`0` = no limit) |
+| `compare_modes` | `default` | Comma/semicolon list of compare modes (`default,attributes,front-panel`) |
+| `compare_ignore_flags` | `none` | LVCompare ignore toggles (`none`, `default`, or comma-separated flags) |
+| `compare_additional_flags` | _(empty)_ | Extra LVCompare switches (space-delimited) |
+| `compare_fail_fast` | `false` | Stop after the first diff |
+| `compare_fail_on_diff` | `false` | Fail the workflow when any diff is detected |
+| `sample_id` | _(empty)_ | Optional concurrency key (advanced use) |
+| `notify_issue` | _(empty)_ | Issue number to receive the summary table as a comment |
 
 These inputs map directly onto the parameters in `tools/Compare-VIHistory.ps1`,
 so advanced behaviour remains available without cluttering the default UX.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -116,11 +116,11 @@ Common remediation:
 ## Tooling helpers
 
 | Variable | Purpose |
-| -------- | ------- |
+| --- | --- |
 | `COMPAREVI_TOOLS_IMAGE` | Default image when `-UseToolsImage` is set without `-ToolsImageTag`. |
-|                          | Used by `tools/Run-NonLVChecksInDocker.ps1`. |
-|                          | Example: `ghcr.io/labview-community-ci-cd/comparevi-tools:latest`. |
-|                          | Mutable tags like `latest` are not sufficient freshness evidence by themselves; repo tooling now forces pull-or-digest evidence before treating them as stale. |
+| | Used by `tools/Run-NonLVChecksInDocker.ps1`. |
+| | Example: `ghcr.io/labview-community-ci-cd/comparevi-tools:latest`. |
+| | Mutable tags like `latest` are not sufficient freshness evidence by themselves; repo tooling now forces pull-or-digest evidence before treating them as stale. |
 
 ## Schema locations
 
@@ -131,7 +131,7 @@ Common remediation:
 ## Runbook & fixture reporting
 
 | Variable | Purpose |
-| -------- | ------- |
+| --- | --- |
 | `RUNBOOK_LOOP_ITERATIONS`, `RUNBOOK_LOOP_QUICK`, `RUNBOOK_LOOP_FAIL_ON_DIFF` | Integration runbook knobs |
 | `FAIL_ON_NEW_STRUCTURAL`, `SUMMARY_VERBOSE` | Fixture reporting strictness |
 | `DELTA_FORCE_V2`, `DELTA_SCHEMA_VERSION` | Fixture delta schema selection |

--- a/docs/LabVIEWCliShimPattern.md
+++ b/docs/LabVIEWCliShimPattern.md
@@ -57,9 +57,9 @@ abstraction, and clean up temporary overrides.
 
 ## Versioning
 
-| Version | Date       | Commit                                  | Notes                            |
-|---------|------------|-----------------------------------------|----------------------------------|
-| 1.0     | 2025-10-14 | 9a3ee054e21157311443c134b9e7dece29f03ce4 | Initial definition and example. |
+| Version | Date | Commit | Notes |
+| --- | --- | --- | --- |
+| 1.0 | 2025-10-14 | 9a3ee054e21157311443c134b9e7dece29f03ce4 | Initial definition and example. |
 
 When the pattern changes (for example, to support additional providers or expanded environment handling),
 increment the version, update this document, and annotate the affected shims with the new version number.

--- a/docs/archive/releases/RELEASE_NOTES_v0.4.1.md
+++ b/docs/archive/releases/RELEASE_NOTES_v0.4.1.md
@@ -61,7 +61,7 @@ Begin updating workflows now to avoid disruption.
 ## 🧪 Contract / Coverage Additions
 
 | Area | Addition | Purpose |
-|------|----------|---------|
+| --- | --- | --- |
 | CompareVI | Short-circuit contract test | Ensures identical-path detection stays stable |
 | Release | Checklist verifier script | Prevents partial / inconsistent tag creation |
 | Runbook | Schema + script | Standardizes environment readiness & documentation |
@@ -69,7 +69,7 @@ Begin updating workflows now to avoid disruption.
 ## 🔭 Roadmap (Forward Looking)
 
 | Target | Planned Item | Status |
-|--------|--------------|--------|
+| --- | --- | --- |
 | v0.5.0 | Remove legacy Base/Head fallback | Planned |
 | v0.5.0 | Expand naming guard to scripts + docs | Planned |
 | v0.5.x | Potential additional runbook event enrichment | Under evaluation |

--- a/docs/plans/VALIDATION_MATRIX.md
+++ b/docs/plans/VALIDATION_MATRIX.md
@@ -10,7 +10,8 @@ single source of truth when deciding which helper to run locally, invoke from VS
   - Scope: workflow linting (`actionlint`), dependency-audit observation, and rendered-review certification.
   - Typical invocation: `pwsh -File tools/PrePush-Checks.ps1`.
   - Exit semantics: `0` = clean, non-zero = lint failure.
-  - Artifacts: `tests/results/_agent/security/dependency-audit-report.json` plus the NI/rendering receipts already emitted by the script.
+  - Artifacts: `tests/results/_agent/security/dependency-audit-report.json`
+    plus the NI/rendering receipts already emitted by the script.
 - **`Invoke-PesterTests.ps1`**
   - Scope: unit plus integration Pester suites.
   - Typical invocation: `pwsh -File Invoke-PesterTests.ps1 -IntegrationMode exclude`.

--- a/docs/release/ROLLBACK_PLAN.md
+++ b/docs/release/ROLLBACK_PLAN.md
@@ -69,7 +69,7 @@ Next Update ETA: <time>
 ## 8. Decision Matrix Snapshot
 
 | Scenario | Action | Tag Path |
-|----------|--------|---------|
+| --- | --- | --- |
 | Single feature regression (naming warning too noisy) | Hotfix adjust warning gating | v0.4.1 |
 | Bitness guard false positives | Hotfix relax guard behind env | v0.4.1 |
 | Multiple interdependent failures | Full rollback | v0.3.x line |

--- a/fixtures/cross-repo/labview-icon-editor/settings-init/history-report.md
+++ b/fixtures/cross-repo/labview-icon-editor/settings-init/history-report.md
@@ -4,13 +4,13 @@ Target: `resource/plugins/NIIconEditor/Miscellaneous/Settings Init.vi`
 Requested Start Ref: `HEAD`
 Effective Start Ref: `8e3f56a41ce7f06519f77dd021d7f0b91234abcd`
 
-| Metric   | Value |
-| ---      | ---   |
-| Modes    | 1     |
+| Metric | Value |
+| --- | --- |
+| Modes | 1 |
 | Comparisons | 2 |
-| Diffs    | 1     |
-| Missing  | 0     |
-| Errors   | 0     |
+| Diffs | 1 |
+| Missing | 0 |
+| Errors | 0 |
 
 ## Bucket summary
 
@@ -18,8 +18,8 @@ Effective Start Ref: `8e3f56a41ce7f06519f77dd021d7f0b91234abcd`
 
 ## Commit pairs
 
-| Mode    | Pair | Base | Head | Diff | Categories | Buckets |
-| ---     | ---  | ---  | ---  | ---  | ---        | ---     |
+| Mode | Pair | Base | Head | Diff | Categories | Buckets |
+| --- | --- | --- | --- | --- | --- | --- |
 | default | 1 | 6c5d77b9e120 (calibrate staging defaults) | 9a8728f4d0bb (Settings Init cosmetic cleanup) | _none_ | vi-attribute | metadata |
 | default | 2 | 9a8728f4d0bb (Settings Init cosmetic cleanup) | 1f2d3c4b5a6e (Preserve icon editor metadata) | 🔄 | vi-attribute | metadata |
 


### PR DESCRIPTION
## Summary
- remove the temporary `MD060: false` override from `.markdownlint.jsonc`
- normalize the finite MD060 offender set across legacy docs and fixtures
- fix the one unrelated MD013 line that blocked a clean re-enable pass
- preserve the docs lane as an intentional normalization pass instead of a policy bypass

## Validation
- `npx --yes markdownlint-cli2@0.21.0 --config .markdownlint.jsonc README.md AGENTS.md docs/**/*.md fixtures/**/*.md tests/**/*.md`
- `git diff --check`
