### PR TITLE
Add NI Linux custom-operation runner for PrintToSingleFileHtml proof lane

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/documentation-manifest-v1.schema.json",
   "schema": "documentation-manifest-v1",
   "version": "1.0.0",
-  "updated": "2026-03-20T19:44:05.8724152Z",
+  "updated": "2026-03-21T00:00:00Z",
   "entries": [
     {
       "name": "Root Entry Points",
@@ -218,9 +218,14 @@
         "docs/knowledgebase/PrintToSingleFileHtml-Provenance.md",
         "docs/schemas/headless-sample-vi-corpus-targets-v1.schema.json",
         "docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json",
+        "docs/schemas/headless-sample-vi-corpus-print-proof-v1.schema.json",
         "fixtures/headless-corpus/sample-vi-corpus.targets.json",
         "tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1",
-        "tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1"
+        "tools/Invoke-HeadlessSampleVICorpusPrintProof.ps1",
+        "tools/Run-NILinuxContainerCustomOperation.ps1",
+        "tests/Invoke-HeadlessSampleVICorpusEvaluation.Tests.ps1",
+        "tests/Invoke-HeadlessSampleVICorpusPrintProof.Tests.ps1",
+        "tests/Run-NILinuxContainerCustomOperation.Tests.ps1"
       ]
     },
     {
@@ -269,9 +274,11 @@
         "docs/knowledgebase/LabVIEWCLI-CustomOperation-Proof.md",
         "docs/schemas/labview-cli-custom-operation-proof-v1.schema.json",
         "tools/LabVIEWCLICustomOperationProof.psm1",
+        "tools/Run-NILinuxContainerCustomOperation.ps1",
         "tools/Run-NIWindowsContainerCustomOperation.ps1",
         "tools/Test-LabVIEWCLICustomOperationProof.ps1",
         "tests/LabVIEWCLICustomOperationProof.Tests.ps1",
+        "tests/Run-NILinuxContainerCustomOperation.Tests.ps1",
         "tests/Run-NIWindowsContainerCustomOperation.Tests.ps1"
       ]
     },

--- a/docs/knowledgebase/Headless-SampleVI-Corpus.md
+++ b/docs/knowledgebase/Headless-SampleVI-Corpus.md
@@ -25,6 +25,10 @@ This corpus is not the pre-push gate.
   `docs/schemas/headless-sample-vi-corpus-evaluation-v1.schema.json`
 - Evaluator:
   `tools/Invoke-HeadlessSampleVICorpusEvaluation.ps1`
+- Print proof wrapper:
+  `tools/Invoke-HeadlessSampleVICorpusPrintProof.ps1`
+- Linux print runner:
+  `tools/Run-NILinuxContainerCustomOperation.ps1`
 
 ## Admission states
 
@@ -149,3 +153,21 @@ Do not let this corpus replace:
 
 It exists to strengthen those surfaces with public, realistic, machine-tracked
 sample provenance.
+
+## Print proof lane
+
+For `print-single-file` targets, the checked-in wrapper now has two explicit
+states:
+
+- `blocked`
+  - the repo-owned payload still inspects as `source-only`
+  - no execution is attempted
+- `succeeded` / `failed`
+  - the payload inspects as runnable
+  - the wrapper materializes the pinned public sample repo (or uses an explicit
+    local checkout override)
+  - the Linux proof lane runs `PrintToSingleFileHtml` through
+    `tools/Run-NILinuxContainerCustomOperation.ps1`
+
+That keeps the wrapper fail-closed while still giving the repo a real Linux
+execution plane as soon as the repo-owned payload becomes runnable.

--- a/docs/knowledgebase/PrintToSingleFileHtml-Provenance.md
+++ b/docs/knowledgebase/PrintToSingleFileHtml-Provenance.md
@@ -50,7 +50,9 @@ As of March 21, 2026, the bundle is still explicitly `source-only`:
   executable-state receipt for the checked-in bundle
 - `tools/Invoke-HeadlessSampleVICorpusPrintProof.ps1` now turns the current
   `source-only` payload state into a deterministic blocked proof receipt for the
-  sample-corpus print lane instead of relying on human interpretation
+  sample-corpus print lane instead of relying on human interpretation; when the
+  payload becomes runnable, the same wrapper now executes the Linux proof lane
+  through `tools/Run-NILinuxContainerCustomOperation.ps1`
 - `tools/New-PrintToSingleFileHtmlAuthoringWorkspace.ps1` now wraps the generic
   scaffold so this payload has a dedicated disposable authoring bootstrap
 - `tools/New-PrintToSingleFileHtmlAuthoringPacket.ps1` now turns the remaining

--- a/docs/schemas/headless-sample-vi-corpus-print-proof-v1.schema.json
+++ b/docs/schemas/headless-sample-vi-corpus-print-proof-v1.schema.json
@@ -18,7 +18,16 @@
     "payloadInspectionMarkdownPath",
     "payloadDeclaredExecutableState",
     "payloadObservedExecutableState",
+    "runnerPath",
+    "targetRepositoryPath",
+    "targetRepositoryMaterialized",
     "executionAttempted",
+    "executionResultsRoot",
+    "executionCapturePath",
+    "scenarioResultPath",
+    "renderedOutputPath",
+    "executionExitCode",
+    "executionStatus",
     "finalStatus",
     "blockingReason",
     "notes"
@@ -76,14 +85,64 @@
       "type": "string",
       "minLength": 1
     },
+    "runnerPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "targetRepositoryPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "targetRepositoryMaterialized": {
+      "type": "boolean"
+    },
     "executionAttempted": {
       "type": "boolean"
+    },
+    "executionResultsRoot": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "executionCapturePath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "scenarioResultPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "renderedOutputPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "executionExitCode": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "executionStatus": {
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "finalStatus": {
       "type": "string",
       "enum": [
         "blocked",
-        "ready"
+        "succeeded",
+        "failed"
       ]
     },
     "blockingReason": {

--- a/tests/Invoke-HeadlessSampleVICorpusPrintProof.Tests.ps1
+++ b/tests/Invoke-HeadlessSampleVICorpusPrintProof.Tests.ps1
@@ -103,7 +103,7 @@ $report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ReportPath -Encodi
     $report.payloadObservedExecutableState | Should -Be 'source-only'
   }
 
