### PR TITLE
Add package-state fingerprints to dependency audit receipts (#1546)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -223,6 +223,11 @@ node tools/npm/run-script.mjs priority:security:audit:gate   # explicit blocking
 ./tools/PrePush-Checks.ps1  # actionlint, dependency-audit observation, optional YAML round-trip
 ```
 
+The dependency-audit receipt now records a deterministic `packageState` block,
+including `package.json` / `package-lock.json` hashes and a
+`fingerprintSha256` so vulnerability changes can be tied back to the exact
+audited Node dependency graph.
+
 For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 
 - Single-lane strict (recommended before full loop):

--- a/docs/plans/VALIDATION_MATRIX.md
+++ b/docs/plans/VALIDATION_MATRIX.md
@@ -54,6 +54,8 @@ Audience: anyone touching `.github/workflows/**`.
   document). No additional env vars required.
 - **Expected output** – Streams `actionlint` diagnostics and audit summaries to the console. The dependency-audit lane
   writes `tests/results/_agent/security/dependency-audit-report.json` and the raw npm payload under the same directory.
+  The report also includes a deterministic `packageState.fingerprintSha256`
+  keyed from the audited `package.json` / `package-lock.json` inputs.
 - **Failure modes** – Missing binary (when `-InstallIfMissing:$false`), lint errors, or transient download failures.
   The dependency-audit lane is observe-only in this script, so vulnerability or transport findings are reported in the
   receipt without turning pre-push into a blind fail-everything audit gate. Use

--- a/docs/schemas/dependency-audit-report-v1.schema.json
+++ b/docs/schemas/dependency-audit-report-v1.schema.json
@@ -10,6 +10,7 @@
     "result",
     "command",
     "execution",
+    "packageState",
     "thresholds",
     "summary",
     "packages",
@@ -89,6 +90,95 @@
         },
         "jsonParsed": {
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "packageState": {
+      "type": "object",
+      "required": [
+        "nodeVersion",
+        "packageJson",
+        "packageLock",
+        "fingerprintSha256"
+      ],
+      "properties": {
+        "nodeVersion": {
+          "type": "string"
+        },
+        "packageJson": {
+          "type": "object",
+          "required": [
+            "path",
+            "exists",
+            "sha256",
+            "packageName",
+            "packageVersion"
+          ],
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "exists": {
+              "type": "boolean"
+            },
+            "sha256": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "packageName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "packageVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "packageLock": {
+          "type": "object",
+          "required": [
+            "path",
+            "exists",
+            "sha256",
+            "lockfileVersion"
+          ],
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "exists": {
+              "type": "boolean"
+            },
+            "sha256": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "lockfileVersion": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "fingerprintSha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
         }
       },
       "additionalProperties": false

--- a/tests/PrePushDependencyAuditObservation.Tests.ps1
+++ b/tests/PrePushDependencyAuditObservation.Tests.ps1
@@ -68,6 +68,23 @@ Describe 'Pre-push dependency audit observation' -Tag 'Unit' {
           stderr = $null
           jsonParsed = $true
         }
+        packageState = @{
+          nodeVersion = 'v24.13.1'
+          packageJson = @{
+            path = 'package.json'
+            exists = $true
+            sha256 = ('a' * 64)
+            packageName = 'compare-vi-cli-action'
+            packageVersion = '0.6.3'
+          }
+          packageLock = @{
+            path = 'package-lock.json'
+            exists = $true
+            sha256 = ('b' * 64)
+            lockfileVersion = 3
+          }
+          fingerprintSha256 = ('c' * 64)
+        }
         thresholds = @{
           total = 0
           critical = 0

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -318,6 +318,9 @@ function Invoke-DependencyAuditObservation([string]$repoRoot) {
 
   $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
   $result = if ($report.PSObject.Properties['result']) { [string]$report.result } else { 'unknown' }
+  $packageState = if ($report.PSObject.Properties['packageState']) { $report.packageState } else { $null }
+  $auditFingerprint = if ($packageState -and $packageState.PSObject.Properties['fingerprintSha256']) { [string]$packageState.fingerprintSha256 } else { '' }
+  $lockfileVersion = if ($packageState -and $packageState.packageLock -and $packageState.packageLock.PSObject.Properties['lockfileVersion']) { $packageState.packageLock.lockfileVersion } else { $null }
   switch ($result) {
     'pass' {
       Write-Host '[pre-push] dependency audit observation OK' -ForegroundColor Green
@@ -331,6 +334,12 @@ function Invoke-DependencyAuditObservation([string]$repoRoot) {
     default {
       Write-Host ("[pre-push] dependency audit observation produced unexpected result '{0}'" -f $result) -ForegroundColor Yellow
     }
+  }
+  if (-not [string]::IsNullOrWhiteSpace($auditFingerprint)) {
+    Write-Host ("[pre-push] dependency audit fingerprint: {0}" -f $auditFingerprint) -ForegroundColor DarkGray
+  }
+  if ($null -ne $lockfileVersion) {
+    Write-Host ("[pre-push] dependency audit lockfileVersion: {0}" -f $lockfileVersion) -ForegroundColor DarkGray
   }
   Write-Host ("[pre-push] Dependency audit report: {0}" -f $reportPath) -ForegroundColor DarkGray
 }

--- a/tools/priority/__tests__/dependency-audit.test.mjs
+++ b/tools/priority/__tests__/dependency-audit.test.mjs
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  collectPackageState,
   DEFAULT_MODE,
   DEFAULT_OUTPUT_PATH,
   DEFAULT_RAW_OUTPUT_PATH,
@@ -45,6 +46,8 @@ test('parseArgs supports mode, outputs, and thresholds', () => {
   const parsed = parseArgs([
     'node',
     'dependency-audit.mjs',
+    '--repo-root',
+    'repo-root',
     '--output',
     'custom-report.json',
     '--raw-output',
@@ -61,6 +64,7 @@ test('parseArgs supports mode, outputs, and thresholds', () => {
     '4',
   ]);
 
+  assert.equal(parsed.repoRoot, 'repo-root');
   assert.equal(parsed.outputPath, 'custom-report.json');
   assert.equal(parsed.rawOutputPath, 'custom-raw.json');
   assert.equal(parsed.mode, 'enforce');
@@ -147,9 +151,20 @@ test('runDependencyAudit reports clean audits as pass in observe mode', async ()
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dependency-audit-pass-'));
   const outputPath = path.join(tmpDir, 'report.json');
   const rawOutputPath = path.join(tmpDir, 'npm-audit.json');
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({ name: 'audit-pass', version: '1.2.3' }, null, 2),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'package-lock.json'),
+    JSON.stringify({ name: 'audit-pass', lockfileVersion: 3 }, null, 2),
+    'utf8',
+  );
 
   const result = await runDependencyAudit(
     {
+      repoRoot: tmpDir,
       outputPath,
       rawOutputPath,
       mode: 'observe',
@@ -171,6 +186,10 @@ test('runDependencyAudit reports clean audits as pass in observe mode', async ()
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.result, 'pass');
+  assert.equal(result.report.packageState.packageJson.packageName, 'audit-pass');
+  assert.equal(result.report.packageState.packageJson.packageVersion, '1.2.3');
+  assert.equal(result.report.packageState.packageLock.lockfileVersion, 3);
+  assert.match(result.report.packageState.fingerprintSha256, /^[0-9a-f]{64}$/);
   assert.equal(result.report.summary.total, 0);
   assert.equal(fs.existsSync(outputPath), true);
   assert.equal(fs.existsSync(rawOutputPath), true);
@@ -180,9 +199,11 @@ test('runDependencyAudit warns without failing in observe mode when thresholds a
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dependency-audit-warn-'));
   const outputPath = path.join(tmpDir, 'report.json');
   const rawOutputPath = path.join(tmpDir, 'npm-audit.json');
+  fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'audit-warn', version: '1.0.0' }), 'utf8');
 
   const result = await runDependencyAudit(
     {
+      repoRoot: tmpDir,
       outputPath,
       rawOutputPath,
       mode: 'observe',
@@ -241,9 +262,11 @@ test('runDependencyAudit warns without failing in observe mode when thresholds a
 
 test('runDependencyAudit fails in enforce mode when thresholds are breached', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dependency-audit-fail-'));
+  fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'audit-fail', version: '2.0.0' }), 'utf8');
 
   const result = await runDependencyAudit(
     {
+      repoRoot: tmpDir,
       outputPath: path.join(tmpDir, 'report.json'),
       rawOutputPath: path.join(tmpDir, 'npm-audit.json'),
       mode: 'enforce',
@@ -298,9 +321,11 @@ test('runDependencyAudit fails in enforce mode when thresholds are breached', as
 
 test('runDependencyAudit records execution errors without failing observe mode', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dependency-audit-error-'));
+  fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'audit-error', version: '3.0.0' }), 'utf8');
 
   const result = await runDependencyAudit(
     {
+      repoRoot: tmpDir,
       outputPath: path.join(tmpDir, 'report.json'),
       rawOutputPath: path.join(tmpDir, 'npm-audit.json'),
       mode: 'observe',
@@ -325,8 +350,35 @@ test('runDependencyAudit records execution errors without failing observe mode',
   assert.equal(result.report.errors.length >= 1, true);
 });
 
+test('collectPackageState fingerprints the audited package manifest and lockfile deterministically', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dependency-audit-package-state-'));
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({ name: 'package-state', version: '9.9.9' }, null, 2),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'package-lock.json'),
+    JSON.stringify({ name: 'package-state', lockfileVersion: 3 }, null, 2),
+    'utf8',
+  );
+
+  const first = await collectPackageState({ repoRoot: tmpDir }, { nodeVersion: 'v24.13.1' });
+  const second = await collectPackageState({ repoRoot: tmpDir }, { nodeVersion: 'v24.13.1' });
+
+  assert.equal(first.packageJson.path, 'package.json');
+  assert.equal(first.packageLock.path, 'package-lock.json');
+  assert.equal(first.packageJson.packageName, 'package-state');
+  assert.equal(first.packageJson.packageVersion, '9.9.9');
+  assert.equal(first.packageLock.lockfileVersion, 3);
+  assert.match(first.packageJson.sha256, /^[0-9a-f]{64}$/);
+  assert.match(first.packageLock.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(first.fingerprintSha256, second.fingerprintSha256);
+});
+
 test('parseArgs defaults align with the contract', () => {
   const parsed = parseArgs(['node', 'dependency-audit.mjs']);
+  assert.equal(parsed.repoRoot, '.');
   assert.equal(parsed.outputPath, DEFAULT_OUTPUT_PATH);
   assert.equal(parsed.rawOutputPath, DEFAULT_RAW_OUTPUT_PATH);
   assert.equal(parsed.mode, DEFAULT_MODE);

--- a/tools/priority/dependency-audit.mjs
+++ b/tools/priority/dependency-audit.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs/promises';
+import crypto from 'node:crypto';
 import path from 'node:path';
 import process from 'node:process';
 import { spawn } from 'node:child_process';
@@ -11,6 +12,7 @@ import { createNpmLaunchSpec } from '../npm/spawn.mjs';
 export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'security', 'dependency-audit-report.json');
 export const DEFAULT_RAW_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'security', 'npm-audit.json');
 export const DEFAULT_MODE = 'observe';
+export const DEFAULT_REPO_ROOT = '.';
 export const DEFAULT_THRESHOLDS = Object.freeze({
   total: 0,
   critical: 0,
@@ -22,6 +24,7 @@ const HELP = [
   'Usage: node tools/priority/dependency-audit.mjs [options]',
   '',
   'Options:',
+  `  --repo-root <path>               (default: ${DEFAULT_REPO_ROOT})`,
   `  --output <path>                  (default: ${DEFAULT_OUTPUT_PATH})`,
   `  --raw-output <path>              (default: ${DEFAULT_RAW_OUTPUT_PATH})`,
   `  --mode observe|enforce           (default: ${DEFAULT_MODE})`,
@@ -80,6 +83,7 @@ function compareSeverity(left, right) {
 export function parseArgs(argv = process.argv) {
   const args = argv.slice(2);
   const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
     outputPath: DEFAULT_OUTPUT_PATH,
     rawOutputPath: DEFAULT_RAW_OUTPUT_PATH,
     mode: DEFAULT_MODE,
@@ -96,6 +100,7 @@ export function parseArgs(argv = process.argv) {
     }
 
     if (
+      token === '--repo-root' ||
       token === '--output' ||
       token === '--raw-output' ||
       token === '--mode' ||
@@ -108,6 +113,7 @@ export function parseArgs(argv = process.argv) {
         throw new Error(`Missing value for ${token}.`);
       }
       index += 1;
+      if (token === '--repo-root') options.repoRoot = next;
       if (token === '--output') options.outputPath = next;
       if (token === '--raw-output') options.rawOutputPath = next;
       if (token === '--mode') options.mode = normalizeMode(next);
@@ -122,6 +128,91 @@ export function parseArgs(argv = process.argv) {
   }
 
   return options;
+}
+
+function normalizeRelativePath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+async function readOptionalText(filePath, readFileFn = fs.readFile) {
+  try {
+    const content = await readFileFn(filePath, 'utf8');
+    return {
+      exists: true,
+      content,
+    };
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return {
+        exists: false,
+        content: null,
+      };
+    }
+    throw error;
+  }
+}
+
+function sha256Text(content) {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export async function collectPackageState(
+  {
+    repoRoot = process.cwd(),
+  } = {},
+  {
+    readFileFn = fs.readFile,
+    nodeVersion = process.version,
+  } = {},
+) {
+  const resolvedRepoRoot = path.resolve(repoRoot);
+  const packageJsonPath = path.join(resolvedRepoRoot, 'package.json');
+  const packageLockPath = path.join(resolvedRepoRoot, 'package-lock.json');
+
+  const packageJson = await readOptionalText(packageJsonPath, readFileFn);
+  const packageLock = await readOptionalText(packageLockPath, readFileFn);
+
+  let packageJsonPayload = null;
+  let packageLockPayload = null;
+  if (packageJson.content) {
+    packageJsonPayload = JSON.parse(packageJson.content);
+  }
+  if (packageLock.content) {
+    packageLockPayload = JSON.parse(packageLock.content);
+  }
+
+  const packageStateFingerprintInput = {
+    nodeVersion,
+    packageName: asOptional(packageJsonPayload?.name),
+    packageVersion: asOptional(packageJsonPayload?.version),
+    packageJsonSha256: packageJson.content ? sha256Text(packageJson.content) : null,
+    packageLockSha256: packageLock.content ? sha256Text(packageLock.content) : null,
+    packageLockVersion:
+      typeof packageLockPayload?.lockfileVersion === 'number'
+        ? packageLockPayload.lockfileVersion
+        : null,
+  };
+
+  return {
+    nodeVersion,
+    packageJson: {
+      path: normalizeRelativePath(path.relative(resolvedRepoRoot, packageJsonPath) || 'package.json'),
+      exists: packageJson.exists,
+      sha256: packageStateFingerprintInput.packageJsonSha256,
+      packageName: packageStateFingerprintInput.packageName,
+      packageVersion: packageStateFingerprintInput.packageVersion,
+    },
+    packageLock: {
+      path: normalizeRelativePath(path.relative(resolvedRepoRoot, packageLockPath) || 'package-lock.json'),
+      exists: packageLock.exists,
+      sha256: packageStateFingerprintInput.packageLockSha256,
+      lockfileVersion: packageStateFingerprintInput.packageLockVersion,
+    },
+    fingerprintSha256: crypto
+      .createHash('sha256')
+      .update(JSON.stringify(packageStateFingerprintInput))
+      .digest('hex'),
+  };
 }
 
 function normalizeSeverity(value) {
@@ -311,10 +402,19 @@ export async function runDependencyAudit(
     runAuditCommandFn = runSanitizedNpmAudit,
     writeFileFn = fs.writeFile,
     mkdirFn = fs.mkdir,
+    readFileFn = fs.readFile,
     log = console.log,
     error = console.error,
   } = {},
 ) {
+  const packageState = await collectPackageState(
+    {
+      repoRoot: options.repoRoot,
+    },
+    {
+      readFileFn,
+    },
+  );
   const auditExecution = await runAuditCommandFn();
   const rawAuditPath = await writeTextFile(options.rawOutputPath, auditExecution.stdout || '', writeFileFn, mkdirFn);
 
@@ -391,6 +491,12 @@ export async function runDependencyAudit(
       stderr: asOptional(auditExecution.stderr),
       jsonParsed: executionErrors.length === 0,
     },
+    packageState: {
+      nodeVersion: packageState.nodeVersion,
+      packageJson: packageState.packageJson,
+      packageLock: packageState.packageLock,
+      fingerprintSha256: packageState.fingerprintSha256,
+    },
     thresholds: options.thresholds,
     summary,
     packages,
@@ -407,6 +513,7 @@ export async function runDependencyAudit(
 
   log(`[dependency-audit] report: ${reportPath}`);
   log(`[dependency-audit] raw: ${rawAuditPath}`);
+  log(`[dependency-audit] fingerprint=${packageState.fingerprintSha256}`);
   if (result === 'pass') {
     log('[dependency-audit] result=pass');
   } else if (result === 'warn') {


### PR DESCRIPTION
## Summary
- add package-state fingerprint metadata to the dependency-audit receipt
- project the fingerprint into pre-push audit observation output
- document the audited package/lockfile identity in the receipt contract

## Testing
- node --test tools/priority/__tests__/dependency-audit.test.mjs tools/priority/__tests__/dependency-audit-schema.test.mjs
- pwsh -NoLogo -NoProfile -File tests/PrePushDependencyAuditObservation.Tests.ps1
- node tools/priority/dependency-audit.mjs --output tests/results/_agent/security/dependency-audit-report-1399b.json --raw-output tests/results/_agent/security/npm-audit-1399b.json
- git diff --check
