### PR TITLE
Define LabVIEW container shell contracts (#1477)

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -82,6 +82,8 @@ Notes:
 
 - Default image: `nationalinstruments/labview:2026q1-windows`.
 - Override image explicitly with `tools/Run-NIWindowsContainerCompare.ps1 -Image <tag>`.
+- The in-container shell boundary is defined by `tools/policy/labview-container-shell-contract.json`:
+  Windows uses native `powershell`, while the host-side wrapper shell remains `pwsh`.
 - Docker daemon must run in `windows` mode; `compare:docker:ni:windows:probe` fails fast when mode/image checks fail.
 - Output defaults to `tests/results/ni-windows-container/compare-report.html` with deterministic capture logs.
 - Capture JSON (`ni-windows-container-capture.json`) records machine-readable classification fields
@@ -118,6 +120,14 @@ Common remediation:
 - Docker mode mismatch: `desktop-local` now fails before image bootstrap or container probe when Docker Desktop is still on the Linux engine; switch Docker Desktop to Windows containers (`desktop-windows`) and retry.
 - Image pull failure: verify Docker Hub/GHCR connectivity and authentication, then rerun bootstrap.
 - Runtime probe failure: confirm the host can run Windows containers and that the NI tag is available.
+
+## LabVIEW container shell contract
+
+`tools/policy/labview-container-shell-contract.json` is the shared shell boundary for the NI helper planes.
+
+- Windows container helpers invoke native `powershell` inside the container and may rely on `-EncodedCommand`.
+- Linux container helpers invoke `bash` inside the container; host-side `pwsh` wrappers are outside that plane contract.
+- `tools/Get-LabVIEWContainerShellContract.ps1` is the supported accessor for helper scripts and tests.
 
 ## Tooling helpers
 

--- a/tests/Get-LabVIEWContainerShellContract.Tests.ps1
+++ b/tests/Get-LabVIEWContainerShellContract.Tests.ps1
@@ -1,0 +1,51 @@
+Describe 'Get-LabVIEWContainerShellContract' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools/Get-LabVIEWContainerShellContract.ps1'
+    $contractPath = Join-Path $repoRoot 'tools/policy/labview-container-shell-contract.json'
+  }
+
+  It 'returns the repository Windows shell contract' {
+    $contract = & $scriptPath -Plane windows -ContractPath $contractPath
+
+    $contract.plane | Should -Be 'windows'
+    $contract.executable | Should -Be 'powershell'
+    $contract.family | Should -Be 'windows-powershell'
+    $contract.encodedCommand | Should -BeTrue
+    $contract.pwshRequired | Should -BeFalse
+    $contract.hostWrapperShell | Should -Be 'pwsh'
+  }
+
+  It 'returns the repository Linux shell contract' {
+    $contract = & $scriptPath -Plane linux -ContractPath $contractPath
+
+    $contract.plane | Should -Be 'linux'
+    $contract.executable | Should -Be 'bash'
+    $contract.family | Should -Be 'posix-bash'
+    $contract.encodedCommand | Should -BeFalse
+    $contract.pwshRequired | Should -BeFalse
+    $contract.hostWrapperShell | Should -Be 'pwsh'
+  }
+
+  It 'fails closed when the contract schema drifts' {
+    $badContractPath = Join-Path $TestDrive 'labview-container-shell-contract.json'
+    @'
+{
+  "schema": "unexpected/v1",
+  "hostWrapperShell": "pwsh",
+  "planes": {
+    "windows": {
+      "executable": "powershell",
+      "family": "windows-powershell",
+      "encodedCommand": true,
+      "pwshRequired": false
+    }
+  }
+}
+'@ | Set-Content -LiteralPath $badContractPath -Encoding utf8
+
+    {
+      & $scriptPath -Plane windows -ContractPath $badContractPath
+    } | Should -Throw '*Unexpected LabVIEW container shell contract schema*'
+  }
+}

