### PR TITLE
Update for standing priority #1502

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1350,12 +1350,30 @@ jobs:
           $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
           $gateOutcome = if ($capture.PSObject.Properties['gateOutcome']) { [string]$capture.gateOutcome } else { '' }
           $resultClass = if ($capture.PSObject.Properties['resultClass']) { [string]$capture.resultClass } else { '' }
+          $observedDockerHost = if ($capture.PSObject.Properties['observedDockerHost']) { [string]$capture.observedDockerHost } else { '' }
+          $dockerContext = if ($capture.PSObject.Properties['dockerContext']) { [string]$capture.dockerContext } else { '' }
+          $dockerServerOs = if ($capture.PSObject.Properties['dockerServerOs']) { [string]$capture.dockerServerOs } else { '' }
           Write-Host ("[linux-compare] exit={0} gateOutcome={1} resultClass={2}" -f $compareExit, $gateOutcome, $resultClass)
+          Write-Host ("[linux-compare] observedDockerHost={0} dockerContext={1} dockerServerOs={2} capture={3}" -f ($observedDockerHost ?? '<null>'), ($dockerContext ?? '<null>'), ($dockerServerOs ?? '<null>'), $capturePath)
           if ($compareExit -ne 0 -and $gateOutcome -ne 'pass') {
             exit $compareExit
           }
         } elseif ($compareExit -ne 0) {
           throw ("Linux compare failed (exit={0}) and capture file was not found at {1}" -f $compareExit, $capturePath)
+        }
+
+    - name: Show Linux live Docker evidence
+      if: always() && needs.vi-history-scenarios-plan.outputs.execute_lanes == 'true'
+      run: |
+        $resultsRoot = 'tests/results/local-parity/linux'
+        $capturePath = Join-Path $resultsRoot 'ni-linux-container-capture.json'
+        if (Test-Path -LiteralPath $capturePath -PathType Leaf) {
+          pwsh -NoLogo -NoProfile -File tools/Show-NIContainerCaptureEvidence.ps1 `
+            -CapturePath $capturePath `
+            -BasePath $resultsRoot `
+            -TailLineCount 20
+        } else {
+          Write-Host ("::warning::Linux compare capture not found at {0}" -f $capturePath)
         }
 
     - name: Validate Linux comparison report artifact contract
@@ -1603,12 +1621,31 @@ jobs:
           $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
           $gateOutcome = if ($capture.PSObject.Properties['gateOutcome']) { [string]$capture.gateOutcome } else { '' }
           $resultClass = if ($capture.PSObject.Properties['resultClass']) { [string]$capture.resultClass } else { '' }
+          $observedDockerHost = if ($capture.PSObject.Properties['observedDockerHost']) { [string]$capture.observedDockerHost } else { '' }
+          $dockerContext = if ($capture.PSObject.Properties['dockerContext']) { [string]$capture.dockerContext } else { '' }
+          $dockerServerOs = if ($capture.PSObject.Properties['dockerServerOs']) { [string]$capture.dockerServerOs } else { '' }
           Write-Host ("[windows-compare] exit={0} gateOutcome={1} resultClass={2}" -f $compareExit, $gateOutcome, $resultClass)
+          Write-Host ("[windows-compare] observedDockerHost={0} dockerContext={1} dockerServerOs={2} capture={3}" -f ($observedDockerHost ?? '<null>'), ($dockerContext ?? '<null>'), ($dockerServerOs ?? '<null>'), $capturePath)
           if ($compareExit -ne 0 -and $gateOutcome -ne 'pass') {
             exit $compareExit
           }
         } elseif ($compareExit -ne 0) {
           throw ("Windows compare failed (exit={0}) and capture file was not found at {1}" -f $compareExit, $capturePath)
+        }
+
+    - name: Show Windows live Docker evidence
+      if: always()
+      shell: pwsh
+      run: |
+        $resultsRoot = 'tests/results/local-parity/windows'
+        $capturePath = Join-Path $resultsRoot 'ni-windows-container-capture.json'
+        if (Test-Path -LiteralPath $capturePath -PathType Leaf) {
+          pwsh -NoLogo -NoProfile -File tools/Show-NIContainerCaptureEvidence.ps1 `
+            -CapturePath $capturePath `
+            -BasePath $resultsRoot `
+            -TailLineCount 20
+        } else {
+          Write-Host ("::warning::Windows compare capture not found at {0}" -f $capturePath)
         }
 
     - name: Validate Windows comparison report artifact contract

