### PR TITLE
docs: map cost telemetry precursor surfaces for #1639

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -61,6 +61,7 @@
         "docs/knowledgebase/LVCompare-Git-CLI-Guide_Windows-LabVIEW-2025Q3.md",
         "docs/knowledgebase/CrossRepo-VIHistory.md",
         "docs/knowledgebase/Cookiecutter-Certification-Scaffolds.md",
+        "docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md",
         "docs/knowledgebase/GitHub-Intake-Layer.md",
         "docs/knowledgebase/GitHub-Wiki-Portal-Automation-Evaluation.md",
         "docs/knowledgebase/GitHub-Wiki-Portal.md",

--- a/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
+++ b/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
@@ -1,0 +1,235 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Agent Cost Telemetry Surfaces
+
+This note documents the best existing checked-in and repo-visible surfaces that
+can feed `#1639` cost telemetry without relying on hidden billing APIs or local
+operator memory.
+
+The goal here is evidence gathering, not a billing rewrite. Use these surfaces
+to ground the first cost-telemetry slice in data the repository already emits.
+
+## Best Existing Per-Turn Surface
+
+The strongest current per-turn precursor is the local collaboration ledger:
+
+- code: `tools/local-collab/ledger/local-review-ledger.mjs`
+- schemas:
+  - `comparevi/local-collab-ledger-receipt@v1`
+  - `comparevi/local-collab-ledger-latest@v1`
+- emitted receipts:
+  - `tests/results/_agent/local-collab/ledger/receipts/<phase>/<head-sha>.json`
+  - `tests/results/_agent/local-collab/ledger/latest/<phase>.json`
+
+The ledger already records the fields most useful for cost attribution:
+
+- `forkPlane`
+- `persona`
+- `executionPlane`
+- `providerRuntime`
+- `providerId`
+- `requestedModel`
+- `effectiveModel`
+- `inputTokens`
+- `cachedInputTokens`
+- `outputTokens`
+- `durationMs`
+- `status`
+- `outcome`
+- `sourcePaths`
+- `sourceReceiptIds`
+
+That makes the ledger the best first source for per-turn cost receipts, because
+it is already:
+
+- machine-readable
+- phase-aware
+- plane-aware
+- provider-aware
+- token-aware
+- linked back to source receipts
+
+## Best Existing Provider/Model Provenance Surface
+
+For local review providers, the best provenance source is the Copilot CLI review
+receipt:
+
+- code: `tools/local-collab/providers/copilot-cli-review.mjs`
+- tests: `tools/priority/__tests__/copilot-cli-review.test.mjs`
+- example receipt paths:
+  - `tests/results/_hooks/pre-commit-copilot-cli-review.json`
+  - `tests/results/_hooks/pre-push-copilot-cli-review.json`
+  - `tests/results/docker-tools-parity/copilot-cli-review/receipt.json`
+
+This receipt already captures:
+
+- actual executed `copilot.model`
+- `permissionPolicy`
+- `sessionPolicy`
+- pass-level outcomes and convergence
+- actionable finding counts
+- selected files / diff scope
+
+Use this receipt as provider/model/session provenance for ledger-backed cost
+estimates. Do not make up provider metadata when this receipt is present.
+
+## Best Existing Lane And Issue Attribution Surfaces
+
+To tie cost to delivery context, use the runtime task packet and runtime state:
+
+- schema: `docs/schemas/runtime-delivery-task-packet-v1.schema.json`
+- schema: `docs/schemas/delivery-agent-runtime-state-v1.schema.json`
+- code: `tools/priority/delivery-agent.mjs`
+- emitted receipt:
+  - `tests/results/_agent/runtime/delivery-agent-state.json`
+
+These surfaces already provide:
+
+- `laneId`
+- selected issue / standing issue context
+- `workerProviderSelection`
+- `providerDispatch`
+- `workerSlotId`
+- `selectedExecutionPlane`
+- `selectedAssignmentMode`
+- `dispatchSurface`
+- `completionMode`
+
+This is the right path for correlating spend with:
+
+- issue
+- lane
+- worker slot
+- provider kind
+- execution plane
+
+These surfaces are not sufficient alone for cost telemetry because they do not
+carry token counts.
+
+## Best Existing Roll-Up Surface
+
+The strongest current roll-up precursor is the local collaboration KPI summary:
+
+- code: `tools/local-collab/kpi/rollup-local-collab-kpi.mjs`
+- schema: `comparevi/local-collab-kpi-summary@v1`
+- tests: `tools/local-collab/kpi/__tests__/rollup-local-collab-kpi.test.mjs`
+- emitted receipt:
+  - `tests/results/_agent/local-collab/kpi/summary.json`
+
+The KPI summary already aggregates:
+
+- `inputTokens`
+- `cachedInputTokens`
+- `outputTokens`
+- `durationMs`
+- planes
+- personas
+- providers
+- requested/effective models
+
+That makes it the best current roll-up base for:
+
+- spend by provider
+- spend by plane
+- spend by persona
+- spend by head
+
+It does not yet emit dollars, rate-card provenance, or exact-versus-estimated
+classification.
+
+## Best Existing Correlation Surfaces
+
+To correlate cost against throughput and delivered outcomes, use these checked-in
+reports instead of inventing a separate shadow KPI:
+
+- `tests/results/_agent/throughput/throughput-scorecard.json`
+  - code: `tools/priority/throughput-scorecard.mjs`
+  - schema: `docs/schemas/throughput-scorecard-v1.schema.json`
+- `tests/results/_agent/runtime/delivery-memory.json`
+  - schema: `docs/schemas/delivery-memory-v1.schema.json`
+
+These provide the denominator side of the question:
+
+- worker utilization
+- queue occupancy
+- concurrent-lane activity
+- hosted wait escape count
+- terminal PR counts
+- effort levels and duration
+
+They are the right correlation surfaces for executive reporting after cost data
+exists. They are not the right source for model/token spend by themselves.
+
+## Intent And Policy Surfaces, Not Billing Surfaces
+
+Mission control is still useful, but only as declared intent:
+
+- `docs/schemas/mission-control-envelope-v1.schema.json`
+- `docs/schemas/mission-control-profile-resolution-v1.schema.json`
+- `docs/MISSION_CONTROL_CONSUMPTION.md`
+
+These surfaces can explain:
+
+- configured lane counts
+- preset operator intent
+- expected utilization posture
+
+They should not be treated as cost evidence, because they describe intended
+behavior rather than actual per-turn execution.
+
+## Visible Codex Metadata: Safe Use And Unsafe Use
+
+The Codex hygiene report is useful only as visible session-volume evidence:
+
+- schema: `docs/schemas/codex-state-hygiene-v1.schema.json`
+- code: `tools/priority/codex-state-hygiene.mjs`
+- emitted receipt:
+  - `tests/results/_agent/runtime/codex-state-hygiene.json`
+
+Safe uses:
+
+- session file counts
+- session byte growth
+- stale-thread candidate counts
+- extension-log health indicators
+
+Unsafe uses:
+
+- exact token billing
+- inferred per-turn model spend
+- dollar estimates from file size alone
+
+Treat this report as auxiliary observability, not as a billing source of truth.
+
+## Smallest Coherent Implementation Slice For #1639
+
+The smallest defensible first implementation is:
+
+1. define a new cost receipt schema that projects from ledger receipts
+2. require explicit provenance fields:
+   - `amountKind = exact | estimated`
+   - `rateCardSource`
+   - `usageSourceReceiptPath`
+   - `providerModelSourceReceiptPath`
+3. generate estimates from:
+   - local-collab ledger receipts
+   - provider receipts such as Copilot CLI review receipts
+   - runtime task packet / runtime state lane attribution
+4. roll up cost by:
+   - issue
+   - lane
+   - provider
+   - repo
+   - session
+5. correlate the roll-up with:
+   - `throughput-scorecard.json`
+   - `delivery-memory.json`
+
+## Follow-Up Seams To Keep Separate
+
+- separate rate-card contract/schema
+- projection of cost summaries into delivery-agent runtime state
+- provider-specific exact billing reconciliation
+- any future Codex-native exact usage ingestion
+
+Those should stay follow-up lanes. The first slice should stay anchored to
+existing repo-visible receipts.

