### PR TITLE
Add VI History cross-plane budget receipts (#1488)

### DIFF
--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -310,6 +310,33 @@ The local receipts are:
 - `comparevi/local-refinement-benchmark@v1`
 - `comparevi/local-operator-session@v1`
 
+The cross-plane budget receipt layers on top of those timing artifacts:
+
+- `vi-history/cross-plane-performance-budget@v1`
+- default JSON path:
+  `tests/results/_agent/vi-history/cross-plane-performance-budget.json`
+- companion Markdown summary:
+  `tests/results/_agent/vi-history/cross-plane-performance-budget.md`
+
+Run the budget after Linux proof and Windows mirror proof receipts exist:
+
+```powershell
+node tools/npm/run-script.mjs env:labview:2026:host-planes
+node tools/npm/run-script.mjs priority:vi-history:budget -- `
+  --linux-receipt tests/results/local-vi-history/proof/local-refinement.json `
+  --windows-receipt tests/results/local-vi-history/windows-mirror-proof/local-refinement.json `
+  --host-plane-report tests/results/_agent/host-planes/labview-2026-host-plane-report.json
+```
+
+Add `--shadow-receipt <path>` when a host-native 32-bit VI History lane emits a
+timing receipt for the same workload. The budget report:
+
+- enforces the Windows budget at `<= 1.2x` Linux wall-clock time
+- records when a justification was supplied for an over-budget Windows result
+- warns when shadow 32-bit timing is missing or when it is not acting as a
+  throughput accelerator against the measured container planes
+- writes a PR-comment-ready Markdown summary next to the JSON report
+
 Windows mirror proof also records host/image evidence under the local
 refinement and operator-session receipts:
 

--- a/docs/schemas/vi-history-cross-plane-budget-v1.schema.json
+++ b/docs/schemas/vi-history-cross-plane-budget-v1.schema.json
@@ -1,0 +1,535 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/vi-history-cross-plane-budget-v1.schema.json",
+  "title": "VI History Cross-Plane Performance Budget",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "budget",
+    "workload",
+    "hostPlaneReport",
+    "planes",
+    "comparisons",
+    "overall"
+  ],
+  "properties": {
+    "schema": {
+      "const": "vi-history/cross-plane-performance-budget@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "windowsVsLinuxMaxRatio",
+        "shadowAccelerationMaxRatio",
+        "windowsOverBudgetJustification"
+      ],
+      "properties": {
+        "windowsVsLinuxMaxRatio": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "shadowAccelerationMaxRatio": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "windowsOverBudgetJustification": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetPath",
+        "targetPathComparable",
+        "branchRef",
+        "baselineRef",
+        "maxPairs",
+        "maxCommitCount",
+        "comparable"
+      ],
+      "properties": {
+        "targetPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "targetPathComparable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branchRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "baselineRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maxPairs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "maxCommitCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "comparable": {
+          "type": "boolean"
+        }
+      }
+    },
+    "hostPlaneReport": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "schema",
+        "native32Status",
+        "native64Status",
+        "parallelLabVIEWSupported"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "native32Status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "native64Status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parallelLabVIEWSupported": {
+          "type": "boolean"
+        }
+      }
+    },
+    "planes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "linux",
+        "windows",
+        "shadow32"
+      ],
+      "properties": {
+        "linux": {
+          "$ref": "#/$defs/planeMeasurement"
+        },
+        "windows": {
+          "$ref": "#/$defs/planeMeasurement"
+        },
+        "shadow32": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/planeMeasurement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "comparisons": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "windowsVsLinux",
+        "shadowVsLinux",
+        "shadowVsWindows",
+        "shadowSummary"
+      ],
+      "properties": {
+        "windowsVsLinux": {
+          "$ref": "#/$defs/comparison"
+        },
+        "shadowVsLinux": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/comparison"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "shadowVsWindows": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/comparison"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "shadowSummary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "message",
+            "fasterThan"
+          ],
+          "properties": {
+            "status": {
+              "enum": [
+                "pass",
+                "warn",
+                "missing"
+              ]
+            },
+            "message": {
+              "type": "string"
+            },
+            "fasterThan": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "overall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "blockers",
+        "warnings"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "blockers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/issue"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/issue"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "schema",
+        "measurementPath",
+        "measurementSchema"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "measurementPath": {
+          "type": "string"
+        },
+        "measurementSchema": {
+          "type": "string"
+        }
+      }
+    },
+    "history": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetPath",
+        "targetPathComparable",
+        "branchRef",
+        "baselineRef",
+        "maxPairs",
+        "maxCommitCount"
+      ],
+      "properties": {
+        "targetPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "targetPathComparable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branchRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "baselineRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maxPairs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "maxCommitCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    },
+    "timings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "elapsedMilliseconds",
+        "elapsedSeconds"
+      ],
+      "properties": {
+        "elapsedMilliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "elapsedSeconds": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "workloadMismatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field",
+        "reference",
+        "candidate"
+      ],
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "reference": {},
+        "candidate": {}
+      }
+    },
+    "planeMeasurement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "source",
+        "runtimeProfile",
+        "runtimePlane",
+        "benchmarkSampleKind",
+        "repoRoot",
+        "resultsRoot",
+        "finalStatus",
+        "history",
+        "timings",
+        "workloadMismatch"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "runtimeProfile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runtimePlane": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "benchmarkSampleKind": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repoRoot": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resultsRoot": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "finalStatus": {
+          "type": "string"
+        },
+        "history": {
+          "$ref": "#/$defs/history"
+        },
+        "timings": {
+          "$ref": "#/$defs/timings"
+        },
+        "workloadMismatch": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workloadMismatch"
+          }
+        }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "kind",
+        "baselinePlane",
+        "candidatePlane",
+        "baselineMilliseconds",
+        "candidateMilliseconds",
+        "deltaMilliseconds",
+        "candidateToBaselineRatio",
+        "thresholdRatio",
+        "withinBudget",
+        "justification",
+        "status",
+        "message"
+      ],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "budget-max",
+            "accelerator"
+          ]
+        },
+        "baselinePlane": {
+          "type": "string"
+        },
+        "candidatePlane": {
+          "type": "string"
+        },
+        "baselineMilliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candidateMilliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deltaMilliseconds": {
+          "type": "integer"
+        },
+        "candidateToBaselineRatio": {
+          "type": "number",
+          "minimum": 0
+        },
+        "thresholdRatio": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "withinBudget": {
+          "type": "boolean"
+        },
+        "justification": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "priority:promote:downstream:manifest": "node tools/priority/downstream-promotion-manifest.mjs",
     "priority:promote:downstream:scorecard": "node tools/priority/downstream-promotion-scorecard.mjs",
     "priority:diagnostics:public-linux": "node tools/priority/public-linux-diagnostics-harness.mjs",
+    "priority:vi-history:budget": "node tools/priority/vi-history-cross-plane-budget.mjs",
     "priority:develop:sync": "node tools/priority/develop-sync.mjs",
     "priority:github:metadata:apply": "tsc -p tsconfig.cli.json && node dist/tools/cli/github-metadata.js",
     "priority:policy": "node tools/priority/check-policy.mjs",

--- a/tests/CrossRepoVIHistoryDocs.Tests.ps1
+++ b/tests/CrossRepoVIHistoryDocs.Tests.ps1
@@ -19,6 +19,8 @@ Describe 'Cross-repo VI history docs' -Tag 'CompareVI' {
     $script:crossRepoDoc | Should -Match 'comparevi-history'
     $script:crossRepoDoc | Should -Match 'local-review'
     $script:crossRepoDoc | Should -Match 'local-proof'
+    $script:crossRepoDoc | Should -Match 'priority:vi-history:budget'
+    $script:crossRepoDoc | Should -Match 'cross-plane-performance-budget\.json'
     $script:crossRepoDoc | Should -Match 'develop'
     $script:crossRepoDoc | Should -Match 'VIP_Post-Install Custom Action\.vi'
   }

--- a/tools/priority/__tests__/vi-history-cross-plane-budget-schema.test.mjs
+++ b/tools/priority/__tests__/vi-history-cross-plane-budget-schema.test.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { buildCrossPlaneBudgetReport } from '../vi-history-cross-plane-budget.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function createMeasurement({
+  runtimeProfile,
+  runtimePlane,
+  benchmarkSampleKind,
+  elapsedMilliseconds,
+}) {
+  return {
+    schema: 'comparevi/local-refinement@v1',
+    generatedAt: '2026-03-21T06:30:00.000Z',
+    runtimeProfile,
+    runtimePlane,
+    image: 'placeholder-image',
+    toolSource: 'test-stub',
+    cacheReuseState: 'test',
+    coldWarmClass: 'cold',
+    benchmarkSampleKind,
+    repoRoot: 'C:/repo',
+    resultsRoot: `C:/repo/tests/results/local-vi-history/${runtimeProfile}`,
+    timings: {
+      elapsedMilliseconds,
+      elapsedSeconds: Number((elapsedMilliseconds / 1000).toFixed(3)),
+    },
+    history: {
+      targetPath: 'C:/repo/fixtures/vi-attr/Head.vi',
+      branchRef: 'HEAD',
+      baselineRef: '',
+      maxPairs: 2,
+      maxCommitCount: 64,
+    },
+    finalStatus: 'succeeded',
+  };
+}
+
+test('cross-plane budget report validates schema', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'vi-history-cross-plane-budget-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-history-cross-plane-budget-schema-'));
+  const linuxPath = path.join(tempDir, 'linux.json');
+  const windowsPath = path.join(tempDir, 'windows.json');
+  const shadowPath = path.join(tempDir, 'shadow.json');
+  const hostPath = path.join(tempDir, 'host.json');
+
+  writeJson(linuxPath, createMeasurement({
+    runtimeProfile: 'proof',
+    runtimePlane: 'linux',
+    benchmarkSampleKind: 'proof-cold',
+    elapsedMilliseconds: 1000,
+  }));
+  writeJson(windowsPath, createMeasurement({
+    runtimeProfile: 'windows-mirror-proof',
+    runtimePlane: 'windows-mirror',
+    benchmarkSampleKind: 'windows-mirror-proof-cold',
+    elapsedMilliseconds: 1180,
+  }));
+  writeJson(shadowPath, createMeasurement({
+    runtimeProfile: 'host-32bit-shadow',
+    runtimePlane: 'host-32bit-shadow',
+    benchmarkSampleKind: 'host-32bit-shadow-cold',
+    elapsedMilliseconds: 900,
+  }));
+  writeJson(hostPath, {
+    schema: 'labview-2026-host-plane-report@v1',
+    native: {
+      parallelLabVIEWSupported: false,
+      planes: {
+        x64: { status: 'ready' },
+        x32: { status: 'ready' },
+      },
+    },
+  });
+
+  const { report } = await buildCrossPlaneBudgetReport({
+    linuxReceiptPath: linuxPath,
+    windowsReceiptPath: windowsPath,
+    shadowReceiptPath: shadowPath,
+    hostPlaneReportPath: hostPath,
+  });
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/vi-history-cross-plane-budget.test.mjs
+++ b/tools/priority/__tests__/vi-history-cross-plane-budget.test.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_OUTPUT_PATH,
+  buildCrossPlaneBudgetReport,
+  main,
+  parseArgs,
+} from '../vi-history-cross-plane-budget.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function createMeasurement({
+  runtimeProfile,
+  runtimePlane,
+  benchmarkSampleKind,
+  elapsedMilliseconds,
+  targetPath = 'fixtures/vi-attr/Head.vi',
+  branchRef = 'HEAD',
+  baselineRef = '',
+  maxPairs = 2,
+  maxCommitCount = 64,
+  finalStatus = 'succeeded',
+  generatedAt = '2026-03-21T06:30:00.000Z',
+}) {
+  return {
+    schema: 'comparevi/local-refinement@v1',
+    generatedAt,
+    runtimeProfile,
+    runtimePlane,
+    image: 'placeholder-image',
+    toolSource: 'test-stub',
+    cacheReuseState: 'test',
+    coldWarmClass: 'cold',
+    benchmarkSampleKind,
+    repoRoot: 'C:/repo',
+    resultsRoot: `C:/repo/tests/results/local-vi-history/${runtimeProfile}`,
+    timings: {
+      elapsedMilliseconds,
+      elapsedSeconds: Number((elapsedMilliseconds / 1000).toFixed(3)),
+    },
+    history: {
+      targetPath: `C:/repo/${targetPath}`,
+      branchRef,
+      baselineRef,
+      maxPairs,
+      maxCommitCount,
+    },
+    finalStatus,
+  };
+}
+
+test('parseArgs supports the cross-plane budget contract surface', () => {
+  const parsed = parseArgs([
+    'node',
+    'vi-history-cross-plane-budget.mjs',
+    '--linux-receipt',
+    'linux.json',
+    '--windows-receipt',
+    'windows.json',
+    '--shadow-receipt',
+    'shadow.json',
+    '--host-plane-report',
+    'host.json',
+    '--output',
+    'custom-report.json',
+    '--markdown',
+    'custom-report.md',
+    '--windows-threshold-ratio',
+    '1.25',
+    '--shadow-accelerator-ratio',
+    '1.0',
+    '--windows-over-budget-justification',
+    'approved drift',
+    '--fail-on-warn',
+  ]);
+
+  assert.equal(parsed.linuxReceiptPath, 'linux.json');
+  assert.equal(parsed.windowsReceiptPath, 'windows.json');
+  assert.equal(parsed.shadowReceiptPath, 'shadow.json');
+  assert.equal(parsed.hostPlaneReportPath, 'host.json');
+  assert.equal(parsed.outputPath, 'custom-report.json');
+  assert.equal(parsed.markdownPath, 'custom-report.md');
+  assert.equal(parsed.windowsThresholdRatio, 1.25);
+  assert.equal(parsed.shadowAcceleratorRatio, 1.0);
+  assert.equal(parsed.windowsOverBudgetJustification, 'approved drift');
+  assert.equal(parsed.failOnWarn, true);
+});
+
+test('buildCrossPlaneBudgetReport passes when Windows stays within budget and shadow accelerates at least one plane', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-history-cross-plane-budget-'));
+  const linuxPath = path.join(tempDir, 'linux.json');
+  const windowsPath = path.join(tempDir, 'windows.json');
+  const shadowPath = path.join(tempDir, 'shadow.json');
+  const hostPath = path.join(tempDir, 'host-plane.json');
+
+  writeJson(linuxPath, createMeasurement({
+    runtimeProfile: 'proof',
+    runtimePlane: 'linux',
+    benchmarkSampleKind: 'proof-cold',
+    elapsedMilliseconds: 1000,
+  }));
+  writeJson(windowsPath, createMeasurement({
+    runtimeProfile: 'windows-mirror-proof',
+    runtimePlane: 'windows-mirror',
+    benchmarkSampleKind: 'windows-mirror-proof-cold',
+    elapsedMilliseconds: 1150,
+  }));
+  writeJson(shadowPath, createMeasurement({
+    runtimeProfile: 'host-32bit-shadow',
+    runtimePlane: 'host-32bit-shadow',
+    benchmarkSampleKind: 'host-32bit-shadow-cold',
+    elapsedMilliseconds: 850,
+  }));
+  writeJson(hostPath, {
+    schema: 'labview-2026-host-plane-report@v1',
+    native: {
+      parallelLabVIEWSupported: false,
+      planes: {
+        x64: { status: 'ready' },
+        x32: { status: 'ready' },
+      },
+    },
+  });
+
+  const { report, markdown } = await buildCrossPlaneBudgetReport({
+    linuxReceiptPath: linuxPath,
+    windowsReceiptPath: windowsPath,
+    shadowReceiptPath: shadowPath,
+    hostPlaneReportPath: hostPath,
+  });
+
+  assert.equal(report.schema, 'vi-history/cross-plane-performance-budget@v1');
+  assert.equal(report.workload.comparable, true);
+  assert.equal(report.comparisons.windowsVsLinux.status, 'pass');
+  assert.equal(report.comparisons.windowsVsLinux.candidateToBaselineRatio, 1.15);
+  assert.equal(report.comparisons.shadowVsLinux.status, 'pass');
+  assert.equal(report.comparisons.shadowVsWindows.status, 'pass');
+  assert.equal(report.comparisons.shadowSummary.status, 'pass');
+  assert.equal(report.overall.status, 'pass');
+  assert.match(markdown, /Windows\/Linux ratio: `1\.15x`/);
+  assert.match(markdown, /Shadow 32-bit: `0\.85s`/);
+});
+
+test('buildCrossPlaneBudgetReport fails on over-budget Windows timing and warns when shadow measurement is missing', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-history-cross-plane-budget-warn-'));
+  const linuxPath = path.join(tempDir, 'linux.json');
+  const windowsPath = path.join(tempDir, 'windows.json');
+  const hostPath = path.join(tempDir, 'host-plane.json');
+
+  writeJson(linuxPath, createMeasurement({
+    runtimeProfile: 'proof',
+    runtimePlane: 'linux',
+    benchmarkSampleKind: 'proof-cold',
+    elapsedMilliseconds: 1000,
+  }));
+  writeJson(windowsPath, createMeasurement({
+    runtimeProfile: 'windows-mirror-proof',
+    runtimePlane: 'windows-mirror',
+    benchmarkSampleKind: 'windows-mirror-proof-cold',
+    elapsedMilliseconds: 1400,
+  }));
+  writeJson(hostPath, {
+    schema: 'labview-2026-host-plane-report@v1',
+    native: {
+      parallelLabVIEWSupported: false,
+      planes: {
+        x64: { status: 'ready' },
+        x32: { status: 'ready' },
+      },
+    },
+  });
+
+  const { report } = await buildCrossPlaneBudgetReport({
+    linuxReceiptPath: linuxPath,
+    windowsReceiptPath: windowsPath,
+    hostPlaneReportPath: hostPath,
+  });
+
+  assert.equal(report.comparisons.windowsVsLinux.status, 'fail');
+  assert.equal(report.comparisons.windowsVsLinux.candidateToBaselineRatio, 1.4);
+  assert.equal(report.planes.shadow32, null);
+  assert.equal(report.comparisons.shadowSummary.status, 'missing');
+  assert.equal(report.overall.status, 'fail');
+  assert.equal(report.overall.blockers[0].code, 'windows-over-budget');
+  assert.equal(report.overall.warnings[0].code, 'shadow-measurement-missing');
+});
+
+test('main writes JSON and Markdown receipts', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-history-cross-plane-budget-main-'));
+  const linuxPath = path.join(tempDir, 'linux.json');
+  const windowsPath = path.join(tempDir, 'windows.json');
+  const outputPath = path.join(tempDir, 'report.json');
+  const markdownPath = path.join(tempDir, 'report.md');
+
+  writeJson(linuxPath, createMeasurement({
+    runtimeProfile: 'proof',
+    runtimePlane: 'linux',
+    benchmarkSampleKind: 'proof-cold',
+    elapsedMilliseconds: 1000,
+  }));
+  writeJson(windowsPath, createMeasurement({
+    runtimeProfile: 'windows-mirror-proof',
+    runtimePlane: 'windows-mirror',
+    benchmarkSampleKind: 'windows-mirror-proof-cold',
+    elapsedMilliseconds: 1100,
+  }));
+
+  const exitCode = await main([
+    'node',
+    'vi-history-cross-plane-budget.mjs',
+    '--linux-receipt',
+    linuxPath,
+    '--windows-receipt',
+    windowsPath,
+    '--output',
+    outputPath,
+    '--markdown',
+    markdownPath,
+  ]);
+
+  assert.equal(DEFAULT_OUTPUT_PATH.endsWith('cross-plane-performance-budget.json'), true);
+  assert.equal(exitCode, 0);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+});

--- a/tools/priority/vi-history-cross-plane-budget.mjs
+++ b/tools/priority/vi-history-cross-plane-budget.mjs
@@ -1,0 +1,652 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const REPORT_SCHEMA = 'vi-history/cross-plane-performance-budget@v1';
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'vi-history', 'cross-plane-performance-budget.json');
+export const DEFAULT_WINDOWS_THRESHOLD_RATIO = 1.2;
+export const DEFAULT_SHADOW_ACCELERATOR_RATIO = 1.0;
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function asOptional(value) {
+  const text = normalizeText(value);
+  return text || null;
+}
+
+function parsePositiveNumber(value, flag) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid value for ${flag}: ${value}`);
+  }
+  return parsed;
+}
+
+function parseBooleanFlag(options, key, argv, index) {
+  if (argv[index + 1] && !argv[index + 1].startsWith('-')) {
+    throw new Error(`${argv[index]} does not accept a value.`);
+  }
+  options[key] = true;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    linuxReceiptPath: null,
+    windowsReceiptPath: null,
+    shadowReceiptPath: null,
+    hostPlaneReportPath: null,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    markdownPath: null,
+    windowsThresholdRatio: DEFAULT_WINDOWS_THRESHOLD_RATIO,
+    shadowAcceleratorRatio: DEFAULT_SHADOW_ACCELERATOR_RATIO,
+    windowsOverBudgetJustification: null,
+    failOnWarn: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (token === '--fail-on-warn') {
+      parseBooleanFlag(options, 'failOnWarn', args, index);
+      continue;
+    }
+
+    if (
+      token === '--linux-receipt' ||
+      token === '--windows-receipt' ||
+      token === '--shadow-receipt' ||
+      token === '--host-plane-report' ||
+      token === '--output' ||
+      token === '--markdown' ||
+      token === '--windows-threshold-ratio' ||
+      token === '--shadow-accelerator-ratio' ||
+      token === '--windows-over-budget-justification'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--linux-receipt') options.linuxReceiptPath = next;
+      if (token === '--windows-receipt') options.windowsReceiptPath = next;
+      if (token === '--shadow-receipt') options.shadowReceiptPath = next;
+      if (token === '--host-plane-report') options.hostPlaneReportPath = next;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--markdown') options.markdownPath = next;
+      if (token === '--windows-threshold-ratio') options.windowsThresholdRatio = parsePositiveNumber(next, token);
+      if (token === '--shadow-accelerator-ratio') options.shadowAcceleratorRatio = parsePositiveNumber(next, token);
+      if (token === '--windows-over-budget-justification') options.windowsOverBudgetJustification = normalizeText(next);
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!options.help) {
+    if (!options.linuxReceiptPath) {
+      throw new Error('Missing required --linux-receipt.');
+    }
+    if (!options.windowsReceiptPath) {
+      throw new Error('Missing required --windows-receipt.');
+    }
+  }
+
+  return options;
+}
+
+function deriveMarkdownPath(outputPath, markdownPath) {
+  if (markdownPath) {
+    return markdownPath;
+  }
+  const ext = path.extname(outputPath);
+  if (ext) {
+    return `${outputPath.slice(0, -ext.length)}.md`;
+  }
+  return `${outputPath}.md`;
+}
+
+async function readJson(filePath) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  const payload = JSON.parse(await fs.readFile(resolved, 'utf8'));
+  return { resolvedPath: resolved, payload };
+}
+
+async function readJsonOptional(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  return readJson(filePath);
+}
+
+async function resolveMeasurementInput(filePath) {
+  const initial = await readJson(filePath);
+  const sessionPayload = initial.payload;
+  if (
+    sessionPayload &&
+    sessionPayload.schema === 'comparevi/local-operator-session@v1' &&
+    sessionPayload.artifacts &&
+    sessionPayload.artifacts.localRefinementPath
+  ) {
+    const refinementPath = path.resolve(path.dirname(initial.resolvedPath), sessionPayload.artifacts.localRefinementPath);
+    const refinementPayload = JSON.parse(await fs.readFile(refinementPath, 'utf8'));
+    return {
+      sourcePath: initial.resolvedPath,
+      sourceSchema: sessionPayload.schema,
+      measurementPath: refinementPath,
+      measurementSchema: refinementPayload?.schema ? String(refinementPayload.schema) : 'unknown',
+      payload: refinementPayload,
+    };
+  }
+
+  return {
+    sourcePath: initial.resolvedPath,
+    sourceSchema: initial.payload?.schema ? String(initial.payload.schema) : 'unknown',
+    measurementPath: initial.resolvedPath,
+    measurementSchema: initial.payload?.schema ? String(initial.payload.schema) : 'unknown',
+    payload: initial.payload,
+  };
+}
+
+function toFiniteMilliseconds(value, fieldName) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Missing or invalid ${fieldName}.`);
+  }
+  return Math.trunc(parsed);
+}
+
+function toFiniteSeconds(value, fieldName) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Missing or invalid ${fieldName}.`);
+  }
+  return Number(parsed.toFixed(3));
+}
+
+function toComparablePath(targetPath, repoRoot) {
+  const targetText = asOptional(targetPath);
+  if (!targetText) {
+    return null;
+  }
+  if (!repoRoot) {
+    return targetText.replace(/\\/g, '/');
+  }
+
+  const resolvedRepoRoot = path.resolve(repoRoot);
+  const resolvedTargetPath = path.resolve(targetText);
+  const relative = path.relative(resolvedRepoRoot, resolvedTargetPath);
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+    return relative.replace(/\\/g, '/');
+  }
+  return resolvedTargetPath.replace(/\\/g, '/');
+}
+
+function normalizeHistory(history, repoRoot) {
+  if (!history || typeof history !== 'object') {
+    throw new Error('Missing history payload.');
+  }
+
+  return {
+    targetPath: asOptional(history.targetPath),
+    targetPathComparable: toComparablePath(history.targetPath, repoRoot),
+    branchRef: asOptional(history.branchRef),
+    baselineRef: asOptional(history.baselineRef),
+    maxPairs: Number.isFinite(Number(history.maxPairs)) ? Math.trunc(Number(history.maxPairs)) : null,
+    maxCommitCount: Number.isFinite(Number(history.maxCommitCount)) ? Math.trunc(Number(history.maxCommitCount)) : null,
+  };
+}
+
+function normalizeMeasurement(role, measurementInput) {
+  const payload = measurementInput.payload;
+  if (!payload || typeof payload !== 'object') {
+    throw new Error(`Unable to parse ${role} receipt payload.`);
+  }
+
+  const repoRoot = asOptional(payload.repoRoot);
+  const history = normalizeHistory(payload.history, repoRoot);
+  const timings = payload.timings && typeof payload.timings === 'object' ? payload.timings : null;
+  if (!timings) {
+    throw new Error(`Missing timings payload for ${role} receipt.`);
+  }
+
+  return {
+    role,
+    source: {
+      path: measurementInput.sourcePath,
+      schema: measurementInput.sourceSchema,
+      measurementPath: measurementInput.measurementPath,
+      measurementSchema: measurementInput.measurementSchema,
+    },
+    runtimeProfile: asOptional(payload.runtimeProfile),
+    runtimePlane: asOptional(payload.runtimePlane),
+    benchmarkSampleKind: asOptional(payload.benchmarkSampleKind),
+    repoRoot,
+    resultsRoot: asOptional(payload.resultsRoot),
+    finalStatus: asOptional(payload.finalStatus) ?? 'unknown',
+    history,
+    timings: {
+      elapsedMilliseconds: toFiniteMilliseconds(timings.elapsedMilliseconds, `${role}.timings.elapsedMilliseconds`),
+      elapsedSeconds: toFiniteSeconds(timings.elapsedSeconds, `${role}.timings.elapsedSeconds`),
+    },
+  };
+}
+
+function compareWorkloads(referencePlane, candidatePlane) {
+  const mismatches = [];
+  const referenceHistory = referencePlane.history;
+  const candidateHistory = candidatePlane.history;
+  const fields = [
+    ['targetPath', referenceHistory.targetPathComparable, candidateHistory.targetPathComparable],
+    ['branchRef', referenceHistory.branchRef, candidateHistory.branchRef],
+    ['baselineRef', referenceHistory.baselineRef, candidateHistory.baselineRef],
+    ['maxPairs', referenceHistory.maxPairs, candidateHistory.maxPairs],
+    ['maxCommitCount', referenceHistory.maxCommitCount, candidateHistory.maxCommitCount],
+  ];
+
+  for (const [field, left, right] of fields) {
+    if (left !== right) {
+      mismatches.push({
+        field,
+        reference: left,
+        candidate: right,
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+function buildBudgetComparison({
+  key,
+  baseline,
+  candidate,
+  thresholdRatio,
+  justification = null,
+}) {
+  const ratio = Number((candidate.timings.elapsedMilliseconds / baseline.timings.elapsedMilliseconds).toFixed(4));
+  const deltaMilliseconds = candidate.timings.elapsedMilliseconds - baseline.timings.elapsedMilliseconds;
+  const withinBudget = ratio <= thresholdRatio;
+  const status = withinBudget ? 'pass' : justification ? 'warn' : 'fail';
+
+  return {
+    key,
+    kind: 'budget-max',
+    baselinePlane: baseline.role,
+    candidatePlane: candidate.role,
+    baselineMilliseconds: baseline.timings.elapsedMilliseconds,
+    candidateMilliseconds: candidate.timings.elapsedMilliseconds,
+    deltaMilliseconds,
+    candidateToBaselineRatio: ratio,
+    thresholdRatio: Number(thresholdRatio.toFixed(4)),
+    withinBudget,
+    justification: justification || null,
+    status,
+    message: withinBudget
+      ? `${candidate.role} stays within ${thresholdRatio.toFixed(2)}x of ${baseline.role}.`
+      : justification
+        ? `${candidate.role} exceeds ${thresholdRatio.toFixed(2)}x of ${baseline.role}, but justification was provided.`
+        : `${candidate.role} exceeds ${thresholdRatio.toFixed(2)}x of ${baseline.role}.`,
+  };
+}
+
+function buildAccelerationComparison({
+  key,
+  baseline,
+  candidate,
+  thresholdRatio,
+}) {
+  const ratio = Number((candidate.timings.elapsedMilliseconds / baseline.timings.elapsedMilliseconds).toFixed(4));
+  const deltaMilliseconds = candidate.timings.elapsedMilliseconds - baseline.timings.elapsedMilliseconds;
+  const isAccelerator = ratio < thresholdRatio;
+
+  return {
+    key,
+    kind: 'accelerator',
+    baselinePlane: baseline.role,
+    candidatePlane: candidate.role,
+    baselineMilliseconds: baseline.timings.elapsedMilliseconds,
+    candidateMilliseconds: candidate.timings.elapsedMilliseconds,
+    deltaMilliseconds,
+    candidateToBaselineRatio: ratio,
+    thresholdRatio: Number(thresholdRatio.toFixed(4)),
+    withinBudget: isAccelerator,
+    justification: null,
+    status: isAccelerator ? 'pass' : 'warn',
+    message: isAccelerator
+      ? `${candidate.role} is acting as a throughput accelerator against ${baseline.role}.`
+      : `${candidate.role} is not acting as a throughput accelerator against ${baseline.role}.`,
+  };
+}
+
+function summarizeShadowAcceleration(shadowComparisons) {
+  if (!shadowComparisons.length) {
+    return {
+      status: 'missing',
+      message: 'Shadow 32-bit timing receipt was not provided.',
+      fasterThan: [],
+    };
+  }
+
+  const fasterThan = shadowComparisons.filter((entry) => entry.status === 'pass').map((entry) => entry.baselinePlane);
+  if (fasterThan.length > 0) {
+    return {
+      status: 'pass',
+      message: `Shadow 32-bit is faster than ${fasterThan.join(', ')}.`,
+      fasterThan,
+    };
+  }
+
+  return {
+    status: 'warn',
+    message: 'Shadow 32-bit is measured but not faster than the container planes that were compared.',
+    fasterThan: [],
+  };
+}
+
+function normalizeHostPlaneReport(reportInput) {
+  if (!reportInput) {
+    return null;
+  }
+
+  const payload = reportInput.payload;
+  const native = payload && payload.native && typeof payload.native === 'object' ? payload.native : null;
+  const planes = native && native.planes && typeof native.planes === 'object' ? native.planes : null;
+  const x32 = planes && planes.x32 && typeof planes.x32 === 'object' ? planes.x32 : null;
+  const x64 = planes && planes.x64 && typeof planes.x64 === 'object' ? planes.x64 : null;
+
+  return {
+    path: reportInput.resolvedPath,
+    schema: payload?.schema ? String(payload.schema) : 'unknown',
+    native32Status: asOptional(x32?.status),
+    native64Status: asOptional(x64?.status),
+    parallelLabVIEWSupported: native?.parallelLabVIEWSupported === true,
+  };
+}
+
+function collectIssues(planes, windowsComparison, shadowComparisons, shadowSummary, hostPlaneReport) {
+  const blockers = [];
+  const warnings = [];
+
+  for (const plane of [planes.linux, planes.windows]) {
+    if (plane.finalStatus !== 'succeeded') {
+      blockers.push({
+        code: `${plane.role}-not-succeeded`,
+        message: `${plane.role} receipt finalStatus is '${plane.finalStatus}'.`,
+      });
+    }
+  }
+
+  if (planes.windows.workloadMismatch.length > 0) {
+    blockers.push({
+      code: 'windows-workload-mismatch',
+      message: 'Linux and Windows receipts do not describe the same certification workload.',
+    });
+  }
+
+  if (planes.shadow32 && planes.shadow32.workloadMismatch.length > 0) {
+    blockers.push({
+      code: 'shadow-workload-mismatch',
+      message: 'Shadow 32-bit receipt does not match the Linux certification workload.',
+    });
+  }
+
+  if (windowsComparison.status === 'fail') {
+    blockers.push({
+      code: 'windows-over-budget',
+      message: windowsComparison.message,
+    });
+  } else if (windowsComparison.status === 'warn') {
+    warnings.push({
+      code: 'windows-over-budget-justified',
+      message: windowsComparison.message,
+    });
+  }
+
+  if (!planes.shadow32) {
+    warnings.push({
+      code: 'shadow-measurement-missing',
+      message: hostPlaneReport?.native32Status
+        ? `Shadow 32-bit timing receipt missing; host native 32-bit readiness is '${hostPlaneReport.native32Status}'.`
+        : 'Shadow 32-bit timing receipt missing.',
+    });
+  } else {
+    for (const comparison of shadowComparisons) {
+      if (comparison.status === 'warn') {
+        warnings.push({
+          code: `${comparison.key}-not-accelerating`,
+          message: comparison.message,
+        });
+      }
+    }
+  }
+
+  if (shadowSummary.status === 'warn') {
+    warnings.push({
+      code: 'shadow-not-accelerator',
+      message: shadowSummary.message,
+    });
+  }
+
+  return { blockers, warnings };
+}
+
+function buildMarkdown(report) {
+  const lines = [];
+  lines.push('### VI History Cross-Plane Performance Budget');
+  lines.push('');
+  lines.push(`- Overall: \`${report.overall.status}\``);
+  lines.push(`- Workload: \`${report.workload.targetPathComparable || report.workload.targetPath || 'unknown'}\` @ \`${report.workload.branchRef || 'unknown'}\``);
+  lines.push(`- Linux: \`${report.planes.linux.timings.elapsedSeconds}s\` (${report.planes.linux.benchmarkSampleKind || 'n/a'})`);
+  lines.push(`- Windows: \`${report.planes.windows.timings.elapsedSeconds}s\` (${report.planes.windows.benchmarkSampleKind || 'n/a'})`);
+  if (report.planes.shadow32) {
+    lines.push(`- Shadow 32-bit: \`${report.planes.shadow32.timings.elapsedSeconds}s\` (${report.planes.shadow32.benchmarkSampleKind || 'n/a'})`);
+  } else {
+    lines.push(`- Shadow 32-bit: _not measured_${report.hostPlaneReport?.native32Status ? ` (host status: \`${report.hostPlaneReport.native32Status}\`)` : ''}`);
+  }
+  lines.push(`- Windows/Linux ratio: \`${report.comparisons.windowsVsLinux.candidateToBaselineRatio}x\` (budget <= \`${report.budget.windowsVsLinuxMaxRatio}x\`, status \`${report.comparisons.windowsVsLinux.status}\`)`);
+  if (report.comparisons.shadowVsLinux) {
+    lines.push(`- Shadow/Linux ratio: \`${report.comparisons.shadowVsLinux.candidateToBaselineRatio}x\` (status \`${report.comparisons.shadowVsLinux.status}\`)`);
+  }
+  if (report.comparisons.shadowVsWindows) {
+    lines.push(`- Shadow/Windows ratio: \`${report.comparisons.shadowVsWindows.candidateToBaselineRatio}x\` (status \`${report.comparisons.shadowVsWindows.status}\`)`);
+  }
+  if (report.overall.blockers.length > 0) {
+    lines.push(`- Blockers: ${report.overall.blockers.map((item) => `\`${item.code}\``).join(', ')}`);
+  }
+  if (report.overall.warnings.length > 0) {
+    lines.push(`- Warnings: ${report.overall.warnings.map((item) => `\`${item.code}\``).join(', ')}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export async function buildCrossPlaneBudgetReport({
+  linuxReceiptPath,
+  windowsReceiptPath,
+  shadowReceiptPath = null,
+  hostPlaneReportPath = null,
+  windowsThresholdRatio = DEFAULT_WINDOWS_THRESHOLD_RATIO,
+  shadowAcceleratorRatio = DEFAULT_SHADOW_ACCELERATOR_RATIO,
+  windowsOverBudgetJustification = null,
+  now = new Date(),
+} = {}) {
+  const linuxInput = await resolveMeasurementInput(linuxReceiptPath);
+  const windowsInput = await resolveMeasurementInput(windowsReceiptPath);
+  const shadowInput = shadowReceiptPath ? await resolveMeasurementInput(shadowReceiptPath) : null;
+  const hostPlaneInput = await readJsonOptional(hostPlaneReportPath);
+
+  const linux = normalizeMeasurement('linux', linuxInput);
+  const windows = normalizeMeasurement('windows', windowsInput);
+  const shadow32 = shadowInput ? normalizeMeasurement('shadow32', shadowInput) : null;
+
+  linux.workloadMismatch = [];
+  windows.workloadMismatch = compareWorkloads(linux, windows);
+  if (shadow32) {
+    shadow32.workloadMismatch = compareWorkloads(linux, shadow32);
+  }
+
+  const hostPlaneReport = normalizeHostPlaneReport(hostPlaneInput);
+  const windowsComparison = buildBudgetComparison({
+    key: 'windowsVsLinux',
+    baseline: linux,
+    candidate: windows,
+    thresholdRatio: windowsThresholdRatio,
+    justification: asOptional(windowsOverBudgetJustification),
+  });
+
+  const shadowComparisons = [];
+  if (shadow32) {
+    shadowComparisons.push(buildAccelerationComparison({
+      key: 'shadowVsLinux',
+      baseline: linux,
+      candidate: shadow32,
+      thresholdRatio: shadowAcceleratorRatio,
+    }));
+    shadowComparisons.push(buildAccelerationComparison({
+      key: 'shadowVsWindows',
+      baseline: windows,
+      candidate: shadow32,
+      thresholdRatio: shadowAcceleratorRatio,
+    }));
+  }
+
+  const shadowSummary = summarizeShadowAcceleration(shadowComparisons);
+  const issues = collectIssues(
+    { linux, windows, shadow32 },
+    windowsComparison,
+    shadowComparisons,
+    shadowSummary,
+    hostPlaneReport,
+  );
+
+  const overallStatus = issues.blockers.length > 0 ? 'fail' : issues.warnings.length > 0 ? 'warn' : 'pass';
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: now.toISOString(),
+    budget: {
+      windowsVsLinuxMaxRatio: Number(windowsThresholdRatio.toFixed(4)),
+      shadowAccelerationMaxRatio: Number(shadowAcceleratorRatio.toFixed(4)),
+      windowsOverBudgetJustification: asOptional(windowsOverBudgetJustification),
+    },
+    workload: {
+      targetPath: linux.history.targetPath,
+      targetPathComparable: linux.history.targetPathComparable,
+      branchRef: linux.history.branchRef,
+      baselineRef: linux.history.baselineRef,
+      maxPairs: linux.history.maxPairs,
+      maxCommitCount: linux.history.maxCommitCount,
+      comparable: windows.workloadMismatch.length === 0 && (!shadow32 || shadow32.workloadMismatch.length === 0),
+    },
+    hostPlaneReport,
+    planes: {
+      linux,
+      windows,
+      shadow32,
+    },
+    comparisons: {
+      windowsVsLinux: windowsComparison,
+      shadowVsLinux: shadowComparisons.find((entry) => entry.key === 'shadowVsLinux') ?? null,
+      shadowVsWindows: shadowComparisons.find((entry) => entry.key === 'shadowVsWindows') ?? null,
+      shadowSummary,
+    },
+    overall: {
+      status: overallStatus,
+      blockers: issues.blockers,
+      warnings: issues.warnings,
+    },
+  };
+
+  return {
+    report,
+    markdown: buildMarkdown(report),
+  };
+}
+
+async function writeOutputs(outputPath, markdownPath, report, markdown) {
+  const resolvedOutputPath = path.resolve(process.cwd(), outputPath);
+  const resolvedMarkdownPath = path.resolve(process.cwd(), markdownPath);
+  await fs.mkdir(path.dirname(resolvedOutputPath), { recursive: true });
+  await fs.mkdir(path.dirname(resolvedMarkdownPath), { recursive: true });
+  await fs.writeFile(resolvedOutputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await fs.writeFile(resolvedMarkdownPath, markdown, 'utf8');
+  return {
+    outputPath: resolvedOutputPath,
+    markdownPath: resolvedMarkdownPath,
+  };
+}
+
+function printUsage() {
+  console.log('Usage: node tools/priority/vi-history-cross-plane-budget.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --linux-receipt <path>                 Required Linux local-refinement receipt.');
+  console.log('  --windows-receipt <path>               Required Windows mirror local-refinement receipt.');
+  console.log('  --shadow-receipt <path>                Optional host-native 32-bit shadow timing receipt.');
+  console.log('  --host-plane-report <path>             Optional LabVIEW 2026 host-plane diagnostics report.');
+  console.log(`  --output <path>                        JSON report path (default: ${DEFAULT_OUTPUT_PATH})`);
+  console.log('  --markdown <path>                      Markdown summary path (default: alongside JSON report).');
+  console.log(`  --windows-threshold-ratio <n>          Windows/Linux budget threshold (default: ${DEFAULT_WINDOWS_THRESHOLD_RATIO}).`);
+  console.log(`  --shadow-accelerator-ratio <n>         Shadow acceleration threshold (default: ${DEFAULT_SHADOW_ACCELERATOR_RATIO}).`);
+  console.log('  --windows-over-budget-justification <text>');
+  console.log('                                         Downgrades an over-budget Windows ratio to warn.');
+  console.log('  --fail-on-warn                         Return non-zero when the report status is warn.');
+  console.log('  -h, --help                             Show help.');
+}
+
+export async function main(argv = process.argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+
+  const markdownPath = deriveMarkdownPath(options.outputPath, options.markdownPath);
+  const { report, markdown } = await buildCrossPlaneBudgetReport({
+    linuxReceiptPath: options.linuxReceiptPath,
+    windowsReceiptPath: options.windowsReceiptPath,
+    shadowReceiptPath: options.shadowReceiptPath,
+    hostPlaneReportPath: options.hostPlaneReportPath,
+    windowsThresholdRatio: options.windowsThresholdRatio,
+    shadowAcceleratorRatio: options.shadowAcceleratorRatio,
+    windowsOverBudgetJustification: options.windowsOverBudgetJustification,
+  });
+  const written = await writeOutputs(options.outputPath, markdownPath, report, markdown);
+
+  console.log(`[vi-history-cross-plane-budget] report: ${written.outputPath}`);
+  console.log(`[vi-history-cross-plane-budget] markdown: ${written.markdownPath}`);
+  console.log(`[vi-history-cross-plane-budget] overall=${report.overall.status} windowsRatio=${report.comparisons.windowsVsLinux.candidateToBaselineRatio}x`);
+
+  if (report.overall.status === 'fail') {
+    return 1;
+  }
+  if (report.overall.status === 'warn' && options.failOnWarn) {
+    return 1;
+  }
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv).then(
+    (exitCode) => process.exit(exitCode),
+    (error) => {
+      console.error(`[vi-history-cross-plane-budget] ${error.message}`);
+      process.exit(1);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add a VI History cross-plane budget evaluator over existing lane receipts
- encode the Windows <= 1.2x Linux timing contract in a machine-readable schema
- document how shadow 32-bit timing participates when available without blocking the base budget