--- a/tests/Run-NILinuxContainerCompare.Tests.ps1
+++ b/tests/Run-NILinuxContainerCompare.Tests.ps1
@@ -742,6 +742,7 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
     Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
     Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '1'
     Set-Item Env:DOCKER_STUB_RUN_STDOUT 'CreateComparisonReport completed with diff.'
+    Set-Item Env:DOCKER_HOST 'unix:///var/run/docker.sock'
 
     $baseVi = Join-Path $work 'Base.vi'
     $headVi = Join-Path $work 'Head.vi'
@@ -774,6 +775,8 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
     $capture.flags | Should -Contain '-Headless'
     $capture.containerName | Should -Match '^ni-lnx-compare-flag-baseline-[a-f0-9]{8}$'
     $capture.command | Should -Match ('docker run --name {0}\b' -f [regex]::Escape([string]$capture.containerName))
+    $capture.observedDockerHost | Should -Be 'unix:///var/run/docker.sock'
+    $capture.runtimeDeterminism.observed.dockerHost | Should -Be 'unix:///var/run/docker.sock'
     $capture.headlessContract.required | Should -BeTrue
     $capture.headlessContract.enforcedCliHeadless | Should -BeTrue
     $capture.headlessContract.lvRteHeadlessEnv | Should -BeTrue
@@ -792,6 +795,7 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
     $cpIndex = [array]::IndexOf($records, $cpRecords[0])
     $rmIndex = [array]::IndexOf($records, $rmRecords[0])
     $cpIndex | Should -BeLessThan $rmIndex
+    ($output -join "`n") | Should -Match 'observedDockerHost=unix:///var/run/docker.sock'
   }
 
   It 'disables prelaunch when reusing an existing linux container' {

--- a/tests/Run-NIWindowsContainerCompare.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCompare.Tests.ps1
@@ -449,6 +449,7 @@ exit 0
     Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-windows'
     Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '1'
     Set-Item Env:DOCKER_STUB_RUN_STDOUT 'CreateComparisonReport completed with diff.'
+    Set-Item Env:DOCKER_HOST 'npipe:////./pipe/docker_engine'
 
     $baseVi = Join-Path $work 'Base.vi'
     $headVi = Join-Path $work 'Head.vi'
@@ -592,6 +593,8 @@ exit 0
     $capture.labviewPath | Should -Be $script:ContainerLabVIEWPath
     $capture.flags | Should -Contain '-noattr'
     $capture.flags | Should -Contain '-Headless'
+    $capture.observedDockerHost | Should -Be 'npipe:////./pipe/docker_engine'
+    $capture.runtimeDeterminism.observed.dockerHost | Should -Be 'npipe:////./pipe/docker_engine'
     $capture.timedOut | Should -BeFalse
     $capture.headlessContract.required | Should -BeTrue
     $capture.headlessContract.enforcedCliHeadless | Should -BeTrue
@@ -631,6 +634,7 @@ exit 0
     $cpIndex = [array]::IndexOf($records, $cpRecords[0])
     $rmIndex = [array]::IndexOf($records, $rmRecords[0])
     $cpIndex | Should -BeLessThan $rmIndex
+    ($output -join "`n") | Should -Match 'observedDockerHost=npipe:////./pipe/docker_engine'
   }
 
   It 'validates report flag labels against docker compare flags' {

--- a/tests/Show-NIContainerCaptureEvidence.Tests.ps1
+++ b/tests/Show-NIContainerCaptureEvidence.Tests.ps1
@@ -1,0 +1,60 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Show-NIContainerCaptureEvidence.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ShowScript = Join-Path $repoRoot 'tools' 'Show-NIContainerCaptureEvidence.ps1'
+    if (-not (Test-Path -LiteralPath $script:ShowScript -PathType Leaf)) {
+      throw "Show-NIContainerCaptureEvidence.ps1 not found at $script:ShowScript"
+    }
+  }
+
+  It 'prints host alignment and tailed stdout/stderr content from a capture artifact' {
+    $work = Join-Path $TestDrive 'capture-evidence'
+    $resultsRoot = Join-Path $work 'results'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+    $stdoutPath = Join-Path $resultsRoot 'ni-linux-container-stdout.txt'
+    $stderrPath = Join-Path $resultsRoot 'ni-linux-container-stderr.txt'
+    $capturePath = Join-Path $resultsRoot 'ni-linux-container-capture.json'
+
+    @(
+      'booting compare'
+      'CreateComparisonReport completed with diff.'
+    ) | Set-Content -LiteralPath $stdoutPath -Encoding utf8
+    @(
+      'notice: prelaunch enabled'
+    ) | Set-Content -LiteralPath $stderrPath -Encoding utf8
+
+    $capture = [ordered]@{
+      schema = 'ni-linux-container-compare/v1'
+      status = 'diff'
+      gateOutcome = 'pass'
+      resultClass = 'success-diff'
+      containerName = 'ni-lnx-compare-test'
+      image = 'nationalinstruments/labview:2026q1-linux'
+      reportPath = (Join-Path $resultsRoot 'linux-compare-report.html')
+      stdoutPath = $stdoutPath
+      stderrPath = $stderrPath
+      observedDockerHost = 'unix:///var/run/docker.sock'
+      dockerContext = 'desktop-linux'
+      dockerServerOs = 'linux'
+    }
+    $capture | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $capturePath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ShowScript `
+      -CapturePath $capturePath `
+      -BasePath $resultsRoot `
+      -TailLineCount 5 2>&1
+
+    $text = $output -join "`n"
+    $text | Should -Match 'observedDockerHost=unix:///var/run/docker.sock'
+    $text | Should -Match 'dockerContext=desktop-linux'
+    $text | Should -Match 'dockerServerOs=linux'
+    $text | Should -Match 'stdout=ni-linux-container-stdout.txt'
+    $text | Should -Match 'stderr=ni-linux-container-stderr.txt'
+    $text | Should -Match '\[ni-container-evidence\]\[stdout\] CreateComparisonReport completed with diff.'
+    $text | Should -Match '\[ni-container-evidence\]\[stderr\] notice: prelaunch enabled'
+  }
+}

