### PR TITLE
Define the host-native 32-bit shadow plane contract (#1481)

### DIFF
--- a/docs/SINGLE_HOST_LABVIEW_2026_PLANES.md
+++ b/docs/SINGLE_HOST_LABVIEW_2026_PLANES.md
@@ -16,6 +16,23 @@ Treat these four planes as distinct:
 Do not collapse them into a generic “LabVIEW 2026 host” concept. The repo contracts and artifacts are written so future
 agents can tell which plane actually produced the evidence.
 
+## Shadow policy
+
+`native-labview-2026-32` is a shadow acceleration surface, not an authoritative
+proof plane.
+
+- role: manual opt-in acceleration fallback
+- authoritative: false
+- hosted CI: forbidden
+- promotion prerequisites:
+  - `docker-desktop/linux-container-2026`
+  - `docker-desktop/windows-container-2026`
+
+That means the host-native 32-bit plane can help reduce idle time for agents or
+humans on a prepared Windows host, but it does not replace the image-backed
+Linux or Windows proof lanes. Use it only after the same scenario has an image
+proof path.
+
 ## Mutual-exclusion rule
 
 The two Docker Desktop planes are mutually exclusive:
@@ -107,6 +124,7 @@ Use the artifacts in this order:
    - should remain hash-stable for a given report payload
 3. `concurrent-lane-plan.json`
    - records the current hosted/manual/shadow lane availability
+   - projects the host-native 32-bit shadow policy into lane metadata
    - ranks safe concurrent bundles for the present host, RAM, and Docker-runtime state
    - keeps the mutually exclusive local Docker planes out of the same recommended bundle
 4. `docker-runtime-fastloop-readiness.json`
@@ -149,6 +167,7 @@ trustworthy.
 5. Use `priority:lane:concurrency:plan` before dispatching hosted Windows/Linux plus manual lanes so the plan stays
    explicit and replayable.
 6. When summarizing a run, name the exact plane identifier instead of saying “host” or “Docker” without qualification.
+7. Do not treat `native-labview-2026-32` as a release or CI authority surface; it is a shadow accelerator only.
 
 ## Related contracts
 

--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -344,6 +344,13 @@ timing receipt for the same workload. The budget report:
   throughput accelerator against the measured container planes
 - writes a PR-comment-ready Markdown summary next to the JSON report
 
+Treat that shadow receipt as acceleration evidence only:
+
+- the authoritative proof planes remain the Linux and Windows image-backed
+  lanes
+- host-native 32-bit stays manual and opt-in
+- hosted CI must not promote host-native 32-bit into a required proof surface
+
 Windows mirror proof also records host/image evidence under the local
 refinement and operator-session receipts:
 

--- a/docs/schemas/labview-2026-host-plane-report-v1.schema.json
+++ b/docs/schemas/labview-2026-host-plane-report-v1.schema.json
@@ -9,6 +9,7 @@
     "host",
     "runner",
     "docker",
+    "policy",
     "native",
     "executionPolicy"
   ],
@@ -47,6 +48,42 @@
           "type": "array",
           "items": { "type": "string" },
           "minItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": ["authoritativePlanes", "hostNativeShadowPlane"],