-  It 'emits a ready receipt when the payload bundle is no longer source-only' {
+  It 'executes the Linux custom-operation runner once the payload bundle is runnable' {
     $catalogPath = Join-Path $TestDrive 'catalog-ready.json'
     @'
 {
@@ -175,6 +175,50 @@ $report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ReportPath -Encodi
 '# Inspection summary' | Set-Content -LiteralPath $MarkdownPath -Encoding utf8
 '@ | Set-Content -LiteralPath $inspectionStub -Encoding utf8
 
+    $fakeRepo = Join-Path $TestDrive 'sample-repo'
+    $fakeTargetDir = Join-Path $fakeRepo 'Tooling' 'comparevi-history-canary'
+    New-Item -ItemType Directory -Path $fakeTargetDir -Force | Out-Null
+    'stub-vi' | Set-Content -LiteralPath (Join-Path $fakeTargetDir 'CanaryProbe.vi') -Encoding utf8
+
+    $runnerStub = Join-Path $TestDrive 'Stub-RunLinuxCustomOperation.ps1'
+    @'
+param(
+  [string]$OperationName,
+  [string]$AdditionalOperationDirectory,
+  [string]$ResultsRoot,
+  [string[]]$AdditionalMount,
+  [object[]]$Arguments,
+  [string]$ExpectedOutputPath,
+  [switch]$Headless,
+  [switch]$LogToConsole
+)
+$resultsRootResolved = [System.IO.Path]::GetFullPath($ResultsRoot)
+if (-not (Test-Path -LiteralPath $resultsRootResolved -PathType Container)) {
+  New-Item -ItemType Directory -Path $resultsRootResolved -Force | Out-Null
+}
+$capturePath = Join-Path $resultsRootResolved 'ni-linux-custom-operation-capture.json'
+$scenarioResultPath = Join-Path $resultsRootResolved 'scenario-result.json'
+$renderedOutputPath = Join-Path $resultsRootResolved 'print-output.html'
+[ordered]@{
+  schema = 'ni-linux-container-custom-operation/v1'
+  status = 'ok'
+  operationName = $OperationName
+  additionalMounts = @($AdditionalMount)
+  preview = [ordered]@{
+    args = @($Arguments)
+  }
+  exitCode = 0
+} | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $capturePath -Encoding utf8
+[ordered]@{
+  schema = 'ni-linux-container-custom-operation-scenario@v1'
+  status = 'succeeded'
+  exitCode = 0
+  expectedOutputPath = $ExpectedOutputPath
+  outputExists = $true
+} | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $scenarioResultPath -Encoding utf8
+'<html><body>printed</body></html>' | Set-Content -LiteralPath $renderedOutputPath -Encoding utf8
+'@ | Set-Content -LiteralPath $runnerStub -Encoding utf8
+
     $resultsRoot = Join-Path $TestDrive 'results-ready'
     $output = & pwsh -NoLogo -NoProfile -File $script:ProofScript `
       -CatalogPath $catalogPath `
@@ -182,14 +226,20 @@ $report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ReportPath -Encodi
       -PayloadBundlePath 'fixtures/headless-corpus/operation-payloads/PrintToSingleFileHtml' `
       -ResultsRoot $resultsRoot `
       -InspectionScriptPath $inspectionStub `
+      -RunnerScriptPath $runnerStub `
+      -TargetRepositoryPath $fakeRepo `
       -SkipSchemaValidation *>&1
     $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
 
     $reportPath = Join-Path $resultsRoot 'print-proof-print-target.json'
     $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 20
-    $report.finalStatus | Should -Be 'ready'
+    $report.finalStatus | Should -Be 'succeeded'
     $report.blockingReason | Should -BeNullOrEmpty
-    $report.executionAttempted | Should -BeFalse
+    $report.executionAttempted | Should -BeTrue
     $report.payloadObservedExecutableState | Should -Be 'runnable'
+    $report.executionStatus | Should -Be 'succeeded'
+    $report.executionExitCode | Should -Be 0
+    $report.executionCapturePath | Should -Match 'ni-linux-custom-operation-capture\.json$'
+    $report.renderedOutputPath | Should -Match 'print-output\.html$'
   }
 }

--- a/tests/Run-NILinuxContainerCustomOperation.Tests.ps1
+++ b/tests/Run-NILinuxContainerCustomOperation.Tests.ps1
@@ -1,0 +1,239 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Run-NILinuxContainerCustomOperation.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:RunnerScript = Join-Path $script:RepoRoot 'tools' 'Run-NILinuxContainerCustomOperation.ps1'
+    if (-not (Test-Path -LiteralPath $script:RunnerScript -PathType Leaf)) {
+      throw "Run-NILinuxContainerCustomOperation.ps1 not found at $script:RunnerScript"
+    }
+
+    $script:NewDockerStub = {
+      param([Parameter(Mandatory)][string]$WorkRoot)
+
+      $stubPath = Join-Path $WorkRoot 'docker-stub.ps1'
+      @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+$logPath = [System.Environment]::GetEnvironmentVariable('DOCKER_STUB_LOG')
+if (-not [string]::IsNullOrWhiteSpace($logPath)) {
+  $record = [ordered]@{
+    at = (Get-Date).ToUniversalTime().ToString('o')
+    args = @($Args)
+  }
+  ($record | ConvertTo-Json -Compress) | Add-Content -LiteralPath $logPath -Encoding utf8
+}
+
+function Get-EnvValue {
+  param([Parameter(Mandatory)][string]$Name)
+  return [System.Environment]::GetEnvironmentVariable($Name)
+}
+
+function Resolve-HostPathFromContainerPath {
+  param(
+    [Parameter(Mandatory)][string]$ContainerPath,
+    [Parameter(Mandatory)][object[]]$VolumeMap
+  )
+
+  $normalizedContainerPath = $ContainerPath.Replace('\', '/')
+  foreach ($mapping in $VolumeMap) {
+    $containerRoot = [string]$mapping.container
+    $normalizedRoot = $containerRoot.Replace('\', '/').TrimEnd('/')
+    if ($normalizedContainerPath -eq $normalizedRoot) {
+      return [string]$mapping.host
+    }
+    $prefix = '{0}/' -f $normalizedRoot
+    if ($normalizedContainerPath.StartsWith($prefix, [System.StringComparison]::Ordinal)) {
+      $relative = $normalizedContainerPath.Substring($prefix.Length).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+      return (Join-Path ([string]$mapping.host) $relative)
+    }
+  }
+  return $ContainerPath
+}
+
+if ($Args.Count -eq 0) { exit 0 }
+
+if ($Args[0] -eq 'context' -and $Args.Count -ge 2 -and $Args[1] -eq 'show') {
+  Write-Output 'desktop-linux'
+  exit 0
+}
+
+if ($Args[0] -eq 'info') {
+  Write-Output 'linux'
+  exit 0
+}
+
+if ($Args[0] -eq 'image' -and $Args.Count -ge 2 -and $Args[1] -eq 'inspect') {
+  if ([string]::Equals((Get-EnvValue -Name 'DOCKER_STUB_IMAGE_EXISTS'), '1', [System.StringComparison]::OrdinalIgnoreCase)) {
+    Write-Output '[]'
+    exit 0
+  }
+  [Console]::Error.WriteLine('Error: No such image')
+  exit 1
+}
+
+  if ($Args[0] -eq 'run') {
+    $stubEnv = @{}
+    $volumeMap = @()
+  for ($i = 0; $i -lt $Args.Count; $i++) {
+    if ($Args[$i] -eq '--env' -and ($i + 1) -lt $Args.Count) {
+      $pair = [string]$Args[$i + 1]
+      if ($pair -match '^(?<k>[^=]+)=(?<v>.*)$') {
+        $stubEnv[$Matches['k']] = $Matches['v']
+      }
+      $i++
+      continue
+    }
+    if ($Args[$i] -eq '-v' -and ($i + 1) -lt $Args.Count) {
+      $spec = [string]$Args[$i + 1]
+      $separator = $spec.LastIndexOf(':/')
+      if ($separator -gt 0) {
+        $volumeMap += [pscustomobject]@{
+          host = $spec.Substring(0, $separator)
+          container = $spec.Substring($separator + 1)
+        }
+      }
+      $i++
+      }
+    }
+
+  $captureRoot = Get-EnvValue -Name 'DOCKER_STUB_CAPTURE_ROOT'
+  if ([string]::IsNullOrWhiteSpace($captureRoot)) {
+    $captureMapping = @($volumeMap | Where-Object { [string]$_.container -eq '/capture' } | Select-Object -First 1)
+    if ($captureMapping.Count -eq 0) {
+      throw 'Missing /capture volume mapping.'
+    }
+    $captureRoot = [string]$captureMapping[0].host
+  }
+  if (-not (Test-Path -LiteralPath $captureRoot -PathType Container)) {
+    New-Item -ItemType Directory -Path $captureRoot -Force | Out-Null
+  }
+  $argsFile = Join-Path $captureRoot 'custom-operation-args.txt'
+  $cliArgs = if (Test-Path -LiteralPath $argsFile -PathType Leaf) { Get-Content -LiteralPath $argsFile } else { @() }
+  $expectedOutputPath = [string]$stubEnv['CUSTOM_OP_EXPECT_OUTPUT_PATH']
+  $hostOutputPath = Join-Path $captureRoot 'print-output.html'
+  '<html><body>printed</body></html>' | Set-Content -LiteralPath $hostOutputPath -Encoding utf8
+
+  [ordered]@{
+    schema = 'ni-linux-container-custom-operation-scenario@v1'
+    status = 'succeeded'
+    timedOut = $false
+    exitCode = 0
+    cliPath = 'LabVIEWCLI'
+    stdoutPath = '/capture/labview-cli-stdout.txt'
+    stderrPath = '/capture/labview-cli-stderr.txt'
+    prelaunchAttempted = $true
+    iniPath = '/etc/natinst/LabVIEWCLI/LabVIEWCLI.ini'
+    expectedOutputPath = $expectedOutputPath
+    outputExists = $true
+    args = @($cliArgs)
+    finishedAt = '2026-03-21T00:00:00Z'
+  } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $captureRoot 'scenario-result.json') -Encoding utf8
+
+  'stdout' | Set-Content -LiteralPath (Join-Path $captureRoot 'labview-cli-stdout.txt') -Encoding utf8
+  'stderr' | Set-Content -LiteralPath (Join-Path $captureRoot 'labview-cli-stderr.txt') -Encoding utf8
+  Write-Output 'stub run ok'
+  exit 0
+}
+
+exit 0
+'@ | Set-Content -LiteralPath $stubPath -Encoding utf8
+      return $stubPath
+    }
+  }
+
+  It 'writes a probe-ok capture from the Linux shell contract' {
+    $resultsRoot = Join-Path $TestDrive 'results-probe'
+    $logPath = Join-Path $TestDrive 'docker-probe.log'
+    $stubPath = & $script:NewDockerStub -WorkRoot $TestDrive
+
+    $previousOverride = $env:DOCKER_COMMAND_OVERRIDE
+    $previousLog = $env:DOCKER_STUB_LOG
+    $previousImageExists = $env:DOCKER_STUB_IMAGE_EXISTS
+    $previousCaptureRoot = $env:DOCKER_STUB_CAPTURE_ROOT
+    try {
+      $env:DOCKER_COMMAND_OVERRIDE = $stubPath
+      $env:DOCKER_STUB_LOG = $logPath
+      $env:DOCKER_STUB_IMAGE_EXISTS = '1'
+      $env:DOCKER_STUB_CAPTURE_ROOT = $resultsRoot
+
+      $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+        -Probe `
+        -ResultsRoot $resultsRoot *>&1
+      $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+      $capturePath = Join-Path $resultsRoot 'ni-linux-custom-operation-capture.json'
+      $capturePath | Should -Exist
+      $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
+      $capture.schema | Should -Be 'ni-linux-container-custom-operation/v1'
+      $capture.status | Should -Be 'probe-ok'
+      $capture.image | Should -Be 'nationalinstruments/labview:2026q1-linux'
+      $capture.dockerServerOs | Should -Be 'linux'
+      $capture.dockerContext | Should -Be 'desktop-linux'
+      $capture.shellContract.executable | Should -Be 'bash'
+      $capture.shellContract.pwshRequired | Should -BeFalse
+    } finally {
+      $env:DOCKER_COMMAND_OVERRIDE = $previousOverride
+      $env:DOCKER_STUB_LOG = $previousLog
+      $env:DOCKER_STUB_IMAGE_EXISTS = $previousImageExists
+      $env:DOCKER_STUB_CAPTURE_ROOT = $previousCaptureRoot
+    }
+  }
+
+  It 'uses bash and preserves additional mounts during execution' {
+    $resultsRoot = Join-Path $TestDrive 'results-run'
+    $operationRoot = Join-Path $TestDrive 'operation'
+    $targetRepo = Join-Path $TestDrive 'target-repo'
+    $logPath = Join-Path $TestDrive 'docker-run.log'
+    $stubPath = & $script:NewDockerStub -WorkRoot $TestDrive
+    New-Item -ItemType Directory -Path $operationRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $targetRepo -Force | Out-Null
+    'placeholder' | Set-Content -LiteralPath (Join-Path $targetRepo 'Sample.vi') -Encoding utf8
+
+    $previousOverride = $env:DOCKER_COMMAND_OVERRIDE
+    $previousLog = $env:DOCKER_STUB_LOG
+    $previousImageExists = $env:DOCKER_STUB_IMAGE_EXISTS
+    $previousCaptureRoot = $env:DOCKER_STUB_CAPTURE_ROOT
+    try {
+      $env:DOCKER_COMMAND_OVERRIDE = $stubPath
+      $env:DOCKER_STUB_LOG = $logPath
+      $env:DOCKER_STUB_IMAGE_EXISTS = '1'
+      $env:DOCKER_STUB_CAPTURE_ROOT = $resultsRoot
+
+      $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+        -OperationName 'PrintToSingleFileHtml' `
+        -AdditionalOperationDirectory $operationRoot `
+        -ResultsRoot $resultsRoot `
+        -AdditionalMount ('{0}::/target-repo' -f $targetRepo) `
+        -ArgumentsJson '["-VI","/target-repo/Sample.vi","-OutputPath","/capture/print-output.html"]' `
+        -ExpectedOutputPath '/capture/print-output.html' `
+        -Headless `
+        -LogToConsole *>&1
+      $capturePath = Join-Path $resultsRoot 'ni-linux-custom-operation-capture.json'
+      $captureDebug = if (Test-Path -LiteralPath $capturePath -PathType Leaf) { Get-Content -LiteralPath $capturePath -Raw } else { '<missing capture>' }
+      $LASTEXITCODE | Should -Be 0 -Because ((($output -join "`n") + "`n" + $captureDebug))
+
+      $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 12
+      $capture.status | Should -Be 'ok'
+      $capture.preview.args | Should -Contain '-VI'
+      $capture.preview.args | Should -Contain '/target-repo/Sample.vi'
+      $capture.scenarioResult.status | Should -Be 'succeeded'
+      (Join-Path $resultsRoot 'print-output.html') | Should -Exist
+
+      $logRecords = Get-Content -LiteralPath $logPath | ForEach-Object { $_ | ConvertFrom-Json -Depth 8 }
+      $runRecord = @($logRecords | Where-Object { @($_.args)[0] -eq 'run' } | Select-Object -Last 1)
+      $runRecord.Count | Should -Be 1
+      $runArgs = @($runRecord[0].args)
+      $runArgs | Should -Contain 'bash'
+      $runArgs | Should -Contain '/capture/custom-operation-runner.sh'
+      (($runArgs -join ' ')) | Should -Match '/target-repo'
+    } finally {
+      $env:DOCKER_COMMAND_OVERRIDE = $previousOverride
+      $env:DOCKER_STUB_LOG = $previousLog
+      $env:DOCKER_STUB_IMAGE_EXISTS = $previousImageExists
+      $env:DOCKER_STUB_CAPTURE_ROOT = $previousCaptureRoot
+    }
+  }
+}

--- a/tools/Invoke-HeadlessSampleVICorpusPrintProof.ps1
+++ b/tools/Invoke-HeadlessSampleVICorpusPrintProof.ps1
@@ -9,6 +9,8 @@ param(
   [string]$ReportPath = '',
   [string]$MarkdownPath = '',
   [string]$InspectionScriptPath = '',
+  [string]$RunnerScriptPath = '',
+  [string]$TargetRepositoryPath = '',
   [switch]$SkipSchemaValidation,
   [switch]$PassThru
 )
@@ -67,6 +69,29 @@ function Convert-ToRepoRelativePath {
   return ($relative -replace '\\', '/')
 }
 
+function Resolve-ScriptPath {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [AllowEmptyString()][string]$PathValue,
+    [Parameter(Mandatory)][string]$DefaultRelativePath
+  )
+
+  $effective = if ([string]::IsNullOrWhiteSpace($PathValue)) { $DefaultRelativePath } else { $PathValue }
+  $resolved = Resolve-AbsolutePath -BasePath $RepoRoot -PathValue $effective
+  if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+    throw "Script path was not found: '$resolved'."
+  }
+  return $resolved
+}
+
+function Assert-Tool {
+  param([Parameter(Mandatory)][string]$Name)
+
+  if (-not (Get-Command -Name $Name -ErrorAction SilentlyContinue)) {
+    throw ("Required tool not found on PATH: {0}" -f $Name)
+  }
+}
+
 function Invoke-SchemaValidation {
   param(
     [Parameter(Mandatory)][string]$RepoRoot,
@@ -84,6 +109,63 @@ function Invoke-SchemaValidation {
     $message = ($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
     throw "Schema validation failed for '$DataPath': $message"
   }
+}
+
+function Invoke-NativeCommand {
+  param(
+    [Parameter(Mandatory)][string]$FilePath,
+    [Parameter(Mandatory)][string[]]$Arguments,
+    [string]$WorkingDirectory = '',
+    [Parameter(Mandatory)][string]$FailureContext
+  )
+
+  $output = @()
+  $exitCode = 0
+  try {
+    if (-not [string]::IsNullOrWhiteSpace($WorkingDirectory)) {
+      Push-Location $WorkingDirectory
+    }
+    $output = @(& $FilePath @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+  } finally {
+    if (-not [string]::IsNullOrWhiteSpace($WorkingDirectory)) {
+      Pop-Location
+    }
+  }
+
+  if ($exitCode -ne 0) {
+    $message = ($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    throw "{0} failed with exit code {1}: {2}" -f $FailureContext, $exitCode, $message
+  }
+
+  return @($output)
+}
+
+function Materialize-PinnedRepository {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$RepoUrl,
+    [Parameter(Mandatory)][string]$RepoSlug,
+    [Parameter(Mandatory)][string]$PinnedCommit,
+    [Parameter(Mandatory)][string]$DestinationRoot
+  )
+
+  Assert-Tool -Name 'git'
+
+  $slugSegment = ($RepoSlug -replace '[^A-Za-z0-9._-]+', '-')
+  $commitSegment = if ($PinnedCommit.Length -ge 12) { $PinnedCommit.Substring(0, 12) } else { $PinnedCommit }
+  $destination = Join-Path $DestinationRoot ("sample-repo-{0}-{1}" -f $slugSegment, $commitSegment)
+  if (Test-Path -LiteralPath $destination) {
+    Remove-Item -LiteralPath $destination -Recurse -Force
+  }
+  New-Item -ItemType Directory -Path $destination -Force | Out-Null
+
+  Invoke-NativeCommand -FilePath 'git' -Arguments @('init') -WorkingDirectory $destination -FailureContext 'git init'
+  Invoke-NativeCommand -FilePath 'git' -Arguments @('remote', 'add', 'origin', $RepoUrl) -WorkingDirectory $destination -FailureContext 'git remote add origin'
+  Invoke-NativeCommand -FilePath 'git' -Arguments @('fetch', '--depth', '1', 'origin', $PinnedCommit) -WorkingDirectory $destination -FailureContext 'git fetch pinned commit'
+  Invoke-NativeCommand -FilePath 'git' -Arguments @('checkout', '--detach', 'FETCH_HEAD') -WorkingDirectory $destination -FailureContext 'git checkout detached'
+
+  return (Resolve-Path -LiteralPath $destination).Path
 }
 
 $repoRoot = Resolve-RepoRoot
@@ -161,14 +243,81 @@ $inspectionReport = Get-Content -LiteralPath $inspectionReportPath -Raw | Conver
 $observedExecutableState = [string]$inspectionReport.observedExecutableState
 $declaredExecutableState = [string]$inspectionReport.declaredExecutableState
 
-$finalStatus = if ($observedExecutableState -eq 'source-only') { 'blocked' } else { 'ready' }
+$runnerScriptResolved = Resolve-ScriptPath -RepoRoot $repoRoot -PathValue $RunnerScriptPath -DefaultRelativePath 'tools/Run-NILinuxContainerCustomOperation.ps1'
+$targetRepositoryResolved = $null
+$targetRepositoryMaterialized = $false
+$executionResultsRoot = $null
+$executionCapturePath = $null
+$scenarioResultPath = $null
+$renderedOutputPath = $null
+$executionExitCode = $null
+$executionStatus = $null
+$finalExitCode = 0
+
+$finalStatus = if ($observedExecutableState -eq 'source-only') { 'blocked' } else { 'succeeded' }
 $blockingReason = if ($finalStatus -eq 'blocked') { 'payload-source-only' } else { $null }
 $notes = New-Object System.Collections.Generic.List[string]
 if ($finalStatus -eq 'blocked') {
   $notes.Add('Proof execution was not attempted because the repo-owned payload bundle is still source-only.') | Out-Null
   $notes.Add('This is the intended fail-closed state until runnable repo-owned payload files land.') | Out-Null
 } else {
-  $notes.Add('Payload inspection no longer reports source-only; the Linux execution runner can be wired next.') | Out-Null
+  if ([string]::IsNullOrWhiteSpace($TargetRepositoryPath)) {
+    $targetRepositoryResolved = Materialize-PinnedRepository `
+      -RepoRoot $repoRoot `
+      -RepoUrl ([string]$target.source.repoUrl) `
+      -RepoSlug ([string]$target.source.repoSlug) `
+      -PinnedCommit ([string]$target.source.pinnedCommit) `
+      -DestinationRoot $resultsRootResolved
+    $targetRepositoryMaterialized = $true
+  } else {
+    $targetRepositoryResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $TargetRepositoryPath
+  }
+  if (-not (Test-Path -LiteralPath $targetRepositoryResolved -PathType Container)) {
+    throw "Target repository path was not found at '$targetRepositoryResolved'."
+  }
+
+  $targetFileResolved = Resolve-AbsolutePath -BasePath $targetRepositoryResolved -PathValue ([string]$target.source.targetPath)
+  if (-not (Test-Path -LiteralPath $targetFileResolved -PathType Leaf)) {
+    throw "Target VI path was not found at '$targetFileResolved'."
+  }
+
+  $executionResultsRoot = New-DirectoryIfMissing -Path (Join-Path $resultsRootResolved ("execution-{0}" -f $TargetId))
+  $renderedOutputResolved = Join-Path $executionResultsRoot 'print-output.html'
+  $targetPathUnix = ([string]$target.source.targetPath).Replace('\', '/').TrimStart('/')
+  $containerTargetPath = '/target-repo/{0}' -f $targetPathUnix
+  $containerOutputPath = '/capture/print-output.html'
+  $runnerArgumentsJson = (@('-VI', $containerTargetPath, '-OutputPath', $containerOutputPath) | ConvertTo-Json -Compress)
+
+  $runnerArgs = @(
+    '-NoLogo',
+    '-NoProfile',
+    '-File', $runnerScriptResolved,
+    '-OperationName', 'PrintToSingleFileHtml',
+    '-AdditionalOperationDirectory', (Resolve-AbsolutePath -BasePath $repoRoot -PathValue $PayloadBundlePath),
+    '-ResultsRoot', $executionResultsRoot,
+    '-AdditionalMount', ('{0}::/target-repo' -f $targetRepositoryResolved),
+    '-ArgumentsJson', $runnerArgumentsJson,
+    '-ExpectedOutputPath', $containerOutputPath,
+    '-Headless',
+    '-LogToConsole'
+  )
+  $runnerOutput = @(& pwsh @runnerArgs 2>&1)
+  $executionExitCode = $LASTEXITCODE
+  $executionCapturePath = Join-Path $executionResultsRoot 'ni-linux-custom-operation-capture.json'
+  $scenarioResultPath = Join-Path $executionResultsRoot 'scenario-result.json'
+  $renderedOutputPath = $renderedOutputResolved
+  if (Test-Path -LiteralPath $scenarioResultPath -PathType Leaf) {
+    $scenarioResult = Get-Content -LiteralPath $scenarioResultPath -Raw | ConvertFrom-Json -Depth 20
+    $executionStatus = [string]$scenarioResult.status
+  }
+
+  if ($executionExitCode -ne 0 -or -not (Test-Path -LiteralPath $executionCapturePath -PathType Leaf) -or -not (Test-Path -LiteralPath $renderedOutputResolved -PathType Leaf)) {
+    $finalStatus = 'failed'
+    $finalExitCode = if ($executionExitCode -ne 0) { [int]$executionExitCode } else { 1 }
+    $notes.Add('Payload inspection reported runnable and the Linux execution lane was attempted, but the proof did not finish cleanly.') | Out-Null
+  } else {
+    $notes.Add('Payload inspection reported runnable and the Linux execution lane produced a rendered print artifact.') | Out-Null
+  }
 }
 
 $report = [ordered]@{
@@ -185,7 +334,16 @@ $report = [ordered]@{
   payloadInspectionMarkdownPath = Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $inspectionMarkdownPath
   payloadDeclaredExecutableState = $declaredExecutableState
   payloadObservedExecutableState = $observedExecutableState
-  executionAttempted = $false
+  runnerPath = Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $runnerScriptResolved
+  targetRepositoryPath = if ($targetRepositoryResolved) { Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $targetRepositoryResolved } else { $null }
+  targetRepositoryMaterialized = [bool]$targetRepositoryMaterialized
+  executionAttempted = ($finalStatus -ne 'blocked')
+  executionResultsRoot = if ($executionResultsRoot) { Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $executionResultsRoot } else { $null }
+  executionCapturePath = if ($executionCapturePath) { Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $executionCapturePath } else { $null }
+  scenarioResultPath = if ($scenarioResultPath) { Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $scenarioResultPath } else { $null }
+  renderedOutputPath = if ($renderedOutputPath) { Convert-ToRepoRelativePath -RepoRoot $repoRoot -PathValue $renderedOutputPath } else { $null }
+  executionExitCode = $executionExitCode
+  executionStatus = $executionStatus
   finalStatus = $finalStatus
   blockingReason = $blockingReason
   notes = @($notes.ToArray())
@@ -208,6 +366,20 @@ if ($blockingReason) {
   $markdownLines += ('- Blocking Reason: `{0}`' -f $blockingReason)
   $markdownLines += ''
 }
+$markdownLines += ('- Runner: `{0}`' -f $report.runnerPath)
+if ($report.targetRepositoryPath) {
+  $markdownLines += ('- Target Repository Path: `{0}`' -f $report.targetRepositoryPath)
+}
+if ($report.renderedOutputPath) {
+  $markdownLines += ('- Rendered Output Path: `{0}`' -f $report.renderedOutputPath)
+}
+if ($null -ne $report.executionExitCode) {
+  $markdownLines += ('- Execution Exit Code: `{0}`' -f $report.executionExitCode)
+}
+if ($report.executionStatus) {
+  $markdownLines += ('- Execution Status: `{0}`' -f $report.executionStatus)
+}
+$markdownLines += ''
 $markdownLines += '## Notes'
 $markdownLines += ''
 foreach ($note in @($report.notes)) {
@@ -216,6 +388,12 @@ foreach ($note in @($report.notes)) {
 $markdownLines += ''
 $markdownLines += ('- Payload Inspection Report: `{0}`' -f $report.payloadInspectionPath)
 $markdownLines += ('- Payload Inspection Summary: `{0}`' -f $report.payloadInspectionMarkdownPath)
+if ($report.executionCapturePath) {
+  $markdownLines += ('- Execution Capture: `{0}`' -f $report.executionCapturePath)
+}
+if ($report.scenarioResultPath) {
+  $markdownLines += ('- Execution Scenario Result: `{0}`' -f $report.scenarioResultPath)
+}
 
 $markdownLines -join [Environment]::NewLine | Set-Content -LiteralPath $markdownResolved -Encoding utf8
 
@@ -229,3 +407,5 @@ Write-Output ("Headless sample print proof summary: {0}" -f (Convert-ToRepoRelat
 if ($PassThru.IsPresent) {
   [pscustomobject]$report
 }
+
+exit $finalExitCode

--- a/tools/Run-NILinuxContainerCustomOperation.ps1
+++ b/tools/Run-NILinuxContainerCustomOperation.ps1
@@ -1,0 +1,858 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Runs a LabVIEW CLI custom operation inside the pinned NI Linux container.
+
+.DESCRIPTION
+  Preflights Docker Desktop against `nationalinstruments/labview:2026q1-linux`
+  and then executes a LabVIEW CLI custom operation inside that container using a
+  mounted operation workspace, mounted capture directory, and optional extra
+  mounts for scenario inputs such as pinned sample repositories.
+
+  The Linux LabVIEW image uses `bash` inside the container. This helper must
+  not assume `pwsh` exists in that plane.
+#>
+[CmdletBinding()]
+param(
+  [string]$OperationName = 'PrintToSingleFileHtml',
+  [string]$AdditionalOperationDirectory,
+  [string]$Image = 'nationalinstruments/labview:2026q1-linux',
+  [string]$ResultsRoot = 'tests/results/ni-linux-custom-operation',
+  [object[]]$Arguments,
+  [string]$ArgumentsJson = '',
+  [string[]]$AdditionalMount,
+  [string]$ExpectedOutputPath = '',
+  [switch]$Help,
+  [switch]$Headless,
+  [switch]$LogToConsole,
+  [string]$LabVIEWPath,
+  [int]$TimeoutSeconds = 180,
+  [int]$HeartbeatSeconds = 15,
+  [int]$PrelaunchWaitSeconds = 8,
+  [switch]$Probe,
+  [switch]$PassThru
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:PreflightExitCode = 2
+$script:TimeoutExitCode = 124
+$script:ContainerOperationRoot = '/custom-operation'
+$script:ContainerCaptureRoot = '/capture'
+
+function Resolve-RepoRoot {
+  return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory)][string]$BasePath,
+    [Parameter(Mandatory)][string]$PathValue
+  )
+
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $PathValue))
+}
+
+function Ensure-Directory {
+  param([Parameter(Mandatory)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+
+  return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Resolve-ScriptPath {
+  param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [AllowEmptyString()][string]$PathValue,
+    [Parameter(Mandatory)][string]$DefaultRelativePath
+  )
+
+  $effective = if ([string]::IsNullOrWhiteSpace($PathValue)) { $DefaultRelativePath } else { $PathValue }
+  $resolved = Resolve-AbsolutePath -BasePath $RepoRoot -PathValue $effective
+  if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+    throw "Script path was not found: '$resolved'."
+  }
+  return $resolved
+}
+
+function Assert-Tool {
+  param([Parameter(Mandatory)][string]$Name)
+
+  if (-not (Get-Command -Name $Name -ErrorAction SilentlyContinue)) {
+    throw ("Required tool not found on PATH: {0}" -f $Name)
+  }
+}
+
+function Resolve-DockerCommandSource {
+  $override = $env:DOCKER_COMMAND_OVERRIDE
+  if (-not [string]::IsNullOrWhiteSpace($override) -and (Test-Path -LiteralPath $override -PathType Leaf)) {
+    return [System.IO.Path]::GetFullPath($override)
+  }
+
+  $commands = @(Get-Command -Name 'docker' -All -ErrorAction SilentlyContinue)
+  foreach ($command in $commands) {
+    if ([string]::IsNullOrWhiteSpace([string]$command.Source)) { continue }
+    $source = [string]$command.Source
+    if (Test-Path -LiteralPath $source -PathType Leaf) {
+      return [System.IO.Path]::GetFullPath($source)
+    }
+  }
+
+  throw 'Unable to resolve docker command source path.'
+}
+
+function Get-DockerProcessLaunchSpec {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $dockerCommandSource = Resolve-DockerCommandSource
+  $startFilePath = $dockerCommandSource
+  $startArgs = @($DockerArgs)
+  $dockerSourceExt = [System.IO.Path]::GetExtension($dockerCommandSource)
+  if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerSourceExt, '.ps1')) {
+    $pwshExe = (Get-Command -Name 'pwsh' -ErrorAction Stop).Source
+    $escapedScriptPath = $dockerCommandSource.Replace("'", "''")
+    $startFilePath = $pwshExe
+    $startArgs = @(
+      '-NoLogo',
+      '-NoProfile',
+      '-Command',
+      ("& '{0}' @args" -f $escapedScriptPath),
+      '--'
+    ) + @($DockerArgs)
+  }
+
+  return [pscustomobject]@{
+    FilePath = $startFilePath
+    Arguments = @($startArgs)
+  }
+}
+
+function Invoke-DockerCommandAndCapture {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs
+  )
+
+  $stdoutFile = Join-Path $env:TEMP ("ni-linux-custom-op-docker-stdout-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $stderrFile = Join-Path $env:TEMP ("ni-linux-custom-op-docker-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $process = $null
+  try {
+    $launchSpec = Get-DockerProcessLaunchSpec -DockerArgs $DockerArgs
+    $process = Start-Process -FilePath $launchSpec.FilePath `
+      -ArgumentList $launchSpec.Arguments `
+      -RedirectStandardOutput $stdoutFile `
+      -RedirectStandardError $stderrFile `
+      -NoNewWindow `
+      -PassThru
+    $process.WaitForExit()
+    return [pscustomobject]@{
+      ExitCode = [int]$process.ExitCode
+      StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+      StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+    }
+  } finally {
+    if ($process) {
+      try { $process.Dispose() } catch {}
+    }
+    Remove-Item -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+  }
+}
+
+function Invoke-DockerRunWithTimeout {
+  param(
+    [Parameter(Mandatory)][string[]]$DockerArgs,
+    [Parameter(Mandatory)][int]$Seconds,
+    [Parameter(Mandatory)][string]$Image,
+    [int]$HeartbeatSeconds = 15
+  )
+
+  $stdoutFile = Join-Path $env:TEMP ("ni-linux-custom-op-stdout-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $stderrFile = Join-Path $env:TEMP ("ni-linux-custom-op-stderr-{0}.log" -f ([guid]::NewGuid().ToString('N')))
+  $process = $null
+  try {
+    $launchSpec = Get-DockerProcessLaunchSpec -DockerArgs $DockerArgs
+    $process = Start-Process -FilePath $launchSpec.FilePath `
+      -ArgumentList $launchSpec.Arguments `
+      -RedirectStandardOutput $stdoutFile `
+      -RedirectStandardError $stderrFile `
+      -NoNewWindow `
+      -PassThru
+
+    $deadline = (Get-Date).AddSeconds([Math]::Max(1, $Seconds))
+    $lastHeartbeat = Get-Date
+    while (-not $process.HasExited) {
+      if ((Get-Date) -ge $deadline) {
+        try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
+        return [pscustomobject]@{
+          TimedOut = $true
+          ExitCode = $script:TimeoutExitCode
+          StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+          StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+        }
+      }
+
+      if (((Get-Date) - $lastHeartbeat).TotalSeconds -ge [Math]::Max(5, $HeartbeatSeconds)) {
+        Write-Host ("[ni-linux-custom-op] running image={0} elapsed={1:n1}s timeout={2}s" -f $Image, ((Get-Date) - $process.StartTime).TotalSeconds, $Seconds) -ForegroundColor DarkGray
+        $lastHeartbeat = Get-Date
+      }
+      Start-Sleep -Milliseconds 500
+    }
+
+    return [pscustomobject]@{
+      TimedOut = $false
+      ExitCode = [int]$process.ExitCode
+      StdOut = if (Test-Path -LiteralPath $stdoutFile -PathType Leaf) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
+      StdErr = if (Test-Path -LiteralPath $stderrFile -PathType Leaf) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
+    }
+  } finally {
+    if ($process) {
+      try { $process.Dispose() } catch {}
+    }
+    Remove-Item -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $stderrFile -ErrorAction SilentlyContinue
+  }
+}
+
+function Write-TextArtifact {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [AllowNull()][string]$Content
+  )
+
+  $parent = Split-Path -Parent $Path
+  if ($parent) {
+    Ensure-Directory -Path $parent | Out-Null
+  }
+  if ($null -eq $Content) {
+    $Content = ''
+  }
+  Set-Content -LiteralPath $Path -Value $Content -Encoding utf8
+}
+
+function Write-UnixTextArtifact {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [AllowNull()][string]$Content
+  )
+
+  $parent = Split-Path -Parent $Path
+  if ($parent) {
+    Ensure-Directory -Path $parent | Out-Null
+  }
+  if ($null -eq $Content) {
+    $Content = ''
+  }
+  $normalized = $Content -replace "`r`n", "`n"
+  $encoding = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText($Path, $normalized, $encoding)
+}
+
+function Quote-CommandArgument {
+  param([AllowNull()][string]$Text)
+
+  if ($null -eq $Text) {
+    return '""'
+  }
+
+  if ($Text -match '[\s"]') {
+    return '"' + ($Text -replace '"', '\"') + '"'
+  }
+
+  return $Text
+}
+
+function Convert-ToCliBoolToken {
+  param([bool]$Value)
+  if ($Value) { return 'true' }
+  return 'false'
+}
+
+function Build-CustomOperationArgs {
+  param(
+    [Parameter(Mandatory)][string]$OperationName,
+    [Parameter(Mandatory)][string]$ContainerOperationDirectory,
+    [AllowNull()][object[]]$Arguments,
+    [bool]$Help,
+    [bool]$Headless,
+    [bool]$LogToConsole,
+    [AllowEmptyString()][string]$LabVIEWPath
+  )
+
+  $args = New-Object System.Collections.Generic.List[string]
+  $args.Add('-OperationName') | Out-Null
+  $args.Add($OperationName) | Out-Null
+  $args.Add('-AdditionalOperationDirectory') | Out-Null
+  $args.Add($ContainerOperationDirectory) | Out-Null
+
+  if ($Help) {
+    $args.Add('-Help') | Out-Null
+  }
+
+  foreach ($arg in @($Arguments)) {
+    if (-not [string]::IsNullOrWhiteSpace([string]$arg)) {
+      $args.Add([string]$arg) | Out-Null
+    }
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+    $args.Add('-LabVIEWPath') | Out-Null
+    $args.Add($LabVIEWPath) | Out-Null
+  }
+
+  $args.Add('-LogToConsole') | Out-Null
+  $args.Add((Convert-ToCliBoolToken -Value $LogToConsole)) | Out-Null
+  $args.Add('-Headless') | Out-Null
+  $args.Add((Convert-ToCliBoolToken -Value $Headless)) | Out-Null
+
+  return @($args)
+}
+
+function New-InContainerPreview {
+  param(
+    [Parameter(Mandatory)][string]$OperationName,
+    [Parameter(Mandatory)][string]$ContainerOperationDirectory,
+    [AllowNull()][object[]]$Arguments,
+    [bool]$Help,
+    [bool]$Headless,
+    [bool]$LogToConsole,
+    [AllowEmptyString()][string]$LabVIEWPath
+  )
+
+  $args = Build-CustomOperationArgs `
+    -OperationName $OperationName `
+    -ContainerOperationDirectory $ContainerOperationDirectory `
+    -Arguments $Arguments `
+    -Help $Help `
+    -Headless $Headless `
+    -LogToConsole $LogToConsole `
+    -LabVIEWPath $LabVIEWPath
+  $commandText = 'LabVIEWCLI {0}' -f ((@($args | ForEach-Object { Quote-CommandArgument -Text $_ })) -join ' ')
+
+  return [ordered]@{
+    operation = 'RunCustomOperation'
+    provider = 'labviewcli'
+    cliPath = 'in-container'
+    args = @($args)
+    command = $commandText
+  }
+}
+
+function Resolve-AdditionalMounts {
+  param(
+    [Parameter(Mandatory)][string]$BasePath,
+    [AllowNull()][string[]]$Entries
+  )
+
+  $resolved = New-Object System.Collections.Generic.List[object]
+  foreach ($entry in @($Entries)) {
+    if ([string]::IsNullOrWhiteSpace([string]$entry)) {
+      continue
+    }
+
+    $separatorIndex = $entry.IndexOf('::')
+    if ($separatorIndex -lt 1) {
+      throw "Additional mount entry must use 'hostPath::/container/path' format: '$entry'."
+    }
+
+    $hostPath = [string]$entry.Substring(0, $separatorIndex)
+    $containerPath = [string]$entry.Substring($separatorIndex + 2)
+    $resolvedHostPath = Resolve-AbsolutePath -BasePath $BasePath -PathValue $hostPath
+    if (-not (Test-Path -LiteralPath $resolvedHostPath)) {
+      throw "Additional mount host path was not found: '$resolvedHostPath'."
+    }
+
+    $normalizedContainerPath = $containerPath.Trim().Replace('\', '/')
+    if (-not $normalizedContainerPath.StartsWith('/')) {
+      throw "Additional mount container path must be absolute: '$containerPath'."
+    }
+    foreach ($reserved in @($script:ContainerOperationRoot, $script:ContainerCaptureRoot)) {
+      if (
+        [string]::Equals($normalizedContainerPath, $reserved, [System.StringComparison]::Ordinal) -or
+        $normalizedContainerPath.StartsWith($reserved.TrimEnd('/') + '/', [System.StringComparison]::Ordinal)
+      ) {
+        throw "Additional mount container path '$normalizedContainerPath' collides with reserved path '$reserved'."
+      }
+    }
+
+    $resolved.Add([pscustomobject]@{
+        hostPath = $resolvedHostPath
+        containerPath = $normalizedContainerPath
+      }) | Out-Null
+  }
+
+  return @($resolved.ToArray())
+}
+
+function Get-DockerContextName {
+  $result = Invoke-DockerCommandAndCapture -DockerArgs @('context', 'show')
+  if ($result.ExitCode -ne 0) {
+    $message = if ([string]::IsNullOrWhiteSpace($result.StdErr)) { $result.StdOut } else { $result.StdErr }
+    throw "Failed to query docker context: $message"
+  }
+  return ($result.StdOut.Trim())
+}
+
+function Get-DockerInfoRecord {
+  $result = Invoke-DockerCommandAndCapture -DockerArgs @('info', '--format', '{{.OSType}}')
+  if ($result.ExitCode -ne 0) {
+    $message = if ([string]::IsNullOrWhiteSpace($result.StdErr)) { $result.StdOut } else { $result.StdErr }
+    throw "Failed to query docker info: $message"
+  }
+
+  $text = $result.StdOut.Trim()
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    throw 'Docker info returned empty output.'
+  }
+  return [pscustomobject]@{ OSType = $text }
+}
+
+function Test-DockerImageExists {
+  param([Parameter(Mandatory)][string]$Tag)
+
+  $result = Invoke-DockerCommandAndCapture -DockerArgs @('image', 'inspect', $Tag)
+  return ($result.ExitCode -eq 0)
+}
+
+function New-ContainerCommand {
+  return @'
+set -u
+set -o pipefail
+
+ensure_dir() {
+  mkdir -p "$1"
+}
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  printf '%s' "$value"
+}
+
+json_bool() {
+  if [ "$1" = "1" ]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+json_string_or_null() {
+  if [ -n "$1" ]; then
+    printf '"%s"' "$(json_escape "$1")"
+  else
+    printf 'null'
+  fi
+}
+
+find_cli() {
+  if command -v LabVIEWCLI >/dev/null 2>&1; then
+    echo "LabVIEWCLI"
+    return 0
+  fi
+  if command -v labviewcli >/dev/null 2>&1; then
+    echo "labviewcli"
+    return 0
+  fi
+  local found
+  found="$(find / -maxdepth 6 -type f \( -name LabVIEWCLI -o -name LabVIEWCLI.sh -o -name labviewcli \) 2>/dev/null | head -n 1 || true)"
+  if [ -n "$found" ]; then
+    echo "$found"
+    return 0
+  fi
+  return 1
+}
+
+find_labview() {
+  if [ -n "${CUSTOM_OP_REQUESTED_LABVIEW_PATH:-}" ] && [ -x "${CUSTOM_OP_REQUESTED_LABVIEW_PATH}" ]; then
+    echo "${CUSTOM_OP_REQUESTED_LABVIEW_PATH}"
+    return 0
+  fi
+  local candidates=(
+    "/usr/local/natinst/LabVIEW-2026-64/labview"
+    "/usr/local/natinst/LabVIEW/labview"
+    "/usr/local/bin/labview"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -x "$c" ]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+set_ini_timeout_token() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  if [ ! -f "$file" ]; then
+    return 0
+  fi
+  if grep -q "^${key}=" "$file"; then
+    sed -i "s#^${key}=.*#${key}=${value}#g" "$file"
+  else
+    printf "%s=%s\n" "$key" "$value" >> "$file"
+  fi
+}
+
+find_cli_ini() {
+  local candidates=(
+    "/etc/natinst/LabVIEWCLI/LabVIEWCLI.ini"
+    "/usr/local/natinst/LabVIEWCLI/LabVIEWCLI.ini"
+    "/usr/local/natinst/LabVIEW/LabVIEWCLI.ini"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -f "$c" ]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  local found
+  found="$(find / -maxdepth 6 -type f -name LabVIEWCLI.ini 2>/dev/null | head -n 1 || true)"
+  if [ -n "$found" ]; then
+    echo "$found"
+    return 0
+  fi
+  return 1
+}
+
+capture_root="${CUSTOM_OP_CAPTURE_ROOT:-/capture}"
+args_file="${CUSTOM_OP_ARGS_FILE:-}"
+stdout_path="${capture_root}/labview-cli-stdout.txt"
+stderr_path="${capture_root}/labview-cli-stderr.txt"
+result_path="${capture_root}/scenario-result.json"
+expected_output_path="${CUSTOM_OP_EXPECT_OUTPUT_PATH:-}"
+requested_labview_path="${CUSTOM_OP_REQUESTED_LABVIEW_PATH:-}"
+
+ensure_dir "${capture_root}"
+
+if [ -z "${args_file}" ] || [ ! -f "${args_file}" ]; then
+  echo "CUSTOM_OP_ARGS_FILE is required and must exist." 1>&2
+  exit 2
+fi
+
+if ! cli_path="$(find_cli)"; then
+  echo "LabVIEWCLI not found in container. Ensure NI image includes the LabVIEW CLI component." 1>&2
+  exit 2
+fi
+
+if ! command -v xvfb-run >/dev/null 2>&1; then
+  echo "xvfb-run not found. Linux headless custom operations require Xvfb." 1>&2
+  exit 2
+fi
+
+ini_path=""
+if ini_path="$(find_cli_ini)"; then
+  set_ini_timeout_token "$ini_path" "OpenAppReferenceTimeoutInSecond" "${CUSTOM_OP_OPEN_APP_TIMEOUT:-180}"
+  set_ini_timeout_token "$ini_path" "AfterLaunchOpenAppReferenceTimeoutInSecond" "${CUSTOM_OP_AFTER_LAUNCH_TIMEOUT:-180}"
+fi
+
+prelaunch_attempted=0
+if [ "${CUSTOM_OP_PRELAUNCH_ENABLED:-1}" = "1" ]; then
+  if lv_path="$(find_labview)"; then
+    prelaunch_attempted=1
+    "${lv_path}" --headless >/tmp/custom-op-prelaunch.log 2>&1 &
+    sleep "${CUSTOM_OP_PRELAUNCH_WAIT_SECONDS:-8}"
+  fi
+fi
+
+declare -a cli_args
+while IFS= read -r arg || [ -n "$arg" ]; do
+  cli_args+=("$arg")
+done < "${args_file}"
+
+timed_out=0
+exit_code=0
+xvfb-run -a "${cli_path}" "${cli_args[@]}" </dev/null >"${stdout_path}" 2>"${stderr_path}" &
+cli_pid=$!
+deadline=$(( $(date +%s) + ${CUSTOM_OP_TIMEOUT_SECONDS:-180} ))
+while kill -0 "${cli_pid}" 2>/dev/null; do
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    timed_out=1
+    kill -9 "${cli_pid}" 2>/dev/null || true
+    wait "${cli_pid}" 2>/dev/null || true
+    break
+  fi
+  sleep 1
+done
+
+if [ "${timed_out}" = "1" ]; then
+  exit_code=124
+else
+  wait "${cli_pid}"
+  exit_code=$?
+fi
+
+output_exists=0
+if [ -n "${expected_output_path}" ] && [ -f "${expected_output_path}" ]; then
+  output_exists=1
+fi
+if [ "${exit_code}" = "0" ] && [ -n "${expected_output_path}" ] && [ "${output_exists}" = "0" ]; then
+  exit_code=1
+fi
+
+finished_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+status="failed"
+if [ "${timed_out}" = "1" ]; then
+  status="timed-out"
+elif [ "${exit_code}" = "0" ]; then
+  status="succeeded"
+fi
+
+cat > "${result_path}" <<EOF
+{
+  "schema": "ni-linux-container-custom-operation-scenario@v1",
+  "status": "${status}",
+  "timedOut": $(json_bool "${timed_out}"),
+  "exitCode": ${exit_code},
+  "cliPath": $(json_string_or_null "${cli_path}"),
+  "requestedLabVIEWPath": $(json_string_or_null "${requested_labview_path}"),
+  "stdoutPath": $(json_string_or_null "${stdout_path}"),
+  "stderrPath": $(json_string_or_null "${stderr_path}"),
+  "prelaunchAttempted": $(json_bool "${prelaunch_attempted}"),
+  "iniPath": $(json_string_or_null "${ini_path}"),
+  "expectedOutputPath": $(json_string_or_null "${expected_output_path}"),
+  "outputExists": $(json_bool "${output_exists}"),
+  "finishedAt": $(json_string_or_null "${finished_at}")
+}
+EOF
+
+exit "${exit_code}"
+'@
+}
+
+$repoRoot = Resolve-RepoRoot
+$shellContractScriptResolved = Resolve-ScriptPath -RepoRoot $repoRoot -PathValue '' -DefaultRelativePath 'tools/Get-LabVIEWContainerShellContract.ps1'
+$shellContract = & $shellContractScriptResolved -Plane linux
+if ([string]::IsNullOrWhiteSpace([string]$shellContract.executable)) {
+  throw 'Linux shell contract did not declare an executable.'
+}
+
+$effectiveArguments = @()
+if (-not [string]::IsNullOrWhiteSpace($ArgumentsJson)) {
+  $parsedArguments = $ArgumentsJson | ConvertFrom-Json -ErrorAction Stop
+  if ($parsedArguments -is [System.Collections.IEnumerable] -and -not ($parsedArguments -is [string])) {
+    $effectiveArguments = @($parsedArguments | ForEach-Object { [string]$_ })
+  } elseif (-not [string]::IsNullOrWhiteSpace([string]$parsedArguments)) {
+    $effectiveArguments = @([string]$parsedArguments)
+  }
+} elseif ($Arguments) {
+  $effectiveArguments = @($Arguments | ForEach-Object { [string]$_ })
+}
+
+$resultsRootResolved = Ensure-Directory -Path (Resolve-AbsolutePath -BasePath $repoRoot -PathValue $ResultsRoot)
+$capturePath = Join-Path $resultsRootResolved 'ni-linux-custom-operation-capture.json'
+$stdoutPath = Join-Path $resultsRootResolved 'ni-linux-custom-operation-run-stdout.txt'
+$stderrPath = Join-Path $resultsRootResolved 'ni-linux-custom-operation-run-stderr.txt'
+$scenarioResultPath = Join-Path $resultsRootResolved 'scenario-result.json'
+$containerArgsPath = Join-Path $resultsRootResolved 'custom-operation-args.txt'
+$containerScriptHostPath = Join-Path $resultsRootResolved 'custom-operation-runner.sh'
+$containerScriptContainerPath = '{0}/custom-operation-runner.sh' -f $script:ContainerCaptureRoot
+$containerArgsContainerPath = '{0}/custom-operation-args.txt' -f $script:ContainerCaptureRoot
+
+$capture = [ordered]@{
+  schema = 'ni-linux-container-custom-operation/v1'
+  generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  status = 'init'
+  classification = 'init'
+  image = $Image
+  operationName = $OperationName
+  resultsRoot = $resultsRootResolved
+  additionalOperationDirectory = $null
+  additionalMounts = @()
+  requestedLabVIEWPath = if ([string]::IsNullOrWhiteSpace($LabVIEWPath)) { $null } else { $LabVIEWPath }
+  timeoutSeconds = [int]$TimeoutSeconds
+  probe = [bool]$Probe
+  dockerServerOs = $null
+  dockerContext = $null
+  shellContract = $shellContract
+  preview = $null
+  expectedOutputPath = if ([string]::IsNullOrWhiteSpace($ExpectedOutputPath)) { $null } else { $ExpectedOutputPath }
+  scenarioResultPath = $scenarioResultPath
+  stdoutPath = $stdoutPath
+  stderrPath = $stderrPath
+  containerCommand = $null
+  exitCode = $null
+  timedOut = $false
+  message = $null
+  scenarioResult = $null
+}
+
+$finalExitCode = 0
+$stdoutContent = ''
+$stderrContent = ''
+
+try {
+  Assert-Tool -Name 'docker'
+
+  $dockerContext = Get-DockerContextName
+  $dockerInfo = Get-DockerInfoRecord
+  $dockerServerOs = [string]$dockerInfo.OSType
+  $capture.dockerContext = $dockerContext
+  $capture.dockerServerOs = $dockerServerOs
+  if (-not [string]::Equals($dockerServerOs, 'linux', [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw ("Docker server OS must be linux for the NI Linux custom-operation plane; observed '{0}'." -f $dockerServerOs)
+  }
+
+  if (-not (Test-DockerImageExists -Tag $Image)) {
+    throw ("Docker image '{0}' not found locally. Pull it first: docker pull {0}" -f $Image)
+  }
+
+  if ($Probe) {
+    $capture.status = 'probe-ok'
+    $capture.classification = 'probe-ok'
+    $capture.exitCode = 0
+    $capture.message = ("Docker is in linux mode and image '{0}' is available." -f $Image)
+  } else {
+    if ([string]::IsNullOrWhiteSpace($AdditionalOperationDirectory)) {
+      throw '-AdditionalOperationDirectory is required unless -Probe is set.'
+    }
+
+    $operationDirectoryResolved = Resolve-AbsolutePath -BasePath $repoRoot -PathValue $AdditionalOperationDirectory
+    if (-not (Test-Path -LiteralPath $operationDirectoryResolved -PathType Container)) {
+      throw "Custom operation directory was not found at '$operationDirectoryResolved'."
+    }
+    $capture.additionalOperationDirectory = $operationDirectoryResolved
+
+    $resolvedAdditionalMounts = Resolve-AdditionalMounts -BasePath $repoRoot -Entries $AdditionalMount
+    $capture.additionalMounts = @(
+      $resolvedAdditionalMounts | ForEach-Object {
+        [ordered]@{
+          hostPath = [string]$_.hostPath
+          containerPath = [string]$_.containerPath
+        }
+      }
+    )
+
+    $preview = New-InContainerPreview `
+      -OperationName $OperationName `
+      -ContainerOperationDirectory $script:ContainerOperationRoot `
+      -Arguments $effectiveArguments `
+      -Help:$Help.IsPresent `
+      -Headless:$Headless.IsPresent `
+      -LogToConsole:$LogToConsole.IsPresent `
+      -LabVIEWPath $LabVIEWPath
+    $capture.preview = $preview
+
+    Write-UnixTextArtifact -Path $containerArgsPath -Content ((@($preview.args) -join "`n") + "`n")
+    Write-UnixTextArtifact -Path $containerScriptHostPath -Content (New-ContainerCommand)
+
+    $dockerArgs = @(
+      'run',
+      '--rm',
+      '--workdir', $script:ContainerOperationRoot,
+      '-v', ('{0}:{1}' -f $operationDirectoryResolved, $script:ContainerOperationRoot),
+      '-v', ('{0}:{1}' -f $resultsRootResolved, $script:ContainerCaptureRoot)
+    )
+    foreach ($mount in @($resolvedAdditionalMounts)) {
+      $dockerArgs += @('-v', ('{0}:{1}' -f $mount.hostPath, $mount.containerPath))
+    }
+    $dockerArgs += @(
+      '--env', ('CUSTOM_OP_CAPTURE_ROOT={0}' -f $script:ContainerCaptureRoot),
+      '--env', ('CUSTOM_OP_ARGS_FILE={0}' -f $containerArgsContainerPath),
+      '--env', ('CUSTOM_OP_TIMEOUT_SECONDS={0}' -f [Math]::Max(1, $TimeoutSeconds)),
+      '--env', ('CUSTOM_OP_PRELAUNCH_ENABLED={0}' -f 1),
+      '--env', ('CUSTOM_OP_PRELAUNCH_WAIT_SECONDS={0}' -f [Math]::Max(0, $PrelaunchWaitSeconds)),
+      '--env', 'CUSTOM_OP_OPEN_APP_TIMEOUT=180',
+      '--env', 'CUSTOM_OP_AFTER_LAUNCH_TIMEOUT=180'
+    )
+    if (-not [string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+      $dockerArgs += @('--env', ('CUSTOM_OP_REQUESTED_LABVIEW_PATH={0}' -f $LabVIEWPath))
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedOutputPath)) {
+      $dockerArgs += @('--env', ('CUSTOM_OP_EXPECT_OUTPUT_PATH={0}' -f $ExpectedOutputPath))
+    }
+    $dockerArgs += @(
+      $Image,
+      [string]$shellContract.executable,
+      $containerScriptContainerPath
+    )
+
+    $capture.containerCommand = ('docker run --rm --workdir {0} ... {1} {2} {3}' -f $script:ContainerOperationRoot, $Image, [string]$shellContract.executable, $containerScriptContainerPath)
+    Write-Host ("[ni-linux-custom-op] dockerContext={0} dockerServerOs={1} image={2} operation={3}" -f (($dockerContext ?? '<null>')), (($dockerServerOs ?? '<null>')), $Image, $OperationName) -ForegroundColor Cyan
+
+    $runResult = Invoke-DockerRunWithTimeout `
+      -DockerArgs $dockerArgs `
+      -Seconds ([Math]::Max($TimeoutSeconds + 15, $TimeoutSeconds)) `
+      -HeartbeatSeconds $HeartbeatSeconds `
+      -Image $Image
+    $stdoutContent = $runResult.StdOut
+    $stderrContent = $runResult.StdErr
+
+    if ($runResult.TimedOut) {
+      $capture.status = 'timeout'
+      $capture.classification = 'timeout'
+      $capture.timedOut = $true
+      $capture.exitCode = $script:TimeoutExitCode
+      $capture.message = ("Linux container custom operation timed out after {0} second(s)." -f $TimeoutSeconds)
+      $finalExitCode = $script:TimeoutExitCode
+    } else {
+      $capture.exitCode = [int]$runResult.ExitCode
+      $finalExitCode = [int]$runResult.ExitCode
+      if (Test-Path -LiteralPath $scenarioResultPath -PathType Leaf) {
+        $scenarioResult = Get-Content -LiteralPath $scenarioResultPath -Raw | ConvertFrom-Json -Depth 12
+        $capture.scenarioResult = $scenarioResult
+        switch ([string]$scenarioResult.status) {
+          'succeeded' {
+            $capture.status = 'ok'
+            $capture.classification = 'ok'
+          }
+          'timed-out' {
+            $capture.status = 'timeout'
+            $capture.classification = 'timeout'
+            $capture.timedOut = $true
+            if (-not $capture.message) {
+              $capture.message = ("Linux container custom operation timed out after {0} second(s)." -f $TimeoutSeconds)
+            }
+          }
+          default {
+            $capture.status = 'error'
+            $capture.classification = 'run-error'
+            $capture.message = 'Linux container custom operation did not complete successfully.'
+          }
+        }
+      } else {
+        $capture.status = 'error'
+        $capture.classification = 'missing-result'
+        $capture.message = "Container run completed without emitting '$scenarioResultPath'."
+        if ($finalExitCode -eq 0) {
+          $finalExitCode = 1
+        }
+      }
+    }
+  }
+} catch {
+  $capture.status = 'preflight-error'
+  $capture.classification = 'preflight-error'
+  $capture.exitCode = $script:PreflightExitCode
+  $capture.message = $_.Exception.Message
+  $finalExitCode = $script:PreflightExitCode
+} finally {
+  if (-not $Probe) {
+    Write-TextArtifact -Path $stdoutPath -Content $stdoutContent
+    Write-TextArtifact -Path $stderrPath -Content $stderrContent
+  }
+  $capture.generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+  $capture | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $capturePath -Encoding utf8
+  Write-Host ("[ni-linux-custom-op] capture={0} status={1} exit={2}" -f $capturePath, $capture.status, $capture.exitCode) -ForegroundColor DarkGray
+}
+
+if ($PassThru) {
+  [pscustomobject]$capture
+}
+
+exit $finalExitCode


### PR DESCRIPTION
## Summary

Closes #1628.

- add a pinned NI Linux custom-operation runner for `PrintToSingleFileHtml` proof execution
- upgrade the headless sample VI corpus print-proof wrapper from inspection-only into an execution-capable lane
- extend the print-proof contract, docs, and focused tests to cover runnable Linux proof execution and fail-closed blocked states
- harden the test-only `.ps1` docker override path so `docker run` arguments survive PowerShell parsing intact

## Validation

- `pwsh -NoLogo -NoProfile -File tests/Run-NILinuxContainerCustomOperation.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tests/Invoke-HeadlessSampleVICorpusPrintProof.Tests.ps1`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `pwsh -NoLogo -NoProfile -Command "& 'tools/Invoke-HeadlessSampleVICorpusPrintProof.ps1' -TargetId 'icon-editor-demo-canaryprobe-print' -SkipSchemaValidation"`
- `git diff --check`

## Notes

- the sample print proof still blocks cleanly when the repo-owned payload bundle is `source-only`; this lane adds the Linux runner and execution wiring so the proof surface is ready as soon as runnable payload files land
- the active blocked receipt is written to `tests/results/_agent/headless-sample-corpus/print-proof/print-proof-icon-editor-demo-canaryprobe-print.json`
