### PR TITLE
Project immutable manifest provenance into downstream scorecard (#1499)

### DIFF
--- a/.github/workflows/downstream-onboarding-feedback.yml
+++ b/.github/workflows/downstream-onboarding-feedback.yml
@@ -113,6 +113,7 @@ jobs:
           node tools/priority/downstream-promotion-scorecard.mjs \
             --success-report tests/results/_agent/onboarding/downstream-onboarding-success.json \
             --feedback-report tests/results/_agent/onboarding/downstream-onboarding-feedback.json \
+            --manifest-report tests/results/_agent/promotion/downstream-develop-promotion-manifest.json \
             --output tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json
 
       - name: Validate downstream promotion scorecard schema
@@ -157,6 +158,7 @@ jobs:
           name: downstream-onboarding-feedback
           path: |
             tests/results/_agent/onboarding/*.json
+            tests/results/_agent/promotion/downstream-develop-promotion-manifest.json
             tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json
           if-no-files-found: error
 

--- a/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
+++ b/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
@@ -117,6 +117,7 @@ Build the downstream consumer-proving scorecard from the success + feedback outp
 node tools/npm/run-script.mjs priority:promote:downstream:scorecard -- \
   --success-report tests/results/_agent/onboarding/downstream-onboarding-success.json \
   --feedback-report tests/results/_agent/onboarding/downstream-onboarding-feedback.json \
+  --manifest-report tests/results/_agent/promotion/downstream-develop-promotion-manifest.json \
   --output tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json
 ```
 
@@ -142,4 +143,5 @@ It now follows the shared hosted-signal contract in [`HOSTED_SIGNAL_REPORT_FIRST
 - exports both `GH_TOKEN` and `GITHUB_TOKEN`
 - appends a deterministic step summary from the feedback report when present
 - builds and validates the downstream promotion scorecard before artifact upload
+- projects immutable downstream promotion manifest inputs into the scorecard when the manifest artifact is present
 - keeps schema validation and artifact upload existence-aware so missing-report cascades do not mask the primary failure

--- a/docs/schemas/downstream-promotion-scorecard-v1.schema.json
+++ b/docs/schemas/downstream-promotion-scorecard-v1.schema.json
@@ -19,25 +19,27 @@
     "inputs": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["successReport", "feedbackReport"],
+      "required": ["successReport", "feedbackReport", "manifestReport"],
       "properties": {
         "successReport": { "$ref": "#/$defs/inputRef" },
-        "feedbackReport": { "$ref": "#/$defs/inputRef" }
+        "feedbackReport": { "$ref": "#/$defs/inputRef" },
+        "manifestReport": { "$ref": "#/$defs/inputRefNullablePath" }
       }
     },
     "gates": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["successReport", "feedbackReport"],
+      "required": ["successReport", "feedbackReport", "manifestReport"],
       "properties": {
         "successReport": { "$ref": "#/$defs/successGate" },
-        "feedbackReport": { "$ref": "#/$defs/feedbackGate" }
+        "feedbackReport": { "$ref": "#/$defs/feedbackGate" },
+        "manifestReport": { "$ref": "#/$defs/manifestGate" }
       }
     },
     "summary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["status", "blockerCount", "blockers", "metrics"],
+      "required": ["status", "blockerCount", "blockers", "metrics", "provenance"],
       "properties": {
         "status": { "enum": ["pass", "fail"] },
         "blockerCount": { "type": "integer", "minimum": 0 },
@@ -54,6 +56,26 @@
             "totalBlockers": { "type": ["integer", "null"], "minimum": 0 },
             "totalWarnings": { "type": ["integer", "null"], "minimum": 0 }
           }
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "sourceRef",
+            "sourceCommitSha",
+            "compareviToolsRelease",
+            "compareviHistoryRelease",
+            "scenarioPackIdentity",
+            "cookiecutterTemplateIdentity"
+          ],
+          "properties": {
+            "sourceRef": { "type": ["string", "null"] },
+            "sourceCommitSha": { "type": ["string", "null"] },
+            "compareviToolsRelease": { "type": ["string", "null"] },
+            "compareviHistoryRelease": { "type": ["string", "null"] },
+            "scenarioPackIdentity": { "type": ["string", "null"] },
+            "cookiecutterTemplateIdentity": { "type": ["string", "null"] }
+          }
         }
       }
     }
@@ -65,6 +87,16 @@
       "required": ["path", "exists", "error"],
       "properties": {
         "path": { "type": "string" },
+        "exists": { "type": "boolean" },
+        "error": { "type": ["string", "null"] }
+      }
+    },
+    "inputRefNullablePath": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "exists", "error"],
+      "properties": {
+        "path": { "type": ["string", "null"] },
         "exists": { "type": "boolean" },
         "error": { "type": ["string", "null"] }
       }
@@ -102,6 +134,36 @@
         "evaluateExitCode": { "type": ["integer", "null"], "minimum": 0 },
         "successExitCode": { "type": ["integer", "null"], "minimum": 0 },
         "downstreamRepository": { "type": ["string", "null"] }
+      }
+    },
+    "manifestGate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "schema",
+        "targetBranch",
+        "targetBranchClassId",
+        "sourceRef",
+        "sourceCommitSha",
+        "localSourceMatched",
+        "compareviToolsRelease",
+        "compareviHistoryRelease",
+        "scenarioPackIdentity",
+        "cookiecutterTemplateIdentity"
+      ],
+      "properties": {
+        "status": { "enum": ["pass", "fail", "missing"] },
+        "schema": { "type": ["string", "null"] },
+        "targetBranch": { "type": ["string", "null"] },
+        "targetBranchClassId": { "type": ["string", "null"] },
+        "sourceRef": { "type": ["string", "null"] },
+        "sourceCommitSha": { "type": ["string", "null"] },
+        "localSourceMatched": { "type": ["boolean", "null"] },
+        "compareviToolsRelease": { "type": ["string", "null"] },
+        "compareviHistoryRelease": { "type": ["string", "null"] },
+        "scenarioPackIdentity": { "type": ["string", "null"] },
+        "cookiecutterTemplateIdentity": { "type": ["string", "null"] }
       }
     }
   }

--- a/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
+++ b/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
@@ -28,6 +28,7 @@ test('workflow executes onboarding, success, feedback, and promotion scorecard c
   assert.match(workflow, /downstream-onboarding-feedback-v1\.schema\.json/);
   assert.match(workflow, /Build downstream promotion scorecard/);
   assert.match(workflow, /downstream-promotion-scorecard\.mjs/);
+  assert.match(workflow, /--manifest-report tests\/results\/_agent\/promotion\/downstream-develop-promotion-manifest\.json/);
   assert.match(workflow, /downstream-promotion-scorecard-v1\.schema\.json/);
   assert.match(workflow, /tests\/results\/_agent\/promotion\/downstream-develop-promotion-scorecard\.json/);
   assert.match(workflow, /Append onboarding feedback summary/);

--- a/tools/priority/__tests__/downstream-promotion-scorecard-schema.test.mjs
+++ b/tools/priority/__tests__/downstream-promotion-scorecard-schema.test.mjs
@@ -25,6 +25,7 @@ test('downstream promotion scorecard schema validates generated report payload',
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'downstream-promotion-scorecard-schema-'));
   const successReportPath = path.join(tmpDir, 'downstream-onboarding-success.json');
   const feedbackReportPath = path.join(tmpDir, 'downstream-onboarding-feedback.json');
+  const manifestReportPath = path.join(tmpDir, 'downstream-develop-promotion-manifest.json');
   const outputPath = path.join(tmpDir, 'scorecard.json');
 
   writeJson(successReportPath, {
@@ -47,11 +48,31 @@ test('downstream promotion scorecard schema validates generated report payload',
       successExitCode: 0
     }
   });
+  writeJson(manifestReportPath, {
+    schema: 'priority/downstream-promotion-manifest@v1',
+    promotion: {
+      sourceRef: 'upstream/develop',
+      sourceCommitSha: '1234567890abcdef1234567890abcdef12345678',
+      targetBranch: 'downstream/develop',
+      targetBranchClassId: 'downstream-consumer-proving-rail',
+      localSourceVerification: {
+        attempted: true,
+        matched: true
+      }
+    },
+    inputs: {
+      compareviToolsRelease: 'v0.6.3-tools.14',
+      compareviHistoryRelease: 'v1.3.24',
+      scenarioPackIdentity: 'scenario-pack@v1',
+      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0'
+    }
+  });
 
   const result = runDownstreamPromotionScorecard({
     repo: 'example/repo',
     successReportPath,
     feedbackReportPath,
+    manifestReportPath,
     outputPath
   });
 
@@ -64,4 +85,5 @@ test('downstream promotion scorecard schema validates generated report payload',
 
   assert.equal(result.report.summary.status, 'pass');
   assert.equal(result.report.gates.feedbackReport.status, 'pass');
+  assert.equal(result.report.gates.manifestReport.status, 'pass');
 });

--- a/tools/priority/__tests__/downstream-promotion-scorecard.test.mjs
+++ b/tools/priority/__tests__/downstream-promotion-scorecard.test.mjs
@@ -20,6 +20,8 @@ test('parseArgs enforces required downstream promotion scorecard inputs', () => 
     'success.json',
     '--feedback-report',
     'feedback.json',
+    '--manifest-report',
+    'manifest.json',
     '--repo',
     'example/repo',
     '--no-fail-on-blockers'
@@ -27,6 +29,7 @@ test('parseArgs enforces required downstream promotion scorecard inputs', () => 
 
   assert.equal(parsed.successReportPath, 'success.json');
   assert.equal(parsed.feedbackReportPath, 'feedback.json');
+  assert.equal(parsed.manifestReportPath, 'manifest.json');
   assert.equal(parsed.repo, 'example/repo');
   assert.equal(parsed.failOnBlockers, false);
 });
@@ -35,8 +38,10 @@ test('evaluateDownstreamPromotionScorecard reports blockers deterministically', 
   const pass = evaluateDownstreamPromotionScorecard({
     successReport: { exists: true, error: null },
     feedbackReport: { exists: true, error: null },
+    manifestReport: { exists: false, error: null },
     successGate: { status: 'pass', totalBlockers: 0 },
-    feedbackGate: { status: 'pass', executionStatus: 'pass' }
+    feedbackGate: { status: 'pass', executionStatus: 'pass' },
+    manifestGate: { status: 'missing' }
   });
   assert.equal(pass.status, 'pass');
   assert.equal(pass.blockerCount, 0);
@@ -44,8 +49,10 @@ test('evaluateDownstreamPromotionScorecard reports blockers deterministically', 
   const fail = evaluateDownstreamPromotionScorecard({
     successReport: { exists: false, error: null },
     feedbackReport: { exists: true, error: 'bad json' },
+    manifestReport: { exists: true, error: 'bad json' },
     successGate: { status: 'fail', totalBlockers: 2 },
-    feedbackGate: { status: 'fail', executionStatus: 'fail' }
+    feedbackGate: { status: 'fail', executionStatus: 'fail' },
+    manifestGate: { status: 'fail' }
   });
 
   assert.equal(fail.status, 'fail');
@@ -53,12 +60,15 @@ test('evaluateDownstreamPromotionScorecard reports blockers deterministically', 
   assert.ok(fail.blockers.some((entry) => entry.code === 'feedback-report-missing'));
   assert.ok(fail.blockers.some((entry) => entry.code === 'downstream-blockers'));
   assert.ok(fail.blockers.some((entry) => entry.code === 'feedback-execution'));
+  assert.ok(fail.blockers.some((entry) => entry.code === 'manifest-report-unreadable'));
+  assert.ok(fail.blockers.some((entry) => entry.code === 'manifest-contract'));
 });
 
-test('runDownstreamPromotionScorecard writes a pass report for warn-only onboarding noise', () => {
+test('runDownstreamPromotionScorecard projects manifest provenance when present', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'downstream-promotion-scorecard-'));
   const successReportPath = path.join(tmpDir, 'downstream-onboarding-success.json');
   const feedbackReportPath = path.join(tmpDir, 'downstream-onboarding-feedback.json');
+  const manifestReportPath = path.join(tmpDir, 'downstream-develop-promotion-manifest.json');
   const outputPath = path.join(tmpDir, 'downstream-develop-promotion-scorecard.json');
 
   writeJson(successReportPath, {
@@ -81,18 +91,41 @@ test('runDownstreamPromotionScorecard writes a pass report for warn-only onboard
       successExitCode: 0
     }
   });
+  writeJson(manifestReportPath, {
+    schema: 'priority/downstream-promotion-manifest@v1',
+    promotion: {
+      sourceRef: 'upstream/develop',
+      sourceCommitSha: '1234567890abcdef1234567890abcdef12345678',
+      targetBranch: 'downstream/develop',
+      targetBranchClassId: 'downstream-consumer-proving-rail',
+      localSourceVerification: {
+        attempted: true,
+        matched: true
+      }
+    },
+    inputs: {
+      compareviToolsRelease: 'v0.6.3-tools.14',
+      compareviHistoryRelease: 'v1.3.24',
+      scenarioPackIdentity: 'scenario-pack@v1',
+      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0'
+    }
+  });
 
   const result = runDownstreamPromotionScorecard({
     repo: 'example/repo',
     successReportPath,
     feedbackReportPath,
+    manifestReportPath,
     outputPath
   });
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.summary.status, 'pass');
   assert.equal(result.report.gates.successReport.summaryStatus, 'warn');
+  assert.equal(result.report.gates.manifestReport.status, 'pass');
   assert.equal(result.report.summary.metrics.totalWarnings, 3);
+  assert.equal(result.report.summary.provenance.compareviToolsRelease, 'v0.6.3-tools.14');
+  assert.equal(result.report.summary.provenance.cookiecutterTemplateIdentity, 'LabviewGitHubCiTemplate@v0.1.0');
 });
 
 test('runDownstreamPromotionScorecard fails closed when onboarding blockers remain', () => {

--- a/tools/priority/downstream-promotion-scorecard.mjs
+++ b/tools/priority/downstream-promotion-scorecard.mjs
@@ -20,6 +20,7 @@ function printUsage() {
   console.log('Options:');
   console.log('  --success-report <path>         Downstream onboarding success report JSON path (required).');
   console.log('  --feedback-report <path>        Downstream onboarding feedback report JSON path (required).');
+  console.log('  --manifest-report <path>        Downstream promotion manifest JSON path (optional).');
   console.log(`  --output <path>                 Output path (default: ${DEFAULT_OUTPUT_PATH}).`);
   console.log('  --repo <owner/repo>             Repository slug override.');
   console.log('  --fail-on-blockers              Exit non-zero when blockers exist (default true).');
@@ -89,6 +90,7 @@ export function parseArgs(argv = process.argv) {
   const options = {
     successReportPath: null,
     feedbackReportPath: null,
+    manifestReportPath: null,
     outputPath: DEFAULT_OUTPUT_PATH,
     repo: null,
     failOnBlockers: true,
@@ -111,13 +113,20 @@ export function parseArgs(argv = process.argv) {
       options.failOnBlockers = false;
       continue;
     }
-    if (token === '--success-report' || token === '--feedback-report' || token === '--output' || token === '--repo') {
+    if (
+      token === '--success-report' ||
+      token === '--feedback-report' ||
+      token === '--manifest-report' ||
+      token === '--output' ||
+      token === '--repo'
+    ) {
       if (!next || next.startsWith('-')) {
         throw new Error(`Missing value for ${token}.`);
       }
       index += 1;
       if (token === '--success-report') options.successReportPath = next;
       if (token === '--feedback-report') options.feedbackReportPath = next;
+      if (token === '--manifest-report') options.manifestReportPath = next;
       if (token === '--output') options.outputPath = next;
       if (token === '--repo') options.repo = next;
       continue;
@@ -189,7 +198,62 @@ function statusFromFeedbackReport(payload) {
   };
 }
 
-export function evaluateDownstreamPromotionScorecard({ successReport, feedbackReport, successGate, feedbackGate }) {
+function statusFromManifestReport(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 'missing',
+      schema: null,
+      targetBranch: null,
+      targetBranchClassId: null,
+      sourceRef: null,
+      sourceCommitSha: null,
+      localSourceMatched: null,
+      compareviToolsRelease: null,
+      compareviHistoryRelease: null,
+      scenarioPackIdentity: null,
+      cookiecutterTemplateIdentity: null
+    };
+  }
+
+  const schema = normalizeText(payload.schema) || null;
+  const targetBranch = normalizeText(payload?.promotion?.targetBranch) || null;
+  const targetBranchClassId = normalizeText(payload?.promotion?.targetBranchClassId) || null;
+  const sourceRef = normalizeText(payload?.promotion?.sourceRef) || null;
+  const sourceCommitSha = normalizeText(payload?.promotion?.sourceCommitSha) || null;
+  const localSourceMatched =
+    typeof payload?.promotion?.localSourceVerification?.matched === 'boolean'
+      ? payload.promotion.localSourceVerification.matched
+      : null;
+
+  return {
+    status:
+      schema === 'priority/downstream-promotion-manifest@v1' &&
+      targetBranch === 'downstream/develop' &&
+      targetBranchClassId === 'downstream-consumer-proving-rail' &&
+      localSourceMatched === true
+        ? 'pass'
+        : 'fail',
+    schema,
+    targetBranch,
+    targetBranchClassId,
+    sourceRef,
+    sourceCommitSha,
+    localSourceMatched,
+    compareviToolsRelease: normalizeText(payload?.inputs?.compareviToolsRelease) || null,
+    compareviHistoryRelease: normalizeText(payload?.inputs?.compareviHistoryRelease) || null,
+    scenarioPackIdentity: normalizeText(payload?.inputs?.scenarioPackIdentity) || null,
+    cookiecutterTemplateIdentity: normalizeText(payload?.inputs?.cookiecutterTemplateIdentity) || null
+  };
+}
+
+export function evaluateDownstreamPromotionScorecard({
+  successReport,
+  feedbackReport,
+  manifestReport,
+  successGate,
+  feedbackGate,
+  manifestGate
+}) {
   const blockers = [];
   const recordBlocker = (code, message) => blockers.push({ code, message });
 
@@ -207,6 +271,15 @@ export function evaluateDownstreamPromotionScorecard({ successReport, feedbackRe
   }
   if (feedbackGate.status !== 'pass') {
     recordBlocker('feedback-execution', `Downstream onboarding feedback execution status is ${feedbackGate.executionStatus ?? 'missing'}.`);
+  }
+  if (manifestReport?.error) {
+    recordBlocker('manifest-report-unreadable', 'Downstream promotion manifest is unreadable.');
+  }
+  if (manifestReport?.exists && manifestGate.status !== 'pass') {
+    recordBlocker(
+      'manifest-contract',
+      `Downstream promotion manifest did not verify immutable downstream/develop proving inputs (status=${manifestGate.status}).`
+    );
   }
 
   return {
@@ -232,13 +305,17 @@ export function runDownstreamPromotionScorecard(rawOptions = {}) {
 
   const successReport = loadInputFile(options.successReportPath);
   const feedbackReport = loadInputFile(options.feedbackReportPath);
+  const manifestReport = options.manifestReportPath ? loadInputFile(options.manifestReportPath) : null;
   const successGate = statusFromSuccessReport(successReport.payload);
   const feedbackGate = statusFromFeedbackReport(feedbackReport.payload);
+  const manifestGate = statusFromManifestReport(manifestReport?.payload);
   const summary = evaluateDownstreamPromotionScorecard({
     successReport,
     feedbackReport,
+    manifestReport,
     successGate,
-    feedbackGate
+    feedbackGate,
+    manifestGate
   });
 
   const report = {
@@ -255,11 +332,17 @@ export function runDownstreamPromotionScorecard(rawOptions = {}) {
         path: feedbackReport.path,
         exists: feedbackReport.exists,
         error: feedbackReport.error
+      },
+      manifestReport: {
+        path: manifestReport?.path ?? null,
+        exists: manifestReport?.exists ?? false,
+        error: manifestReport?.error ?? null
       }
     },
     gates: {
       successReport: successGate,
-      feedbackReport: feedbackGate
+      feedbackReport: feedbackGate,
+      manifestReport: manifestGate
     },
     summary: {
       ...summary,
@@ -267,6 +350,14 @@ export function runDownstreamPromotionScorecard(rawOptions = {}) {
         repositoriesEvaluated: successGate.repositoriesEvaluated,
         totalBlockers: successGate.totalBlockers,
         totalWarnings: successGate.totalWarnings
+      },
+      provenance: {
+        sourceRef: manifestGate.sourceRef,
+        sourceCommitSha: manifestGate.sourceCommitSha,
+        compareviToolsRelease: manifestGate.compareviToolsRelease,
+        compareviHistoryRelease: manifestGate.compareviHistoryRelease,
+        scenarioPackIdentity: manifestGate.scenarioPackIdentity,
+        cookiecutterTemplateIdentity: manifestGate.cookiecutterTemplateIdentity
       }
     }
   };
@@ -283,7 +374,12 @@ export function runDownstreamPromotionScorecard(rawOptions = {}) {
       `- blockers: \`${report.summary.blockerCount}\``,
       `- repositories evaluated: \`${report.summary.metrics.repositoriesEvaluated ?? 'n/a'}\``,
       `- total blockers: \`${report.summary.metrics.totalBlockers ?? 'n/a'}\``,
-      `- total warnings: \`${report.summary.metrics.totalWarnings ?? 'n/a'}\``
+      `- total warnings: \`${report.summary.metrics.totalWarnings ?? 'n/a'}\``,
+      `- manifest status: \`${report.gates.manifestReport.status}\``,
+      `- CompareVI.Tools: \`${report.summary.provenance.compareviToolsRelease ?? 'n/a'}\``,
+      `- comparevi-history: \`${report.summary.provenance.compareviHistoryRelease ?? 'n/a'}\``,
+      `- scenario/corpus: \`${report.summary.provenance.scenarioPackIdentity ?? 'n/a'}\``,
+      `- cookiecutter template: \`${report.summary.provenance.cookiecutterTemplateIdentity ?? 'n/a'}\``
     ];
     for (const blocker of report.summary.blockers) {
       lines.push(`- ${blocker.code}: ${blocker.message}`);


### PR DESCRIPTION
## Summary
- project optional downstream promotion manifest provenance into the downstream scorecard
- surface immutable CompareVI/cookiecutter/scenario identities when the manifest is present
- wire the hosted onboarding workflow to pass the default manifest path into the scorecard step

## Testing
- `node --test tools/priority/__tests__/downstream-promotion-scorecard.test.mjs tools/priority/__tests__/downstream-promotion-scorecard-schema.test.mjs tools/priority/__tests__/downstream-onboarding-contract.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`
