### PR TITLE
Make agent writer lease resilient to rename contention (#1537)

### DIFF
--- a/tools/priority/__tests__/agent-writer-lease.test.mjs
+++ b/tools/priority/__tests__/agent-writer-lease.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   acquireWriterLease,
+  __test,
   defaultLeaseRoot,
   defaultOwner,
   heartbeatWriterLease,
@@ -216,4 +217,46 @@ test('defaultLeaseRoot resolves git-common-dir for a linked worktree repo root o
     defaultLeaseRoot({ repoRoot: worktreeDir }),
     path.join(worktreeDir, '.git', 'agent-writer-leases')
   );
+});
+
+test('replaceFileWithRetry tolerates a transient Windows-style rename failure', async (t) => {
+  const sandboxRoot = randomTempRoot('agent-writer-lease-rename-retry');
+  await fs.mkdir(sandboxRoot, { recursive: true });
+  t.after(async () => {
+    await fs.rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  const targetPath = path.join(sandboxRoot, 'workspace.json');
+  const tempPath = path.join(sandboxRoot, 'workspace.json.tmp');
+  await fs.writeFile(targetPath, 'old\n', 'utf8');
+  await fs.writeFile(tempPath, 'new\n', 'utf8');
+
+  let renameAttempts = 0;
+  const operations = [];
+  const fsModule = {
+    async rename(source, destination) {
+      renameAttempts += 1;
+      operations.push(`rename:${renameAttempts}`);
+      if (renameAttempts === 1) {
+        const error = new Error('EPERM');
+        error.code = 'EPERM';
+        throw error;
+      }
+      return fs.rename(source, destination);
+    },
+    async rm(filePath, options) {
+      operations.push(`rm:${path.basename(filePath)}`);
+      return fs.rm(filePath, options);
+    }
+  };
+
+  await __test.replaceFileWithRetry(tempPath, targetPath, {
+    retryAttempts: 2,
+    retryWaitMs: 0,
+    fsModule
+  });
+
+  assert.equal(renameAttempts, 2);
+  assert.deepEqual(operations.slice(0, 3), ['rename:1', 'rm:workspace.json', 'rename:2']);
+  assert.equal(await fs.readFile(targetPath, 'utf8'), 'new\n');
 });

--- a/tools/priority/agent-writer-lease.mjs
+++ b/tools/priority/agent-writer-lease.mjs
@@ -14,6 +14,8 @@ const DEFAULT_SCOPE = 'workspace';
 const DEFAULT_STALE_SECONDS = 900;
 const DEFAULT_WAIT_MS = 250;
 const DEFAULT_MAX_ATTEMPTS = 0;
+const DEFAULT_RENAME_RETRY_ATTEMPTS = 5;
+const DEFAULT_RENAME_RETRY_WAIT_MS = 50;
 
 const STATUS = Object.freeze({
   acquired: 'acquired',
@@ -104,6 +106,36 @@ async function readLease(filePath) {
   }
 }
 
+function isRetryableLeaseReplaceError(error) {
+  return ['EPERM', 'EACCES', 'EBUSY', 'EEXIST'].includes(error?.code);
+}
+
+async function replaceFileWithRetry(tempPath, filePath, {
+  retryAttempts = DEFAULT_RENAME_RETRY_ATTEMPTS,
+  retryWaitMs = DEFAULT_RENAME_RETRY_WAIT_MS,
+  fsModule = fs
+} = {}) {
+  let attempt = 0;
+  while (true) {
+    try {
+      await fsModule.rename(tempPath, filePath);
+      return;
+    } catch (error) {
+      if (!isRetryableLeaseReplaceError(error)) {
+        throw error;
+      }
+      if (attempt >= retryAttempts) {
+        throw error;
+      }
+      await fsModule.rm(filePath, { force: true });
+      attempt += 1;
+      if (retryWaitMs > 0) {
+        await sleep(retryWaitMs);
+      }
+    }
+  }
+}
+
 async function writeJsonAtomic(filePath, payload, { createOnly = false } = {}) {
   await ensureParentDir(filePath);
   const body = `${JSON.stringify(payload, null, 2)}\n`;
@@ -113,7 +145,11 @@ async function writeJsonAtomic(filePath, payload, { createOnly = false } = {}) {
   }
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   await fs.writeFile(tempPath, body, { encoding: 'utf8' });
-  await fs.rename(tempPath, filePath);
+  try {
+    await replaceFileWithRetry(tempPath, filePath);
+  } finally {
+    await fs.rm(tempPath, { force: true });
+  }
 }
 
 function buildBaseResult(action, scope, leasePath, owner) {
@@ -470,7 +506,9 @@ export async function runCli(argv = process.argv.slice(2)) {
 
 export const __test = {
   leaseAgeSeconds,
-  parseArgs
+  parseArgs,
+  isRetryableLeaseReplaceError,
+  replaceFileWithRetry
 };
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- make the agent writer lease replace path resilient to transient Windows rename contention
- retry replacement after removing a stale target file when the platform reports EPERM/EACCES-style conflicts
- add a regression test for the parallel-bootstrap rename failure mode
