### PR TITLE
Default priority:develop:sync to all configured fork develop rails (#1608)

### DIFF
--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   parseArgs,
+  listConfiguredForkRemotes,
   resolveForkRemoteTargets,
   buildParityReportPath,
   buildPwshArgs,
@@ -90,10 +91,66 @@ test('develop-sync parseArgs accepts fork-remote and report overrides', () => {
   assert.equal(parsed.reportPath, 'custom/report.json');
 });
 
-test('resolveForkRemoteTargets defaults to origin and supports all lanes', () => {
-  assert.deepEqual(resolveForkRemoteTargets(null, {}), ['origin']);
+test('resolveForkRemoteTargets uses configured fork rails by default and still supports explicit all lanes', () => {
+  assert.deepEqual(resolveForkRemoteTargets(null, {}), ['origin', 'personal']);
   assert.deepEqual(resolveForkRemoteTargets('personal', {}), ['personal']);
   assert.deepEqual(resolveForkRemoteTargets('all', {}), ['origin', 'personal']);
+});
+
+test('listConfiguredForkRemotes returns only supported configured fork remotes', () => {
+  const remotes = listConfiguredForkRemotes({
+    repoRoot: 'C:/repo',
+    spawnSyncFn: (command, args) => {
+      assert.equal(command, 'git');
+      assert.deepEqual(args, ['remote']);
+      return {
+        status: 0,
+        stdout: 'origin\nupstream\npersonal\nmirror\n',
+        stderr: ''
+      };
+    }
+  });
+
+  assert.deepEqual(remotes, ['origin', 'personal']);
+});
+
+test('resolveForkRemoteTargets defaults to all configured fork remotes when both origin and personal exist', () => {
+  const targets = resolveForkRemoteTargets(null, {}, {
+    repoRoot: 'C:/repo',
+    spawnSyncFn: () => ({
+      status: 0,
+      stdout: 'origin\npersonal\nupstream\n',
+      stderr: ''
+    })
+  });
+
+  assert.deepEqual(targets, ['origin', 'personal']);
+});
+
+test('resolveForkRemoteTargets defaults to the only configured fork remote in a single-fork repo shape', () => {
+  const targets = resolveForkRemoteTargets(null, {}, {
+    repoRoot: 'C:/repo',
+    spawnSyncFn: () => ({
+      status: 0,
+      stdout: 'origin\nupstream\n',
+      stderr: ''
+    })
+  });
+
+  assert.deepEqual(targets, ['origin']);
+});
+
+test('resolveForkRemoteTargets still honors explicit remote overrides when multiple fork remotes are configured', () => {
+  const targets = resolveForkRemoteTargets('personal', {}, {
+    repoRoot: 'C:/repo',
+    spawnSyncFn: () => ({
+      status: 0,
+      stdout: 'origin\npersonal\nupstream\n',
+      stderr: ''
+    })
+  });
+
+  assert.deepEqual(targets, ['personal']);
 });
 
 test('buildPwshArgs pins the selected remote and parity path', () => {
@@ -736,6 +793,84 @@ test('runDevelopSync reports every requested remote before failing aggregate all
     ]
   );
   assert.equal(report.actions[1].commitDivergence.headOnly, 5);
+});
+
+test('runDevelopSync defaults to all configured fork remotes when both fork rails exist and no explicit remote is requested', async (t) => {
+  const sandboxRoot = await mkdtemp(path.join(os.tmpdir(), 'develop-sync-default-all-remotes-'));
+  const upstreamBare = path.join(sandboxRoot, 'upstream.git');
+  const originBare = path.join(sandboxRoot, 'origin.git');
+  const personalBare = path.join(sandboxRoot, 'personal.git');
+  const localRepo = path.join(sandboxRoot, 'local');
+  const reportPath = path.join(sandboxRoot, 'develop-sync-report.json');
+  t.after(async () => {
+    await rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  initBareRepo(upstreamBare);
+  initBareRepo(originBare);
+  initBareRepo(personalBare);
+  initTempGitRepo(localRepo);
+  run('git', ['remote', 'add', 'upstream', upstreamBare], { cwd: localRepo });
+  run('git', ['remote', 'add', 'origin', originBare], { cwd: localRepo });
+  run('git', ['remote', 'add', 'personal', personalBare], { cwd: localRepo });
+
+  const attemptedRemotes = [];
+  const writeParityReport = (parityReportPath, remote) => {
+    writeFileSyncImmediate(
+      parityReportPath,
+      JSON.stringify(
+        {
+          schema: `${remote}-upstream-parity@v1`,
+          status: 'ok',
+          tipDiff: { fileCount: 0 },
+          planeTransition: {
+            from: 'upstream',
+            to: remote,
+            action: 'sync',
+            via: 'priority:develop:sync'
+          },
+          syncResult: {
+            mode: 'direct-push',
+            reason: 'direct-push',
+            parityConverged: true
+          }
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+  };
+
+  const { report } = runDevelopSync({
+    repoRoot: localRepo,
+    options: { reportPath },
+    spawnSyncFn: (command, args, options = {}) => {
+      if (command === 'git') {
+        return spawnSync(command, args, {
+          ...options,
+          cwd: options.cwd ?? localRepo,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe']
+        });
+      }
+      if (command === 'pwsh') {
+        const remote = args[args.indexOf('-HeadRemote') + 1];
+        attemptedRemotes.push(remote);
+        const parityReportPath = path.join(localRepo, 'tests', 'results', '_agent', 'issue', `${remote}-upstream-parity.json`);
+        mkdirSync(path.dirname(parityReportPath), { recursive: true });
+        writeParityReport(parityReportPath, remote);
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected command ${command}`);
+    }
+  });
+
+  assert.deepEqual(attemptedRemotes, ['origin', 'personal']);
+  assert.deepEqual(report.remotes, ['origin', 'personal']);
+  assert.equal(report.remoteSelection.requested, null);
+  assert.deepEqual(report.remoteSelection.resolved, ['origin', 'personal']);
+  assert.equal(report.remoteSelection.summary, 'origin, personal');
 });
 
 test('runDevelopSync continues to later remotes after an earlier all-remote failure', async (t) => {

--- a/tools/priority/develop-sync.mjs
+++ b/tools/priority/develop-sync.mjs
@@ -25,7 +25,9 @@ function printUsage() {
   console.log('Usage: node tools/priority/develop-sync.mjs [options]');
   console.log('');
   console.log('Options:');
-  console.log('  --fork-remote <origin|personal|all>  Select which fork remote to sync (default: AGENT_PRIORITY_ACTIVE_FORK_REMOTE or origin).');
+  console.log(
+    '  --fork-remote <origin|personal|all>  Select which fork remote to sync (default: all configured fork remotes, otherwise AGENT_PRIORITY_ACTIVE_FORK_REMOTE or origin).'
+  );
   console.log(`  --report <path>                      Write aggregate report JSON (default: ${DEFAULT_REPORT_PATH}).`);
   console.log('  -h, --help                           Show this help text and exit.');
 }
@@ -63,20 +65,57 @@ export function parseArgs(argv = process.argv) {
   return options;
 }
 
-export function resolveForkRemoteTargets(value, env = process.env) {
-  const selected = String(value || resolveActiveForkRemoteName(env))
+export function listConfiguredForkRemotes({
+  repoRoot = getRepoRoot(),
+  env = process.env,
+  spawnSyncFn = spawnSync
+} = {}) {
+  try {
+    const remoteText = runGitText(spawnSyncFn, repoRoot, ['remote'], env);
+    const configured = remoteText
+      .split(/\r?\n/)
+      .map((entry) => entry.trim().toLowerCase())
+      .filter((entry) => SUPPORTED_FORK_REMOTES.has(entry));
+    return [...new Set(configured)];
+  } catch {
+    return [];
+  }
+}
+
+export function resolveForkRemoteTargets(
+  value,
+  env = process.env,
+  { repoRoot = getRepoRoot(), spawnSyncFn = spawnSync } = {}
+) {
+  const explicit = String(value ?? '')
     .trim()
     .toLowerCase();
-  if (!selected || selected === 'origin') {
+  const configured = listConfiguredForkRemotes({ repoRoot, env, spawnSyncFn });
+  if (!explicit) {
+    if (configured.length > 0) {
+      return configured;
+    }
+    const fallback = String(resolveActiveForkRemoteName(env))
+      .trim()
+      .toLowerCase();
+    if (!fallback || fallback === 'origin') {
+      return ['origin'];
+    }
+    if (!SUPPORTED_FORK_REMOTES.has(fallback)) {
+      throw new Error(`Unsupported --fork-remote '${fallback}'. Expected origin, personal, or all.`);
+    }
+    return [fallback];
+  }
+  if (explicit === 'origin') {
     return ['origin'];
   }
-  if (selected === 'all') {
-    return ['origin', 'personal'];
+  if (explicit === 'all') {
+    return configured.length > 0 ? configured : ['origin', 'personal'];
   }
-  if (!SUPPORTED_FORK_REMOTES.has(selected)) {
+  if (!SUPPORTED_FORK_REMOTES.has(explicit)) {
     throw new Error(`Unsupported --fork-remote '${value}'. Expected origin, personal, or all.`);
   }
-  return [selected];
+  return [explicit];
 }
 
 export function buildParityReportPath(repoRoot, remote) {
@@ -378,12 +417,13 @@ export function buildDevelopSyncBranchClassTrace(repoRoot) {
   };
 }
 
-function writeDevelopSyncReport({ repoRoot, reportPath, remotes, actions, status }) {
+function writeDevelopSyncReport({ repoRoot, reportPath, remotes, actions, status, remoteSelection = null }) {
   const report = {
     schema: 'priority/develop-sync-report@v1',
     generatedAt: new Date().toISOString(),
     repositoryRoot: repoRoot,
     remotes,
+    remoteSelection,
     status,
     actions
   };
@@ -481,7 +521,12 @@ export function runDevelopSync({
   spawnSyncFn = spawnSync
 } = {}) {
   const executionPlan = resolveDevelopSyncExecutionRoot({ repoRoot, env, spawnSyncFn });
-  const remotes = resolveForkRemoteTargets(options.forkRemote, env);
+  const remotes = resolveForkRemoteTargets(options.forkRemote, env, { repoRoot, spawnSyncFn });
+  const remoteSelection = {
+    requested: options.forkRemote ?? null,
+    resolved: remotes,
+    summary: remotes.join(', ') || 'origin'
+  };
   const actions = [];
   const reportPath = path.isAbsolute(options.reportPath) ? options.reportPath : path.join(repoRoot, options.reportPath);
   const reportHint = path.relative(repoRoot, reportPath).replace(/\\/g, '/');
@@ -542,6 +587,7 @@ export function runDevelopSync({
             repoRoot,
             reportPath,
             remotes,
+            remoteSelection,
             actions,
             status: 'failed'
           });
@@ -579,6 +625,7 @@ export function runDevelopSync({
             repoRoot,
             reportPath,
             remotes,
+            remoteSelection,
             actions,
             status: 'failed'
           });
@@ -614,6 +661,7 @@ export function runDevelopSync({
         repoRoot,
         reportPath,
         remotes,
+        remoteSelection,
         actions,
         status: 'failed'
       });
@@ -647,6 +695,7 @@ export function runDevelopSync({
         repoRoot,
         reportPath,
         remotes,
+        remoteSelection,
         actions,
         status: 'failed'
       });
@@ -658,6 +707,7 @@ export function runDevelopSync({
       repoRoot,
       reportPath,
       remotes,
+      remoteSelection,
       actions,
       status: 'failed'
     });
@@ -673,6 +723,7 @@ export function runDevelopSync({
     repoRoot,
     reportPath,
     remotes,
+    remoteSelection,
     actions,
     status: 'ok'
   });


### PR DESCRIPTION
## Summary
- default `priority:develop:sync` to all configured fork remotes instead of one active fork rail
- record the resolved remote selection in the develop-sync report surface
- cover dual-fork and single-fork default selection with focused helper tests

## Testing
- node --test tools/priority/__tests__/develop-sync.test.mjs
- git diff --check
