### PR TITLE
Standardize GitHub token-file resolution across policy and security helpers (#1445)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -507,6 +507,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   `Authorization unavailable` or `authenticated-no-admin`, rotate `GH_TOKEN`/`GITHUB_TOKEN` secrets in upstream. For
   Dependabot-triggered runs, seed `GH_TOKEN` in Dependabot secret scope as well:
   `gh secret set GH_TOKEN --repo <owner/repo> --app dependabot`.
+- Node-based security/policy helpers now share the same GitHub token precedence:
+  `GH_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN_FILE`, `GITHUB_TOKEN_FILE`, then the standard host token file fallback
+  (`C:\github_token.txt` on Windows, `/mnt/c/github_token.txt` on non-Windows host planes).
 - Use `node tools/npm/run-script.mjs priority:policy:apply` only with admin token scope when you intentionally need to
   sync GitHub protections/rulesets back to `tools/priority/policy.json`.
 - Run `node tools/npm/run-script.mjs priority:commit-integrity -- --pr <number>` to evaluate commit trust posture

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -246,7 +246,7 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage
   ```
 
-- Merge-sync and the Copilot queue gate now resolve local GitHub auth in this
+- Merge-sync, the Copilot queue gate, `security-intake`, and `check-policy` now resolve local GitHub auth in this
   order before live review lookups:
   1. `GH_TOKEN`
   2. `GITHUB_TOKEN`

--- a/docs/schemas/policy-drift-report-v1.schema.json
+++ b/docs/schemas/policy-drift-report-v1.schema.json
@@ -38,6 +38,15 @@
       "type": [
         "string",
         "null"
+      ],
+      "enum": [
+        null,
+        "gh-token-env",
+        "github-token-env",
+        "gh-enterprise-token-env",
+        "gh-token-file",
+        "github-token-file",
+        "standard-host-token-file"
       ]
     },
     "forkRun": {

--- a/docs/schemas/security-intake-report-v1.schema.json
+++ b/docs/schemas/security-intake-report-v1.schema.json
@@ -8,6 +8,7 @@
     "schema",
     "generatedAt",
     "repository",
+    "authSource",
     "flags",
     "thresholds",
     "override",
@@ -31,6 +32,18 @@
     "repository": {
       "type": "string",
       "pattern": "^[^/]+/[^/]+$"
+    },
+    "authSource": {
+      "type": ["string", "null"],
+      "enum": [
+        null,
+        "gh-token-env",
+        "github-token-env",
+        "gh-token-file",
+        "github-token-file",
+        "standard-host-token-file",
+        "gh-enterprise-token-env"
+      ]
     },
     "flags": {
       "type": "object",

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -1979,8 +1979,8 @@ test('priority:policy keeps GH_TOKEN when valid and does not fallback', async ()
   assert.ok(tokensSeen.length > 0, 'expected at least one authenticated request');
   assert.ok(tokensSeen.every((token) => token === 'gh-valid'), 'requests should remain on GH_TOKEN');
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
-    'auth source log should report GH_TOKEN'
+    logMessages.some((msg) => msg.includes('auth source: gh-token-env')),
+    'auth source log should report gh-token-env'
   );
   assert.ok(
     !logMessages.some((msg) => msg.includes('auth fallback:')),
@@ -2078,8 +2078,8 @@ test('priority:policy falls back from GH_TOKEN to GITHUB_TOKEN on 401', async ()
   assert.ok(tokensSeen.includes('gh-stale'), 'GH token should be attempted first');
   assert.ok(tokensSeen.includes('github-valid'), 'GITHUB token should be used as fallback');
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth fallback: GH_TOKEN -> GITHUB_TOKEN')),
-    'fallback log should report GH_TOKEN -> GITHUB_TOKEN'
+    logMessages.some((msg) => msg.includes('auth fallback: gh-token-env -> github-token-env')),
+    'fallback log should report gh-token-env -> github-token-env'
   );
   assert.deepEqual(errorMessages, []);
 });
@@ -2107,8 +2107,8 @@ test('priority:policy skips non-apply validation when GH_TOKEN 401 has no fallba
 
   assert.equal(code, 0, 'non-apply mode should skip on auth-unavailable path');
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
-    'auth source log should report GH_TOKEN'
+    logMessages.some((msg) => msg.includes('auth source: gh-token-env')),
+    'auth source log should report gh-token-env'
   );
   assert.ok(
     logMessages.some((msg) => msg.includes('Authorization unavailable for policy check')),
@@ -2143,8 +2143,8 @@ test('priority:policy --apply fails when GH_TOKEN 401 has no fallback', async ()
   );
 
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
-    'auth source log should report GH_TOKEN'
+    logMessages.some((msg) => msg.includes('auth source: gh-token-env')),
+    'auth source log should report gh-token-env'
   );
   assert.deepEqual(errorMessages, []);
 });
@@ -2393,8 +2393,8 @@ test('priority:policy verify fails when queue-managed ruleset is missing merge_q
     'expected merge_queue missing diagnostic'
   );
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth source: GITHUB_TOKEN')),
-    'expected auth source to be logged'
+    logMessages.some((msg) => msg.includes('auth source: github-token-env')),
+    'expected auth source to be logged as github-token-env'
   );
 });
 
@@ -2628,8 +2628,8 @@ test('priority:policy verify uses queue-managed rulesets as required-check sourc
   );
   assert.deepEqual(errorMessages, []);
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth source: GITHUB_TOKEN')),
-    'auth source log expected'
+    logMessages.some((msg) => msg.includes('auth source: github-token-env')),
+    'auth source log expected as github-token-env'
   );
 });
 
@@ -2887,8 +2887,8 @@ test('priority:policy --fail-on-skip fails when admin permission is unavailable 
     'strict-mode failure diagnostic expected for admin-skip path'
   );
   assert.ok(
-    logMessages.some((msg) => msg.includes('auth source: GITHUB_TOKEN')),
-    'auth source log expected'
+    logMessages.some((msg) => msg.includes('auth source: github-token-env')),
+    'auth source log expected as github-token-env'
   );
 });
 

--- a/tools/priority/__tests__/check-policy-auth-resolution.test.mjs
+++ b/tools/priority/__tests__/check-policy-auth-resolution.test.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { __test } from '../check-policy.mjs';
+
+test('check-policy token candidates honor GITHUB_TOKEN_FILE and deterministic file-source labels', async () => {
+  const candidates = await __test.resolveTokenCandidates(
+    {
+      GITHUB_TOKEN_FILE: 'C:\\custom-github-token.txt',
+    },
+    {
+      accessFn: async () => undefined,
+      readFileFn: async (filePath) => {
+        if (filePath === 'C:\\custom-github-token.txt') {
+          return ' file-token ';
+        }
+        throw new Error(`unexpected file path ${filePath}`);
+      },
+      platform: 'win32',
+    },
+  );
+
+  assert.deepEqual(candidates, [
+    { token: 'file-token', source: 'github-token-file' },
+  ]);
+});
+
+test('check-policy token candidates preserve env precedence and keep GH_ENTERPRISE_TOKEN support', async () => {
+  const candidates = await __test.resolveTokenCandidates(
+    {
+      GITHUB_TOKEN: ' github-token ',
+      GH_ENTERPRISE_TOKEN: ' enterprise-token ',
+      GH_TOKEN_FILE: 'C:\\gh-token.txt',
+    },
+    {
+      accessFn: async () => undefined,
+      readFileFn: async (filePath) => {
+        if (filePath === 'C:\\gh-token.txt') {
+          return ' file-token ';
+        }
+        throw new Error(`unexpected file path ${filePath}`);
+      },
+      platform: 'win32',
+    },
+  );
+
+  assert.deepEqual(candidates, [
+    { token: 'github-token', source: 'github-token-env' },
+    { token: 'enterprise-token', source: 'gh-enterprise-token-env' },
+    { token: 'file-token', source: 'gh-token-file' },
+  ]);
+});

--- a/tools/priority/__tests__/copilot-review-gate.test.mjs
+++ b/tools/priority/__tests__/copilot-review-gate.test.mjs
@@ -115,11 +115,11 @@ test('copilot-review-gate auth falls back to the standard host token file path',
   const { getAuthToken, listGitHubTokenFileCandidates, resolveAuthToken } = await loadModule();
 
   assert.deepEqual(
-    listGitHubTokenFileCandidates({}, 'win32'),
+    listGitHubTokenFileCandidates({}, { platform: 'win32' }),
     ['C:\\github_token.txt'],
   );
   assert.deepEqual(
-    listGitHubTokenFileCandidates({}, 'linux'),
+    listGitHubTokenFileCandidates({}, { platform: 'linux' }),
     ['/mnt/c/github_token.txt'],
   );
 

--- a/tools/priority/__tests__/github-auth-token.test.mjs
+++ b/tools/priority/__tests__/github-auth-token.test.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  listGitHubTokenFileCandidates,
+  resolveGitHubAuthToken,
+  resolveGitHubAuthTokenCandidates,
+} from '../lib/github-auth-token.mjs';
+
+test('github-auth-token prefers GH_TOKEN over other token sources', () => {
+  const resolution = resolveGitHubAuthToken(
+    {
+      GH_TOKEN: ' gh-token ',
+      GITHUB_TOKEN: ' github-token ',
+      GH_TOKEN_FILE: 'C:\\gh-token.txt',
+      GITHUB_TOKEN_FILE: 'C:\\github-token.txt',
+    },
+    {
+      readFileSyncFn: () => 'file-token',
+      platform: 'win32',
+    },
+  );
+
+  assert.deepEqual(resolution, {
+    token: 'gh-token',
+    source: 'gh-token-env',
+  });
+});
+
+test('github-auth-token honors GITHUB_TOKEN_FILE before the standard host fallback', () => {
+  const reads = [];
+  const resolution = resolveGitHubAuthToken(
+    {
+      GITHUB_TOKEN_FILE: 'C:\\custom-github-token.txt',
+    },
+    {
+      readFileSyncFn: (filePath) => {
+        reads.push(filePath);
+        return ' file-token ';
+      },
+      platform: 'win32',
+    },
+  );
+
+  assert.deepEqual(resolution, {
+    token: 'file-token',
+    source: 'github-token-file',
+  });
+  assert.deepEqual(reads, ['C:\\custom-github-token.txt']);
+});
+
+test('github-auth-token uses the non-Windows standard host token file fallback', () => {
+  assert.deepEqual(
+    listGitHubTokenFileCandidates({}, { platform: 'linux' }),
+    ['/mnt/c/github_token.txt'],
+  );
+
+  const reads = [];
+  const resolution = resolveGitHubAuthToken(
+    {},
+    {
+      readFileSyncFn: (filePath) => {
+        reads.push(filePath);
+        return ' fallback-token ';
+      },
+      platform: 'linux',
+    },
+  );
+
+  assert.deepEqual(resolution, {
+    token: 'fallback-token',
+    source: 'standard-host-token-file',
+  });
+  assert.deepEqual(reads, ['/mnt/c/github_token.txt']);
+});
+
+test('github-auth-token async candidates preserve deterministic source ordering', async () => {
+  const candidates = await resolveGitHubAuthTokenCandidates(
+    {
+      GITHUB_TOKEN: 'github-token',
+      GITHUB_TOKEN_FILE: 'C:\\custom-github-token.txt',
+    },
+    {
+      accessFn: async () => undefined,
+      readFileFn: async (filePath) => {
+        if (filePath === 'C:\\custom-github-token.txt') {
+          return 'file-token';
+        }
+        throw new Error(`unexpected file path ${filePath}`);
+      },
+      platform: 'win32',
+      extraEnvCandidates: [{ name: 'GH_ENTERPRISE_TOKEN', source: 'gh-enterprise-token-env' }],
+    },
+  );
+
+  assert.deepEqual(candidates, [
+    { token: 'github-token', source: 'github-token-env' },
+    { token: 'file-token', source: 'github-token-file' },
+  ]);
+});

--- a/tools/priority/__tests__/security-intake-schema.test.mjs
+++ b/tools/priority/__tests__/security-intake-schema.test.mjs
@@ -58,7 +58,7 @@ test('security intake schema validates generated report and asserts labels/flags
     {
       now,
       resolveRepositorySlugFn: () => 'example/repo',
-      resolveTokenFn: () => 'token',
+      resolveTokenFn: () => ({ token: 'token', source: 'gh-token-env' }),
       listDependabotAlertsFn: async ({ state }) => {
         if (state === 'open') return [sampleAlert()];
         return [];
@@ -82,8 +82,8 @@ test('security intake schema validates generated report and asserts labels/flags
 
   assert.equal(result.report.flags.routeOnBreach, true);
   assert.equal(result.report.flags.failOnSkip, true);
+  assert.equal(result.report.authSource, 'gh-token-env');
   assert.deepEqual(result.report.route.labels, DEFAULT_ROUTE_LABELS);
   assert.equal(result.report.route.action, 'created');
   assert.equal(result.report.remediation.candidateCount, 1);
 });
-

--- a/tools/priority/__tests__/security-intake.test.mjs
+++ b/tools/priority/__tests__/security-intake.test.mjs
@@ -16,6 +16,7 @@ import {
   normalizeDependabotAlert,
   parseNextLinkFromHeader,
   parseArgs,
+  resolveTokenResult,
   runSecurityIntake,
   summarizeDependabotAlerts,
   verifyLocalRemediationForAlert
@@ -103,6 +104,42 @@ test('parseArgs supports thresholds, routing, and override flags', () => {
   assert.equal(parsed.overrideReason, 'release freeze');
   assert.equal(parsed.overrideExpiresAt, '2026-04-01T00:00:00Z');
   assert.equal(parsed.overrideTicket, '#999');
+});
+
+test('security-intake token resolution honors GITHUB_TOKEN_FILE and the standard host fallback', () => {
+  const githubTokenFile = resolveTokenResult(
+    {
+      GITHUB_TOKEN_FILE: 'C:\\custom-github-token.txt',
+    },
+    {
+      readFileSyncFn: (filePath) => {
+        assert.equal(filePath, 'C:\\custom-github-token.txt');
+        return ' file-token ';
+      },
+      platform: 'win32',
+    }
+  );
+
+  assert.deepEqual(githubTokenFile, {
+    token: 'file-token',
+    source: 'github-token-file'
+  });
+
+  const hostFallback = resolveTokenResult(
+    {},
+    {
+      readFileSyncFn: (filePath) => {
+        assert.equal(filePath, '/mnt/c/github_token.txt');
+        return ' fallback-token ';
+      },
+      platform: 'linux',
+    }
+  );
+
+  assert.deepEqual(hostFallback, {
+    token: 'fallback-token',
+    source: 'standard-host-token-file'
+  });
 });
 
 test('summaries and breaches calculate expected values', () => {
@@ -419,7 +456,7 @@ test('runSecurityIntake writes deterministic report and routes on breach', async
     {
       now,
       resolveRepositorySlugFn: () => 'example/repo',
-      resolveTokenFn: () => 'token',
+      resolveTokenFn: () => ({ token: 'token', source: 'github-token-file' }),
       listDependabotAlertsFn: async ({ state }) => {
         if (state === 'open') return [sampleAlert()];
         return [];
@@ -440,10 +477,12 @@ test('runSecurityIntake writes deterministic report and routes on breach', async
   assert.equal(result.report.route.issueNumber, 123);
   assert.equal(result.report.flags.routeOnBreach, true);
   assert.equal(result.report.flags.failOnBreach, true);
+  assert.equal(result.report.authSource, 'github-token-file');
   assert.equal(result.report.remediation.candidateCount, 1);
 
   const persisted = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
   assert.equal(persisted.schema, 'priority/security-intake@v1');
+  assert.equal(persisted.authSource, 'github-token-file');
   assert.equal(persisted.route.issueNumber, 123);
   assert.deepEqual(persisted.route.labels, DEFAULT_ROUTE_LABELS);
   assert.equal(persisted.verification.platformStale, false);

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -10,6 +10,7 @@ import {
   resolveProjectedRequiredStatusChecks,
   resolveProjectedBranchClassId
 } from './lib/branch-required-check-projection.mjs';
+import { resolveGitHubAuthTokenCandidates } from './lib/github-auth-token.mjs';
 
 const manifestPath = new URL('./policy.json', import.meta.url);
 const branchRequiredChecksPath = new URL('../policy/branch-required-checks.json', import.meta.url);
@@ -325,46 +326,16 @@ async function resolveToken(env = process.env, { readFileFn = readFile, accessFn
 
 async function resolveTokenCandidates(
   env = process.env,
-  { readFileFn = readFile, accessFn = access } = {}
+  { readFileFn = readFile, accessFn = access, platform = process.platform } = {}
 ) {
-  const candidates = [];
-  const seen = new Set();
-  const addCandidate = (tokenValue, source) => {
-    if (!tokenValue || !tokenValue.trim()) {
-      return;
-    }
-    const token = tokenValue.trim();
-    const key = `${source}:${token}`;
-    if (seen.has(key)) {
-      return;
-    }
-    candidates.push({ token, source });
-    seen.add(key);
-  };
-
-  addCandidate(env.GH_TOKEN, 'GH_TOKEN');
-  addCandidate(env.GITHUB_TOKEN, 'GITHUB_TOKEN');
-  addCandidate(env.GH_ENTERPRISE_TOKEN, 'GH_ENTERPRISE_TOKEN');
-
-  const fileCandidates = [env.GH_TOKEN_FILE];
-  if (process.platform === 'win32') {
-    fileCandidates.push('C:\\github_token.txt');
-  }
-
-  for (const candidate of fileCandidates) {
-    if (!candidate) {
-      continue;
-    }
-    try {
-      await accessFn(candidate);
-      const fileToken = (await readFileFn(candidate, 'utf8')).trim();
-      addCandidate(fileToken, `file:${candidate}`);
-    } catch {
-      // ignore missing/invalid file
-    }
-  }
-
-  return candidates;
+  return resolveGitHubAuthTokenCandidates(env, {
+    readFileFn,
+    accessFn,
+    platform,
+    extraEnvCandidates: [
+      { name: 'GH_ENTERPRISE_TOKEN', source: 'gh-enterprise-token-env' }
+    ]
+  });
 }
 
 function isUnauthorizedAuthError(error) {
@@ -1507,7 +1478,7 @@ export async function run({
     report.forkRun = forkRun;
     const tokenCandidates = await resolveTokenCandidates(env);
     if (tokenCandidates.length === 0) {
-      throw new Error('GitHub token not found. Set GITHUB_TOKEN, GH_TOKEN, or GH_TOKEN_FILE.');
+      throw new Error('GitHub token not found. Set GITHUB_TOKEN, GH_TOKEN, GH_TOKEN_FILE, or GITHUB_TOKEN_FILE.');
     }
     let activeTokenIndex = 0;
     let activeTokenResult = tokenCandidates[activeTokenIndex];
@@ -1819,7 +1790,8 @@ export const __test = Object.freeze({
   selectRulesetIdentityCandidate,
   projectManifestRequiredStatusChecks,
   resolveProjectedRequiredStatusChecks,
-  resolveProjectedBranchClassId
+  resolveProjectedBranchClassId,
+  resolveTokenCandidates
 });
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));

--- a/tools/priority/copilot-review-gate.mjs
+++ b/tools/priority/copilot-review-gate.mjs
@@ -4,6 +4,12 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
+import {
+  listGitHubTokenFileCandidates,
+  resolveGitHubAuthToken,
+} from './lib/github-auth-token.mjs';
+
+export { listGitHubTokenFileCandidates };
 
 export const COPILOT_REVIEW_GATE_SCHEMA = 'priority/copilot-review-gate@v1';
 export const DEFAULT_REPORT_PATH = path.join(
@@ -388,79 +394,11 @@ export function parseCliArgs(argv = process.argv) {
   return options;
 }
 
-function readGitHubTokenFile(filePath, readFileSyncFn = readFileSync) {
-  const normalizedPath = normalizeText(filePath);
-  if (!normalizedPath) {
-    return null;
-  }
-
-  try {
-    return normalizeText(readFileSyncFn(normalizedPath, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-function listGitHubTokenFileCandidateDescriptors(env = process.env, platform = process.platform) {
-  const candidates = [];
-  const pushCandidate = (pathValue, source) => {
-    const normalizedPath = normalizeText(pathValue);
-    if (!normalizedPath) {
-      return;
-    }
-    if (candidates.some((candidate) => candidate.path === normalizedPath)) {
-      return;
-    }
-    candidates.push({
-      path: normalizedPath,
-      source,
-    });
-  };
-
-  pushCandidate(env.GH_TOKEN_FILE, 'gh-token-file');
-  pushCandidate(env.GITHUB_TOKEN_FILE, 'github-token-file');
-  pushCandidate(platform === 'win32' ? 'C:\\github_token.txt' : '/mnt/c/github_token.txt', 'standard-host-token-file');
-  return candidates;
-}
-
-export function listGitHubTokenFileCandidates(env = process.env, platform = process.platform) {
-  return listGitHubTokenFileCandidateDescriptors(env, platform).map((candidate) => candidate.path);
-}
-
 export function resolveAuthToken(
   env = process.env,
   { readFileSyncFn = readFileSync, platform = process.platform } = {},
 ) {
-  const ghToken = normalizeText(env.GH_TOKEN);
-  if (ghToken) {
-    return {
-      token: ghToken,
-      source: 'gh-token-env',
-    };
-  }
-
-  const githubToken = normalizeText(env.GITHUB_TOKEN);
-  if (githubToken) {
-    return {
-      token: githubToken,
-      source: 'github-token-env',
-    };
-  }
-
-  for (const candidate of listGitHubTokenFileCandidateDescriptors(env, platform)) {
-    const token = readGitHubTokenFile(candidate.path, readFileSyncFn);
-    if (token) {
-      return {
-        token,
-        source: candidate.source,
-      };
-    }
-  }
-
-  return {
-    token: null,
-    source: null,
-  };
+  return resolveGitHubAuthToken(env, { readFileSyncFn, platform });
 }
 
 export function getAuthToken(env = process.env, { readFileSyncFn = readFileSync, platform = process.platform } = {}) {

--- a/tools/priority/lib/github-auth-token.mjs
+++ b/tools/priority/lib/github-auth-token.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+export const STANDARD_HOST_TOKEN_FILE_WINDOWS = 'C:\\github_token.txt';
+export const STANDARD_HOST_TOKEN_FILE_NON_WINDOWS = '/mnt/c/github_token.txt';
+
+function normalizeText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeExtraEnvCandidates(extraEnvCandidates = []) {
+  if (!Array.isArray(extraEnvCandidates)) {
+    return [];
+  }
+  return extraEnvCandidates
+    .map((candidate) => {
+      if (!candidate || typeof candidate !== 'object') {
+        return null;
+      }
+      const name = normalizeText(candidate.name);
+      const source = normalizeText(candidate.source);
+      if (!name || !source) {
+        return null;
+      }
+      return { name, source };
+    })
+    .filter((candidate) => Boolean(candidate));
+}
+
+function buildEnvCandidates(env = process.env, extraEnvCandidates = []) {
+  return [
+    { name: 'GH_TOKEN', source: 'gh-token-env' },
+    { name: 'GITHUB_TOKEN', source: 'github-token-env' },
+    ...normalizeExtraEnvCandidates(extraEnvCandidates),
+  ].map((candidate) => ({
+    value: env[candidate.name],
+    source: candidate.source,
+  }));
+}
+
+export function listGitHubTokenFileCandidateDescriptors(
+  env = process.env,
+  { platform = process.platform } = {},
+) {
+  const candidates = [];
+  const pushCandidate = (pathValue, source) => {
+    const normalizedPath = normalizeText(pathValue);
+    if (!normalizedPath) {
+      return;
+    }
+    if (candidates.some((candidate) => candidate.path === normalizedPath)) {
+      return;
+    }
+    candidates.push({
+      path: normalizedPath,
+      source,
+    });
+  };
+
+  pushCandidate(env.GH_TOKEN_FILE, 'gh-token-file');
+  pushCandidate(env.GITHUB_TOKEN_FILE, 'github-token-file');
+  pushCandidate(
+    platform === 'win32' ? STANDARD_HOST_TOKEN_FILE_WINDOWS : STANDARD_HOST_TOKEN_FILE_NON_WINDOWS,
+    'standard-host-token-file',
+  );
+  return candidates;
+}
+
+export function listGitHubTokenFileCandidates(
+  env = process.env,
+  { platform = process.platform } = {},
+) {
+  return listGitHubTokenFileCandidateDescriptors(env, { platform }).map((candidate) => candidate.path);
+}
+
+function addUniqueCandidate(candidates, seen, tokenValue, source) {
+  const token = normalizeText(tokenValue);
+  const normalizedSource = normalizeText(source);
+  if (!token || !normalizedSource) {
+    return;
+  }
+  const key = `${normalizedSource}:${token}`;
+  if (seen.has(key)) {
+    return;
+  }
+  candidates.push({ token, source: normalizedSource });
+  seen.add(key);
+}
+
+export function resolveGitHubAuthToken(
+  env = process.env,
+  {
+    readFileSyncFn = readFileSync,
+    platform = process.platform,
+    extraEnvCandidates = [],
+  } = {},
+) {
+  for (const candidate of buildEnvCandidates(env, extraEnvCandidates)) {
+    const token = normalizeText(candidate.value);
+    if (token) {
+      return {
+        token,
+        source: candidate.source,
+      };
+    }
+  }
+
+  for (const candidate of listGitHubTokenFileCandidateDescriptors(env, { platform })) {
+    try {
+      const token = normalizeText(readFileSyncFn(candidate.path, 'utf8'));
+      if (token) {
+        return {
+          token,
+          source: candidate.source,
+        };
+      }
+    } catch {
+      // ignore unreadable token files
+    }
+  }
+
+  return {
+    token: null,
+    source: null,
+  };
+}
+
+export async function resolveGitHubAuthTokenCandidates(
+  env = process.env,
+  {
+    readFileFn = readFile,
+    accessFn = access,
+    platform = process.platform,
+    extraEnvCandidates = [],
+  } = {},
+) {
+  const candidates = [];
+  const seen = new Set();
+
+  for (const candidate of buildEnvCandidates(env, extraEnvCandidates)) {
+    addUniqueCandidate(candidates, seen, candidate.value, candidate.source);
+  }
+
+  for (const candidate of listGitHubTokenFileCandidateDescriptors(env, { platform })) {
+    try {
+      await accessFn(candidate.path);
+      const token = await readFileFn(candidate.path, 'utf8');
+      addUniqueCandidate(candidates, seen, token, candidate.source);
+    } catch {
+      // ignore unreadable token files
+    }
+  }
+
+  return candidates;
+}

--- a/tools/priority/security-intake.mjs
+++ b/tools/priority/security-intake.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { resolveGitHubAuthToken } from './lib/github-auth-token.mjs';
 
 const MS_DAY = 24 * 60 * 60 * 1000;
 export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'security', 'security-intake-report.json');
@@ -186,17 +187,22 @@ export function resolveRepositorySlug(explicitRepo) {
   throw new Error('Unable to resolve repository slug. Pass --repo or set GITHUB_REPOSITORY.');
 }
 
-export function resolveToken() {
-  for (const candidate of [process.env.GH_TOKEN, process.env.GITHUB_TOKEN]) {
-    const value = asOptional(candidate);
-    if (value) return value;
+export function resolveTokenResult(
+  env = process.env,
+  { readFileSyncFn = fs.readFileSync, platform = process.platform } = {}
+) {
+  const resolution = resolveGitHubAuthToken(env, { readFileSyncFn, platform });
+  if (resolution.token) {
+    return resolution;
   }
-  for (const candidate of [asOptional(process.env.GH_TOKEN_FILE), process.platform === 'win32' ? 'C:\\github_token.txt' : null]) {
-    if (!candidate || !fs.existsSync(candidate)) continue;
-    const value = asOptional(fs.readFileSync(candidate, 'utf8'));
-    if (value) return value;
-  }
-  throw new Error('GitHub token not found. Set GH_TOKEN/GITHUB_TOKEN (or GH_TOKEN_FILE).');
+  throw new Error('GitHub token not found. Set GH_TOKEN/GITHUB_TOKEN (or GH_TOKEN_FILE/GITHUB_TOKEN_FILE).');
+}
+
+export function resolveToken(
+  env = process.env,
+  { readFileSyncFn = fs.readFileSync, platform = process.platform } = {}
+) {
+  return resolveTokenResult(env, { readFileSyncFn, platform }).token;
 }
 
 function parseDate(value) {
@@ -604,7 +610,7 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     routeLabels: normalizeLabels((rawOptions.routeLabels || DEFAULT_ROUTE_LABELS).join(','))
   };
   const resolveRepo = deps.resolveRepositorySlugFn || resolveRepositorySlug;
-  const resolveAuth = deps.resolveTokenFn || resolveToken;
+  const resolveAuth = deps.resolveTokenFn || resolveTokenResult;
   const listAlerts = deps.listDependabotAlertsFn || listDependabotAlerts;
   const routeIssue = deps.upsertRemediationIssueFn || upsertRemediationIssue;
   const writeReport = deps.writeJsonFn || writeJson;
@@ -615,6 +621,7 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     schema: 'priority/security-intake@v1',
     generatedAt: now.toISOString(),
     repository,
+    authSource: null,
     flags: {
       routeOnBreach: Boolean(options.routeOnBreach),
       failOnBreach: Boolean(options.failOnBreach),
@@ -647,9 +654,18 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     errors: []
   };
 
-  let token;
+  let authResolution;
   try {
-    token = resolveAuth();
+    const resolved = resolveAuth();
+    authResolution = typeof resolved === 'string'
+      ? { token: asOptional(resolved), source: null }
+      : {
+          token: asOptional(resolved?.token),
+          source: asOptional(resolved?.source)
+        };
+    if (!authResolution.token) {
+      throw new Error('GitHub token not found. Set GH_TOKEN/GITHUB_TOKEN (or GH_TOKEN_FILE/GITHUB_TOKEN_FILE).');
+    }
   } catch (error) {
     const report = { ...base, status: 'skip', errors: [toError(error, 'token-unavailable')] };
     const reportPath = writeReport(options.outputPath, report);
@@ -659,10 +675,10 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
 
   try {
     const fetchImpl = deps.fetchImpl;
-    const openRaw = await listAlerts({ repo: repository, token, state: 'open', maxPages: options.maxPages, fetchImpl });
-    const fixedRaw = await listAlerts({ repo: repository, token, state: 'fixed', maxPages: options.maxPages, fetchImpl });
-    const dismissedRaw = await listAlerts({ repo: repository, token, state: 'dismissed', maxPages: options.maxPages, fetchImpl });
-    const autoDismissedRaw = await listAlerts({ repo: repository, token, state: 'auto_dismissed', maxPages: options.maxPages, fetchImpl });
+    const openRaw = await listAlerts({ repo: repository, token: authResolution.token, state: 'open', maxPages: options.maxPages, fetchImpl });
+    const fixedRaw = await listAlerts({ repo: repository, token: authResolution.token, state: 'fixed', maxPages: options.maxPages, fetchImpl });
+    const dismissedRaw = await listAlerts({ repo: repository, token: authResolution.token, state: 'dismissed', maxPages: options.maxPages, fetchImpl });
+    const autoDismissedRaw = await listAlerts({ repo: repository, token: authResolution.token, state: 'auto_dismissed', maxPages: options.maxPages, fetchImpl });
     const openAlerts = openRaw.map((item) => normalizeDependabotAlert(item, now));
     const resolvedAlerts = [...fixedRaw, ...dismissedRaw, ...autoDismissedRaw].map((item) => normalizeDependabotAlert(item, now));
     const verification = analyzeLocalAlertVerification(openAlerts, { repoRoot });
@@ -680,6 +696,7 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     const candidates = buildRemediationCandidates(effectiveOpenAlerts);
     const report = {
       ...base,
+      authSource: authResolution.source,
       source: { dependabot: { sampledStates: ['open', 'fixed', 'dismissed', 'auto_dismissed'], openCount: openAlerts.length, resolvedCount: resolvedAlerts.length } },
       verification,
       summary,
@@ -690,7 +707,7 @@ export async function runSecurityIntake(rawOptions = {}, deps = {}) {
     if (options.routeOnBreach && breaches.length) {
       const routed = await routeIssue({
         repo: repository,
-        token,
+        token: authResolution.token,
         report,
         titlePrefix: options.routeTitlePrefix,
         labels: options.routeLabels,


### PR DESCRIPTION
## Summary
- add a shared GitHub token-resolution helper for policy/security tooling
- standardize token/env/file precedence across security-intake, check-policy, and copilot-review-gate
- project auth-source classification into receipts and lock the behavior in focused tests

## Testing
- node --test tools/priority/__tests__/github-auth-token.test.mjs tools/priority/__tests__/copilot-review-gate.test.mjs tools/priority/__tests__/security-intake.test.mjs tools/priority/__tests__/security-intake-schema.test.mjs tools/priority/__tests__/check-policy-auth-resolution.test.mjs tools/priority/__tests__/check-policy-apply.test.mjs
- node tools/npm/run-script.mjs lint:md:changed
- git diff --check
