### PR TITLE
Update for standing priority #1636

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -67,6 +67,7 @@
         "docs/knowledgebase/Headless-SampleVI-Corpus.md",
         "docs/knowledgebase/PrintToSingleFileHtml-Provenance.md",
         "docs/knowledgebase/Offline-RealHistory-Corpus.md",
+        "docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md",
         "docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md",
         "docs/knowledgebase/DOCKER_TOOLS_PARITY.md",
         "docs/LABVIEW_GATING.md",

--- a/docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md
+++ b/docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md
@@ -1,0 +1,91 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Unattended Delivery Daemon Surfaces
+
+This page is the bounded daemon-first entrypoint for future agents auditing or
+resuming unattended delivery. Use it before opening the larger runtime design
+docs or digging through `tools/priority/*`.
+
+## Stable Operator Entry Points
+
+Use these checked-in commands first instead of reaching for ad hoc
+`node`/`pwsh` invocations:
+
+- `node tools/npm/run-script.mjs priority:delivery:agent:ensure`
+- `node tools/npm/run-script.mjs priority:delivery:agent:status`
+- `node tools/npm/run-script.mjs priority:delivery:agent:stop`
+- `node tools/npm/run-script.mjs priority:runtime:daemon`
+- `node tools/npm/run-script.mjs priority:runtime:daemon:docker`
+- `node tools/npm/run-script.mjs priority:runtime:daemon:docker:status`
+
+Prefer `priority:delivery:agent:status` as the first read. That surface already
+normalizes manager state, heartbeat fallback, and lane/runtime evidence into one
+bounded status payload.
+
+## Canonical Receipt Read Order
+
+When a daemon lane needs diagnosis, read receipts in this order:
+
+1. `tests/results/_agent/runtime/delivery-agent-state.json`
+2. `tests/results/_agent/runtime/delivery-agent-lanes/<lane-id>.json`
+3. `tests/results/_agent/runtime/delivery-memory.json`
+4. `tests/results/_agent/runtime/observer-heartbeat.json`
+5. `tests/results/_agent/runtime/task-packet.json`
+6. `tests/results/_agent/runtime/codex-state-hygiene.json`
+7. `tests/results/_agent/marketplace/lane-marketplace-snapshot.json`
+
+Secondary control-plane receipts worth checking only when the main runtime view
+looks stale:
+
+- `tests/results/_agent/runtime/delivery-agent-manager-state.json`
+- `tests/results/_agent/runtime/delivery-agent-manager-pid.json`
+- `tests/results/_agent/runtime/delivery-agent-manager-stop.json`
+- `tests/results/_agent/runtime/delivery-agent-wsl-daemon-pid.json`
+- `tests/results/_agent/runtime/daemon-host-signal.json`
+
+## Current Compatibility And Debt Register
+
+### Runtime-state naming split
+
+- `delivery-agent-state.json` is the intended primary runtime receipt.
+- `runtime-state.json` still exists as a compatibility surface in parts of the
+  manager/status path.
+- Treat this as tracked debt, not a cue to invent a third receipt family.
+- Owner lane: `#1634`.
+
+### Marketplace snapshot contract
+
+- `lane-marketplace-snapshot.json` is already persisted and referenced through
+  `artifacts.marketplaceSnapshotPath`.
+- The surface is test-backed, but it does not yet have its own checked-in docs
+  schema entry.
+- Until that is split, trust the persisted path plus the lane-marketplace tests
+  over any inferred file naming.
+
+### Thin daemon entrypoint
+
+- `tools/priority/runtime-daemon.mjs` is intentionally a thin CLI wrapper.
+- The behavioral authority lives in:
+  - `tools/priority/runtime-supervisor.mjs`
+  - `tools/priority/delivery-agent.mjs`
+  - `tools/priority/lib/delivery-agent-common.ts`
+- When behavior and docs disagree, prefer the contract tests below before
+  changing runtime code.
+
+## Authoritative Tests
+
+These tests are the fastest way to confirm the daemon contract without opening a
+large hosted run:
+
+- `tools/priority/__tests__/runtime-daemon.test.mjs`
+- `tools/priority/__tests__/runtime-daemon-docker.test.mjs`
+- `tools/priority/__tests__/runtime-supervisor.test.mjs`
+- `tools/priority/__tests__/delivery-agent-schema.test.mjs`
+- `tools/priority/__tests__/delivery-agent-manager-contract.test.mjs`
+- `tools/priority/__tests__/agent-writer-lease.test.mjs`
+- `tools/priority/__tests__/codex-state-hygiene.test.mjs`
+
+## Related Runbooks
+
+- [External-Agent-Runtime.md](./External-Agent-Runtime.md)
+- [Agent-Handoff-Surfaces.md](./Agent-Handoff-Surfaces.md)
+- [DOCKER_TOOLS_PARITY.md](./DOCKER_TOOLS_PARITY.md)