+      "properties": {
+        "authoritativePlanes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 2
+        },
+        "hostNativeShadowPlane": {
+          "type": "object",
+          "required": [
+            "plane",
+            "role",
+            "authoritative",
+            "executionMode",
+            "hostedCiAllowed",
+            "promotionPrerequisites"
+          ],
+          "properties": {
+            "plane": { "const": "native-labview-2026-32" },
+            "role": { "const": "acceleration-surface" },
+            "authoritative": { "const": false },
+            "executionMode": { "const": "manual-opt-in" },
+            "hostedCiAllowed": { "const": false },
+            "promotionPrerequisites": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/tests/Write-LabVIEW2026HostPlaneDiagnostics.Tests.ps1
+++ b/tests/Write-LabVIEW2026HostPlaneDiagnostics.Tests.ps1
@@ -48,6 +48,14 @@ Describe 'Write-LabVIEW2026HostPlaneDiagnostics.ps1' -Tag 'Unit' {
     $report.schema | Should -Be 'labview-2026-host-plane-report@v1'
     $report.runner.hostIsRunner | Should -BeTrue
     $report.runner.runnerName | Should -Not -BeNullOrEmpty
+    $report.policy.authoritativePlanes | Should -Contain 'docker-desktop/linux-container-2026'
+    $report.policy.authoritativePlanes | Should -Contain 'docker-desktop/windows-container-2026'
+    $report.policy.hostNativeShadowPlane.plane | Should -Be 'native-labview-2026-32'
+    $report.policy.hostNativeShadowPlane.role | Should -Be 'acceleration-surface'
+    $report.policy.hostNativeShadowPlane.authoritative | Should -BeFalse
+    $report.policy.hostNativeShadowPlane.executionMode | Should -Be 'manual-opt-in'
+    $report.policy.hostNativeShadowPlane.hostedCiAllowed | Should -BeFalse
+    $report.policy.hostNativeShadowPlane.promotionPrerequisites | Should -Contain 'docker-desktop/windows-container-2026'
     $report.native.planes.x64.status | Should -Be 'ready'
     $report.native.planes.x32.status | Should -Be 'ready'
     $report.native.parallelLabVIEWSupported | Should -BeTrue
@@ -62,6 +70,9 @@ Describe 'Write-LabVIEW2026HostPlaneDiagnostics.ps1' -Tag 'Unit' {
     $summary | Should -Match '# LabVIEW 2026 Host Plane Summary'
     $summary | Should -Match '- Native 64-bit: `ready`'
     $summary | Should -Match '- Native 32-bit: `ready`'
+    $summary | Should -Match 'Host-native 32-bit shadow: `acceleration-surface`'
+    $summary | Should -Match 'authoritative=False'
+    $summary | Should -Match 'hostedCiAllowed=False'
     $summary | Should -Match 'docker-desktop/windows-container-2026 \+ native-labview-2026-64'
   }
 

--- a/tools/LabVIEW2026HostPlaneDiagnostics.psm1
+++ b/tools/LabVIEW2026HostPlaneDiagnostics.psm1
@@ -61,6 +61,20 @@ function Get-HostPlaneStatus {
   return 'missing'
 }
 
+function Get-HostNativeShadowPlanePolicy {
+  return [pscustomobject][ordered]@{
+    plane = 'native-labview-2026-32'
+    role = 'acceleration-surface'
+    authoritative = $false
+    executionMode = 'manual-opt-in'
+    hostedCiAllowed = $false
+    promotionPrerequisites = @(
+      'docker-desktop/linux-container-2026',
+      'docker-desktop/windows-container-2026'
+    )
+  }
+}
+
 function New-LabVIEW2026HostPlaneRecord {
   param(
     [Parameter(Mandatory)][string]$Plane,
@@ -139,6 +153,7 @@ function Get-LabVIEW2026HostPlaneReport {
   $sharedCliAcrossNativePlanes = `
     (-not [string]::IsNullOrWhiteSpace([string]$native64.cliPath)) -and `
     ([string]::Equals([string]$native64.cliPath, [string]$native32.cliPath, [System.StringComparison]::OrdinalIgnoreCase))
+  $shadowPolicy = Get-HostNativeShadowPlanePolicy
 
   return [pscustomobject][ordered]@{
     schema = 'labview-2026-host-plane-report@v1'
@@ -158,6 +173,13 @@ function Get-LabVIEW2026HostPlaneReport {
         'windows-docker-fast-loop',
         'dual-docker-fast-loop'
       )
+    }
+    policy = [ordered]@{
+      authoritativePlanes = @(
+        'docker-desktop/linux-container-2026',
+        'docker-desktop/windows-container-2026'
+      )
+      hostNativeShadowPlane = $shadowPolicy
     }
     native = [ordered]@{
       parallelLabVIEWSupported = $nativeParallelReady

--- a/tools/Write-LabVIEW2026HostPlaneDiagnostics.ps1
+++ b/tools/Write-LabVIEW2026HostPlaneDiagnostics.ps1
@@ -111,11 +111,13 @@ function New-HostPlaneSummaryMarkdown {
   $runner = Get-ObjectValue -Object $Report -Name 'runner'
   $native = Get-ObjectValue -Object $Report -Name 'native'
   $executionPolicy = Get-ObjectValue -Object $Report -Name 'executionPolicy'
+  $policy = Get-ObjectValue -Object $Report -Name 'policy'
   $nativePlanes = Get-ObjectValue -Object $native -Name 'planes'
   $x64Plane = Get-ObjectValue -Object $nativePlanes -Name 'x64'
   $x32Plane = Get-ObjectValue -Object $nativePlanes -Name 'x32'
   $candidateParallelPairs = Get-ObjectValue -Object $executionPolicy -Name 'candidateParallelPairs'
   $mutuallyExclusivePairSet = Get-ObjectValue -Object $executionPolicy -Name 'mutuallyExclusivePairs'
+  $shadowPolicy = Get-ObjectValue -Object $policy -Name 'hostNativeShadowPlane'
 
   $candidatePairs = if ($candidateParallelPairs) {
     Format-PlanePairList -Pairs (Get-ObjectValue -Object $candidateParallelPairs -Name 'pairs')
@@ -136,6 +138,11 @@ function New-HostPlaneSummaryMarkdown {
     ('- Native 64-bit: `{0}`' -f ([string](Get-ObjectValue -Object $x64Plane -Name 'status'))),
     ('- Native 32-bit: `{0}`' -f ([string](Get-ObjectValue -Object $x32Plane -Name 'status'))),
     ('- Parallel native support: `{0}`' -f ([string][bool](Get-ObjectValue -Object $native -Name 'parallelLabVIEWSupported'))),
+    ('- Host-native 32-bit shadow: `{0}` (manual={1}, authoritative={2}, hostedCiAllowed={3})' -f `
+        ([string](Get-ObjectValue -Object $shadowPolicy -Name 'role')), `
+        ([string](Get-ObjectValue -Object $shadowPolicy -Name 'executionMode')), `
+        ([string][bool](Get-ObjectValue -Object $shadowPolicy -Name 'authoritative')), `
+        ([string][bool](Get-ObjectValue -Object $shadowPolicy -Name 'hostedCiAllowed'))),
     ('- Candidate parallel pairs: {0}' -f $candidatePairs),
     ('- Mutually exclusive pairs: {0}' -f $mutuallyExclusivePairs)
   ) -join "`n"

--- a/tools/priority/__tests__/concurrent-lane-plan-schema.test.mjs
+++ b/tools/priority/__tests__/concurrent-lane-plan-schema.test.mjs
@@ -23,6 +23,23 @@ test('concurrent lane plan schema validates the generated report', async () => {
       docker: {
         operatorLabels: ['linux-docker-fast-loop', 'windows-docker-fast-loop', 'dual-docker-fast-loop']
       },
+      policy: {
+        authoritativePlanes: [
+          'docker-desktop/linux-container-2026',
+          'docker-desktop/windows-container-2026'
+        ],
+        hostNativeShadowPlane: {
+          plane: 'native-labview-2026-32',
+          role: 'acceleration-surface',
+          authoritative: false,
+          executionMode: 'manual-opt-in',
+          hostedCiAllowed: false,
+          promotionPrerequisites: [
+            'docker-desktop/linux-container-2026',
+            'docker-desktop/windows-container-2026'
+          ]
+        }
+      },
       native: {
         parallelLabVIEWSupported: true,
         sharedCliAcrossNativePlanes: true,

--- a/tools/priority/__tests__/concurrent-lane-plan.test.mjs
+++ b/tools/priority/__tests__/concurrent-lane-plan.test.mjs
@@ -13,6 +13,23 @@ function createHostPlaneReport({ native32Status = 'ready', nativeParallelLabVIEW
     docker: {
       operatorLabels: ['linux-docker-fast-loop', 'windows-docker-fast-loop', 'dual-docker-fast-loop']
     },
+    policy: {
+      authoritativePlanes: [
+        'docker-desktop/linux-container-2026',
+        'docker-desktop/windows-container-2026'
+      ],
+      hostNativeShadowPlane: {
+        plane: 'native-labview-2026-32',
+        role: 'acceleration-surface',
+        authoritative: false,
+        executionMode: 'manual-opt-in',
+        hostedCiAllowed: false,
+        promotionPrerequisites: [
+          'docker-desktop/linux-container-2026',
+          'docker-desktop/windows-container-2026'
+        ]
+      }
+    },
     native: {
       parallelLabVIEWSupported: nativeParallelLabVIEWSupported,
       sharedCliAcrossNativePlanes: true,
@@ -102,6 +119,14 @@ test('buildConcurrentLanePlan falls back to hosted plus shadow when docker engin
   const shadowLane = report.lanes.find((entry) => entry.id === 'host-native-32-shadow');
   assert.equal(shadowLane.availability, 'available');
   assert.equal(shadowLane.metadata.recommendedParallelism, 1);
+  assert.equal(shadowLane.metadata.authoritative, false);
+  assert.equal(shadowLane.metadata.executionMode, 'manual-opt-in');
+  assert.equal(shadowLane.metadata.hostedCiAllowed, false);
+  assert.deepEqual(shadowLane.metadata.promotionPrerequisites, [
+    'docker-desktop/linux-container-2026',
+    'docker-desktop/windows-container-2026'
+  ]);
+  assert.ok(report.observations.includes('host-native-32-shadow-remains-non-authoritative'));
 });
 
 test('buildConcurrentLanePlan disables the shadow lane when the native 32-bit plane is unavailable', () => {

--- a/tools/priority/__tests__/labview-2026-host-plane-report-schema.test.mjs
+++ b/tools/priority/__tests__/labview-2026-host-plane-report-schema.test.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('labview-2026 host plane schema validates the shadow-plane policy contract', async () => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'labview-2026-host-plane-report-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const report = {
+    schema: 'labview-2026-host-plane-report@v1',
+    generatedAt: '2026-03-21T00:00:00.000Z',
+    host: { os: 'windows', computerName: 'builder' },
+    runner: { hostIsRunner: true, runnerName: 'builder', githubActions: false },
+    docker: {
+      operatorLabels: ['linux-docker-fast-loop', 'windows-docker-fast-loop', 'dual-docker-fast-loop']
+    },
+    policy: {
+      authoritativePlanes: [
+        'docker-desktop/linux-container-2026',
+        'docker-desktop/windows-container-2026'
+      ],
+      hostNativeShadowPlane: {
+        plane: 'native-labview-2026-32',
+        role: 'acceleration-surface',
+        authoritative: false,
+        executionMode: 'manual-opt-in',
+        hostedCiAllowed: false,
+        promotionPrerequisites: [
+          'docker-desktop/linux-container-2026',
+          'docker-desktop/windows-container-2026'
+        ]
+      }
+    },
+    native: {
+      parallelLabVIEWSupported: true,
+      sharedCliAcrossNativePlanes: true,
+      recommendedParallelPlanes: ['native-labview-2026-64', 'native-labview-2026-32'],
+      planes: {
+        x64: {
+          plane: 'native-labview-2026-64',
+          operatorLabel: 'native-labview-2026-64',
+          architecture: '64-bit',
+          requestedLabVIEWPath: 'C:/lv64/LabVIEW.exe',
+          requestedCliPath: 'C:/cli/LabVIEWCLI.exe',
+          requestedComparePath: 'C:/compare/LVCompare.exe',
+          labviewPath: 'C:/lv64/LabVIEW.exe',
+          cliPath: 'C:/cli/LabVIEWCLI.exe',
+          comparePath: 'C:/compare/LVCompare.exe',
+          labviewPresent: true,
+          cliPresent: true,
+          comparePresent: true,
+          status: 'ready',
+          issues: []
+        },
+        x32: {
+          plane: 'native-labview-2026-32',
+          operatorLabel: 'native-labview-2026-32',
+          architecture: '32-bit',
+          requestedLabVIEWPath: 'C:/lv32/LabVIEW.exe',
+          requestedCliPath: 'C:/cli/LabVIEWCLI.exe',
+          requestedComparePath: 'C:/compare/LVCompare.exe',
+          labviewPath: 'C:/lv32/LabVIEW.exe',
+          cliPath: 'C:/cli/LabVIEWCLI.exe',
+          comparePath: 'C:/compare/LVCompare.exe',
+          labviewPresent: true,
+          cliPresent: true,
+          comparePresent: true,
+          status: 'ready',
+          issues: []
+        }
+      }
+    },
+    executionPolicy: {
+      mutuallyExclusivePairs: {
+        pairs: [{ left: 'docker-desktop/linux-container-2026', right: 'docker-desktop/windows-container-2026' }]
+      },
+      provenParallelPairs: {
+        pairs: [
+          { left: 'docker-desktop/windows-container-2026', right: 'native-labview-2026-64' },
+          { left: 'native-labview-2026-64', right: 'native-labview-2026-32' }
+        ]
+      },
+      candidateParallelPairs: {
+        pairs: [
+          { left: 'docker-desktop/windows-container-2026', right: 'native-labview-2026-64' },
+          { left: 'native-labview-2026-64', right: 'native-labview-2026-32' }
+        ]
+      }
+    }
+  };
+
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/concurrent-lane-plan.mjs
+++ b/tools/priority/concurrent-lane-plan.mjs
@@ -139,6 +139,36 @@ function buildPairIndex(report) {
   return index;
 }
 
+function resolveShadowPlanePolicy(report = null) {
+  const policy = report?.policy?.hostNativeShadowPlane;
+  if (!policy || typeof policy !== 'object') {
+    return {
+      plane: 'native-labview-2026-32',
+      role: 'acceleration-surface',
+      authoritative: false,
+      executionMode: 'manual-opt-in',
+      hostedCiAllowed: false,
+      promotionPrerequisites: [
+        'docker-desktop/linux-container-2026',
+        'docker-desktop/windows-container-2026'
+      ]
+    };
+  }
+
+  return {
+    plane: toOptionalText(policy.plane) ?? 'native-labview-2026-32',
+    role: toOptionalText(policy.role) ?? 'acceleration-surface',
+    authoritative: policy.authoritative === true,
+    executionMode: toOptionalText(policy.executionMode) ?? 'manual-opt-in',
+    hostedCiAllowed: policy.hostedCiAllowed === true,
+    promotionPrerequisites: Array.isArray(policy.promotionPrerequisites)
+      ? policy.promotionPrerequisites
+          .map((entry) => toOptionalText(entry))
+          .filter(Boolean)
+      : []
+  };
+}
+
 function resolveDockerObservation(snapshot = null) {
   const observed = snapshot?.observed && typeof snapshot.observed === 'object' ? snapshot.observed : {};
   return {
@@ -190,6 +220,7 @@ export function buildConcurrentLanePlan({
 } = {}) {
   const pairIndex = buildPairIndex(hostPlaneReport);
   const dockerObservation = resolveDockerObservation(dockerRuntimeSnapshot);
+  const shadowPolicy = resolveShadowPlanePolicy(hostPlaneReport);
   const nativeX32Status = normalizeText(hostPlaneReport?.native?.planes?.x32?.status).toLowerCase() || 'missing';
   const nativeParallelLabVIEWSupported = hostPlaneReport?.native?.parallelLabVIEWSupported === true;
   const hostRamRecommendedParallelism =
@@ -349,7 +380,13 @@ export function buildConcurrentLanePlan({
       reasons: shadowReasons,
       metadata: {
         recommendedParallelism: hostRamRecommendedParallelism || null,
-        hostRamProfile
+        hostRamProfile,
+        plane: shadowPolicy.plane,
+        role: shadowPolicy.role,
+        authoritative: shadowPolicy.authoritative,
+        executionMode: shadowPolicy.executionMode,
+        hostedCiAllowed: shadowPolicy.hostedCiAllowed,
+        promotionPrerequisites: shadowPolicy.promotionPrerequisites
       }
     })
   );
@@ -426,6 +463,9 @@ export function buildConcurrentLanePlan({
   }
   if (shadowAllowed && localLaneIds.length > 0) {
     observations.push('shadow-lane-kept-out-of-local-docker-bundles-until-same-host-proof-exists');
+  }
+  if (!shadowPolicy.authoritative) {
+    observations.push('host-native-32-shadow-remains-non-authoritative');
   }
 
   const recommendedBundle = bundles.find((entry) => entry.classification === 'recommended') ?? null;


### PR DESCRIPTION
## Summary
- define the host-native LabVIEW 2026 32-bit plane explicitly as a non-authoritative shadow acceleration surface
- project that contract into host-plane diagnostics and the concurrent lane planner
- document the promotion rule: Linux and Windows image-backed lanes stay authoritative

## Testing
- pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1
- pwsh -NoLogo -NoProfile -File tests/Write-LabVIEW2026HostPlaneDiagnostics.Tests.ps1
- node --test tools/priority/__tests__/concurrent-lane-plan.test.mjs tools/priority/__tests__/concurrent-lane-plan-schema.test.mjs tools/priority/__tests__/labview-2026-host-plane-report-schema.test.mjs tools/priority/__tests__/labview-2026-host-plane-runbook.test.mjs
- node tools/npm/run-script.mjs lint:md:changed
- git diff --check