--- a/tests/Run-NILinuxContainerCompare.Tests.ps1
+++ b/tests/Run-NILinuxContainerCompare.Tests.ps1
@@ -778,6 +778,7 @@ exec "__PWSH__" -NoLogo -NoProfile -File "${script_dir}/docker.ps1" "$@"
     $capture.containerShellContract.family | Should -Be 'posix-bash'
     $capture.containerShellContract.encodedCommand | Should -BeFalse
     $capture.containerShellContract.pwshRequired | Should -BeFalse
+    $capture.containerShellContract.hostWrapperShell | Should -Be 'pwsh'
     $capture.containerName | Should -Match '^ni-lnx-compare-flag-baseline-[a-f0-9]{8}$'
     $capture.command | Should -Match ('docker run --name {0}\b' -f [regex]::Escape([string]$capture.containerName))
     $capture.observedDockerHost | Should -Be 'unix:///var/run/docker.sock'

--- a/tests/Run-NIWindowsContainerCompare.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCompare.Tests.ps1
@@ -599,6 +599,7 @@ exit 0
     $capture.containerShellContract.family | Should -Be 'windows-powershell'
     $capture.containerShellContract.encodedCommand | Should -BeTrue
     $capture.containerShellContract.pwshRequired | Should -BeFalse
+    $capture.containerShellContract.hostWrapperShell | Should -Be 'pwsh'
     $capture.runtimeDeterminism.observed.dockerHost | Should -Be 'npipe:////./pipe/docker_engine'
     $capture.timedOut | Should -BeFalse
     $capture.PSObject.Properties.Name | Should -Contain 'observedDockerHost'

--- a/tools/Get-LabVIEWContainerShellContract.ps1
+++ b/tools/Get-LabVIEWContainerShellContract.ps1
@@ -1,0 +1,59 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [ValidateSet('windows', 'linux')]
+  [string]$Plane,
+  [string]$ContractPath = (Join-Path (Join-Path (Split-Path -Parent $PSCommandPath) 'policy') 'labview-container-shell-contract.json')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ContractPath -PathType Leaf)) {
+  throw ("LabVIEW container shell contract not found: {0}" -f $ContractPath)
+}
+
+try {
+  $contract = Get-Content -LiteralPath $ContractPath -Raw | ConvertFrom-Json -Depth 10 -ErrorAction Stop
+} catch {
+  throw ("Failed to parse LabVIEW container shell contract '{0}': {1}" -f $ContractPath, $_.Exception.Message)
+}
+
+if ([string]$contract.schema -ne 'labview-container-shell-contract/v1') {
+  throw ("Unexpected LabVIEW container shell contract schema in {0}: {1}" -f $ContractPath, [string]$contract.schema)
+}
+
+if ([string]::IsNullOrWhiteSpace([string]$contract.hostWrapperShell)) {
+  throw ("LabVIEW container shell contract is missing hostWrapperShell in {0}" -f $ContractPath)
+}
+
+$planeContract = $null
+if ($contract.PSObject.Properties.Name -contains 'planes' -and $contract.planes) {
+  $planeContract = $contract.planes.$Plane
+}
+if (-not $planeContract) {
+  throw ("LabVIEW container shell contract is missing plane '{0}' in {1}" -f $Plane, $ContractPath)
+}
+
+if ([string]::IsNullOrWhiteSpace([string]$planeContract.executable)) {
+  throw ("LabVIEW container shell contract plane '{0}' is missing executable in {1}" -f $Plane, $ContractPath)
+}
+if ([string]::IsNullOrWhiteSpace([string]$planeContract.family)) {
+  throw ("LabVIEW container shell contract plane '{0}' is missing family in {1}" -f $Plane, $ContractPath)
+}
+if (-not ($planeContract.PSObject.Properties.Name -contains 'encodedCommand')) {
+  throw ("LabVIEW container shell contract plane '{0}' is missing encodedCommand in {1}" -f $Plane, $ContractPath)
+}
+if (-not ($planeContract.PSObject.Properties.Name -contains 'pwshRequired')) {
+  throw ("LabVIEW container shell contract plane '{0}' is missing pwshRequired in {1}" -f $Plane, $ContractPath)
+}
+
+[pscustomobject][ordered]@{
+  plane = $Plane
+  executable = [string]$planeContract.executable
+  family = [string]$planeContract.family
+  encodedCommand = [bool]$planeContract.encodedCommand
+  pwshRequired = [bool]$planeContract.pwshRequired
+  hostWrapperShell = [string]$contract.hostWrapperShell
+}

