### PR TITLE
Degrade develop sync safely from dirty work branches (#1538)

### DIFF
--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -171,6 +171,51 @@ test('resolveDevelopSyncExecutionRoot delegates work-branch syncs to an existing
   );
 });
 
+test('resolveDevelopSyncExecutionRoot degrades dirty work-branch syncs to ref-refresh when no develop helper worktree exists', () => {
+  const repoRoot = path.join('C:', 'repo', 'issue-root');
+  const calls = [];
+  const plan = resolveDevelopSyncExecutionRoot({
+    repoRoot,
+    spawnSyncFn: (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      if (command !== 'git') {
+        throw new Error(`Unexpected command ${command}`);
+      }
+      if (args[0] === 'branch' && args[1] === '--show-current') {
+        return { status: 0, stdout: 'issue/origin-1538-dirty-branch\n', stderr: '' };
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          status: 0,
+          stdout: [
+            `worktree ${repoRoot}`,
+            'HEAD 1111111111111111111111111111111111111111',
+            'branch refs/heads/issue/origin-1538-dirty-branch',
+            ''
+          ].join('\n'),
+          stderr: ''
+        };
+      }
+      if (args[0] === 'status' && args[1] === '--porcelain') {
+        return { status: 0, stdout: ' M tools/priority/develop-sync.mjs\n?? dirty-note.txt\n', stderr: '' };
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`);
+    }
+  });
+
+  assert.equal(plan.executionRepoRoot, repoRoot);
+  assert.equal(plan.currentBranch, 'issue/origin-1538-dirty-branch');
+  assert.equal(plan.mode, 'ref-refresh');
+  assert.equal(plan.reason, 'dirty-work-branch');
+  assert.equal(plan.dirtyWorktree, true);
+  assert.equal(plan.delegated, false);
+  assert.equal(plan.helperRoot, null);
+  assert.deepEqual(
+    calls.map((entry) => entry.args.join(' ')),
+    ['branch --show-current', 'worktree list --porcelain', 'status --porcelain']
+  );
+});
+
 test('buildDevelopSyncBranchClassTrace classifies upstream develop to fork develop as a mirror sync', () => {
   const trace = buildDevelopSyncBranchClassTrace(repoRoot);
 
@@ -357,6 +402,83 @@ test('runDevelopSync launches the sync script from the delegated develop helper 
   assert.ok(spawnCalls.some((entry) => entry.command === 'pwsh' && entry.cwd === helperRoot));
 });
 
+test('runDevelopSync refreshes remote develop refs from a dirty work branch without invoking the checkout-based sync script', async (t) => {
+  const sandboxRoot = await mkdtemp(path.join(os.tmpdir(), 'develop-sync-dirty-ref-refresh-'));
+  const upstreamBare = path.join(sandboxRoot, 'upstream.git');
+  const originBare = path.join(sandboxRoot, 'origin.git');
+  const seedRepo = path.join(sandboxRoot, 'seed');
+  const localRepo = path.join(sandboxRoot, 'local');
+  const reportPath = path.join(sandboxRoot, 'develop-sync-report.json');
+  const parityReportPath = path.join(localRepo, 'tests', 'results', '_agent', 'issue', 'origin-upstream-parity.json');
+  t.after(async () => {
+    await rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  initBareRepo(upstreamBare);
+  initBareRepo(originBare);
+  initTempGitRepo(seedRepo);
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: seedRepo });
+  run('git', ['remote', 'add', 'origin', originBare], { cwd: seedRepo });
+  run('git', ['push', 'upstream', 'develop'], { cwd: seedRepo });
+  run('git', ['push', 'origin', 'develop'], { cwd: seedRepo });
+
+  run('git', ['clone', '--origin', 'origin', originBare, localRepo], { cwd: sandboxRoot });
+  run('git', ['config', 'user.email', 'agent@example.com'], { cwd: localRepo });
+  run('git', ['config', 'user.name', 'Agent Runner'], { cwd: localRepo });
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: localRepo });
+  run('git', ['checkout', '-b', 'issue/test-sync-dirty'], { cwd: localRepo });
+
+  writeFileSyncImmediate(path.join(localRepo, '.gitkeep'), 'dirty tracked\n', 'utf8');
+  writeFileSyncImmediate(path.join(localRepo, 'dirty-untracked.txt'), 'dirty untracked\n', 'utf8');
+
+  writeFileSyncImmediate(path.join(seedRepo, 'upstream-only.txt'), 'upstream only\n', 'utf8');
+  run('git', ['add', 'upstream-only.txt'], { cwd: seedRepo });
+  run('git', ['commit', '-m', 'advance upstream'], { cwd: seedRepo });
+  const upstreamHead = run('git', ['rev-parse', 'HEAD'], { cwd: seedRepo });
+  run('git', ['push', 'upstream', 'develop'], { cwd: seedRepo });
+
+  const result = runDevelopSync({
+    repoRoot: localRepo,
+    options: { forkRemote: 'origin', reportPath },
+    spawnSyncFn: (command, args, options) => {
+      if (command === 'git') {
+        return spawnSync(command, args, options);
+      }
+      throw new Error(`Unexpected command ${command}`);
+    }
+  });
+
+  assert.equal(result.report.status, 'ok');
+  assert.equal(result.report.actions[0].status, 'ok');
+  assert.equal(result.report.actions[0].syncMode, 'ref-refresh');
+  assert.equal(result.report.actions[0].syncReason, 'dirty-work-branch');
+  assert.equal(result.report.actions[0].parityConverged, false);
+  assert.equal(result.report.actions[0].execution.mode, 'ref-refresh');
+  assert.equal(result.report.actions[0].execution.reason, 'dirty-work-branch');
+  assert.equal(result.report.actions[0].execution.currentBranch, 'issue/test-sync-dirty');
+  assert.equal(result.report.actions[0].execution.dirtyWorktree, true);
+  assert.equal(result.report.actions[0].execution.delegated, false);
+  assert.equal(result.report.actions[0].execution.helperRoot, null);
+
+  const parityReport = readJson(parityReportPath);
+  assert.equal(parityReport.syncResult.mode, 'ref-refresh');
+  assert.equal(parityReport.syncResult.reason, 'dirty-work-branch');
+  assert.equal(parityReport.syncResult.parityConverged, false);
+  assert.equal(parityReport.execution.mode, 'ref-refresh');
+  assert.equal(parityReport.execution.currentBranch, 'issue/test-sync-dirty');
+  assert.equal(parityReport.execution.dirtyWorktree, true);
+
+  assert.equal(run('git', ['branch', '--show-current'], { cwd: localRepo }), 'issue/test-sync-dirty');
+  const status = run('git', ['status', '--porcelain'], { cwd: localRepo });
+  assert.match(status, /dirty-untracked\.txt/);
+  assert.match(status, /\.gitkeep/);
+
+  const upstreamTrackingHead = run('git', ['rev-parse', '--verify', 'upstream/develop'], { cwd: localRepo });
+  const originTrackingHead = run('git', ['rev-parse', '--verify', 'origin/develop'], { cwd: localRepo });
+  assert.equal(upstreamTrackingHead, upstreamHead);
+  assert.notEqual(originTrackingHead, upstreamTrackingHead);
+});
+
 test('buildSyncAdminPaths uses git-common-dir for repo-wide lock serialization in a linked worktree', () => {
   const adminPaths = buildSyncAdminPaths({ repoRoot, remote: 'origin' });
   const gitCommonDirRaw = run('git', ['rev-parse', '--git-common-dir'], { cwd: repoRoot });
@@ -380,10 +502,11 @@ test('runDevelopSync writes admin-path diagnostics when the underlying sync comm
     await rm(tempRoot, { recursive: true, force: true });
   });
 
+  initTempGitRepo(tempRoot);
   const reportPath = path.join(tempRoot, 'develop-sync-report.json');
   await assert.rejects(
     async () => runDevelopSync({
-      repoRoot,
+      repoRoot: tempRoot,
       options: {
         forkRemote: 'origin',
         reportPath

--- a/tools/priority/develop-sync.mjs
+++ b/tools/priority/develop-sync.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import { resolveGitAdminPaths } from './lib/git-admin-paths.mjs';
 import { resolveActiveForkRemoteName } from './lib/remote-utils.mjs';
+import { collectParity } from './report-origin-upstream-parity.mjs';
 import {
   DEFAULT_BRANCH_CLASS_CONTRACT_RELATIVE_PATH,
   assertAllowedTransition,
@@ -18,6 +19,7 @@ import {
 
 const DEFAULT_REPORT_PATH = path.join('tests', 'results', '_agent', 'issue', 'develop-sync-report.json');
 const SUPPORTED_FORK_REMOTES = new Set(['origin', 'personal']);
+const WORK_BRANCH_PATTERN = /^(issue\/|feature\/|release\/|hotfix\/|bugfix\/)/i;
 
 function printUsage() {
   console.log('Usage: node tools/priority/develop-sync.mjs [options]');
@@ -168,6 +170,68 @@ function runGitText(spawnSyncFn, cwd, args, env) {
   return String(result.stdout ?? '').trim();
 }
 
+function isWorkBranch(branch) {
+  return WORK_BRANCH_PATTERN.test(branch);
+}
+
+function isDirtyWorktree({ repoRoot, env = process.env, spawnSyncFn = spawnSync } = {}) {
+  const statusText = runGitText(spawnSyncFn, repoRoot, ['status', '--porcelain'], env);
+  return statusText.length > 0;
+}
+
+function writeJsonFile(filePath, payload) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function refreshDevelopTrackingRef({ repoRoot, remote, branch = 'develop', env = process.env, spawnSyncFn = spawnSync }) {
+  const trackingRef = `refs/remotes/${remote}/${branch}`;
+  const refSpec = `+refs/heads/${branch}:${trackingRef}`;
+  runGitText(spawnSyncFn, repoRoot, ['fetch', '--no-tags', remote, refSpec], env);
+}
+
+function collectRefRefreshParity({
+  repoRoot,
+  remote,
+  currentBranch,
+  parityReportPath,
+  env = process.env,
+  spawnSyncFn = spawnSync
+}) {
+  refreshDevelopTrackingRef({ repoRoot, remote: 'upstream', env, spawnSyncFn });
+  refreshDevelopTrackingRef({ repoRoot, remote, env, spawnSyncFn });
+
+  const parityReport = collectParity(
+    {
+      repoRoot,
+      baseRef: 'upstream/develop',
+      headRef: `${remote}/develop`,
+      strict: true
+    },
+    (command, args) =>
+      spawnSyncFn(command, args, {
+        cwd: repoRoot,
+        env,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+  );
+
+  parityReport.syncResult = {
+    mode: 'ref-refresh',
+    reason: 'dirty-work-branch',
+    parityConverged: parityReport?.tipDiff?.fileCount === 0
+  };
+  parityReport.execution = {
+    mode: 'ref-refresh',
+    reason: 'dirty-work-branch',
+    currentBranch,
+    dirtyWorktree: true
+  };
+  writeJsonFile(parityReportPath, parityReport);
+  return parityReport;
+}
+
 export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, spawnSyncFn = spawnSync } = {}) {
   const normalizedRepoRoot = path.resolve(repoRoot);
   let currentBranch = '';
@@ -178,16 +242,22 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
       repoRoot: normalizedRepoRoot,
       executionRepoRoot: normalizedRepoRoot,
       currentBranch: null,
+      mode: 'full-sync',
+      reason: null,
+      dirtyWorktree: false,
       delegated: false,
       helperRoot: null
     };
   }
 
-  if (!/^(issue\/|feature\/|release\/|hotfix\/|bugfix\/)/i.test(currentBranch)) {
+  if (!isWorkBranch(currentBranch)) {
     return {
       repoRoot: normalizedRepoRoot,
       executionRepoRoot: normalizedRepoRoot,
       currentBranch,
+      mode: 'full-sync',
+      reason: null,
+      dirtyWorktree: false,
       delegated: false,
       helperRoot: null
     };
@@ -206,8 +276,26 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
         repoRoot: normalizedRepoRoot,
         executionRepoRoot: helperRoot,
         currentBranch,
+        mode: 'full-sync',
+        reason: null,
+        dirtyWorktree: false,
         delegated: true,
         helperRoot
+      };
+    }
+  } catch {}
+
+  try {
+    if (isDirtyWorktree({ repoRoot: normalizedRepoRoot, env, spawnSyncFn })) {
+      return {
+        repoRoot: normalizedRepoRoot,
+        executionRepoRoot: normalizedRepoRoot,
+        currentBranch,
+        mode: 'ref-refresh',
+        reason: 'dirty-work-branch',
+        dirtyWorktree: true,
+        delegated: false,
+        helperRoot: null
       };
     }
   } catch {}
@@ -216,6 +304,9 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
     repoRoot: normalizedRepoRoot,
     executionRepoRoot: normalizedRepoRoot,
     currentBranch,
+    mode: 'full-sync',
+    reason: null,
+    dirtyWorktree: false,
     delegated: false,
     helperRoot: null
   };
@@ -288,7 +379,6 @@ export function buildDevelopSyncBranchClassTrace(repoRoot) {
 }
 
 function writeDevelopSyncReport({ repoRoot, reportPath, remotes, actions, status }) {
-  mkdirSync(path.dirname(reportPath), { recursive: true });
   const report = {
     schema: 'priority/develop-sync-report@v1',
     generatedAt: new Date().toISOString(),
@@ -297,7 +387,7 @@ function writeDevelopSyncReport({ repoRoot, reportPath, remotes, actions, status
     status,
     actions
   };
-  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  writeJsonFile(reportPath, report);
   return report;
 }
 
@@ -340,6 +430,7 @@ function buildActionFromParityReport({
   adminPaths,
   branchClassTrace,
   parityReport,
+  executionPlan,
   status,
   exitCode,
   error
@@ -364,6 +455,16 @@ function buildActionFromParityReport({
       typeof parityReport?.syncResult?.parityConverged === 'boolean'
         ? parityReport.syncResult.parityConverged
         : parityReport?.tipDiff?.fileCount === 0,
+    execution: executionPlan
+      ? {
+          mode: executionPlan.mode ?? 'full-sync',
+          reason: executionPlan.reason ?? null,
+          currentBranch: executionPlan.currentBranch ?? null,
+          dirtyWorktree: executionPlan.dirtyWorktree === true,
+          delegated: executionPlan.delegated === true,
+          helperRoot: executionPlan.helperRoot ?? null
+        }
+      : null,
     protectedSync: parityReport?.syncResult?.protectedSync ?? null,
     parityRemediation: parityReport?.syncResult?.parityRemediation ?? null,
     recommendation: parityReport?.recommendation ?? null,
@@ -391,17 +492,38 @@ export function runDevelopSync({
   for (const remote of remotes) {
     const parityReportPath = buildParityReportPath(repoRoot, remote);
     const adminPaths = buildSyncAdminPaths({ repoRoot: executionPlan.executionRepoRoot, remote, env, spawnSyncFn });
-    const args = buildPwshArgs({ repoRoot: executionPlan.executionRepoRoot, remote, parityReportPath });
     if (existsSync(parityReportPath)) {
       rmSync(parityReportPath, { force: true });
     }
-    const result = spawnSyncFn('pwsh', args, {
-      cwd: executionPlan.executionRepoRoot,
-      stdio: 'inherit',
-      encoding: 'utf8'
-    });
-    if (result.status !== 0) {
-      const commandError = String(result.stderr ?? result.stdout ?? '').trim() || `pwsh exited with status ${result.status}`;
+    let result = null;
+    let commandError = null;
+    try {
+      if (executionPlan.mode === 'ref-refresh') {
+        collectRefRefreshParity({
+          repoRoot,
+          remote,
+          currentBranch: executionPlan.currentBranch,
+          parityReportPath,
+          env,
+          spawnSyncFn
+        });
+      } else {
+        const args = buildPwshArgs({ repoRoot: executionPlan.executionRepoRoot, remote, parityReportPath });
+        result = spawnSyncFn('pwsh', args, {
+          cwd: executionPlan.executionRepoRoot,
+          stdio: 'inherit',
+          encoding: 'utf8'
+        });
+        if (result.status !== 0) {
+          commandError = String(result.stderr ?? result.stdout ?? '').trim() || `pwsh exited with status ${result.status}`;
+        }
+      }
+    } catch (error) {
+      commandError = error.message;
+      result = { status: 1, stdout: '', stderr: error.message };
+    }
+    const exitCode = result?.status ?? 0;
+    if (exitCode !== 0) {
       if (existsSync(parityReportPath)) {
         let parityReport;
         try {
@@ -434,8 +556,9 @@ export function runDevelopSync({
               adminPaths,
               branchClassTrace,
               parityReport,
+              executionPlan,
               status: 'failed',
-              exitCode: result.status,
+              exitCode,
               error: commandError
             })
           );
@@ -449,7 +572,7 @@ export function runDevelopSync({
             parityReportPath: path.relative(repoRoot, parityReportPath).replace(/\\/g, '/'),
             adminPaths,
             branchClassTrace,
-            exitCode: result.status,
+            exitCode,
             error: error.message
           });
           writeDevelopSyncReport({
@@ -468,7 +591,7 @@ export function runDevelopSync({
           parityReportPath: path.relative(repoRoot, parityReportPath).replace(/\\/g, '/'),
           adminPaths,
           branchClassTrace,
-          exitCode: result.status,
+          exitCode,
           error: commandError
         });
       }
@@ -505,6 +628,7 @@ export function runDevelopSync({
           adminPaths,
           branchClassTrace,
           parityReport,
+          executionPlan,
           status: 'ok',
           exitCode: 0,
           error: null


### PR DESCRIPTION
## Summary
- let priority:develop:sync degrade safely when invoked from a dirty work branch
- keep helper-worktree delegation when available
- fall back to a safe parity receipt path instead of trying to checkout develop from the dirty lane

## Testing
- node --test tools/priority/__tests__/develop-sync.test.mjs
- git diff --check
