### PR TITLE
Fix Windows tsx wrapper execution (#1461)

### DIFF
--- a/tools/npm/__tests__/run-local-typescript.test.mjs
+++ b/tools/npm/__tests__/run-local-typescript.test.mjs
@@ -4,7 +4,8 @@ import assert from 'node:assert/strict';
 import {
   buildExecutionPlan,
   parseArgs,
-  resolveExecutionMode
+  resolveExecutionMode,
+  resolveTsxCliPath
 } from '../run-local-typescript.mjs';
 
 test('parseArgs preserves script arguments after --', () => {
@@ -42,7 +43,8 @@ test('buildExecutionPlan emits tsx locally and node+dist for compiled fallback',
     fallbackDist: 'dist/tools/priority/runtime-daemon.js',
     scriptArgs: ['--status'],
     mode: 'tsx',
-    tsxBinary: 'node_modules/.bin/tsx'
+    tsxBinary: 'node_modules/.bin/tsx',
+    platform: 'linux'
   });
   assert.deepEqual(tsxPlan, {
     mode: 'tsx',
@@ -61,4 +63,36 @@ test('buildExecutionPlan emits tsx locally and node+dist for compiled fallback',
   assert.equal(compiledPlan.mode, 'compiled');
   assert.equal(compiledPlan.command, process.execPath);
   assert.deepEqual(compiledPlan.args, ['dist/tools/priority/runtime-daemon.js', '--status']);
+});
+
+test('buildExecutionPlan runs the local tsx cli through node on Windows', () => {
+  const plan = buildExecutionPlan({
+    project: 'tsconfig.cli.json',
+    entry: 'tools/cli/project-portfolio.ts',
+    fallbackDist: 'dist/tools/cli/project-portfolio.js',
+    scriptArgs: ['check', '--help'],
+    mode: 'tsx',
+    tsxBinary: 'node_modules/.bin/tsx.cmd',
+    tsxCliPath: 'node_modules/tsx/dist/cli.mjs',
+    platform: 'win32'
+  });
+
+  assert.deepEqual(plan, {
+    mode: 'tsx',
+    command: process.execPath,
+    args: [
+      'node_modules/tsx/dist/cli.mjs',
+      '--tsconfig',
+      'tsconfig.cli.json',
+      'tools/cli/project-portfolio.ts',
+      'check',
+      '--help'
+    ]
+  });
+});
+
+test('resolveTsxCliPath locates the installed tsx cli entrypoint', () => {
+  const resolved = resolveTsxCliPath();
+  assert.ok(resolved);
+  assert.match(resolved, /node_modules[\\/]+tsx[\\/]+dist[\\/]+cli\.mjs$/i);
 });

--- a/tools/npm/run-local-typescript.mjs
+++ b/tools/npm/run-local-typescript.mjs
@@ -50,6 +50,11 @@ export function resolveTtsxBinary(root = repoRoot) {
   return candidates.find((candidate) => existsSync(candidate)) || null;
 }
 
+export function resolveTsxCliPath(root = repoRoot) {
+  const cliPath = path.join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+  return existsSync(cliPath) ? cliPath : null;
+}
+
 export function resolveExecutionMode({
   githubActions = process.env.GITHUB_ACTIONS === 'true',
   forceCompiled = process.env.COMPAREVI_FORCE_COMPILED_TS === '1',
@@ -89,9 +94,18 @@ export function buildExecutionPlan({
   fallbackDist,
   scriptArgs = [],
   mode = resolveExecutionMode(),
-  tsxBinary = resolveTtsxBinary(repoRoot)
+  tsxBinary = resolveTtsxBinary(repoRoot),
+  tsxCliPath = resolveTsxCliPath(repoRoot),
+  platform = process.platform
 }) {
   if (mode === 'tsx') {
+    if (platform === 'win32' && tsxCliPath) {
+      return {
+        mode,
+        command: process.execPath,
+        args: [tsxCliPath, '--tsconfig', project, entry, ...scriptArgs]
+      };
+    }
     return {
       mode,
       command: tsxBinary,


### PR DESCRIPTION
## Summary
- run local TypeScript entrypoints through `node` on Windows instead of spawning `tsx.cmd` directly
- preserve the compiled fallback path unchanged
- lock the Windows wrapper behavior with focused tests

## Testing
- node --test tools/npm/__tests__/run-local-typescript.test.mjs
- node tools/npm/run-local-typescript.mjs --project tsconfig.cli.json --entry tools/cli/project-portfolio.ts --fallback-dist dist/tools/cli/project-portfolio.js -- check --help