--- a/tools/Run-NILinuxContainerCompare.ps1
+++ b/tools/Run-NILinuxContainerCompare.ps1
@@ -130,6 +130,11 @@ if (-not (Test-Path -LiteralPath $classifierScriptPath -PathType Leaf)) {
 }
 . $classifierScriptPath
 
+$shellContractScriptPath = Join-Path (Split-Path -Parent $PSCommandPath) 'Get-LabVIEWContainerShellContract.ps1'
+if (-not (Test-Path -LiteralPath $shellContractScriptPath -PathType Leaf)) {
+  throw ("LabVIEW container shell contract script not found: {0}" -f $shellContractScriptPath)
+}
+
 $script:PreflightExitCode = 2
 $script:TimeoutExitCode = 124
 
@@ -2022,6 +2027,8 @@ if ($StartupRetryCount -lt 0) {
   throw '-StartupRetryCount must be zero or greater.'
 }
 
+$containerShellContract = & $shellContractScriptPath -Plane 'linux'
+
 $capture = [ordered]@{
   schema         = 'ni-linux-container-compare/v1'
   generatedAt    = (Get-Date).ToUniversalTime().ToString('o')
@@ -2035,13 +2042,7 @@ $capture = [ordered]@{
   dockerServerOs = $null
   dockerContext  = $null
   observedDockerHost = $null
-  containerShellContract = [ordered]@{
-    plane = 'linux'
-    executable = 'bash'
-    family = 'posix-bash'
-    encodedCommand = $false
-    pwshRequired = $false
-  }
+  containerShellContract = $containerShellContract
   baseVi         = $null
   headVi         = $null
   reportPath     = $null
@@ -2696,10 +2697,10 @@ try {
     if ($useExistingContainer) {
       $dockerArgs += @(
         $containerName,
-        'bash',
+        [string]$containerShellContract.executable,
         $containerScriptPath
       )
-      $capture.command = ('docker exec --workdir {0} {1} bash {2}' -f $ReuseRepoContainerPath, $containerName, $containerScriptPath)
+      $capture.command = ('docker exec --workdir {0} {1} {2} {3}' -f $ReuseRepoContainerPath, $containerName, [string]$containerShellContract.executable, $containerScriptPath)
       Write-Host ("[ni-linux-container-compare] mode=docker-exec container={0} image={1} report={2} capture={3} stdout={4} stderr={5}" -f $containerName, $Image, $resolvedReportPath, $capturePath, $stdoutPath, $stderrPath) -ForegroundColor Cyan
       $runResult = Invoke-DockerExecWithTimeout `
         -DockerArgs $dockerArgs `
@@ -2709,10 +2710,10 @@ try {
     } else {
       $dockerArgs += @(
         $Image,
-        'bash',
+        [string]$containerShellContract.executable,
         $containerScriptPath
       )
-      $capture.command = ('docker run --name {0} ... {1} bash -lc <linux-compare-script>' -f $containerName, $Image)
+      $capture.command = ('docker run --name {0} ... {1} {2} <linux-compare-script>' -f $containerName, $Image, [string]$containerShellContract.executable)
       Write-Host ("[ni-linux-container-compare] mode=docker-run image={0} report={1} capture={2} stdout={3} stderr={4}" -f $Image, $resolvedReportPath, $capturePath, $stdoutPath, $stderrPath) -ForegroundColor Cyan
       $runResult = Invoke-DockerRunWithTimeout `
         -DockerArgs $dockerArgs `

--- a/tools/Run-NIWindowsContainerCompare.ps1
+++ b/tools/Run-NIWindowsContainerCompare.ps1
@@ -80,6 +80,11 @@ if (-not (Test-Path -LiteralPath $classifierScriptPath -PathType Leaf)) {
 }
 . $classifierScriptPath
 
+$shellContractScriptPath = Join-Path (Split-Path -Parent $PSCommandPath) 'Get-LabVIEWContainerShellContract.ps1'
+if (-not (Test-Path -LiteralPath $shellContractScriptPath -PathType Leaf)) {
+  throw ("LabVIEW container shell contract script not found: {0}" -f $shellContractScriptPath)
+}
+
 $script:PreflightExitCode = 2
 $script:TimeoutExitCode = 124
 
@@ -930,6 +935,8 @@ if ($TimeoutSeconds -le 0) {
   throw '-TimeoutSeconds must be greater than zero.'
 }
 
+$containerShellContract = & $shellContractScriptPath -Plane 'windows'
+
 $capture = [ordered]@{
   schema        = 'ni-windows-container-compare/v1'
   generatedAt   = (Get-Date).ToUniversalTime().ToString('o')
@@ -944,13 +951,7 @@ $capture = [ordered]@{
   dockerServerOs= $null
   dockerContext = $null
   observedDockerHost = $null
-  containerShellContract = [ordered]@{
-    plane = 'windows'
-    executable = 'powershell'
-    family = 'windows-powershell'
-    encodedCommand = $true
-    pwshRequired = $false
-  }
+  containerShellContract = $containerShellContract
   baseVi        = $null
   headVi        = $null
   reportPath    = $null
@@ -1175,14 +1176,14 @@ try {
     $dockerArgs += @('--env', 'COMPARE_LABVIEW_PATH')
     $dockerArgs += @(
       $Image,
-      'powershell',
+      [string]$containerShellContract.executable,
       '-NoLogo',
       '-NoProfile',
       '-EncodedCommand',
       $encodedContainerCommand
     )
 
-    $capture.command = ('docker run --name {0} ... {1} powershell -NoLogo -NoProfile -EncodedCommand <base64-compare-script>' -f $containerName, $Image)
+    $capture.command = ('docker run --name {0} ... {1} {2} -NoLogo -NoProfile -EncodedCommand <base64-compare-script>' -f $containerName, $Image, [string]$containerShellContract.executable)
     Write-Host ("[ni-container-compare] image={0} report={1} capture={2} stdout={3} stderr={4}" -f $Image, $resolvedReportPath, $capturePath, $stdoutPath, $stderrPath) -ForegroundColor Cyan
 
     $runResult = Invoke-DockerRunWithTimeout `

--- a/tools/policy/labview-container-shell-contract.json
+++ b/tools/policy/labview-container-shell-contract.json
@@ -1,0 +1,19 @@
+{
+  "schema": "labview-container-shell-contract/v1",
+  "schemaVersion": "1.0.0",
+  "hostWrapperShell": "pwsh",
+  "planes": {
+    "windows": {
+      "executable": "powershell",
+      "family": "windows-powershell",
+      "encodedCommand": true,
+      "pwshRequired": false
+    },
+    "linux": {
+      "executable": "bash",
+      "family": "posix-bash",
+      "encodedCommand": false,
+      "pwshRequired": false
+    }
+  }
+}


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1477
- Issue title: Define per-plane shell contracts for Windows and Linux LabVIEW container helpers
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1477
- Standing priority at PR creation: No
- Base branch: `develop`
- Head branch: `issue/origin-1477-shell-contracts`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