--- a/tools/priority/__tests__/unattended-delivery-daemon-contract.test.mjs
+++ b/tools/priority/__tests__/unattended-delivery-daemon-contract.test.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('unattended delivery daemon knowledgebase is checked in and points to the bounded daemon surfaces', () => {
+  const manifest = JSON.parse(readText('docs/documentation-manifest.json'));
+  const docsEntry = manifest.entries.find((entry) => entry.name === 'Docs Tree');
+  const guide = readText('docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md');
+
+  assert.ok(docsEntry);
+  assert.ok(docsEntry.files.includes('docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md'));
+  assert.match(guide, /priority:delivery:agent:ensure/);
+  assert.match(guide, /priority:delivery:agent:status/);
+  assert.match(guide, /priority:delivery:agent:stop/);
+  assert.match(guide, /priority:runtime:daemon/);
+  assert.match(guide, /priority:runtime:daemon:docker/);
+  assert.match(guide, /delivery-agent-state\.json/);
+  assert.match(guide, /delivery-agent-lanes\/<lane-id>\.json/);
+  assert.match(guide, /delivery-memory\.json/);
+  assert.match(guide, /observer-heartbeat\.json/);
+  assert.match(guide, /task-packet\.json/);
+  assert.match(guide, /codex-state-hygiene\.json/);
+  assert.match(guide, /lane-marketplace-snapshot\.json/);
+  assert.match(guide, /runtime-state\.json/);
+  assert.match(guide, /#1634/);
+  assert.match(guide, /runtime-daemon\.mjs/);
+  assert.match(guide, /runtime-supervisor\.mjs/);
+  assert.match(guide, /delivery-agent\.mjs/);
+  assert.match(guide, /delivery-agent-common\.ts/);
+  assert.match(guide, /delivery-agent-manager-contract\.test\.mjs/);
+  assert.match(guide, /runtime-supervisor\.test\.mjs/);
+});


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1636
- Issue title: [program]: audit unattended delivery daemon debt and expansion seams
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1636
- Standing priority at PR creation: No
- Base branch: `develop`
- Head branch: `issue/origin-1636-program-audit-unattended-delivery-daemon-debt-and-expansion-seams`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Add a bounded unattended-delivery daemon knowledgebase page and a focused
contract test so future agents can find the stable daemon command/receipt
surfaces without re-auditing `tools/priority/*`.

This change is intentionally documentation- and contract-only:

- adds `docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md`
- registers that guide in `docs/documentation-manifest.json`
- adds a focused docs contract test for the new daemon guide

The runtime-state naming split remains tracked separately in `#1634`; this PR
documents that seam instead of changing daemon behavior.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched: none
- Check names, required-status contracts, or merge-queue behavior affected: none
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed: none
- Manual dispatch, comment command, or branch-protection effects: none

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/unattended-delivery-daemon-contract.test.mjs`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs lint:md:changed`
  - `git diff --check`
- Contract, schema, or guard tests:
  - `tools/priority/__tests__/unattended-delivery-daemon-contract.test.mjs`
- Live workflow or dry-run evidence:
  - `docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md`

## Rollout and Rollback

- Rollout notes:
  - future agents can use the new daemon guide as the bounded entrypoint before opening runtime code
- Rollback path:
  - revert this PR to remove the new guide/test if the daemon contract is reorganized later
- Residual risks:
  - `runtime-state.json` versus `delivery-agent-state.json` remains an active compatibility seam under `#1634`
  - `lane-marketplace-snapshot.json` is still test-backed without its own checked-in docs schema

## Reviewer Focus

- Please verify:
  - the new guide accurately reflects the current daemon commands and receipt read order
  - the doc/test slice stays clear of `#1632` and `#1634`
- Policy assumptions to double-check:
  - none; this PR does not change policy behavior
- Follow-up issues or guardrails:
  - keep `#1634` as the runtime-state naming fix lane
