### PR TITLE
Clarify CompareVI.Tools immutable tag semantics (#1484)

### DIFF
--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -55,6 +55,13 @@ is the reviewed release tag plus its published checksum/provenance.
    `consumerContract.historyFacade` and
    `consumerContract.hostedNiLinuxRunner`.
 
+   `versionContract` is the authoritative interpretation layer for release
+   identity. Treat `versionContract.authoritativeConsumerPin` as the immutable
+   consumer pin for the bundle. When `versionContract.toolsIteration` is
+   present, `versionContract.baseSemver` and `versionContract.stableFamilyTag`
+   only describe the compatibility family; they do not supersede the immutable
+   `vX.Y.Z-tools.N` release identity.
+
 4. **Import the module from the extracted bundle**
 
    ```powershell

--- a/docs/requirements/DOTNET_CLI_RELEASE_CHECKLIST.md
+++ b/docs/requirements/DOTNET_CLI_RELEASE_CHECKLIST.md
@@ -15,6 +15,9 @@
       match the release semver/core version.
 - [ ] `CompareVI.Tools.psd1` `ModuleVersion` (and prerelease metadata, when
       used) matches the release semver.
+- [ ] If `CompareVI.Tools` publishes `X.Y.Z-tools.N`, the release plan and
+      bundle metadata treat `vX.Y.Z-tools.N` as the immutable consumer pin and
+      `vX.Y.Z` only as the stable-family alias.
 
 ## Stable backend surfaces
 
@@ -23,6 +26,9 @@
 - [ ] `CompareVi.Shared` package version matches the backend release semver.
 - [ ] `CompareVI.Tools` bundle is published from the same source ref/tag as the
       CLI assets.
+- [ ] `comparevi-tools-release.json` exposes a version contract that separates
+      compatibility family (`X.Y.Z`) from immutable tools payload identity
+      (`X.Y.Z-tools.N` when present).
 - [ ] Release notes call out stable versus rc expectations explicitly.
 
 ## Artifact packaging

--- a/docs/schemas/comparevi-tools-release-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-tools-release-manifest-v1.schema.json
@@ -7,6 +7,7 @@
     "schema",
     "generatedAtUtc",
     "module",
+    "versionContract",
     "source",
     "compatibility",
     "consumerContract",
@@ -49,6 +50,61 @@
           "type": "string"
         },
         "exportedFunctions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "versionContract": {
+      "type": "object",
+      "required": [
+        "schema",
+        "baseSemver",
+        "releaseVersion",
+        "stableFamilyTag",
+        "stableFamilyTagMutable",
+        "toolsIteration",
+        "authoritativeConsumerPin",
+        "authoritativeConsumerPinKind",
+        "notes"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-tools/version-contract@v1"
+        },
+        "baseSemver": {
+          "type": "string"
+        },
+        "releaseVersion": {
+          "type": "string"
+        },
+        "stableFamilyTag": {
+          "type": "string"
+        },
+        "stableFamilyTagMutable": {
+          "type": "boolean"
+        },
+        "toolsIteration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "authoritativeConsumerPin": {
+          "type": "string"
+        },
+        "authoritativeConsumerPinKind": {
+          "type": "string",
+          "enum": [
+            "release-tag",
+            "release-version"
+          ]
+        },
+        "notes": {
           "type": "array",
           "items": {
             "type": "string"

--- a/tests/CompareVITools.Artifact.Tests.ps1
+++ b/tests/CompareVITools.Artifact.Tests.ps1
@@ -79,6 +79,15 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $metadata.module.name | Should -Be 'CompareVI.Tools'
     $metadata.module.version | Should -Be $moduleVersion
     $metadata.module.releaseVersion | Should -Be $moduleReleaseVersion
+    $metadata.versionContract.schema | Should -Be 'comparevi-tools/version-contract@v1'
+    $metadata.versionContract.baseSemver | Should -Be $moduleVersion
+    $metadata.versionContract.releaseVersion | Should -Be $moduleReleaseVersion
+    $metadata.versionContract.stableFamilyTag | Should -Be "v$moduleVersion"
+    $metadata.versionContract.stableFamilyTagMutable | Should -Be ($moduleReleaseVersion -ne $moduleVersion)
+    $metadata.versionContract.toolsIteration | Should -BeNullOrEmpty
+    $metadata.versionContract.authoritativeConsumerPin | Should -Be 'v9.9.9'
+    $metadata.versionContract.authoritativeConsumerPinKind | Should -Be 'release-tag'
+    ((@($metadata.versionContract.notes) -join [Environment]::NewLine)) | Should -Match 'immutable consumer identity'
     @($metadata.module.exportedFunctions) | Should -Contain 'Invoke-CompareVIHistoryFacade'
     @($metadata.module.exportedFunctions) | Should -Contain 'Invoke-CompareVIHistoryLocalRefinementFacade'
     @($metadata.module.exportedFunctions) | Should -Contain 'Invoke-CompareVIHistoryLocalOperatorSessionFacade'
@@ -151,6 +160,7 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $bundleReadme | Should -Match 'labview-icon-editor-demo'
     $bundleReadme | Should -Match 'comparevi-history'
     $bundleReadme | Should -Match 'windows-mirror-proof'
+    $bundleReadme | Should -Match 'authoritativeConsumerPin'
 
     $expectedFiles = @(
       'comparevi-tools-release.json',
@@ -201,6 +211,44 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Test-WindowsNI2026q1HostPreflight.ps1'
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Assert-DockerRuntimeDeterminism.ps1'
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Compare-ExitCodeClassifier.ps1'
+  }
+
+  It 'records tools-iteration releases as immutable toolchain identities distinct from the stable family alias' {
+    $outDir = Join-Path $TestDrive 'artifacts-tools-iteration'
+    $metadataPath = Join-Path $TestDrive 'comparevi-tools-artifact-tools-iteration.json'
+    $tempModulePath = Join-Path $TestDrive 'CompareVI.Tools.ToolsIteration.psd1'
+    $tempModuleContents = Get-Content -LiteralPath $modulePath -Raw
+    $tempModuleContents = $tempModuleContents.Replace(
+      "ProjectUri = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'",
+      "ProjectUri = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'`r`n      Prerelease = 'tools.14'"
+    )
+    Set-Content -LiteralPath $tempModulePath -Value $tempModuleContents -Encoding utf8
+    $relativeModulePath = [System.IO.Path]::GetRelativePath($repoRoot, $tempModulePath)
+
+    & $publishScript `
+      -ModuleManifestPath $relativeModulePath `
+      -OutputRoot $outDir `
+      -MetadataReportPath $metadataPath `
+      -Repository 'owner/repo' `
+      -SourceRef 'refs/tags/v0.6.3-tools.14' `
+      -SourceSha '0123456789abcdef0123456789abcdef01234567' `
+      -ReleaseTag 'v0.6.3-tools.14'
+
+    Test-Path -LiteralPath $metadataPath | Should -BeTrue
+    & $schemaScript -JsonPath $metadataPath -SchemaPath $schemaPath
+    $LASTEXITCODE | Should -Be 0
+
+    $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+    $metadata.module.version | Should -Be '0.6.3'
+    $metadata.module.releaseVersion | Should -Be '0.6.3-tools.14'
+    $metadata.versionContract.baseSemver | Should -Be '0.6.3'
+    $metadata.versionContract.releaseVersion | Should -Be '0.6.3-tools.14'
+    $metadata.versionContract.stableFamilyTag | Should -Be 'v0.6.3'
+    $metadata.versionContract.stableFamilyTagMutable | Should -BeTrue
+    $metadata.versionContract.toolsIteration | Should -Be 14
+    $metadata.versionContract.authoritativeConsumerPin | Should -Be 'v0.6.3-tools.14'
+    $metadata.versionContract.authoritativeConsumerPinKind | Should -Be 'release-tag'
+    ((@($metadata.versionContract.notes) -join [Environment]::NewLine)) | Should -Match 'stableFamilyTag'
   }
 
   It 'emits an empty prerelease GitHub output for stable CompareVI.Tools bundles' {

--- a/tools/Publish-CompareVIToolsArtifact.ps1
+++ b/tools/Publish-CompareVIToolsArtifact.ps1
@@ -110,6 +110,42 @@ function Write-GitHubOutputValue {
   "$Key=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 }
 
+function Get-CompareVIToolsVersionContract {
+  param(
+    [Parameter(Mandatory = $true)][string]$ModuleVersion,
+    [Parameter(Mandatory = $true)][string]$ModuleReleaseVersion,
+    [AllowEmptyString()][string]$ReleaseTag
+  )
+
+  $toolsIteration = $null
+  $toolsMatch = [regex]::Match($ModuleReleaseVersion, '^(?<family>\d+\.\d+\.\d+)-tools\.(?<iteration>\d+)$')
+  if ($toolsMatch.Success) {
+    $toolsIteration = [int]$toolsMatch.Groups['iteration'].Value
+  }
+
+  $stableFamilyTag = "v$ModuleVersion"
+  $releaseTagNormalized = if ([string]::IsNullOrWhiteSpace($ReleaseTag)) { $null } else { $ReleaseTag.Trim() }
+  $authoritativePin = if ($releaseTagNormalized) { $releaseTagNormalized } else { $ModuleReleaseVersion }
+  $authoritativePinKind = if ($releaseTagNormalized) { 'release-tag' } else { 'release-version' }
+  $stableFamilyTagMutable = $ModuleReleaseVersion -ne $ModuleVersion
+
+  return [ordered]@{
+    schema = 'comparevi-tools/version-contract@v1'
+    baseSemver = $ModuleVersion
+    releaseVersion = $ModuleReleaseVersion
+    stableFamilyTag = $stableFamilyTag
+    stableFamilyTagMutable = $stableFamilyTagMutable
+    toolsIteration = $toolsIteration
+    authoritativeConsumerPin = $authoritativePin
+    authoritativeConsumerPinKind = $authoritativePinKind
+    notes = @(
+      'Use authoritativeConsumerPin as the immutable consumer identity for this bundle.',
+      'baseSemver and stableFamilyTag describe the compatibility family, not a mutable-friendly pin override.',
+      'When toolsIteration is present, stableFamilyTag stays on the X.Y.Z family while the immutable bundle identity moves to X.Y.Z-tools.N.'
+    )
+  }
+}
+
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
 $moduleManifestResolved = (Resolve-Path -LiteralPath (Join-Path $repoRoot $ModuleManifestPath)).Path
 $moduleRoot = Split-Path -Parent $moduleManifestResolved
@@ -181,6 +217,10 @@ $resolvedReleaseTag = if (-not [string]::IsNullOrWhiteSpace($ReleaseTag)) {
 } else {
   ''
 }
+$versionContract = Get-CompareVIToolsVersionContract `
+  -ModuleVersion $moduleVersion `
+  -ModuleReleaseVersion $moduleReleaseVersion `
+  -ReleaseTag $resolvedReleaseTag
 
 $outputRootResolved = if ([System.IO.Path]::IsPathRooted($OutputRoot)) {
   $OutputRoot
@@ -241,6 +281,7 @@ try {
     '- For Windows mirror proof on a Windows host, keep `tools/Test-WindowsNI2026q1HostPreflight.ps1` and `tools/Run-NIWindowsContainerCompare.ps1` adjacent in the extracted bundle; `windows-mirror-proof` is pinned to `nationalinstruments/labview:2026q1-windows`.'
     '- For a unified local operator shell, use `tools/Invoke-VIHistoryLocalOperatorSession.ps1` or the exported `Invoke-CompareVIHistoryLocalOperatorSessionFacade` wrapper from this bundle.'
     '- The first documented downstream local-first consumer is `LabVIEW-Community-CI-CD/labview-icon-editor-demo` via comparevi-history local-review/local-proof targeting `develop`.'
+    '- Treat the bundle metadata `versionContract.authoritativeConsumerPin` as the immutable toolchain identity. If `versionContract.toolsIteration` is present, `vX.Y.Z` remains the compatibility family tag and `vX.Y.Z-tools.N` is the immutable release identity.'
     '- The runtime facade JSON is written to `history-summary.json` under the selected results directory.'
     '- Real compare execution still requires the same LVCompare/LabVIEW prerequisites as the source repository.'
   ) | Set-Content -LiteralPath $bundleReadmePath -Encoding utf8
@@ -430,6 +471,7 @@ try {
     schema = 'comparevi-tools-release-manifest@v1'
     generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
     module = $moduleMetadata
+    versionContract = $versionContract
     source = $sourceMetadata
     compatibility = $compatibilityMetadata
     consumerContract = $consumerContractMetadata


### PR DESCRIPTION
## Summary
- make CompareVI.Tools release manifests distinguish stable family aliases from immutable tools identities
- lock the artifact contract so consumers can pin the authoritative immutable tag deterministically
- document the release semantics in the operator-facing runbooks
