### PR TITLE
Add provisional PrintToSingleFileHtml sample seed (#1467)

### DIFF
--- a/docs/knowledgebase/Headless-SampleVI-Corpus.md
+++ b/docs/knowledgebase/Headless-SampleVI-Corpus.md
@@ -71,9 +71,24 @@ This corpus is not the pre-push gate.
 - Public evidence: PR `#7` plus successful Linux compare/headless runs
 - Blocking gap: the repository currently declares no license
 
-That provisional seed is intentionally kept out of accepted certification until
-there is either explicit licensing or a replacement seed from a licensed public
-repository.
+2. `icon-editor-demo-canaryprobe-print`
+- Repo: `LabVIEW-Community-CI-CD/labview-icon-editor-demo`
+- License: `MIT`
+- Surface: `print-single-file`
+- Plane: `linux-proof`
+- Change kind: `added`
+- Public evidence: PR `#29` plus successful CompareVI History diagnostics on the
+  added-VI PR head
+- Blocking gap: the public run published history-surface evidence, not a
+  standalone `PrintToSingleFileHtml` proof
+
+These provisional seeds now separate the two remaining blockers:
+
+- `linuxcontainerdemo-newthing-print` still shows the clearest explicit public
+  print proof, but it remains license-ambiguous.
+- `icon-editor-demo-canaryprobe-print` gives us a licensed added-VI sample on a
+  public consumer repo, but it still lacks explicit print-single-file
+  publication evidence.
 
 ## Render strategy rules
 

--- a/docs/knowledgebase/PrintToSingleFileHtml-Provenance.md
+++ b/docs/knowledgebase/PrintToSingleFileHtml-Provenance.md
@@ -6,15 +6,24 @@ pre-push requirement.
 
 The reason is provenance, not usefulness.
 
-## Current finding
+## Current findings
 
-The best public added/deleted VI example we have today is
-`aphill93/linuxContainerDemo#7`.
+- The clearest explicit public `PrintToSingleFileHtml` proof we have today is
+  still `aphill93/linuxContainerDemo#7`.
 
-That proof uses a custom `AdditionalOperationDirectory` payload under
-`VICompareTooling/PrintToSingleFileHtml`. The sample is technically useful, but
-the repository does not currently declare a license, so the payload cannot be
-treated as promotable certification input.
+  That proof uses a custom `AdditionalOperationDirectory` payload under
+  `VICompareTooling/PrintToSingleFileHtml`. The sample is technically useful,
+  but the repository does not currently declare a license, so the payload
+  cannot be treated as promotable certification input.
+
+- A licensed added-VI sample candidate now exists on
+  `LabVIEW-Community-CI-CD/labview-icon-editor-demo#29`.
+
+  That PR added `Tooling/comparevi-history-canary/CanaryProbe.vi` on an
+  MIT-licensed public consumer repository, and public CompareVI History
+  diagnostics succeeded on the PR head. The remaining gap is narrower: the
+  published public receipts are history-surface artifacts, not a standalone
+  `PrintToSingleFileHtml` proof, so the seed is still only provisional.
 
 ## Repo policy
 
@@ -48,4 +57,8 @@ That distinction matters for added/deleted VI rendering because the current
 the default compare path.
 
 The headless sample corpus therefore tracks `operationPayload` separately from
-the target repository metadata.
+the target repository metadata, and `#1467` now carries both remaining blocker
+shapes explicitly:
+
+- licensed sample still missing explicit print proof
+- explicit print proof still missing promotable licensing

--- a/fixtures/headless-corpus/sample-vi-corpus.targets.json
+++ b/fixtures/headless-corpus/sample-vi-corpus.targets.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json",
   "schema": "vi-headless/sample-targets@v1",
-  "generatedAt": "2026-03-19T23:55:00Z",
+  "generatedAt": "2026-03-21T07:20:00Z",
   "description": "Evidence-backed public sample VIs used to certify headless compare and history rendering lanes above the minimal local fixtures.",
   "storagePolicy": {
     "checkedInCatalogPath": "fixtures/headless-corpus/sample-vi-corpus.targets.json",
@@ -125,6 +125,60 @@
       "notes": [
         "This seed is the cleanest public target-specific proof currently available for CompareVI History reviewer rendering.",
         "No checked-in local fixture is required because the public PR and workflow evidence are already target-specific."
+      ]
+    },
+    {
+      "id": "icon-editor-demo-canaryprobe-print",
+      "label": "labview-icon-editor-demo CanaryProbe.vi licensed added-VI print candidate",
+      "admission": {
+        "state": "provisional",
+        "reasons": [
+          "MIT-licensed public consumer repository with a pinned added-VI proof PR.",
+          "Public CompareVI History diagnostics succeeded on the added-VI PR head and recorded CanaryProbe.vi as an added target.",
+          "The published public evidence is still history-surface only, so standalone PrintToSingleFileHtml certification remains unproven."
+        ]
+      },
+      "source": {
+        "repoSlug": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+        "repoUrl": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+        "licenseSpdx": "MIT",
+        "targetPath": "Tooling/comparevi-history-canary/CanaryProbe.vi",
+        "changeKind": "added",
+        "pinnedCommit": "91516373bf6c95e1d3cee2ee97452bc9d08f4ed7"
+      },
+      "renderStrategy": {
+        "certificationSurface": "print-single-file",
+        "operation": "PrintToSingleFileHtml",
+        "planeApplicability": [
+          "linux-proof"
+        ],
+        "evidenceClass": "change-kind-print"
+      },
+      "operationPayload": {
+        "mode": "builtin",
+        "provenanceState": "research-only",
+        "notes": [
+          "The candidate is intentionally tracked against the builtin PrintToSingleFileHtml surface rather than an external AdditionalOperationDirectory payload.",
+          "Public evidence for this licensed sample currently proves added-VI discovery and history publication only, so builtin print metadata stays research-only until a standalone print proof run exists."
+        ]
+      },
+      "publicEvidence": [
+        {
+          "kind": "pull-request",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/pull/29",
+          "status": "merged",
+          "note": "Merged public PR that added CanaryProbe.vi and its variants on the MIT-licensed consumer repository."
+        },
+        {
+          "kind": "workflow-run",
+          "url": "https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/actions/runs/23225926010",
+          "status": "success",
+          "note": "CompareVI History pull-request diagnostics succeeded on the added-VI PR head and recorded CanaryProbe.vi as an added target, but the published receipts remained history-surface artifacts rather than standalone print-single-file proof."
+        }
+      ],
+      "notes": [
+        "This target narrows the remaining blocker from sample licensing to print-surface evidence: the sample repository is licensed and pinned, but the public proof still needs an explicit PrintToSingleFileHtml run.",
+        "Keep this seed provisional until a public workflow publishes print-single-file receipts for the same or an equivalent licensed added/deleted VI."
       ]
     },
     {

--- a/tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
+++ b/tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Invoke-HeadlessSampleVICorpusEvaluation.ps1' -Tag 'Unit' {
     $report.schema | Should -Be 'vi-headless/sample-corpus-evaluation@v1'
     $report.overallStatus | Should -Be 'ok'
     $report.summary.acceptedCount | Should -Be 2
-    $report.summary.provisionalCount | Should -Be 1
+    $report.summary.provisionalCount | Should -Be 2
     $report.summary.driftCount | Should -Be 0
 
     $accepted = @($report.targets | Where-Object { [string]$_.id -eq 'icon-editor-demo-vip-preinstall-history' } | Select-Object -First 1)
@@ -48,6 +48,19 @@ Describe 'Invoke-HeadlessSampleVICorpusEvaluation.ps1' -Tag 'Unit' {
     $provisional.checks.operationPayloadLicenseDeclared | Should -BeFalse
     $provisional.checks.operationPayloadPromotable | Should -BeFalse
     (($provisional.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'Custom operation payload has no declared license'
+
+    $licensedCandidate = @($report.targets | Where-Object { [string]$_.id -eq 'icon-editor-demo-canaryprobe-print' } | Select-Object -First 1)
+    $licensedCandidate | Should -Not -BeNullOrEmpty
+    $licensedCandidate.status | Should -Be 'warning'
+    $licensedCandidate.certificationSurface | Should -Be 'print-single-file'
+    $licensedCandidate.operationPayloadMode | Should -Be 'builtin'
+    $licensedCandidate.operationPayloadProvenanceState | Should -Be 'research-only'
+    $licensedCandidate.checks.licenseDeclared | Should -BeTrue
+    $licensedCandidate.checks.successfulWorkflowEvidence | Should -BeTrue
+    $licensedCandidate.checks.operationPayloadTracked | Should -BeTrue
+    $licensedCandidate.checks.operationPayloadLicenseDeclared | Should -BeTrue
+    $licensedCandidate.checks.operationPayloadPromotable | Should -BeFalse
+    (($licensedCandidate.notes | ForEach-Object { [string]$_ }) -join [Environment]::NewLine) | Should -Match 'Builtin operation payload metadata must still be marked accepted before promotion'
   }
 
   It 'fails closed when an accepted seed loses its declared license' {

--- a/tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1
+++ b/tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1
@@ -272,9 +272,9 @@ foreach ($target in @($catalog.targets)) {
     } else {
       $operationPayloadMode = [string]$target.operationPayload.mode
       $operationPayloadProvenanceState = [string]$target.operationPayload.provenanceState
-      $payloadSourceRepoSlug = [string]$target.operationPayload.sourceRepositorySlug
-      $payloadSourceRepoUrl = [string]$target.operationPayload.sourceRepositoryUrl
-      $payloadSourceLicense = [string]$target.operationPayload.sourceLicenseSpdx
+      $payloadSourceRepoSlug = if ($target.operationPayload.PSObject.Properties['sourceRepositorySlug']) { [string]$target.operationPayload.sourceRepositorySlug } else { '' }
+      $payloadSourceRepoUrl = if ($target.operationPayload.PSObject.Properties['sourceRepositoryUrl']) { [string]$target.operationPayload.sourceRepositoryUrl } else { '' }
+      $payloadSourceLicense = if ($target.operationPayload.PSObject.Properties['sourceLicenseSpdx']) { [string]$target.operationPayload.sourceLicenseSpdx } else { '' }
       $payloadNotes = @(Get-StringArray -Value $target.operationPayload.notes)
 
       if ($operationPayloadMode -eq 'additional-operation-directory') {


### PR DESCRIPTION
## Summary
- add a provisional licensed added-VI sample seed for `PrintToSingleFileHtml` certification
- document the provenance and keep the provisional boundary explicit
- fix a narrow evaluator bug exposed by builtin payload candidates

## Testing
- node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json --data fixtures/headless-corpus/sample-vi-corpus.targets.json
- pwsh -NoLogo -NoProfile -File tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1
- node tools/npm/run-script.mjs history:corpus:samples:evaluate
- node tools/npm/run-script.mjs lint:md:changed

## Tracking
- Partial slice for #1467
- This PR does not close #1467
