### PR TITLE
Clarify queue-safe branch cleanup semantics (#1545)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -303,6 +303,12 @@ to confirm each workflow includes both triggers.
    groups.
 4. If the run fails or new commits land, the queue ejects the entry back to the PR. Address the failure, rerun the
    relevant check (`priority:validate`, `Validate` workflow, or manual reruns), and re-enable the queue.
+   Queue-safe cleanup note: `priority:merge-sync` does not send `gh pr merge --delete-branch` on queue-managed bases.
+   Without `--keep-branch`, direct merges still use inline branch deletion, but queue-managed or retried `--auto`
+   promotions record `branchCleanup` in `tests/results/_agent/queue/merge-sync-<pr>.json` and use post-merge API
+   deletion once the merge materializes. When the PR remains queued after the current helper turn, `priority:queue:supervisor`
+   reconciles that deferred cleanup and records the outcome under `deferredBranchCleanup` in
+   `tests/results/_agent/queue/queue-supervisor-report.json`.
 5. For autonomous queueing, run `node tools/npm/run-script.mjs priority:queue:supervisor -- --dry-run` first, then
    `--apply` when trunk health is green. The supervisor enforces required checks, dependency ordering, and queue caps.
    Use `QUEUE_AUTOPILOT_MAX_INFLIGHT` for cap tuning and keep `QUEUE_AUTOPILOT_ADAPTIVE_CAP=1`

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -1184,6 +1184,131 @@ test('runMergeSync records queued promotion state after auto merge activation ma
   assert.equal(written.promotion.status, 'queued');
 });
 
+test('runMergeSync retries policy-blocked direct merges without reintroducing inline branch deletion', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'merge-sync-pr-retry-cleanup-'));
+  const mergeArgs = [];
+  let promotionReads = 0;
+
+  const payload = await runMergeSync({
+    argv: [
+      'node',
+      'tools/priority/merge-sync-pr.mjs',
+      '--pr',
+      '557',
+      '--repo',
+      'svelderrainruiz/compare-vi-cli-action',
+      '--summary-path',
+      path.join(tempDir, 'summary.json')
+    ],
+    repoRoot,
+    ensureGhCliFn: () => {},
+    readRepositoryMergeCapabilitiesFn: () => buildRepositoryMergeCapabilities(),
+    readPrInfoFn: () => ({
+      number: 557,
+      state: 'OPEN',
+      isDraft: false,
+      mergeStateStatus: 'CLEAN',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'develop',
+      headRefName: 'issue/personal-1397-retry-cleanup',
+      headRepository: {
+        name: 'compare-vi-cli-action'
+      },
+      headRepositoryOwner: {
+        login: 'svelderrainruiz'
+      },
+      headRefOid: '1234567890123456789012345678901234567890',
+      url: 'https://example.test/pr/557'
+    }),
+    evaluatePromotionReviewClearanceFn: async () => ({
+      ok: true,
+      report: {
+        status: 'pass',
+        gateState: 'ready',
+        reasons: ['current-head-review-run-completed-clean']
+      }
+    }),
+    readPromotionStateFn: () => {
+      promotionReads += 1;
+      return promotionReads === 1
+        ? {
+            state: 'OPEN',
+            mergeStateStatus: 'CLEAN',
+            isInMergeQueue: false,
+            autoMergeRequest: null,
+            mergedAt: null
+          }
+        : {
+            state: 'OPEN',
+            mergeStateStatus: 'BLOCKED',
+            isInMergeQueue: true,
+            autoMergeRequest: null,
+            mergedAt: null
+          };
+    },
+    runMergeAttemptFn: ({ args }) => {
+      mergeArgs.push(args);
+      return mergeArgs.length === 1
+        ? {
+            status: 1,
+            stdout: '',
+            stderr: 'Base branch policy requires merge queue; direct merge blocked.'
+          }
+        : {
+            status: 0,
+            stdout: 'queued',
+            stderr: ''
+          };
+    },
+    sleepFn: async () => {}
+  });
+
+  assert.deepEqual(mergeArgs, [
+    [
+      'pr',
+      'merge',
+      '557',
+      '--repo',
+      'svelderrainruiz/compare-vi-cli-action',
+      '--squash'
+    ],
+    [
+      'pr',
+      'merge',
+      '557',
+      '--repo',
+      'svelderrainruiz/compare-vi-cli-action',
+      '--squash',
+      '--auto'
+    ]
+  ]);
+  assert.equal(payload.selectedMode, 'direct');
+  assert.equal(payload.finalMode, 'auto');
+  assert.equal(payload.finalReason, 'direct-merge-policy-block-retry-auto');
+  assert.deepEqual(
+    payload.attempts.map((attempt) => ({ mode: attempt.mode, exitCode: attempt.exitCode })),
+    [
+      { mode: 'direct', exitCode: 1 },
+      { mode: 'auto', exitCode: 0 }
+    ]
+  );
+  assert.deepEqual(payload.branchCleanup, {
+    requested: true,
+    attempted: false,
+    status: 'deferred',
+    reason: 'promotion-not-yet-merged',
+    inlineDeleteBranch: false,
+    postMergeDelete: true,
+    repository: 'svelderrainruiz/compare-vi-cli-action',
+    headRefName: 'issue/personal-1397-retry-cleanup'
+  });
+
+  const written = JSON.parse(await readFile(path.join(tempDir, 'summary.json'), 'utf8'));
+  assert.equal(written.finalReason, 'direct-merge-policy-block-retry-auto');
+  assert.equal(written.branchCleanup.status, 'deferred');
+  assert.equal(written.branchCleanup.postMergeDelete, true);
+});
+
 test('runMergeSync falls back to a supported repository merge method before invoking gh pr merge', async () => {
   const mergeArgs = [];
   let promotionReads = 0;

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -32,9 +32,9 @@ const USAGE_LINES = [
   '  --method <merge|squash|rebase>',
   '                           Merge method override (default: repository-aware selection preferring squash)',
   '  --admin                  Explicitly use admin merge override',
-  '  --keep-branch            Keep head branch after merge',
+  '  --keep-branch            Keep head branch after merge (default cleanup is inline for direct merges and post-merge for queue-managed/--auto flows)',
   '  --dry-run                Print selected mode and merge command without executing',
-  '  --summary-path <path>    Write JSON summary payload',
+  '  --summary-path <path>    Write JSON summary payload including promotion and branchCleanup state',
   '  -h, --help               Show this message and exit'
 ];
 


### PR DESCRIPTION
## Summary
- clarify that queue-managed promotion uses receipt-backed deferred branch cleanup instead of inline delete-branch flags
- lock the queue-safe retry path in merge-sync tests
- align feature-branch policy docs with the queue-safe cleanup contract

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs
- node --test tools/priority/__tests__/queue-supervisor.test.mjs --test-name-pattern "deferred branch cleanup|merge-sync exits 0 without durable promotion state"
