### PR TITLE
Fix stale expected-count drift in project portfolio check (#1574)

### DIFF
--- a/dist/tools/cli/project-portfolio.js
+++ b/dist/tools/cli/project-portfolio.js
@@ -1239,12 +1239,11 @@ function compareProject(config, view, fields, items) {
         .filter((item) => !actualByUrl.has(item.url))
         .map((item) => item.url)
         .sort((a, b) => a.localeCompare(b));
-    const extraItems = config.allowAdditionalItems
-        ? []
-        : items
-            .filter((item) => !expectedByUrl.has(item.url))
-            .map((item) => item.url)
-            .sort((a, b) => a.localeCompare(b));
+    const observedExtraItems = items
+        .filter((item) => !expectedByUrl.has(item.url))
+        .map((item) => item.url)
+        .sort((a, b) => a.localeCompare(b));
+    const extraItems = config.allowAdditionalItems ? [] : observedExtraItems;
     const fieldMismatches = [];
     for (const expected of config.items) {
         const actual = actualByUrl.get(expected.url);
@@ -1300,6 +1299,13 @@ function compareProject(config, view, fields, items) {
         fieldCatalogMismatches,
         missingItems,
         extraItems,
+        inventory: {
+            trackedItemCount: config.items.length,
+            actualItemCount: items.length,
+            missingItemCount: missingItems.length,
+            extraItemCount: observedExtraItems.length,
+            additionalItemsAllowed: config.allowAdditionalItems,
+        },
         fieldMismatches,
         missingRepositories,
         unexpectedRepositories,
@@ -1650,7 +1656,7 @@ function main() {
     // eslint-disable-next-line no-console
     console.log(`${statusLabel} Project ${owner}#${number} snapshot written to ${outPath}`);
     // eslint-disable-next-line no-console
-    console.log(`${statusLabel} Items expected=${config.items.length} actual=${context.normalizedItems.length} drift=${drift.ok ? 'none' : 'present'}`);
+    console.log(`${statusLabel} Inventory tracked=${drift.inventory.trackedItemCount} actual=${drift.inventory.actualItemCount} missing=${drift.inventory.missingItemCount} extra=${drift.inventory.extraItemCount} extraAllowed=${drift.inventory.additionalItemsAllowed ? 'yes' : 'no'} drift=${drift.ok ? 'none' : 'present'}`);
     if (args.mode === 'check' && !drift.ok) {
         throw new Error('Project portfolio drift detected. Review the JSON report for details.');
     }

--- a/tools/cli/project-portfolio.ts
+++ b/tools/cli/project-portfolio.ts
@@ -1671,12 +1671,12 @@ function compareProject(
     .map((item) => item.url)
     .sort((a, b) => a.localeCompare(b));
 
-  const extraItems = config.allowAdditionalItems
-    ? []
-    : items
-        .filter((item) => !expectedByUrl.has(item.url))
-        .map((item) => item.url)
-        .sort((a, b) => a.localeCompare(b));
+  const observedExtraItems = items
+    .filter((item) => !expectedByUrl.has(item.url))
+    .map((item) => item.url)
+    .sort((a, b) => a.localeCompare(b));
+
+  const extraItems = config.allowAdditionalItems ? [] : observedExtraItems;
 
   const fieldMismatches: Array<{ url: string; drifts: DriftEntry[] }> = [];
   for (const expected of config.items) {
@@ -1738,6 +1738,13 @@ function compareProject(
     fieldCatalogMismatches,
     missingItems,
     extraItems,
+    inventory: {
+      trackedItemCount: config.items.length,
+      actualItemCount: items.length,
+      missingItemCount: missingItems.length,
+      extraItemCount: observedExtraItems.length,
+      additionalItemsAllowed: config.allowAdditionalItems,
+    },
     fieldMismatches,
     missingRepositories,
     unexpectedRepositories,
@@ -2167,7 +2174,7 @@ function main(): void {
   console.log(`${statusLabel} Project ${owner}#${number} snapshot written to ${outPath}`);
   // eslint-disable-next-line no-console
   console.log(
-    `${statusLabel} Items expected=${config.items.length} actual=${context.normalizedItems.length} drift=${drift.ok ? 'none' : 'present'}`,
+    `${statusLabel} Inventory tracked=${drift.inventory.trackedItemCount} actual=${drift.inventory.actualItemCount} missing=${drift.inventory.missingItemCount} extra=${drift.inventory.extraItemCount} extraAllowed=${drift.inventory.additionalItemsAllowed ? 'yes' : 'no'} drift=${drift.ok ? 'none' : 'present'}`,
   );
 
   if (args.mode === 'check' && !drift.ok) {

--- a/tools/priority/__tests__/project-portfolio-cli.test.mjs
+++ b/tools/priority/__tests__/project-portfolio-cli.test.mjs
@@ -32,6 +32,7 @@ function buildConfig({
   fieldNames = {},
   itemUrl = 'https://github.com/example/repo/issues/1',
   status = 'Todo',
+  allowAdditionalItems = false,
 } = {}) {
   return {
     schema: 'project-portfolio-config@v1',
@@ -41,7 +42,7 @@ function buildConfig({
     shortDescription: 'Example description',
     readme: 'Example readme',
     public: false,
-    allowAdditionalItems: false,
+    allowAdditionalItems,
     repositories: ['example/repo'],
     fieldCatalog: {
       status: { name: fieldNames.status ?? 'Status', options: ['Todo', 'In Progress'] },
@@ -583,6 +584,101 @@ test('project portfolio CLI normalizes item values using fieldCatalog display na
   assert.equal(report.items[0].evidenceState, 'Ready');
   assert.equal(report.items[0].portfolioTrack, 'Agent UX');
   assert.deepEqual(report.drift.fieldMismatches, []);
+});
+
+test('project portfolio CLI check treats project growth as inventory, not drift, when additional items are allowed', async (t) => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'project-portfolio-allow-growth-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const configPath = path.join(tempRoot, 'config.json');
+  const viewPath = path.join(tempRoot, 'view.json');
+  const fieldsPath = path.join(tempRoot, 'fields.json');
+  const itemsPath = path.join(tempRoot, 'items.json');
+  const outPath = path.join(tempRoot, 'report.json');
+
+  await writeJson(configPath, buildConfig({
+    allowAdditionalItems: true,
+    itemUrl: 'https://github.com/example/repo/issues/1',
+  }));
+  await writeJson(viewPath, buildView({ itemCount: 3 }));
+  await writeJson(fieldsPath, buildFields());
+  await writeJson(itemsPath, {
+    totalCount: 3,
+    items: [
+      {
+        id: 'item-1',
+        Status: 'Todo',
+        Program: 'Shared Infra',
+        Phase: 'Policy',
+        'Environment Class': 'Infra',
+        'Blocking Signal': 'Scope',
+        'Evidence State': 'Ready',
+        'Portfolio Track': 'Agent UX',
+        content: {
+          url: 'https://github.com/example/repo/issues/1',
+          title: 'Tracked issue',
+          repository: 'example/repo',
+          type: 'Issue',
+        },
+      },
+      {
+        id: 'item-2',
+        Status: 'In Progress',
+        Program: 'Shared Infra',
+        Phase: 'Policy',
+        'Environment Class': 'Infra',
+        'Blocking Signal': 'Scope',
+        'Evidence State': 'Ready',
+        'Portfolio Track': 'Agent UX',
+        content: {
+          url: 'https://github.com/example/repo/issues/2',
+          title: 'Extra issue 1',
+          repository: 'example/repo',
+          type: 'Issue',
+        },
+      },
+      {
+        id: 'item-3',
+        Status: 'In Progress',
+        Program: 'Shared Infra',
+        Phase: 'Policy',
+        'Environment Class': 'Infra',
+        'Blocking Signal': 'Scope',
+        'Evidence State': 'Ready',
+        'Portfolio Track': 'Agent UX',
+        content: {
+          url: 'https://github.com/example/repo/issues/3',
+          title: 'Extra issue 2',
+          repository: 'example/repo',
+          type: 'Issue',
+        },
+      },
+    ],
+  });
+
+  const result = runCli([
+    'check',
+    '--config', configPath,
+    '--view-file', viewPath,
+    '--fields-file', fieldsPath,
+    '--item-file', itemsPath,
+    '--out', outPath,
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(await readFile(outPath, 'utf8'));
+  assert.equal(report.drift.ok, true);
+  assert.deepEqual(report.drift.extraItems, []);
+  assert.deepEqual(report.drift.inventory, {
+    trackedItemCount: 1,
+    actualItemCount: 3,
+    missingItemCount: 0,
+    extraItemCount: 2,
+    additionalItemsAllowed: true,
+  });
+  assert.match(result.stdout, /Inventory tracked=1 actual=3 missing=0 extra=2 extraAllowed=yes drift=none/);
 });
 
 test('project portfolio CLI rejects config field values outside fieldCatalog options', async (t) => {


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1574
- Issue title: Fix stale expected-count drift in project portfolio check
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1574
- Standing priority at PR creation: No
- Base branch: `develop`
- Head branch: `issue/origin-1574-project-portfolio-growth-drift-summary`
- Template variant: `default-agent-template`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the outcome in 2-4 sentences. Lead with reviewer-visible behavior or operator impact, not implementation
chronology.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context:
- Files, tools, workflows, or policies touched:
- Cross-repo or external-consumer impact:
- Required checks, merge-queue behavior, or approval flows affected:

## Validation Evidence

- Commands run:
  - `node tools/npm/run-script.mjs <script>`
- Key artifacts, logs, or workflow runs:
  - `tests/results/...`
- Risk-based checks not run:
  - None or explain why

## Risks and Follow-ups

- Residual risks:
- Follow-up issues or deferred work:
- Deployment, approval, or rollback notes:

## Reviewer Focus

- Please verify:
- Areas where the reasoning is subtle:
- Manual spot checks requested:
