### PR TITLE
Cache live project context between portfolio apply runs (#1442)

### DIFF
--- a/dist/tools/cli/project-portfolio.js
+++ b/dist/tools/cli/project-portfolio.js
@@ -199,6 +199,17 @@ const itemFieldValuesQuerySchema = z.object({
         }).nullable(),
     }),
 });
+const projectContextCacheSchema = z.object({
+    schema: z.literal('project-portfolio-context-cache@v1'),
+    generatedAt: z.string().min(1),
+    project: z.object({
+        owner: z.string().min(1),
+        number: z.number().int().positive(),
+    }),
+    view: viewSchema,
+    fields: fieldsSchema,
+});
+const defaultContextCacheMaxAgeSeconds = 300;
 function readJsonFile(filePath) {
     return JSON.parse(readFileSync(filePath, 'utf8'));
 }
@@ -295,6 +306,82 @@ function runGhGraphql(query, variables, schema) {
 function loadJsonInput(maybeFile, schema, ghArgs) {
     const payload = maybeFile ? readJsonFile(resolvePath(maybeFile)) : runGhJson(ghArgs);
     return schema.parse(payload);
+}
+function buildProjectContextCacheReportContext(path, status, reason, maxAgeSeconds, generatedAt, ageSeconds) {
+    return {
+        path,
+        status,
+        reason,
+        maxAgeSeconds,
+        generatedAt,
+        ageSeconds,
+    };
+}
+function loadProjectContextCache(cachePath, owner, number, maxAgeSeconds) {
+    if (!existsSync(cachePath)) {
+        return {
+            cache: null,
+            reason: 'cache-missing',
+            generatedAt: null,
+            ageSeconds: null,
+        };
+    }
+    let parsed;
+    try {
+        parsed = projectContextCacheSchema.parse(readJsonFile(cachePath));
+    }
+    catch {
+        return {
+            cache: null,
+            reason: 'cache-invalid',
+            generatedAt: null,
+            ageSeconds: null,
+        };
+    }
+    if (parsed.project.owner !== owner || parsed.project.number !== number) {
+        return {
+            cache: null,
+            reason: 'project-mismatch',
+            generatedAt: parsed.generatedAt,
+            ageSeconds: null,
+        };
+    }
+    const generatedAtMs = Date.parse(parsed.generatedAt);
+    if (!Number.isFinite(generatedAtMs)) {
+        return {
+            cache: null,
+            reason: 'cache-invalid',
+            generatedAt: parsed.generatedAt,
+            ageSeconds: null,
+        };
+    }
+    const ageSeconds = Math.max(0, Math.floor((Date.now() - generatedAtMs) / 1000));
+    if (ageSeconds > maxAgeSeconds) {
+        return {
+            cache: null,
+            reason: 'cache-stale',
+            generatedAt: parsed.generatedAt,
+            ageSeconds,
+        };
+    }
+    return {
+        cache: parsed,
+        reason: null,
+        generatedAt: parsed.generatedAt,
+        ageSeconds,
+    };
+}
+function writeProjectContextCache(cachePath, owner, number, view, fields) {
+    writeJsonFile(cachePath, {
+        schema: 'project-portfolio-context-cache@v1',
+        generatedAt: new Date().toISOString(),
+        project: {
+            owner,
+            number,
+        },
+        view,
+        fields,
+    });
 }
 function fieldValue(item, name) {
     const normalizedName = name.trim().toLowerCase();
@@ -1221,10 +1308,67 @@ function compareProject(config, view, fields, items) {
 function loadProjectContext(args, config, options) {
     const owner = args.owner ?? config.owner;
     const number = args.number ?? config.number;
-    const view = loadJsonInput(args.view_file, viewSchema, ['project', 'view', String(number), '--owner', owner, '--format', 'json']);
-    const fields = loadJsonInput(args.fields_file, fieldsSchema, ['project', 'field-list', String(number), '--owner', owner, '--format', 'json']);
+    const contextCachePath = args.context_cache_file ? resolvePath(args.context_cache_file) : null;
+    const contextCacheMaxAgeSeconds = args.context_cache_max_age_seconds ?? defaultContextCacheMaxAgeSeconds;
+    const explicitContextFiles = Boolean(args.view_file || args.fields_file);
+    let view;
+    let fields;
+    let reportContext;
+    if (explicitContextFiles) {
+        view = loadJsonInput(args.view_file, viewSchema, ['project', 'view', String(number), '--owner', owner, '--format', 'json']);
+        fields = loadJsonInput(args.fields_file, fieldsSchema, ['project', 'field-list', String(number), '--owner', owner, '--format', 'json']);
+        reportContext = {
+            sources: {
+                view: args.view_file ? 'file' : 'live',
+                fields: args.fields_file ? 'file' : 'live',
+                itemList: 'skipped',
+            },
+            cache: buildProjectContextCacheReportContext(contextCachePath, contextCachePath ? 'bypassed' : 'disabled', null, contextCachePath ? contextCacheMaxAgeSeconds : null, null, null),
+        };
+    }
+    else if (contextCachePath) {
+        const cachedContext = loadProjectContextCache(contextCachePath, owner, number, contextCacheMaxAgeSeconds);
+        if (cachedContext.cache) {
+            view = cachedContext.cache.view;
+            fields = cachedContext.cache.fields;
+            reportContext = {
+                sources: {
+                    view: 'cache',
+                    fields: 'cache',
+                    itemList: 'skipped',
+                },
+                cache: buildProjectContextCacheReportContext(contextCachePath, 'used', null, contextCacheMaxAgeSeconds, cachedContext.generatedAt, cachedContext.ageSeconds),
+            };
+        }
+        else {
+            view = loadJsonInput(undefined, viewSchema, ['project', 'view', String(number), '--owner', owner, '--format', 'json']);
+            fields = loadJsonInput(undefined, fieldsSchema, ['project', 'field-list', String(number), '--owner', owner, '--format', 'json']);
+            writeProjectContextCache(contextCachePath, owner, number, view, fields);
+            reportContext = {
+                sources: {
+                    view: 'live',
+                    fields: 'live',
+                    itemList: 'skipped',
+                },
+                cache: buildProjectContextCacheReportContext(contextCachePath, 'refreshed', cachedContext.reason, contextCacheMaxAgeSeconds, cachedContext.generatedAt, cachedContext.ageSeconds),
+            };
+        }
+    }
+    else {
+        view = loadJsonInput(undefined, viewSchema, ['project', 'view', String(number), '--owner', owner, '--format', 'json']);
+        fields = loadJsonInput(undefined, fieldsSchema, ['project', 'field-list', String(number), '--owner', owner, '--format', 'json']);
+        reportContext = {
+            sources: {
+                view: 'live',
+                fields: 'live',
+                itemList: 'skipped',
+            },
+            cache: buildProjectContextCacheReportContext(null, 'disabled', null, null, null, null),
+        };
+    }
     const fieldNames = buildFieldNameMap(config);
     if (options?.includeItems === false) {
+        reportContext.sources.itemList = 'skipped';
         return {
             view,
             fields,
@@ -1233,16 +1377,19 @@ function loadProjectContext(args, config, options) {
                 items: [],
             },
             normalizedItems: [],
+            reportContext,
         };
     }
     const itemListLimit = String(Math.max(view.items.totalCount, 100));
     const itemList = loadJsonInput(args.item_file, itemListSchema, ['project', 'item-list', String(number), '--owner', owner, '--limit', itemListLimit, '--format', 'json']);
     const normalizedItems = itemList.items.map((item) => normalizeItem(item, fieldNames)).sort((a, b) => a.url.localeCompare(b.url));
+    reportContext.sources.itemList = args.item_file ? 'file' : 'live';
     return {
         view,
         fields,
         itemList,
         normalizedItems,
+        reportContext,
     };
 }
 function buildParser() {
@@ -1281,6 +1428,15 @@ function buildParser() {
     parser.add_argument('--item-file', {
         required: false,
         help: 'Optional path to a captured gh project item-list JSON payload.',
+    });
+    parser.add_argument('--context-cache-file', {
+        required: false,
+        help: 'Optional path to a reusable project context cache containing live project view and field-list payloads.',
+    });
+    parser.add_argument('--context-cache-max-age-seconds', {
+        required: false,
+        type: 'int',
+        help: `Maximum age for --context-cache-file before the helper refreshes it live (default: ${defaultContextCacheMaxAgeSeconds}).`,
     });
     parser.add_argument('--url', {
         required: false,
@@ -1411,6 +1567,7 @@ function main() {
             mode: args.mode,
             configPath,
             dryRun,
+            projectContext: context.reportContext,
             project: {
                 owner,
                 number,
@@ -1468,6 +1625,7 @@ function main() {
         generatedAt: new Date().toISOString(),
         mode: args.mode,
         configPath,
+        projectContext: context.reportContext,
         project: {
             owner,
             number,

--- a/docs/knowledgebase/GitHub-Intake-Layer.md
+++ b/docs/knowledgebase/GitHub-Intake-Layer.md
@@ -96,7 +96,11 @@ instead of inferring the correct path from prose alone.
   post-apply verification payload instead of reloading the full board. The report still includes a projected post-apply
   snapshot plus normalized board context for built-in metadata such as `Type`, `Milestone`, `Reviewers`, linked PRs,
   parent issue, and `Sub-issues progress`, so future agents do not need a second board scrape just to reason about
-  intake state. Use this instead of ad hoc `gh project item-add` plus repeated `gh project item-edit` sequences.
+  intake state. When you are applying fields to multiple targets in sequence, pass
+  `--context-cache-file tests/results/_agent/project/portfolio-context-cache.json` so repeated runs can reuse the
+  live `project view` plus `field-list` payloads; the report records this under `projectContext.sources` and
+  `projectContext.cache`. Use this instead of ad hoc `gh project item-add` plus repeated `gh project item-edit`
+  sequences.
 
 - Canonical GitHub metadata application:
 

--- a/tools/cli/project-portfolio.ts
+++ b/tools/cli/project-portfolio.ts
@@ -241,6 +241,8 @@ interface Args {
   view_file?: string;
   fields_file?: string;
   item_file?: string;
+  context_cache_file?: string;
+  context_cache_max_age_seconds?: number;
   url?: string;
   use_config?: boolean;
   dry_run?: boolean;
@@ -369,7 +371,43 @@ interface ProjectContext {
   fields: ProjectFields;
   itemList: ProjectItemList;
   normalizedItems: NormalizedItem[];
+  reportContext: ProjectContextReportContext;
 }
+
+type ProjectContextSource = 'file' | 'cache' | 'live' | 'skipped';
+type ProjectContextCacheStatus = 'disabled' | 'bypassed' | 'used' | 'refreshed';
+type ProjectContextCacheReason = 'cache-missing' | 'cache-invalid' | 'project-mismatch' | 'cache-stale';
+
+interface ProjectContextReportContext {
+  sources: {
+    view: ProjectContextSource;
+    fields: ProjectContextSource;
+    itemList: ProjectContextSource;
+  };
+  cache: {
+    path: string | null;
+    status: ProjectContextCacheStatus;
+    reason: ProjectContextCacheReason | null;
+    maxAgeSeconds: number | null;
+    generatedAt: string | null;
+    ageSeconds: number | null;
+  };
+}
+
+const projectContextCacheSchema = z.object({
+  schema: z.literal('project-portfolio-context-cache@v1'),
+  generatedAt: z.string().min(1),
+  project: z.object({
+    owner: z.string().min(1),
+    number: z.number().int().positive(),
+  }),
+  view: viewSchema,
+  fields: fieldsSchema,
+});
+
+type ProjectContextCache = z.infer<typeof projectContextCacheSchema>;
+
+const defaultContextCacheMaxAgeSeconds = 300;
 
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(readFileSync(filePath, 'utf8')) as T;
@@ -487,6 +525,112 @@ function loadJsonInput<T>(
 ): T {
   const payload = maybeFile ? readJsonFile<unknown>(resolvePath(maybeFile)) : runGhJson(ghArgs);
   return schema.parse(payload);
+}
+
+function buildProjectContextCacheReportContext(
+  path: string | null,
+  status: ProjectContextCacheStatus,
+  reason: ProjectContextCacheReason | null,
+  maxAgeSeconds: number | null,
+  generatedAt: string | null,
+  ageSeconds: number | null,
+): ProjectContextReportContext['cache'] {
+  return {
+    path,
+    status,
+    reason,
+    maxAgeSeconds,
+    generatedAt,
+    ageSeconds,
+  };
+}
+
+function loadProjectContextCache(
+  cachePath: string,
+  owner: string,
+  number: number,
+  maxAgeSeconds: number,
+): {
+    cache: ProjectContextCache | null;
+    reason: ProjectContextCacheReason | null;
+    generatedAt: string | null;
+    ageSeconds: number | null;
+  } {
+  if (!existsSync(cachePath)) {
+    return {
+      cache: null,
+      reason: 'cache-missing',
+      generatedAt: null,
+      ageSeconds: null,
+    };
+  }
+
+  let parsed: ProjectContextCache;
+  try {
+    parsed = projectContextCacheSchema.parse(readJsonFile<unknown>(cachePath));
+  } catch {
+    return {
+      cache: null,
+      reason: 'cache-invalid',
+      generatedAt: null,
+      ageSeconds: null,
+    };
+  }
+
+  if (parsed.project.owner !== owner || parsed.project.number !== number) {
+    return {
+      cache: null,
+      reason: 'project-mismatch',
+      generatedAt: parsed.generatedAt,
+      ageSeconds: null,
+    };
+  }
+
+  const generatedAtMs = Date.parse(parsed.generatedAt);
+  if (!Number.isFinite(generatedAtMs)) {
+    return {
+      cache: null,
+      reason: 'cache-invalid',
+      generatedAt: parsed.generatedAt,
+      ageSeconds: null,
+    };
+  }
+
+  const ageSeconds = Math.max(0, Math.floor((Date.now() - generatedAtMs) / 1000));
+  if (ageSeconds > maxAgeSeconds) {
+    return {
+      cache: null,
+      reason: 'cache-stale',
+      generatedAt: parsed.generatedAt,
+      ageSeconds,
+    };
+  }
+
+  return {
+    cache: parsed,
+    reason: null,
+    generatedAt: parsed.generatedAt,
+    ageSeconds,
+  };
+}
+
+function writeProjectContextCache(
+  cachePath: string,
+  owner: string,
+  number: number,
+  view: ProjectView,
+  fields: ProjectFields,
+): void {
+  writeJsonFile(cachePath, {
+    schema: 'project-portfolio-context-cache@v1',
+    generatedAt: new Date().toISOString(),
+    project: {
+      owner,
+      number,
+    },
+    view,
+    fields,
+  });
 }
 
 function fieldValue(item: RawProjectItem, name: string): string | null {
@@ -1603,18 +1747,117 @@ function compareProject(
 function loadProjectContext(args: Args, config: PortfolioConfig, options?: { includeItems?: boolean }): ProjectContext {
   const owner = args.owner ?? config.owner;
   const number = args.number ?? config.number;
-  const view = loadJsonInput(
-    args.view_file,
-    viewSchema,
-    ['project', 'view', String(number), '--owner', owner, '--format', 'json'],
-  );
-  const fields = loadJsonInput(
-    args.fields_file,
-    fieldsSchema,
-    ['project', 'field-list', String(number), '--owner', owner, '--format', 'json'],
-  );
+  const contextCachePath = args.context_cache_file ? resolvePath(args.context_cache_file) : null;
+  const contextCacheMaxAgeSeconds = args.context_cache_max_age_seconds ?? defaultContextCacheMaxAgeSeconds;
+  const explicitContextFiles = Boolean(args.view_file || args.fields_file);
+
+  let view: ProjectView;
+  let fields: ProjectFields;
+  let reportContext: ProjectContextReportContext;
+  if (explicitContextFiles) {
+    view = loadJsonInput(
+      args.view_file,
+      viewSchema,
+      ['project', 'view', String(number), '--owner', owner, '--format', 'json'],
+    );
+    fields = loadJsonInput(
+      args.fields_file,
+      fieldsSchema,
+      ['project', 'field-list', String(number), '--owner', owner, '--format', 'json'],
+    );
+    reportContext = {
+      sources: {
+        view: args.view_file ? 'file' : 'live',
+        fields: args.fields_file ? 'file' : 'live',
+        itemList: 'skipped',
+      },
+      cache: buildProjectContextCacheReportContext(
+        contextCachePath,
+        contextCachePath ? 'bypassed' : 'disabled',
+        null,
+        contextCachePath ? contextCacheMaxAgeSeconds : null,
+        null,
+        null,
+      ),
+    };
+  } else if (contextCachePath) {
+    const cachedContext = loadProjectContextCache(contextCachePath, owner, number, contextCacheMaxAgeSeconds);
+    if (cachedContext.cache) {
+      view = cachedContext.cache.view;
+      fields = cachedContext.cache.fields;
+      reportContext = {
+        sources: {
+          view: 'cache',
+          fields: 'cache',
+          itemList: 'skipped',
+        },
+        cache: buildProjectContextCacheReportContext(
+          contextCachePath,
+          'used',
+          null,
+          contextCacheMaxAgeSeconds,
+          cachedContext.generatedAt,
+          cachedContext.ageSeconds,
+        ),
+      };
+    } else {
+      view = loadJsonInput(
+        undefined,
+        viewSchema,
+        ['project', 'view', String(number), '--owner', owner, '--format', 'json'],
+      );
+      fields = loadJsonInput(
+        undefined,
+        fieldsSchema,
+        ['project', 'field-list', String(number), '--owner', owner, '--format', 'json'],
+      );
+      writeProjectContextCache(contextCachePath, owner, number, view, fields);
+      reportContext = {
+        sources: {
+          view: 'live',
+          fields: 'live',
+          itemList: 'skipped',
+        },
+        cache: buildProjectContextCacheReportContext(
+          contextCachePath,
+          'refreshed',
+          cachedContext.reason,
+          contextCacheMaxAgeSeconds,
+          cachedContext.generatedAt,
+          cachedContext.ageSeconds,
+        ),
+      };
+    }
+  } else {
+    view = loadJsonInput(
+      undefined,
+      viewSchema,
+      ['project', 'view', String(number), '--owner', owner, '--format', 'json'],
+    );
+    fields = loadJsonInput(
+      undefined,
+      fieldsSchema,
+      ['project', 'field-list', String(number), '--owner', owner, '--format', 'json'],
+    );
+    reportContext = {
+      sources: {
+        view: 'live',
+        fields: 'live',
+        itemList: 'skipped',
+      },
+      cache: buildProjectContextCacheReportContext(
+        null,
+        'disabled',
+        null,
+        null,
+        null,
+        null,
+      ),
+    };
+  }
   const fieldNames = buildFieldNameMap(config);
   if (options?.includeItems === false) {
+    reportContext.sources.itemList = 'skipped';
     return {
       view,
       fields,
@@ -1623,6 +1866,7 @@ function loadProjectContext(args: Args, config: PortfolioConfig, options?: { inc
         items: [],
       },
       normalizedItems: [],
+      reportContext,
     };
   }
 
@@ -1633,12 +1877,14 @@ function loadProjectContext(args: Args, config: PortfolioConfig, options?: { inc
     ['project', 'item-list', String(number), '--owner', owner, '--limit', itemListLimit, '--format', 'json'],
   );
   const normalizedItems = itemList.items.map((item) => normalizeItem(item, fieldNames)).sort((a, b) => a.url.localeCompare(b.url));
+  reportContext.sources.itemList = args.item_file ? 'file' : 'live';
 
   return {
     view,
     fields,
     itemList,
     normalizedItems,
+    reportContext,
   };
 }
 
@@ -1679,6 +1925,15 @@ function buildParser(): ArgumentParser {
   parser.add_argument('--item-file', {
     required: false,
     help: 'Optional path to a captured gh project item-list JSON payload.',
+  });
+  parser.add_argument('--context-cache-file', {
+    required: false,
+    help: 'Optional path to a reusable project context cache containing live project view and field-list payloads.',
+  });
+  parser.add_argument('--context-cache-max-age-seconds', {
+    required: false,
+    type: 'int',
+    help: `Maximum age for --context-cache-file before the helper refreshes it live (default: ${defaultContextCacheMaxAgeSeconds}).`,
   });
   parser.add_argument('--url', {
     required: false,
@@ -1821,6 +2076,7 @@ function main(): void {
       mode: args.mode,
       configPath,
       dryRun,
+      projectContext: context.reportContext,
       project: {
         owner,
         number,
@@ -1883,6 +2139,7 @@ function main(): void {
     generatedAt: new Date().toISOString(),
     mode: args.mode,
     configPath,
+    projectContext: context.reportContext,
     project: {
       owner,
       number,

--- a/tools/priority/Run-UnattendedProjectBoardLoop.ps1
+++ b/tools/priority/Run-UnattendedProjectBoardLoop.ps1
@@ -11,6 +11,7 @@ param(
   [int]$MaxCycles = 0,
   [switch]$QueueApply,
   [switch]$NoPortfolioApply,
+  [string]$ProjectContextCacheFile = 'tests/results/_agent/project/portfolio-context-cache.json',
   [switch]$StopWhenNoOpenIssues,
   [string]$ProjectStatus = 'In Progress',
   [string]$ProjectProgram = 'Shared Infra',
@@ -239,6 +240,9 @@ function Invoke-ProjectPortfolioApply {
     '--portfolio-track',
     $ProjectPortfolioTrack
   )
+  if (-not [string]::IsNullOrWhiteSpace($ProjectContextCacheFile)) {
+    $args += @('--context-cache-file', $ProjectContextCacheFile)
+  }
   if ($DryRun) {
     $args += '--dry-run'
   }

--- a/tools/priority/__tests__/project-portfolio-cli.test.mjs
+++ b/tools/priority/__tests__/project-portfolio-cli.test.mjs
@@ -24,6 +24,10 @@ function runCli(args, options = {}) {
   });
 }
 
+function countGhCalls(state, ...prefix) {
+  return (state.calls ?? []).filter((args) => prefix.every((token, index) => args[index] === token)).length;
+}
+
 function buildConfig({
   fieldNames = {},
   itemUrl = 'https://github.com/example/repo/issues/1',
@@ -440,6 +444,10 @@ test('project portfolio CLI emits v2 report schema for the expanded payload', as
   assert.equal(result.status, 0, result.stderr);
   const report = JSON.parse(await readFile(outPath, 'utf8'));
   assert.equal(report.schema, 'project-portfolio-report@v2');
+  assert.equal(report.projectContext.sources.view, 'file');
+  assert.equal(report.projectContext.sources.fields, 'file');
+  assert.equal(report.projectContext.sources.itemList, 'file');
+  assert.equal(report.projectContext.cache.status, 'disabled');
   assert.equal(report.items[0].portfolioTrack, 'Agent UX');
   assert.equal(report.items[0].type, 'Epic');
   assert.equal(report.items[0].milestone, 'Q1 Sustain');
@@ -648,6 +656,10 @@ test('project portfolio CLI apply mode adds a missing item and seeds fields from
   const fakeGhState = JSON.parse(await readFile(fakeGh.statePath, 'utf8'));
 
   assert.equal(report.schema, 'project-portfolio-apply-report@v1');
+  assert.equal(report.projectContext.sources.view, 'file');
+  assert.equal(report.projectContext.sources.fields, 'file');
+  assert.equal(report.projectContext.sources.itemList, 'file');
+  assert.equal(report.projectContext.cache.status, 'disabled');
   assert.equal(report.target.added, true);
   assert.equal(report.target.itemId, 'item-added-10');
   assert.equal(report.target.projectedItemSnapshot.status, 'Todo');
@@ -668,6 +680,168 @@ test('project portfolio CLI apply mode adds a missing item and seeds fields from
   ]);
   assert.equal(fakeGhState.updateCalls.length, 7);
   assert.ok(fakeGhState.updateCalls.every((call) => call.itemId === 'item-added-10'));
+});
+
+test('project portfolio CLI reuses cached live view and field-list across sequential apply runs', async (t) => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'project-portfolio-apply-context-cache-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const firstTargetUrl = 'https://github.com/example/repo/issues/31';
+  const secondTargetUrl = 'https://github.com/example/repo/issues/32';
+  const configPath = path.join(tempRoot, 'config.json');
+  const outPath1 = path.join(tempRoot, 'apply-report-1.json');
+  const outPath2 = path.join(tempRoot, 'apply-report-2.json');
+  const cachePath = path.join(tempRoot, 'project-context-cache.json');
+  const fields = buildFields();
+  const state = buildFakeGhState({
+    targetUrl: firstTargetUrl,
+    resourceId: 'ISSUE_31',
+    title: 'First apply issue',
+    fields,
+    nextAddedItemId: 'item-added-31',
+  });
+  state.projectView = buildView();
+  state.projectFields = fields;
+  state.resources[secondTargetUrl] = {
+    __typename: 'Issue',
+    id: 'ISSUE_32',
+    url: secondTargetUrl,
+    title: 'Second apply issue',
+    body: null,
+    repository: {
+      nameWithOwner: 'example/repo',
+    },
+    projectItems: [],
+    closingIssuesReferences: [],
+  };
+
+  await writeJson(configPath, buildConfig({ itemUrl: firstTargetUrl }));
+  const fakeGh = await writeFakeGhHarness(tempRoot, state);
+  const buildApplyArgs = (targetUrl, outPath) => [
+    'apply',
+    '--config', configPath,
+    '--context-cache-file', cachePath,
+    '--out', outPath,
+    '--url', targetUrl,
+    '--status', 'In Progress',
+    '--program', 'Shared Infra',
+    '--phase', 'Policy',
+    '--environment-class', 'Infra',
+    '--blocking-signal', 'Scope',
+    '--evidence-state', 'Ready',
+    '--portfolio-track', 'Agent UX',
+  ];
+
+  const firstResult = runCli(buildApplyArgs(firstTargetUrl, outPath1), {
+    env: {
+      ...fakeGh.env,
+      COMPAREVI_PROJECT_PORTFOLIO_VERIFY_DELAY_MS: '0',
+    },
+  });
+  assert.equal(firstResult.status, 0, firstResult.stderr);
+
+  const firstReport = JSON.parse(await readFile(outPath1, 'utf8'));
+  assert.equal(firstReport.projectContext.sources.view, 'live');
+  assert.equal(firstReport.projectContext.sources.fields, 'live');
+  assert.equal(firstReport.projectContext.cache.status, 'refreshed');
+  assert.equal(firstReport.projectContext.cache.reason, 'cache-missing');
+
+  const intermediateState = JSON.parse(await readFile(fakeGh.statePath, 'utf8'));
+  intermediateState.nextAddedItemId = 'item-added-32';
+  await writeJson(fakeGh.statePath, intermediateState);
+
+  const secondResult = runCli(buildApplyArgs(secondTargetUrl, outPath2), {
+    env: {
+      ...fakeGh.env,
+      COMPAREVI_PROJECT_PORTFOLIO_VERIFY_DELAY_MS: '0',
+    },
+  });
+  assert.equal(secondResult.status, 0, secondResult.stderr);
+
+  const secondReport = JSON.parse(await readFile(outPath2, 'utf8'));
+  const finalState = JSON.parse(await readFile(fakeGh.statePath, 'utf8'));
+
+  assert.equal(secondReport.projectContext.sources.view, 'cache');
+  assert.equal(secondReport.projectContext.sources.fields, 'cache');
+  assert.equal(secondReport.projectContext.cache.status, 'used');
+  assert.equal(secondReport.projectContext.cache.reason, null);
+  assert.equal(countGhCalls(finalState, 'project', 'view'), 1);
+  assert.equal(countGhCalls(finalState, 'project', 'field-list'), 1);
+  assert.equal(finalState.addCalls.length, 2);
+});
+
+test('project portfolio CLI refreshes stale live context cache before apply', async (t) => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'project-portfolio-apply-context-cache-stale-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const targetUrl = 'https://github.com/example/repo/issues/33';
+  const configPath = path.join(tempRoot, 'config.json');
+  const outPath = path.join(tempRoot, 'apply-report.json');
+  const cachePath = path.join(tempRoot, 'project-context-cache.json');
+  const fields = buildFields();
+  const staleGeneratedAt = '2000-01-01T00:00:00.000Z';
+  const liveView = buildView();
+  liveView.title = 'Fresh live project';
+
+  await writeJson(configPath, buildConfig({ itemUrl: targetUrl }));
+  await writeJson(cachePath, {
+    schema: 'project-portfolio-context-cache@v1',
+    generatedAt: staleGeneratedAt,
+    project: {
+      owner: 'example-owner',
+      number: 7,
+    },
+    view: {
+      ...buildView(),
+      title: 'Stale cached project',
+    },
+    fields,
+  });
+
+  const fakeGh = await writeFakeGhHarness(tempRoot, {
+    ...buildFakeGhState({
+      targetUrl,
+      resourceId: 'ISSUE_33',
+      title: 'Stale cache refresh issue',
+      fields,
+      nextAddedItemId: 'item-added-33',
+    }),
+    projectView: liveView,
+    projectFields: fields,
+  });
+
+  const result = runCli([
+    'apply',
+    '--config', configPath,
+    '--context-cache-file', cachePath,
+    '--context-cache-max-age-seconds', '60',
+    '--out', outPath,
+    '--url', targetUrl,
+    '--use-config',
+  ], {
+    env: {
+      ...fakeGh.env,
+      COMPAREVI_PROJECT_PORTFOLIO_VERIFY_DELAY_MS: '0',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(await readFile(outPath, 'utf8'));
+  const finalState = JSON.parse(await readFile(fakeGh.statePath, 'utf8'));
+  const refreshedCache = JSON.parse(await readFile(cachePath, 'utf8'));
+
+  assert.equal(report.projectContext.sources.view, 'live');
+  assert.equal(report.projectContext.sources.fields, 'live');
+  assert.equal(report.projectContext.cache.status, 'refreshed');
+  assert.equal(report.projectContext.cache.reason, 'cache-stale');
+  assert.equal(countGhCalls(finalState, 'project', 'view'), 1);
+  assert.equal(countGhCalls(finalState, 'project', 'field-list'), 1);
+  assert.equal(refreshedCache.view.title, 'Fresh live project');
+  assert.notEqual(refreshedCache.generatedAt, staleGeneratedAt);
 });
 
 test('project portfolio CLI apply mode prefers explicit values and skips add when item already exists', async (t) => {


### PR DESCRIPTION
## Summary
- add a fail-closed project context cache for sequential portfolio apply runs
- surface cache/live context provenance in project-portfolio reports
- reuse the shared cache path from the unattended project-board loop to reduce redundant live GraphQL/API traffic

## Testing
- node_modules\\.bin\\tsc -p tsconfig.cli.json
- node --test tools/priority/__tests__/project-portfolio-cli.test.mjs
- PowerShell parse check for tools/priority/Run-UnattendedProjectBoardLoop.ps1