--- a/tools/Run-NILinuxContainerCompare.ps1
+++ b/tools/Run-NILinuxContainerCompare.ps1
@@ -2030,6 +2030,7 @@ $capture = [ordered]@{
   timedOut       = $false
   dockerServerOs = $null
   dockerContext  = $null
+  observedDockerHost = $null
   baseVi         = $null
   headVi         = $null
   reportPath     = $null
@@ -2203,10 +2204,13 @@ try {
       observed = [ordered]@{
         osType = $runtimeObj.observed.osType
         context = $runtimeObj.observed.context
+        dockerHost = $runtimeObj.observed.dockerHost
       }
     }
     $capture.dockerServerOs = $runtimeObj.observed.osType
     $capture.dockerContext = $runtimeObj.observed.context
+    $capture.observedDockerHost = $runtimeObj.observed.dockerHost
+    Write-Host ("[ni-linux-container-compare] observedDockerHost={0} dockerContext={1} dockerServerOs={2} runtimeSnapshot={3}" -f (($capture.observedDockerHost ?? '<null>')), (($capture.dockerContext ?? '<null>')), (($capture.dockerServerOs ?? '<null>')), $runtimeSnapshot) -ForegroundColor DarkCyan
   } catch {
     $capture.runtimeDeterminism = [ordered]@{
       status = 'error'

--- a/tools/Run-NIWindowsContainerCompare.ps1
+++ b/tools/Run-NIWindowsContainerCompare.ps1
@@ -940,6 +940,7 @@ $capture = [ordered]@{
   timedOut      = $false
   dockerServerOs= $null
   dockerContext = $null
+  observedDockerHost = $null
   baseVi        = $null
   headVi        = $null
   reportPath    = $null
@@ -1047,10 +1048,13 @@ try {
       observed = [ordered]@{
         osType = $runtimeObj.observed.osType
         context = $runtimeObj.observed.context
+        dockerHost = $runtimeObj.observed.dockerHost
       }
     }
     $capture.dockerServerOs = $runtimeObj.observed.osType
     $capture.dockerContext = $runtimeObj.observed.context
+    $capture.observedDockerHost = $runtimeObj.observed.dockerHost
+    Write-Host ("[ni-container-compare] observedDockerHost={0} dockerContext={1} dockerServerOs={2} runtimeSnapshot={3}" -f (($capture.observedDockerHost ?? '<null>')), (($capture.dockerContext ?? '<null>')), (($capture.dockerServerOs ?? '<null>')), $runtimeSnapshot) -ForegroundColor DarkCyan
   } catch {
     $capture.runtimeDeterminism = [ordered]@{
       status = 'error'

--- a/tools/Show-NIContainerCaptureEvidence.ps1
+++ b/tools/Show-NIContainerCaptureEvidence.ps1
@@ -1,0 +1,146 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][string]$CapturePath,
+  [string]$BasePath = '',
+  [ValidateRange(1, 200)][int]$TailLineCount = 20
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Resolve-DisplayPath {
+  param(
+    [string]$Path,
+    [string]$BasePath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return '<none>'
+  }
+
+  $resolved = $Path
+  try {
+    $resolved = Resolve-AbsolutePath -Path $Path
+  } catch {}
+
+  if ([string]::IsNullOrWhiteSpace($BasePath)) {
+    return $resolved
+  }
+
+  try {
+    $resolvedBase = Resolve-AbsolutePath -Path $BasePath
+    $relative = [System.IO.Path]::GetRelativePath($resolvedBase, $resolved)
+    if (-not [string]::IsNullOrWhiteSpace($relative) -and -not $relative.StartsWith('..')) {
+      return $relative
+    }
+  } catch {}
+
+  return $resolved
+}
+
+function Get-JsonString {
+  param(
+    [AllowNull()]$InputObject,
+    [Parameter(Mandatory)][string]$PropertyName,
+    [string]$Default = ''
+  )
+
+  if ($null -eq $InputObject) {
+    return $Default
+  }
+
+  if ($InputObject.PSObject.Properties[$PropertyName]) {
+    $value = $InputObject.PSObject.Properties[$PropertyName].Value
+    if ($null -eq $value) {
+      return $Default
+    }
+    return ([string]$value).Trim()
+  }
+
+  return $Default
+}
+
+function Write-ArtifactTail {
+  param(
+    [Parameter(Mandatory)][string]$Label,
+    [string]$Path,
+    [int]$TailLineCount,
+    [string]$BasePath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    Write-Host ("[ni-container-evidence] {0}=<none>" -f $Label) -ForegroundColor DarkGray
+    return
+  }
+
+  $resolved = Resolve-AbsolutePath -Path $Path
+  Write-Host ("[ni-container-evidence] {0}={1}" -f $Label, (Resolve-DisplayPath -Path $resolved -BasePath $BasePath)) -ForegroundColor DarkGray
+
+  if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+    Write-Host ("::warning::{0} artifact not found at {1}" -f $Label, $resolved)
+    return
+  }
+
+  $lines = @(Get-Content -LiteralPath $resolved -ErrorAction Stop)
+  if ($lines.Count -eq 0) {
+    Write-Host ("[ni-container-evidence][{0}] <empty>" -f $Label) -ForegroundColor DarkGray
+    return
+  }
+
+  $tail = @($lines | Select-Object -Last $TailLineCount)
+  foreach ($line in $tail) {
+    Write-Host ("[ni-container-evidence][{0}] {1}" -f $Label, $line)
+  }
+}
+
+$resolvedCapturePath = Resolve-AbsolutePath -Path $CapturePath
+if (-not (Test-Path -LiteralPath $resolvedCapturePath -PathType Leaf)) {
+  throw ("Container capture not found: {0}" -f $resolvedCapturePath)
+}
+
+$capture = Get-Content -LiteralPath $resolvedCapturePath -Raw | ConvertFrom-Json -Depth 16
+$runtimeDeterminism = if ($capture.PSObject.Properties['runtimeDeterminism']) { $capture.runtimeDeterminism } else { $null }
+$runtimeObserved = if ($runtimeDeterminism -and $runtimeDeterminism.PSObject.Properties['observed']) { $runtimeDeterminism.observed } else { $null }
+
+$dockerHost = Get-JsonString -InputObject $capture -PropertyName 'observedDockerHost'
+if ([string]::IsNullOrWhiteSpace($dockerHost)) {
+  $dockerHost = Get-JsonString -InputObject $runtimeObserved -PropertyName 'dockerHost'
+}
+$dockerContext = Get-JsonString -InputObject $capture -PropertyName 'dockerContext'
+if ([string]::IsNullOrWhiteSpace($dockerContext)) {
+  $dockerContext = Get-JsonString -InputObject $runtimeObserved -PropertyName 'context'
+}
+$dockerServerOs = Get-JsonString -InputObject $capture -PropertyName 'dockerServerOs'
+if ([string]::IsNullOrWhiteSpace($dockerServerOs)) {
+  $dockerServerOs = Get-JsonString -InputObject $runtimeObserved -PropertyName 'osType'
+}
+
+$status = Get-JsonString -InputObject $capture -PropertyName 'status'
+$gateOutcome = Get-JsonString -InputObject $capture -PropertyName 'gateOutcome'
+$resultClass = Get-JsonString -InputObject $capture -PropertyName 'resultClass'
+$containerName = Get-JsonString -InputObject $capture -PropertyName 'containerName'
+$image = Get-JsonString -InputObject $capture -PropertyName 'image'
+$reportPath = Get-JsonString -InputObject $capture -PropertyName 'reportPath'
+$stdoutPath = Get-JsonString -InputObject $capture -PropertyName 'stdoutPath'
+$stderrPath = Get-JsonString -InputObject $capture -PropertyName 'stderrPath'
+
+Write-Host ("[ni-container-evidence] capture={0} status={1} gateOutcome={2} resultClass={3} container={4} image={5}" -f (Resolve-DisplayPath -Path $resolvedCapturePath -BasePath $BasePath), ($status ?? '<null>'), ($gateOutcome ?? '<null>'), ($resultClass ?? '<null>'), ($containerName ?? '<null>'), ($image ?? '<null>')) -ForegroundColor Cyan
+Write-Host ("[ni-container-evidence] observedDockerHost={0} dockerContext={1} dockerServerOs={2}" -f (($dockerHost ?? '<null>')), (($dockerContext ?? '<null>')), (($dockerServerOs ?? '<null>'))) -ForegroundColor DarkCyan
+
+if (-not [string]::IsNullOrWhiteSpace($reportPath)) {
+  Write-Host ("[ni-container-evidence] report={0}" -f (Resolve-DisplayPath -Path $reportPath -BasePath $BasePath)) -ForegroundColor DarkGray
+}
+
+Write-ArtifactTail -Label 'stdout' -Path $stdoutPath -TailLineCount $TailLineCount -BasePath $BasePath
+Write-ArtifactTail -Label 'stderr' -Path $stderrPath -TailLineCount $TailLineCount -BasePath $BasePath

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -46,6 +46,8 @@ test('validate workflow Linux VI-history lane consumes shared dispatch-plan outp
   assert.match(workflow, /Append VI history Linux lane plan/);
   assert.match(workflow, /needs\.vi-history-scenarios-plan\.outputs\.execute_lanes == 'true'/);
   assert.match(workflow, /needs\.vi-history-scenarios-plan\.outputs\.history_scenario_set/);
+  assert.match(linuxSection, /Show Linux live Docker evidence/);
+  assert.match(linuxSection, /Show-NIContainerCaptureEvidence\.ps1/);
   assert.doesNotMatch(workflow, /Resolve VI history Linux lane execution mode/);
   assert.doesNotMatch(workflow, /vi-history-scenarios-skip-note:/);
   assert.match(linuxSection, /permissions:\s*\r?\n\s+contents: read/);
@@ -69,5 +71,7 @@ test('validate workflow Windows VI-history lane is gated by shared dispatch plan
   assert.match(windowsSection, /Test-WindowsNI2026q1HostPreflight\.ps1/);
   assert.match(windowsSection, /-ExecutionSurface 'github-hosted-windows'/);
   assert.match(windowsSection, /Run-NIWindowsContainerCompare\.ps1/);
+  assert.match(windowsSection, /Show Windows live Docker evidence/);
+  assert.match(windowsSection, /Show-NIContainerCaptureEvidence\.ps1/);
   assert.doesNotMatch(windowsSection, /Assert-RunnerLabelContract\.ps1/);
 });


### PR DESCRIPTION
## Summary
- surface observed Docker host/context/OS in the Linux and Windows NI compare runners
- add a shared helper that prints live capture, stdout, and stderr evidence to the workflow console
- wire the Validate Linux and Windows VI-history scenario lanes to show that evidence before artifact download

## Testing
- `pwsh -NoLogo -NoProfile -File tests/Run-NILinuxContainerCompare.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Run-NIWindowsContainerCompare.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Show-NIContainerCaptureEvidence.Tests.ps1`
- `node --test tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs`
- `node --test tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -File tests/Workflow.ValidateGuard.Tests.ps1`
- `git diff --check`

## Issue
- closes #1502
