### PR TITLE
Default PR comment flows to body-file in PowerShell (#1396)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -171,6 +171,9 @@ Quick reference for building, testing, and releasing the LVCompare composite act
 - `pwsh -NoLogo -NoProfile -File tools/Post-IssueComment.ps1 -Issue <number> -BodyFile issue-comment.md`
   Posts GitHub issue comments through `--body-file` by default so multiline Markdown survives PowerShell and mixed
   Windows/WSL shells without backtick-escape drift.
+- `pwsh -NoLogo -NoProfile -File tools/Post-PullRequestComment.ps1 -PullRequest <number> -Repo <owner/repo> -BodyFile pr-comment.md`
+  Posts GitHub pull-request comments through `--body-file` by default so multiline Markdown survives PowerShell and
+  mixed Windows/WSL shells without backtick-escape drift.
 - `node tools/priority/github-helper.mjs snippet --issue 531 --prefix Fixes`  
   Emits an auto-link snippet (defaults to `Fixes #531`) you can drop into PR descriptions so GitHub auto-closes the issue.
 - `node tools/npm/run-script.mjs priority:project:portfolio:apply -- --url <issue-or-pr-url> --use-config`  

--- a/docs/knowledgebase/GitHub-Intake-Layer.md
+++ b/docs/knowledgebase/GitHub-Intake-Layer.md
@@ -133,6 +133,13 @@ instead of inferring the correct path from prose alone.
   gh issue comment 875 --body-file issue-comment.md
   ```
 
+- Pull-request comments:
+
+  ```powershell
+  pwsh -File tools/Post-PullRequestComment.ps1 -PullRequest 875 -Repo owner/repo -BodyFile pr-comment.md
+  gh pr comment 875 --repo owner/repo --body-file pr-comment.md
+  ```
+
 - PR bodies:
 
   ```powershell
@@ -220,7 +227,7 @@ Human-authored PRs should use the `human-change` template so they do not acciden
 
 ## Mixed-Shell Guidance
 
-For issue creation, issue comments, and PR creation in mixed WSL/Windows shells, prefer `--body-file` over inline
-multiline `--body` strings. For issue comments, prefer `tools/Post-IssueComment.ps1` so PowerShell lanes always route
-through a temporary or explicit body file. That keeps quoting deterministic and aligns with the guidance in
-`AGENTS.md`.
+For issue creation, issue comments, PR comments, and PR creation in mixed WSL/Windows shells, prefer `--body-file`
+over inline multiline `--body` strings. For comments, prefer `tools/Post-IssueComment.ps1` and
+`tools/Post-PullRequestComment.ps1` so PowerShell lanes always route through a temporary or explicit body file. That
+keeps quoting deterministic and aligns with the guidance in `AGENTS.md`.

--- a/tests/GitHubIntake.Tests.ps1
+++ b/tests/GitHubIntake.Tests.ps1
@@ -89,7 +89,7 @@ Describe 'GitHubIntake.psm1' {
     $catalog.routes.scenario | Should -Contain 'human-pr'
   }
 
-  It 'documents safe body-file issue comment guidance in the agent and intake docs' {
+  It 'documents safe body-file issue and PR comment guidance in the intake docs' {
     $agentGuide = Get-Content (Join-Path $PSScriptRoot '..' 'AGENTS.md') -Raw
     $intakeGuide = Get-Content (Join-Path $PSScriptRoot '..' 'docs' 'knowledgebase' 'GitHub-Intake-Layer.md') -Raw
     $developerGuide = Get-Content (Join-Path $PSScriptRoot '..' 'docs' 'DEVELOPER_GUIDE.md') -Raw
@@ -98,7 +98,18 @@ Describe 'GitHubIntake.psm1' {
     $agentGuide | Should -Match 'gh issue comment'
     $intakeGuide | Should -Match 'pwsh -File tools/Post-IssueComment\.ps1 -Issue 875 -BodyFile issue-comment\.md'
     $intakeGuide | Should -Match 'gh issue comment 875 --body-file issue-comment\.md'
+    $intakeGuide | Should -Match 'pwsh -File tools/Post-PullRequestComment\.ps1 -PullRequest 875 -Repo owner/repo -BodyFile pr-comment\.md'
+    $intakeGuide | Should -Match 'gh pr comment 875 --repo owner/repo --body-file pr-comment\.md'
     $developerGuide | Should -Match 'tools/Post-IssueComment\.ps1'
+    $developerGuide | Should -Match 'tools/Post-PullRequestComment\.ps1'
+  }
+
+  It 'keeps one-button PR updates on body-file transport for PowerShell-safe markdown bodies' {
+    $oneButton = Get-Content (Join-Path $PSScriptRoot '..' 'tools' 'Run-OneButtonValidate.ps1') -Raw
+
+    $oneButton | Should -Match 'gh pr edit \$pr\.number --title \$title --body-file \$tempBodyPath'
+    $oneButton | Should -Match 'priority:pr -- --issue 127 --branch \$branch --base develop --title \$title --body-file \$tempBodyPath'
+    $oneButton | Should -Not -Match 'gh pr edit \$pr\.number --title \$title --body \$body'
   }
 
   It 'resolves workflow-policy intake to the workflow-policy issue template' {

--- a/tests/Post-PullRequestComment.Tests.ps1
+++ b/tests/Post-PullRequestComment.Tests.ps1
@@ -1,0 +1,87 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Post-PullRequestComment.ps1' {
+  BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'tools' 'Post-PullRequestComment.ps1'
+  }
+
+  BeforeEach {
+    $script:ghShimPath = Join-Path $TestDrive 'gh.ps1'
+    $script:capturePath = Join-Path $TestDrive 'gh-capture.json'
+
+    @'
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$RemainingArgs
+)
+
+$bodyFileIndex = [Array]::IndexOf($RemainingArgs, '--body-file')
+$bodyPath = if ($bodyFileIndex -ge 0 -and ($bodyFileIndex + 1) -lt $RemainingArgs.Count) {
+  $RemainingArgs[$bodyFileIndex + 1]
+} else {
+  $null
+}
+
+$payload = [pscustomobject]@{
+  args        = @($RemainingArgs)
+  bodyPath    = $bodyPath
+  bodyContent = if ($bodyPath) { Get-Content -LiteralPath $bodyPath -Raw } else { $null }
+}
+
+$payload | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $env:GH_CAPTURE_PATH -Encoding utf8
+'@ | Set-Content -LiteralPath $script:ghShimPath -Encoding utf8
+
+    Set-Alias -Name gh -Value $script:ghShimPath -Scope Global
+    $env:GH_CAPTURE_PATH = $script:capturePath
+  }
+
+  AfterEach {
+    Remove-Item Alias:gh -ErrorAction SilentlyContinue
+    Remove-Item Env:GH_CAPTURE_PATH -ErrorAction SilentlyContinue
+  }
+
+  It 'uses --body-file when an explicit body file is supplied' {
+    $bodyPath = Join-Path $TestDrive 'comment.md'
+    $bodyText = "PR comment from file`n"
+    [System.IO.File]::WriteAllText($bodyPath, $bodyText)
+
+    & $scriptPath -PullRequest 1396 -Repo 'LabVIEW-Community-CI-CD/compare-vi-cli-action' -BodyFile $bodyPath -Quiet
+
+    $capture = Get-Content -LiteralPath $script:capturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $capture.args[0] | Should -Be 'pr'
+    $capture.args[1] | Should -Be 'comment'
+    $capture.args[2] | Should -Be '1396'
+    $capture.args | Should -Contain '--repo'
+    $capture.args | Should -Contain 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    $capture.args | Should -Contain '--body-file'
+    $capture.bodyPath | Should -Be (Resolve-Path -LiteralPath $bodyPath).Path
+    $capture.bodyContent | Should -BeExactly $bodyText
+  }
+
+  It 'routes inline PR comment text through a temporary body file' {
+    $bodyText = @'
+Continuity line
+`upstream/develop...HEAD`
+'@.TrimEnd("`r", "`n")
+
+    & $scriptPath -PullRequest 1396 -Repo 'LabVIEW-Community-CI-CD/compare-vi-cli-action' -Body $bodyText -Quiet
+
+    $capture = Get-Content -LiteralPath $script:capturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $capture.args | Should -Contain '--body-file'
+    $capture.args | Should -Not -Contain $bodyText
+    [string]::IsNullOrWhiteSpace($capture.bodyPath) | Should -BeFalse
+    $capture.bodyContent.TrimEnd("`r", "`n") | Should -BeExactly $bodyText
+  }
+
+  It 'preserves edit-last mode while still using body-file transport' {
+    $bodyPath = Join-Path $TestDrive 'edit-last.md'
+    Set-Content -LiteralPath $bodyPath -Value 'Edit last PR comment' -Encoding utf8
+
+    & $scriptPath -PullRequest 1396 -Repo 'LabVIEW-Community-CI-CD/compare-vi-cli-action' -BodyFile $bodyPath -EditLast -Quiet
+
+    $capture = Get-Content -LiteralPath $script:capturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $capture.args | Should -Contain '--edit-last'
+    $capture.args | Should -Contain '--body-file'
+  }
+}

--- a/tools/Post-PullRequestComment.ps1
+++ b/tools/Post-PullRequestComment.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 7.0
+[CmdletBinding(DefaultParameterSetName='BodyFile')]
+param(
+  [Parameter(Mandatory = $true)]
+  [int]$PullRequest,
+
+  [Parameter()]
+  [string]$Repo,
+
+  [Parameter(ParameterSetName = 'BodyFile', Mandatory = $true)]
+  [string]$BodyFile,
+
+  [Parameter(ParameterSetName = 'Body', Mandatory = $true)]
+  [string]$Body,
+
+  [switch]$EditLast,
+  [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Gh {
+  if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI ('gh') is required but was not found on PATH."
+  }
+}
+
+function Invoke-GhPullRequestComment {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments
+  )
+
+  & gh @Arguments
+  if (-not $?) {
+    $exitCode = if (Test-Path variable:LASTEXITCODE) { $LASTEXITCODE } else { $null }
+    if ($null -ne $exitCode) {
+      throw "gh pr comment exited with code $exitCode."
+    }
+    throw 'gh pr comment failed.'
+  }
+}
+
+Ensure-Gh
+
+$commentArgs = @('pr', 'comment', $PullRequest.ToString())
+if (-not [string]::IsNullOrWhiteSpace($Repo)) {
+  $commentArgs += @('--repo', $Repo.Trim())
+}
+if ($EditLast) {
+  $commentArgs += '--edit-last'
+}
+
+switch ($PSCmdlet.ParameterSetName) {
+  'BodyFile' {
+    $resolved = Resolve-Path -LiteralPath $BodyFile -ErrorAction Stop
+    $args = $commentArgs + @('--body-file', $resolved.Path)
+    if (-not $Quiet) {
+      Write-Host ("Posting comment from file '{0}' to PR #{1}..." -f $resolved.Path, $PullRequest)
+    }
+    Invoke-GhPullRequestComment -Arguments $args
+  }
+  'Body' {
+    $temp = [System.IO.Path]::GetTempFileName()
+    try {
+      Set-Content -LiteralPath $temp -Value $Body -Encoding utf8
+      $args = $commentArgs + @('--body-file', $temp)
+      if (-not $Quiet) {
+        Write-Host ("Posting comment to PR #{0} using temporary body file..." -f $PullRequest)
+      }
+      Invoke-GhPullRequestComment -Arguments $args
+    } finally {
+      Remove-Item -LiteralPath $temp -ErrorAction SilentlyContinue
+    }
+  }
+  default {
+    throw "Unsupported parameter set '$($PSCmdlet.ParameterSetName)'."
+  }
+}
+
+if (-not $Quiet) {
+  Write-Host 'Pull request comment posted successfully.' -ForegroundColor Green
+}

--- a/tools/Run-OneButtonValidate.ps1
+++ b/tools/Run-OneButtonValidate.ps1
@@ -131,13 +131,19 @@ if ($Push) {
       $title = 'Normalize workflows and local Validate mirrors (#127)'
       $body = 'Automated workflow normalization and Validate task updates for #127.'
     $existingJson = gh pr view $branch --json number 2>$null
-    if ($LASTEXITCODE -eq 0 -and $existingJson) {
-      $pr = $existingJson | ConvertFrom-Json
-      gh pr edit $pr.number --title $title --body $body | Out-Host
-      if ($LASTEXITCODE -ne 0) { throw "gh pr edit failed ($LASTEXITCODE)" }
-    } else {
-      node tools/npm/run-script.mjs priority:pr -- --issue 127 --branch $branch --base develop --title $title --body $body | Out-Host
-      if ($LASTEXITCODE -ne 0) { throw "priority:pr failed ($LASTEXITCODE)" }
+    $tempBodyPath = [System.IO.Path]::GetTempFileName()
+    try {
+      Set-Content -LiteralPath $tempBodyPath -Value $body -Encoding utf8
+      if ($LASTEXITCODE -eq 0 -and $existingJson) {
+        $pr = $existingJson | ConvertFrom-Json
+        gh pr edit $pr.number --title $title --body-file $tempBodyPath | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "gh pr edit failed ($LASTEXITCODE)" }
+      } else {
+        node tools/npm/run-script.mjs priority:pr -- --issue 127 --branch $branch --base develop --title $title --body-file $tempBodyPath | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "priority:pr failed ($LASTEXITCODE)" }
+      }
+    } finally {
+      Remove-Item -LiteralPath $tempBodyPath -ErrorAction SilentlyContinue
     }
   }
 }


### PR DESCRIPTION
## Summary
- make PR comment/update flows default to `--body-file` instead of inline body strings in PowerShell
- add a PR-comment helper parallel to the issue-comment helper
- lock the safe body-file transport in tests and docs