--- a/tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs
+++ b/tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('agent cost telemetry knowledgebase points at the checked-in precursor surfaces instead of hidden billing assumptions', () => {
+  const manifest = JSON.parse(readText('docs/documentation-manifest.json'));
+  const docsEntry = manifest.entries.find((entry) => entry.name === 'Docs Tree');
+  const guide = readText('docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md');
+
+  assert.ok(docsEntry);
+  assert.ok(docsEntry.files.includes('docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md'));
+  assert.match(guide, /tools\/local-collab\/ledger\/local-review-ledger\.mjs/);
+  assert.match(guide, /tests\/results\/_agent\/local-collab\/ledger\/receipts\/<phase>\/<head-sha>\.json/);
+  assert.match(guide, /requestedModel/);
+  assert.match(guide, /effectiveModel/);
+  assert.match(guide, /inputTokens/);
+  assert.match(guide, /cachedInputTokens/);
+  assert.match(guide, /outputTokens/);
+  assert.match(guide, /tools\/local-collab\/providers\/copilot-cli-review\.mjs/);
+  assert.match(guide, /tests\/results\/docker-tools-parity\/copilot-cli-review\/receipt\.json/);
+  assert.match(guide, /docs\/schemas\/runtime-delivery-task-packet-v1\.schema\.json/);
+  assert.match(guide, /docs\/schemas\/delivery-agent-runtime-state-v1\.schema\.json/);
+  assert.match(guide, /tests\/results\/_agent\/runtime\/delivery-agent-state\.json/);
+  assert.match(guide, /tools\/local-collab\/kpi\/rollup-local-collab-kpi\.mjs/);
+  assert.match(guide, /tests\/results\/_agent\/local-collab\/kpi\/summary\.json/);
+  assert.match(guide, /tests\/results\/_agent\/throughput\/throughput-scorecard\.json/);
+  assert.match(guide, /tests\/results\/_agent\/runtime\/delivery-memory\.json/);
+  assert.match(guide, /docs\/schemas\/mission-control-envelope-v1\.schema\.json/);
+  assert.match(guide, /docs\/schemas\/codex-state-hygiene-v1\.schema\.json/);
+  assert.match(guide, /Unsafe uses:/);
+  assert.match(guide, /exact token billing/);
+  assert.match(guide, /amountKind = exact \| estimated/);
+  assert.match(guide, /rateCardSource/);
+});


### PR DESCRIPTION
## Summary
- add a checked-in knowledgebase note for the best existing repo-visible surfaces that can feed agent cost telemetry
- register the guide in the documentation manifest
- add a focused docs contract test so future agents keep pointing at the same precursor receipts and schemas

## Validation
- node --test tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs
- node tools/npm/run-script.mjs docs:manifest:validate
- node tools/npm/run-script.mjs lint:md:changed
- git diff --check