### PR TITLE
Update for standing priority #1639

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -118,6 +118,26 @@
       ]
     },
     {
+      "name": "Agent Cost Telemetry Contracts",
+      "category": "supporting",
+      "status": "reference",
+      "description": "Checked-in invoice-turn, per-turn, and rollup cost telemetry contracts, fixtures, helper CLIs, and focused tests used to anchor spend reporting in repo-visible evidence.",
+      "files": [
+        "docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md",
+        "docs/schemas/agent-cost-invoice-turn-v1.schema.json",
+        "docs/schemas/agent-cost-turn-v1.schema.json",
+        "docs/schemas/agent-cost-rollup-v1.schema.json",
+        "tools/priority/__fixtures__/agent-cost-rollup/live-turn-estimated.json",
+        "tools/priority/__fixtures__/agent-cost-rollup/background-turn-exact.json",
+        "tools/priority/__fixtures__/agent-cost-rollup/invoice-turn-baseline.json",
+        "tools/priority/agent-cost-invoice-turn.mjs",
+        "tools/priority/agent-cost-rollup.mjs",
+        "tools/priority/__tests__/agent-cost-rollup.test.mjs",
+        "tools/priority/__tests__/agent-cost-rollup-schema.test.mjs",
+        "tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs"
+      ]
+    },
+    {
       "name": "GitHub Templates",
       "category": "supporting",
       "status": "reference",

--- a/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
+++ b/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
@@ -224,6 +224,45 @@ The smallest defensible first implementation is:
    - `throughput-scorecard.json`
    - `delivery-memory.json`
 
+## First Implemented Invoice-Turn Slice
+
+`#1639` now has a checked-in first invoice-turn baseline surface:
+
+- schema: `docs/schemas/agent-cost-invoice-turn-v1.schema.json`
+- schema: `docs/schemas/agent-cost-turn-v1.schema.json`
+- schema: `docs/schemas/agent-cost-rollup-v1.schema.json`
+- helper: `tools/priority/agent-cost-invoice-turn.mjs`
+- helper: `tools/priority/agent-cost-rollup.mjs`
+- sample fixtures:
+  - `tools/priority/__fixtures__/agent-cost-rollup/live-turn-estimated.json`
+  - `tools/priority/__fixtures__/agent-cost-rollup/background-turn-exact.json`
+  - `tools/priority/__fixtures__/agent-cost-rollup/invoice-turn-baseline.json`
+
+This first slice intentionally separates:
+
+- checked-in public example baseline
+- local-only normalized invoice receipts that can carry private operator evidence
+
+The checked-in fixture must never embed the private invoice path. Local receipts
+may carry that path under operator control for later reconciliation.
+
+Use the helpers like this:
+
+- `node tools/priority/agent-cost-invoice-turn.mjs ...`
+- `node tools/priority/agent-cost-rollup.mjs --turn-report <path> --invoice-turn <path>`
+- `node tools/npm/run-script.mjs priority:cost:invoice-turn -- ...`
+- `node tools/npm/run-script.mjs priority:cost:rollup -- ...`
+
+This is the right first boundary because it gives future agents:
+
+- a real accounting epoch (`invoice turn`)
+- per-turn and rollup receipts with explicit provenance
+- a reconciliation point for the next operator-provided invoice
+
+It is still not exact billing truth. Until provider exports are available, use
+the invoice-turn baseline plus explicit `exact` versus `estimated` provenance to
+keep the reporting honest.
+
 ## Follow-Up Seams To Keep Separate
 
 - separate rate-card contract/schema

--- a/docs/schemas/agent-cost-invoice-turn-v1.schema.json
+++ b/docs/schemas/agent-cost-invoice-turn-v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.labview-community-cicd.example/compare-vi-cli-action/agent-cost-invoice-turn-v1.schema.json",
+  "title": "Agent Cost Invoice Turn v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "invoiceTurnId",
+    "invoiceId",
+    "billingPeriod",
+    "credits",
+    "billing",
+    "provenance"
+  ],
+  "properties": {
+    "schema": { "const": "priority/agent-cost-invoice-turn@v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "invoiceTurnId": { "type": "string", "minLength": 1 },
+    "invoiceId": { "type": "string", "minLength": 1 },
+    "billingPeriod": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["openedAt", "closedAt"],
+      "properties": {
+        "openedAt": { "type": "string", "format": "date-time" },
+        "closedAt": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "credits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["purchased", "unitPriceUsd"],
+      "properties": {
+        "purchased": { "type": "number", "minimum": 0 },
+        "unitPriceUsd": { "type": "number", "minimum": 0 }
+      }
+    },
+    "billing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "prepaidUsd", "pricingBasis"],
+      "properties": {
+        "currency": { "const": "USD" },
+        "prepaidUsd": { "type": "number", "minimum": 0 },
+        "pricingBasis": { "enum": ["prepaid-credit", "usage-billed", "hybrid"] }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceKind", "sourcePath", "operatorNote"],
+      "properties": {
+        "sourceKind": { "enum": ["operator-invoice", "billing-export", "manual-baseline"] },
+        "sourcePath": { "type": ["string", "null"] },
+        "operatorNote": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/docs/schemas/agent-cost-rollup-v1.schema.json
+++ b/docs/schemas/agent-cost-rollup-v1.schema.json
@@ -1,0 +1,310 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.labview-community-cicd.example/compare-vi-cli-action/agent-cost-rollup-v1.schema.json",
+  "title": "Agent Cost Rollup Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "generatedAt", "repository", "inputs", "turns", "summary", "billingWindow", "breakdown"],
+  "properties": {
+    "schema": { "const": "priority/agent-cost-rollup@v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "repository": { "type": ["string", "null"] },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["turnReportPaths", "invoiceTurnPath"],
+      "properties": {
+        "turnReportPaths": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/inputRef" }
+        },
+        "invoiceTurnPath": {
+          "anyOf": [
+            { "$ref": "#/$defs/inputRef" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "turns": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/turnSummary" }
+    },
+    "summary": { "$ref": "#/$defs/summary" },
+    "billingWindow": {
+      "anyOf": [
+        { "$ref": "#/$defs/billingWindow" },
+        { "type": "null" }
+      ]
+    },
+    "breakdown": { "$ref": "#/$defs/breakdown" }
+  },
+  "$defs": {
+    "nullableString": {
+      "type": ["string", "null"]
+    },
+    "inputRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "exists", "error"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "exists": { "type": "boolean" },
+        "error": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "inputPath"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "inputPath": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "turnSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourcePath",
+        "generatedAt",
+        "repository",
+        "issueNumber",
+        "laneId",
+        "laneBranch",
+        "sessionId",
+        "turnId",
+        "workerSlotId",
+        "agentRole",
+        "providerId",
+        "providerKind",
+        "providerRuntime",
+        "executionPlane",
+        "requestedModel",
+        "effectiveModel",
+        "usageUnitKind",
+        "usageUnitCount",
+        "inputTokens",
+        "cachedInputTokens",
+        "outputTokens",
+        "totalTokens",
+        "exactness",
+        "amountUsd",
+        "amountSource",
+        "rateCardId",
+        "rateCardSource",
+        "rateCardRetrievedAt",
+        "pricingBasis",
+        "provenance"
+      ],
+      "properties": {
+        "sourcePath": { "type": "string", "minLength": 1 },
+        "generatedAt": { "$ref": "#/$defs/nullableString" },
+        "repository": { "$ref": "#/$defs/nullableString" },
+        "issueNumber": { "type": ["integer", "null"], "minimum": 0 },
+        "laneId": { "$ref": "#/$defs/nullableString" },
+        "laneBranch": { "$ref": "#/$defs/nullableString" },
+        "sessionId": { "$ref": "#/$defs/nullableString" },
+        "turnId": { "$ref": "#/$defs/nullableString" },
+        "workerSlotId": { "$ref": "#/$defs/nullableString" },
+        "agentRole": { "$ref": "#/$defs/nullableString" },
+        "providerId": { "$ref": "#/$defs/nullableString" },
+        "providerKind": { "$ref": "#/$defs/nullableString" },
+        "providerRuntime": { "$ref": "#/$defs/nullableString" },
+        "executionPlane": { "$ref": "#/$defs/nullableString" },
+        "requestedModel": { "$ref": "#/$defs/nullableString" },
+        "effectiveModel": { "$ref": "#/$defs/nullableString" },
+        "usageUnitKind": { "$ref": "#/$defs/nullableString" },
+        "usageUnitCount": { "type": ["number", "integer", "null"], "minimum": 0 },
+        "inputTokens": { "type": "integer", "minimum": 0 },
+        "cachedInputTokens": { "type": "integer", "minimum": 0 },
+        "outputTokens": { "type": "integer", "minimum": 0 },
+        "totalTokens": { "type": "integer", "minimum": 0 },
+        "exactness": { "type": "string", "enum": ["exact", "estimated"] },
+        "amountUsd": { "type": "number", "minimum": 0 },
+        "amountSource": { "type": "string", "enum": ["declared-amount", "rate-card-estimate"] },
+        "rateCardId": { "$ref": "#/$defs/nullableString" },
+        "rateCardSource": { "$ref": "#/$defs/nullableString" },
+        "rateCardRetrievedAt": { "$ref": "#/$defs/nullableString" },
+        "pricingBasis": { "$ref": "#/$defs/nullableString" },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceSchema", "sourceReceiptPath", "sourceReportPath", "usageObservedAt"],
+          "properties": {
+            "sourceSchema": { "$ref": "#/$defs/nullableString" },
+            "sourceReceiptPath": { "$ref": "#/$defs/nullableString" },
+            "sourceReportPath": { "$ref": "#/$defs/nullableString" },
+            "usageObservedAt": { "$ref": "#/$defs/nullableString" }
+          }
+        }
+      }
+    },
+    "invoiceTurnSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sourcePath",
+        "invoiceTurnId",
+        "invoiceId",
+        "openedAt",
+        "closedAt",
+        "creditsPurchased",
+        "unitPriceUsd",
+        "prepaidUsd",
+        "pricingBasis",
+        "sourceKind",
+        "sourcePathEvidence",
+        "operatorNote"
+      ],
+      "properties": {
+        "sourcePath": { "type": "string", "minLength": 1 },
+        "invoiceTurnId": { "$ref": "#/$defs/nullableString" },
+        "invoiceId": { "$ref": "#/$defs/nullableString" },
+        "openedAt": { "$ref": "#/$defs/nullableString" },
+        "closedAt": { "$ref": "#/$defs/nullableString" },
+        "creditsPurchased": { "type": "number", "minimum": 0 },
+        "unitPriceUsd": { "type": "number", "minimum": 0 },
+        "prepaidUsd": { "type": "number", "minimum": 0 },
+        "pricingBasis": { "$ref": "#/$defs/nullableString" },
+        "sourceKind": { "$ref": "#/$defs/nullableString" },
+        "sourcePathEvidence": { "$ref": "#/$defs/nullableString" },
+        "operatorNote": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "recommendation", "blockerCount", "blockers", "metrics", "provenance"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "fail"] },
+        "recommendation": {
+          "type": "string",
+          "enum": ["repair-input-receipts", "repair-invoice-turn-baseline", "continue-estimated-telemetry", "exact-cost-ready"]
+        },
+        "blockerCount": { "type": "integer", "minimum": 0 },
+        "blockers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/blocker" }
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "totalTurns",
+            "exactTurnCount",
+            "estimatedTurnCount",
+            "totalUsd",
+            "exactUsd",
+            "estimatedUsd",
+            "totalInputTokens",
+            "totalCachedInputTokens",
+            "totalOutputTokens",
+            "totalTokens",
+            "totalUsageUnits",
+            "estimatedCreditsConsumed",
+            "creditsRemaining",
+            "estimatedPrepaidUsdRemaining",
+            "prepaidUsdConsumedRatio"
+          ],
+          "properties": {
+            "totalTurns": { "type": "integer", "minimum": 0 },
+            "exactTurnCount": { "type": "integer", "minimum": 0 },
+            "estimatedTurnCount": { "type": "integer", "minimum": 0 },
+            "totalUsd": { "type": "number", "minimum": 0 },
+            "exactUsd": { "type": "number", "minimum": 0 },
+            "estimatedUsd": { "type": "number", "minimum": 0 },
+            "totalInputTokens": { "type": "integer", "minimum": 0 },
+            "totalCachedInputTokens": { "type": "integer", "minimum": 0 },
+            "totalOutputTokens": { "type": "integer", "minimum": 0 },
+            "totalTokens": { "type": "integer", "minimum": 0 },
+            "totalUsageUnits": { "type": "number", "minimum": 0 },
+            "estimatedCreditsConsumed": { "type": ["number", "null"], "minimum": 0 },
+            "creditsRemaining": { "type": ["number", "null"], "minimum": 0 },
+            "estimatedPrepaidUsdRemaining": { "type": ["number", "null"], "minimum": 0 },
+            "prepaidUsdConsumedRatio": { "type": ["number", "null"], "minimum": 0 }
+          }
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sessionIds", "issueNumbers", "laneIds", "repositories", "rateCards", "invoiceTurn"],
+          "properties": {
+            "sessionIds": { "type": "array", "items": { "type": "string" } },
+            "issueNumbers": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+            "laneIds": { "type": "array", "items": { "type": "string" } },
+            "repositories": { "type": "array", "items": { "type": "string" } },
+            "rateCards": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id", "source", "retrievedAt", "pricingBasis"],
+                "properties": {
+                  "id": { "$ref": "#/$defs/nullableString" },
+                  "source": { "$ref": "#/$defs/nullableString" },
+                  "retrievedAt": { "$ref": "#/$defs/nullableString" },
+                  "pricingBasis": { "$ref": "#/$defs/nullableString" }
+                }
+              }
+            },
+            "invoiceTurn": {
+              "anyOf": [
+                { "$ref": "#/$defs/invoiceTurnSummary" },
+                { "type": "null" }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "billingWindow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "invoiceTurnId",
+        "invoiceId",
+        "openedAt",
+        "closedAt",
+        "pricingBasis",
+        "sourceKind",
+        "sourcePathEvidence",
+        "operatorNote"
+      ],
+      "properties": {
+        "invoiceTurnId": { "$ref": "#/$defs/nullableString" },
+        "invoiceId": { "$ref": "#/$defs/nullableString" },
+        "openedAt": { "$ref": "#/$defs/nullableString" },
+        "closedAt": { "$ref": "#/$defs/nullableString" },
+        "pricingBasis": { "$ref": "#/$defs/nullableString" },
+        "sourceKind": { "$ref": "#/$defs/nullableString" },
+        "sourcePathEvidence": { "$ref": "#/$defs/nullableString" },
+        "operatorNote": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "breakdownEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "turnCount", "totalUsd"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "turnCount": { "type": "integer", "minimum": 0 },
+        "totalUsd": { "type": "number", "minimum": 0 }
+      }
+    },
+    "breakdown": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["byProvider", "byModel", "byIssue", "byLane", "byAgentRole", "byRepository"],
+      "properties": {
+        "byProvider": { "type": "array", "items": { "$ref": "#/$defs/breakdownEntry" } },
+        "byModel": { "type": "array", "items": { "$ref": "#/$defs/breakdownEntry" } },
+        "byIssue": { "type": "array", "items": { "$ref": "#/$defs/breakdownEntry" } },
+        "byLane": { "type": "array", "items": { "$ref": "#/$defs/breakdownEntry" } },
+        "byAgentRole": { "type": "array", "items": { "$ref": "#/$defs/breakdownEntry" } },
+        "byRepository": { "type": "array", "items": { "$ref": "#/$defs/breakdownEntry" } }
+      }
+    }
+  }
+}

--- a/docs/schemas/agent-cost-turn-v1.schema.json
+++ b/docs/schemas/agent-cost-turn-v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.labview-community-cicd.example/compare-vi-cli-action/agent-cost-turn-v1.schema.json",
+  "title": "Agent Cost Turn Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "provider",
+    "model",
+    "usage",
+    "billing",
+    "context",
+    "provenance"
+  ],
+  "properties": {
+    "schema": { "const": "priority/agent-cost-turn@v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "provider": { "$ref": "#/$defs/provider" },
+    "model": { "$ref": "#/$defs/model" },
+    "usage": { "$ref": "#/$defs/usage" },
+    "billing": { "$ref": "#/$defs/billing" },
+    "context": { "$ref": "#/$defs/context" },
+    "provenance": { "$ref": "#/$defs/provenance" }
+  },
+  "$defs": {
+    "nullableString": {
+      "type": ["string", "null"]
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "runtime", "executionPlane"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "minLength": 1 },
+        "runtime": { "type": "string", "minLength": 1 },
+        "executionPlane": { "type": "string", "minLength": 1 }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requested", "effective"],
+      "properties": {
+        "requested": { "type": "string", "minLength": 1 },
+        "effective": { "type": "string", "minLength": 1 }
+      }
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inputTokens", "cachedInputTokens", "outputTokens", "totalTokens", "usageUnitKind", "usageUnitCount"],
+      "properties": {
+        "inputTokens": { "type": "integer", "minimum": 0 },
+        "cachedInputTokens": { "type": "integer", "minimum": 0 },
+        "outputTokens": { "type": "integer", "minimum": 0 },
+        "totalTokens": { "type": "integer", "minimum": 0 },
+        "usageUnitKind": { "$ref": "#/$defs/nullableString" },
+        "usageUnitCount": { "type": ["number", "integer", "null"], "minimum": 0 }
+      }
+    },
+    "rateCard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "retrievedAt", "pricingBasis"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "minLength": 1 },
+        "retrievedAt": { "type": "string", "format": "date-time" },
+        "pricingBasis": { "type": "string", "minLength": 1 },
+        "inputUsdPer1kTokens": { "type": ["number", "null"], "minimum": 0 },
+        "cachedInputUsdPer1kTokens": { "type": ["number", "null"], "minimum": 0 },
+        "outputUsdPer1kTokens": { "type": ["number", "null"], "minimum": 0 },
+        "usageUnitUsd": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "billing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exactness", "currency", "amountUsd", "rateCard"],
+      "properties": {
+        "exactness": { "type": "string", "enum": ["exact", "estimated"] },
+        "currency": { "const": "USD" },
+        "amountUsd": { "type": ["number", "null"], "minimum": 0 },
+        "rateCard": {
+          "anyOf": [
+            { "$ref": "#/$defs/rateCard" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "issueNumber", "laneId", "laneBranch", "sessionId", "turnId", "workerSlotId", "agentRole"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "issueNumber": { "type": "integer", "minimum": 0 },
+        "laneId": { "type": "string", "minLength": 1 },
+        "laneBranch": { "type": "string", "minLength": 1 },
+        "sessionId": { "type": "string", "minLength": 1 },
+        "turnId": { "type": "string", "minLength": 1 },
+        "workerSlotId": { "$ref": "#/$defs/nullableString" },
+        "agentRole": { "type": "string", "enum": ["live", "background"] }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceSchema", "sourceReceiptPath", "sourceReportPath", "usageObservedAt"],
+      "properties": {
+        "sourceSchema": { "$ref": "#/$defs/nullableString" },
+        "sourceReceiptPath": { "$ref": "#/$defs/nullableString" },
+        "sourceReportPath": { "$ref": "#/$defs/nullableString" },
+        "usageObservedAt": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "priority:security:audit:gate": "node tools/priority/dependency-audit.mjs --mode enforce",
     "priority:security:intake": "node tools/priority/security-intake.mjs",
     "priority:security:gate": "node tools/priority/security-intake.mjs --route-on-breach --fail-on-breach --fail-on-skip",
+    "priority:cost:invoice-turn": "node tools/priority/agent-cost-invoice-turn.mjs",
+    "priority:cost:rollup": "node tools/priority/agent-cost-rollup.mjs",
     "priority:onboard:downstream": "node tools/priority/downstream-onboarding.mjs",
     "priority:onboard:feedback": "node tools/priority/downstream-onboarding-feedback.mjs",
     "priority:onboard:success": "node tools/priority/downstream-onboarding-success.mjs",

--- a/tools/priority/__fixtures__/agent-cost-rollup/background-turn-exact.json
+++ b/tools/priority/__fixtures__/agent-cost-rollup/background-turn-exact.json
@@ -1,0 +1,53 @@
+{
+  "schema": "priority/agent-cost-turn@v1",
+  "generatedAt": "2026-03-21T18:40:00.000Z",
+  "provider": {
+    "id": "copilot-cli",
+    "kind": "remote-copilot-lane",
+    "runtime": "copilot-cli",
+    "executionPlane": "hosted-github-workflow"
+  },
+  "model": {
+    "requested": "gpt-5.4",
+    "effective": "gpt-5.4"
+  },
+  "usage": {
+    "inputTokens": 1200,
+    "cachedInputTokens": 0,
+    "outputTokens": 260,
+    "totalTokens": 1460,
+    "usageUnitKind": "review-turn",
+    "usageUnitCount": 1
+  },
+  "billing": {
+    "exactness": "exact",
+    "currency": "USD",
+    "amountUsd": 0.0425,
+    "rateCard": {
+      "id": "github-copilot-export-2026-03-21",
+      "source": "gh://copilot/billing-export/2026-03-21",
+      "retrievedAt": "2026-03-21T18:41:00.000Z",
+      "pricingBasis": "vendor-export",
+      "inputUsdPer1kTokens": null,
+      "cachedInputUsdPer1kTokens": null,
+      "outputUsdPer1kTokens": null,
+      "usageUnitUsd": null
+    }
+  },
+  "context": {
+    "repository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
+    "issueNumber": 1,
+    "laneId": "fork-standing-priority/org-template-verify",
+    "laneBranch": "issue/origin-1-template-verify",
+    "sessionId": "session-bg-002",
+    "turnId": "turn-bg-002",
+    "workerSlotId": "worker-slot-4",
+    "agentRole": "background"
+  },
+  "provenance": {
+    "sourceSchema": "priority/copilot-cli-review@v1",
+    "sourceReceiptPath": "tests/results/_hooks/pre-push-copilot-cli-review.json",
+    "sourceReportPath": "tests/results/_agent/runtime/worker-slot-4.json",
+    "usageObservedAt": "2026-03-21T18:40:30.000Z"
+  }
+}

--- a/tools/priority/__fixtures__/agent-cost-rollup/invoice-turn-baseline.json
+++ b/tools/priority/__fixtures__/agent-cost-rollup/invoice-turn-baseline.json
@@ -1,0 +1,24 @@
+{
+  "schema": "priority/agent-cost-invoice-turn@v1",
+  "generatedAt": "2026-03-21T17:00:00.000Z",
+  "invoiceTurnId": "invoice-turn-2026-03-HQ1VJLMV-0027",
+  "invoiceId": "HQ1VJLMV-0027",
+  "billingPeriod": {
+    "openedAt": "2026-03-21T10:01:07.000-07:00",
+    "closedAt": null
+  },
+  "credits": {
+    "purchased": 10000,
+    "unitPriceUsd": 0.04
+  },
+  "billing": {
+    "currency": "USD",
+    "prepaidUsd": 400,
+    "pricingBasis": "prepaid-credit"
+  },
+  "provenance": {
+    "sourceKind": "operator-invoice",
+    "sourcePath": null,
+    "operatorNote": "Normalized example for the first invoice-turn baseline."
+  }
+}

--- a/tools/priority/__fixtures__/agent-cost-rollup/live-turn-estimated.json
+++ b/tools/priority/__fixtures__/agent-cost-rollup/live-turn-estimated.json
@@ -1,0 +1,53 @@
+{
+  "schema": "priority/agent-cost-turn@v1",
+  "generatedAt": "2026-03-21T18:30:00.000Z",
+  "provider": {
+    "id": "codex-cli",
+    "kind": "local-codex",
+    "runtime": "codex-cli",
+    "executionPlane": "wsl2"
+  },
+  "model": {
+    "requested": "gpt-5-codex",
+    "effective": "gpt-5-codex"
+  },
+  "usage": {
+    "inputTokens": 2400,
+    "cachedInputTokens": 600,
+    "outputTokens": 500,
+    "totalTokens": 3500,
+    "usageUnitKind": "turn",
+    "usageUnitCount": 1
+  },
+  "billing": {
+    "exactness": "estimated",
+    "currency": "USD",
+    "amountUsd": null,
+    "rateCard": {
+      "id": "openai-public-2026-03-01",
+      "source": "https://openai.com/api/pricing",
+      "retrievedAt": "2026-03-21T18:20:00.000Z",
+      "pricingBasis": "per-1k-tokens",
+      "inputUsdPer1kTokens": 0.005,
+      "cachedInputUsdPer1kTokens": 0.001,
+      "outputUsdPer1kTokens": 0.015,
+      "usageUnitUsd": null
+    }
+  },
+  "context": {
+    "repository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+    "issueNumber": 1639,
+    "laneId": "issue/origin-1639-agent-cost-telemetry",
+    "laneBranch": "issue/origin-1639-agent-cost-telemetry",
+    "sessionId": "session-live-001",
+    "turnId": "turn-live-001",
+    "workerSlotId": "worker-slot-1",
+    "agentRole": "live"
+  },
+  "provenance": {
+    "sourceSchema": "priority/codex-cli-review@v1",
+    "sourceReceiptPath": "tests/results/docker-tools-parity/codex-cli-review/receipt.json",
+    "sourceReportPath": "tests/results/_agent/runtime/worker-slot-1.json",
+    "usageObservedAt": "2026-03-21T18:29:00.000Z"
+  }
+}

--- a/tools/priority/__tests__/agent-cost-rollup-schema.test.mjs
+++ b/tools/priority/__tests__/agent-cost-rollup-schema.test.mjs
@@ -1,0 +1,69 @@
+import '../../shims/punycode-userland.mjs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import { runAgentCostRollup } from '../agent-cost-rollup.mjs';
+
+const repoRoot = path.resolve(process.cwd());
+const fixtureRoot = path.join(repoRoot, 'tools', 'priority', '__fixtures__', 'agent-cost-rollup');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('agent cost turn fixtures and rollup report match the checked-in schemas', () => {
+  const invoiceTurnSchema = readJson(path.join(repoRoot, 'docs', 'schemas', 'agent-cost-invoice-turn-v1.schema.json'));
+  const turnSchema = readJson(path.join(repoRoot, 'docs', 'schemas', 'agent-cost-turn-v1.schema.json'));
+  const rollupSchema = readJson(path.join(repoRoot, 'docs', 'schemas', 'agent-cost-rollup-v1.schema.json'));
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validateInvoiceTurn = ajv.compile(invoiceTurnSchema);
+  const validateTurn = ajv.compile(turnSchema);
+  const validateRollup = ajv.compile(rollupSchema);
+
+  const invoiceTurnFixture = readJson(path.join(fixtureRoot, 'invoice-turn-baseline.json'));
+  const validInvoiceTurn = validateInvoiceTurn(invoiceTurnFixture);
+  if (!validInvoiceTurn) {
+    const errors = (validateInvoiceTurn.errors || [])
+      .map((entry) => `${entry.instancePath || '(root)'} ${entry.message}`)
+      .join('\n');
+    assert.fail(`Invoice turn fixture failed schema validation:\n${errors}`);
+  }
+
+  for (const fixtureName of ['live-turn-estimated.json', 'background-turn-exact.json']) {
+    const fixturePayload = readJson(path.join(fixtureRoot, fixtureName));
+    const valid = validateTurn(fixturePayload);
+    if (!valid) {
+      const errors = (validateTurn.errors || [])
+        .map((entry) => `${entry.instancePath || '(root)'} ${entry.message}`)
+        .join('\n');
+      assert.fail(`Turn fixture ${fixtureName} failed schema validation:\n${errors}`);
+    }
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-schema-'));
+  const result = runAgentCostRollup({
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    turnReportPaths: [
+      path.join(fixtureRoot, 'live-turn-estimated.json'),
+      path.join(fixtureRoot, 'background-turn-exact.json')
+    ],
+    invoiceTurnPath: path.join(fixtureRoot, 'invoice-turn-baseline.json'),
+    outputPath: path.join(tmpDir, 'agent-cost-rollup.json')
+  });
+
+  const validRollup = validateRollup(result.report);
+  if (!validRollup) {
+    const errors = (validateRollup.errors || [])
+      .map((entry) => `${entry.instancePath || '(root)'} ${entry.message}`)
+      .join('\n');
+    assert.fail(`Agent cost rollup report failed schema validation:\n${errors}`);
+  }
+});

--- a/tools/priority/__tests__/agent-cost-rollup.test.mjs
+++ b/tools/priority/__tests__/agent-cost-rollup.test.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { buildAgentCostInvoiceTurn, parseArgs as parseInvoiceTurnArgs, runAgentCostInvoiceTurn } from '../agent-cost-invoice-turn.mjs';
+import { evaluateAgentCostRollup, parseArgs, runAgentCostRollup } from '../agent-cost-rollup.mjs';
+
+const repoRoot = path.resolve(process.cwd());
+const fixtureRoot = path.join(repoRoot, 'tools', 'priority', '__fixtures__', 'agent-cost-rollup');
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+test('parseArgs accepts repeated turn reports and optional repo override', () => {
+  const parsed = parseArgs([
+    'node',
+    'agent-cost-rollup.mjs',
+    '--turn-report',
+    'turn-a.json',
+    '--turn-report',
+    'turn-b.json',
+    '--repo',
+    'example/repo',
+    '--no-fail-on-invalid-inputs'
+  ]);
+
+  assert.deepEqual(parsed.turnReportPaths, ['turn-a.json', 'turn-b.json']);
+  assert.equal(parsed.repo, 'example/repo');
+  assert.equal(parsed.failOnInvalidInputs, false);
+});
+
+test('invoice turn helper derives the prepaid baseline deterministically', () => {
+  const parsed = parseInvoiceTurnArgs([
+    'node',
+    'agent-cost-invoice-turn.mjs',
+    '--invoice-id',
+    'HQ1VJLMV-0027',
+    '--opened-at',
+    '2026-03-21T10:01:07.000-07:00',
+    '--credits-purchased',
+    '10000',
+    '--unit-price-usd',
+    '0.04'
+  ]);
+
+  const { report } = buildAgentCostInvoiceTurn(parsed, new Date('2026-03-21T17:00:00.000Z'));
+  assert.equal(report.invoiceTurnId, 'invoice-turn-2026-03-HQ1VJLMV-0027');
+  assert.equal(report.billing.prepaidUsd, 400);
+  assert.equal(report.credits.purchased, 10000);
+  assert.equal(report.credits.unitPriceUsd, 0.04);
+});
+
+test('evaluateAgentCostRollup reports blockers deterministically', () => {
+  const pass = evaluateAgentCostRollup({
+    turnInputs: [{ exists: true, error: null, path: path.join(repoRoot, 'turn-a.json') }],
+    normalizedTurns: [
+      {
+        status: 'valid',
+        blockers: [],
+        turn: { exactness: 'estimated', amountUsd: 0.02 }
+      }
+    ]
+  });
+  assert.equal(pass.status, 'pass');
+  assert.equal(pass.recommendation, 'continue-estimated-telemetry');
+
+  const fail = evaluateAgentCostRollup({
+    turnInputs: [{ exists: false, error: null, path: path.join(repoRoot, 'missing.json') }],
+    normalizedTurns: [
+      {
+        status: 'invalid',
+        blockers: [{ code: 'turn-schema-mismatch', message: 'bad schema', inputPath: 'missing.json' }]
+      }
+    ]
+  });
+  assert.equal(fail.status, 'fail');
+  assert.ok(fail.blockers.some((entry) => entry.code === 'turn-report-missing'));
+  assert.ok(fail.blockers.some((entry) => entry.code === 'turn-schema-mismatch'));
+});
+
+test('estimated turns do not let a declared zero amount mask a computable rate-card estimate', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-zero-mask-'));
+  const turnPath = path.join(tmpDir, 'estimated-zero-turn.json');
+
+  writeJson(turnPath, {
+    schema: 'priority/agent-cost-turn@v1',
+    generatedAt: '2026-03-21T19:10:00.000Z',
+    provider: {
+      id: 'codex-cli',
+      kind: 'local-codex',
+      runtime: 'codex-cli',
+      executionPlane: 'wsl2'
+    },
+    model: {
+      requested: 'gpt-5-codex',
+      effective: 'gpt-5-codex'
+    },
+    usage: {
+      inputTokens: 2000,
+      cachedInputTokens: 0,
+      outputTokens: 500,
+      totalTokens: 2500,
+      usageUnitKind: 'turn',
+      usageUnitCount: 1
+    },
+    billing: {
+      exactness: 'estimated',
+      amountUsd: 0,
+      currency: 'USD',
+      rateCard: {
+        id: 'openai-public-2026-03-01',
+        source: 'https://openai.com/api/pricing',
+        retrievedAt: '2026-03-21T18:20:00.000Z',
+        pricingBasis: 'per-1k-tokens',
+        inputUsdPer1kTokens: 0.005,
+        cachedInputUsdPer1kTokens: 0,
+        outputUsdPer1kTokens: 0.016,
+        usageUnitUsd: 0
+      }
+    },
+    context: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      issueNumber: 1639,
+      laneId: 'issue/origin-1639-agent-cost-telemetry',
+      laneBranch: 'issue/origin-1639-agent-cost-telemetry',
+      sessionId: 'session-live-002',
+      turnId: 'turn-live-002',
+      workerSlotId: 'worker-slot-1',
+      agentRole: 'live'
+    },
+    provenance: {
+      sourceSchema: 'priority/codex-cli-review@v1',
+      sourceReceiptPath: 'tests/results/_agent/runtime/worker-slot-1.json',
+      sourceReportPath: null,
+      usageObservedAt: '2026-03-21T19:10:30.000Z'
+    }
+  });
+
+  const result = runAgentCostRollup({
+    turnReportPaths: [turnPath],
+    outputPath: path.join(tmpDir, 'agent-cost-rollup.json')
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.turns[0].amountUsd, 0.018);
+  assert.equal(result.report.turns[0].amountSource, 'rate-card-estimate');
+});
+
+test('runAgentCostRollup aggregates exact and estimated turn spend with provenance', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-'));
+  const outputPath = path.join(tmpDir, 'agent-cost-rollup.json');
+
+  const result = runAgentCostRollup({
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    turnReportPaths: [
+      path.join(fixtureRoot, 'live-turn-estimated.json'),
+      path.join(fixtureRoot, 'background-turn-exact.json')
+    ],
+    invoiceTurnPath: path.join(fixtureRoot, 'invoice-turn-baseline.json'),
+    outputPath
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.summary.status, 'pass');
+  assert.equal(result.report.summary.recommendation, 'continue-estimated-telemetry');
+  assert.equal(result.report.summary.metrics.totalTurns, 2);
+  assert.equal(result.report.summary.metrics.exactTurnCount, 1);
+  assert.equal(result.report.summary.metrics.estimatedTurnCount, 1);
+  assert.equal(result.report.summary.metrics.totalUsd, 0.0626);
+  assert.equal(result.report.summary.metrics.exactUsd, 0.0425);
+  assert.equal(result.report.summary.metrics.estimatedUsd, 0.0201);
+  assert.equal(result.report.summary.metrics.estimatedCreditsConsumed, 1.565);
+  assert.equal(result.report.summary.metrics.creditsRemaining, 9998.435);
+  assert.equal(result.report.summary.metrics.estimatedPrepaidUsdRemaining, 399.9374);
+  assert.equal(result.report.summary.metrics.totalInputTokens, 3600);
+  assert.equal(result.report.summary.metrics.totalOutputTokens, 760);
+  assert.ok(result.report.summary.provenance.sessionIds.includes('session-live-001'));
+  assert.equal(result.report.summary.provenance.invoiceTurn.invoiceId, 'HQ1VJLMV-0027');
+  assert.equal(result.report.billingWindow.invoiceTurnId, 'invoice-turn-2026-03-HQ1VJLMV-0027');
+  assert.ok(result.report.summary.provenance.repositories.includes('LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'));
+  assert.ok(result.report.breakdown.byProvider.some((entry) => entry.key === 'codex-cli' && entry.totalUsd === 0.0201));
+  assert.ok(result.report.breakdown.byAgentRole.some((entry) => entry.key === 'background' && entry.turnCount === 1));
+  assert.equal(fs.existsSync(outputPath), true);
+});
+
+test('runAgentCostRollup fails closed when a turn report cannot resolve cost', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-invalid-'));
+  const invalidTurnPath = path.join(tmpDir, 'invalid-turn.json');
+
+  writeJson(invalidTurnPath, {
+    schema: 'priority/agent-cost-turn@v1',
+    generatedAt: '2026-03-21T19:00:00.000Z',
+    provider: {
+      id: 'codex-cli',
+      kind: 'local-codex',
+      runtime: 'codex-cli',
+      executionPlane: 'wsl2'
+    },
+    model: {
+      requested: 'gpt-5-codex',
+      effective: 'gpt-5-codex'
+    },
+    usage: {
+      inputTokens: 100,
+      cachedInputTokens: 0,
+      outputTokens: 20,
+      totalTokens: 120,
+      usageUnitKind: 'turn',
+      usageUnitCount: 1
+    },
+    billing: {
+      exactness: 'estimated',
+      currency: 'USD',
+      amountUsd: null,
+      rateCard: null
+    },
+    context: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      issueNumber: 1639,
+      laneId: 'issue/origin-1639-agent-cost-telemetry',
+      laneBranch: 'issue/origin-1639-agent-cost-telemetry',
+      sessionId: 'session-live-999',
+      turnId: 'turn-live-999',
+      workerSlotId: 'worker-slot-9',
+      agentRole: 'live'
+    },
+    provenance: {
+      sourceSchema: 'priority/codex-cli-review@v1',
+      sourceReceiptPath: 'tests/results/_agent/runtime/worker-slot-9.json',
+      sourceReportPath: null,
+      usageObservedAt: '2026-03-21T19:00:30.000Z'
+    }
+  });
+
+  const result = runAgentCostRollup({
+    turnReportPaths: [invalidTurnPath],
+    outputPath: path.join(tmpDir, 'agent-cost-rollup.json'),
+    failOnInvalidInputs: true
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.report.summary.status, 'fail');
+  assert.ok(result.report.summary.blockers.some((entry) => entry.code === 'billing-amount-unresolved'));
+  assert.equal(result.report.summary.recommendation, 'repair-input-receipts');
+});
+
+test('runAgentCostInvoiceTurn writes a normalized invoice-turn receipt', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-invoice-turn-'));
+  const outputPath = path.join(tmpDir, 'invoice-turn.json');
+  const result = runAgentCostInvoiceTurn(
+    {
+      invoiceTurnId: null,
+      invoiceId: 'HQ1VJLMV-0027',
+      openedAt: '2026-03-21T10:01:07.000-07:00',
+      closedAt: null,
+      creditsPurchased: 10000,
+      unitPriceUsd: 0.04,
+      prepaidUsd: 400,
+      pricingBasis: 'prepaid-credit',
+      sourceKind: 'operator-invoice',
+      sourcePath: 'C:/Users/sveld/Downloads/Invoice-HQ1VJLMV-0027.pdf',
+      operatorNote: 'First invoice turn baseline.',
+      outputPath
+    },
+    new Date('2026-03-21T17:00:00.000Z')
+  );
+
+  assert.equal(result.report.invoiceTurnId, 'invoice-turn-2026-03-HQ1VJLMV-0027');
+  assert.equal(result.report.billing.prepaidUsd, 400);
+  assert.equal(fs.existsSync(outputPath), true);
+});
+
+test('agent-cost-invoice-turn CLI writes a receipt when invoked directly', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-invoice-turn-cli-'));
+  const outputPath = path.join(tmpDir, 'invoice-turn.json');
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join('tools', 'priority', 'agent-cost-invoice-turn.mjs'),
+      '--invoice-id',
+      'HQ1VJLMV-0027',
+      '--opened-at',
+      '2026-03-21T10:01:07.000-07:00',
+      '--credits-purchased',
+      '10000',
+      '--unit-price-usd',
+      '0.04',
+      '--output',
+      outputPath
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /\[agent-cost-invoice-turn\] wrote /);
+  assert.equal(fs.existsSync(outputPath), true);
+});
+
+test('agent-cost-rollup CLI writes a rollup receipt when invoked directly', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-rollup-cli-'));
+  const outputPath = path.join(tmpDir, 'agent-cost-rollup.json');
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join('tools', 'priority', 'agent-cost-rollup.mjs'),
+      '--turn-report',
+      path.join('tools', 'priority', '__fixtures__', 'agent-cost-rollup', 'live-turn-estimated.json'),
+      '--turn-report',
+      path.join('tools', 'priority', '__fixtures__', 'agent-cost-rollup', 'background-turn-exact.json'),
+      '--invoice-turn',
+      path.join('tools', 'priority', '__fixtures__', 'agent-cost-rollup', 'invoice-turn-baseline.json'),
+      '--output',
+      outputPath
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /\[agent-cost-rollup\] wrote /);
+  assert.equal(fs.existsSync(outputPath), true);
+});

--- a/tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs
+++ b/tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs
@@ -15,10 +15,15 @@ function readText(relativePath) {
 test('agent cost telemetry knowledgebase points at the checked-in precursor surfaces instead of hidden billing assumptions', () => {
   const manifest = JSON.parse(readText('docs/documentation-manifest.json'));
   const docsEntry = manifest.entries.find((entry) => entry.name === 'Docs Tree');
+  const contractEntry = manifest.entries.find((entry) => entry.name === 'Agent Cost Telemetry Contracts');
   const guide = readText('docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md');
 
   assert.ok(docsEntry);
+  assert.ok(contractEntry);
   assert.ok(docsEntry.files.includes('docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md'));
+  assert.ok(contractEntry.files.includes('docs/schemas/agent-cost-invoice-turn-v1.schema.json'));
+  assert.ok(contractEntry.files.includes('tools/priority/agent-cost-invoice-turn.mjs'));
+  assert.ok(contractEntry.files.includes('tools/priority/agent-cost-rollup.mjs'));
   assert.match(guide, /tools\/local-collab\/ledger\/local-review-ledger\.mjs/);
   assert.match(guide, /tests\/results\/_agent\/local-collab\/ledger\/receipts\/<phase>\/<head-sha>\.json/);
   assert.match(guide, /requestedModel/);
@@ -41,4 +46,9 @@ test('agent cost telemetry knowledgebase points at the checked-in precursor surf
   assert.match(guide, /exact token billing/);
   assert.match(guide, /amountKind = exact \| estimated/);
   assert.match(guide, /rateCardSource/);
+  assert.match(guide, /First Implemented Invoice-Turn Slice/);
+  assert.match(guide, /docs\/schemas\/agent-cost-invoice-turn-v1\.schema\.json/);
+  assert.match(guide, /tools\/priority\/agent-cost-invoice-turn\.mjs/);
+  assert.match(guide, /priority:cost:invoice-turn/);
+  assert.match(guide, /priority:cost:rollup/);
 });

--- a/tools/priority/agent-cost-invoice-turn.mjs
+++ b/tools/priority/agent-cost-invoice-turn.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REPORT_SCHEMA = 'priority/agent-cost-invoice-turn@v1';
+export const DEFAULT_OUTPUT_DIR = path.join('tests', 'results', '_agent', 'cost', 'invoice-turns');
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function toNonNegativeNumber(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function roundUsd(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Number(parsed.toFixed(6));
+}
+
+function computeDefaultInvoiceTurnId(invoiceId, openedAt) {
+  const normalizedInvoiceId = normalizeText(invoiceId);
+  const normalizedOpenedAt = normalizeText(openedAt);
+  const datePrefix = normalizedOpenedAt.length >= 7 ? normalizedOpenedAt.slice(0, 7) : 'unknown-period';
+  return `invoice-turn-${datePrefix}-${normalizedInvoiceId}`;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    invoiceTurnId: null,
+    invoiceId: null,
+    openedAt: null,
+    closedAt: null,
+    creditsPurchased: null,
+    unitPriceUsd: null,
+    prepaidUsd: null,
+    pricingBasis: 'prepaid-credit',
+    sourceKind: 'operator-invoice',
+    sourcePath: null,
+    operatorNote: null,
+    outputPath: null,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (
+      [
+        '--invoice-turn-id',
+        '--invoice-id',
+        '--opened-at',
+        '--closed-at',
+        '--credits-purchased',
+        '--unit-price-usd',
+        '--prepaid-usd',
+        '--pricing-basis',
+        '--source-kind',
+        '--source-path',
+        '--operator-note',
+        '--output'
+      ].includes(token)
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--invoice-turn-id') options.invoiceTurnId = next;
+      if (token === '--invoice-id') options.invoiceId = next;
+      if (token === '--opened-at') options.openedAt = next;
+      if (token === '--closed-at') options.closedAt = next;
+      if (token === '--credits-purchased') options.creditsPurchased = next;
+      if (token === '--unit-price-usd') options.unitPriceUsd = next;
+      if (token === '--prepaid-usd') options.prepaidUsd = next;
+      if (token === '--pricing-basis') options.pricingBasis = next;
+      if (token === '--source-kind') options.sourceKind = next;
+      if (token === '--source-path') options.sourcePath = next;
+      if (token === '--operator-note') options.operatorNote = next;
+      if (token === '--output') options.outputPath = next;
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!options.help && !normalizeText(options.invoiceId)) {
+    throw new Error('Missing required option: --invoice-id <value>.');
+  }
+  if (!options.help && !normalizeText(options.openedAt)) {
+    throw new Error('Missing required option: --opened-at <date-time>.');
+  }
+
+  options.creditsPurchased = toNonNegativeNumber(options.creditsPurchased);
+  options.unitPriceUsd = toNonNegativeNumber(options.unitPriceUsd);
+  options.prepaidUsd = toNonNegativeNumber(options.prepaidUsd);
+  if (!options.help && options.creditsPurchased == null) {
+    throw new Error('Missing required option: --credits-purchased <number>.');
+  }
+  if (!options.help && options.unitPriceUsd == null) {
+    throw new Error('Missing required option: --unit-price-usd <number>.');
+  }
+
+  if (!options.help && options.prepaidUsd == null) {
+    options.prepaidUsd = roundUsd(options.creditsPurchased * options.unitPriceUsd);
+  }
+
+  if (!['prepaid-credit', 'usage-billed', 'hybrid'].includes(normalizeText(options.pricingBasis))) {
+    throw new Error('pricing-basis must be prepaid-credit, usage-billed, or hybrid.');
+  }
+  if (!['operator-invoice', 'billing-export', 'manual-baseline'].includes(normalizeText(options.sourceKind))) {
+    throw new Error('source-kind must be operator-invoice, billing-export, or manual-baseline.');
+  }
+
+  return options;
+}
+
+export function buildAgentCostInvoiceTurn(options, now = new Date()) {
+  const invoiceTurnId = normalizeText(options.invoiceTurnId) || computeDefaultInvoiceTurnId(options.invoiceId, options.openedAt);
+  const outputPath =
+    normalizeText(options.outputPath) ||
+    path.join(DEFAULT_OUTPUT_DIR, `${normalizeText(options.invoiceId).replace(/[^A-Za-z0-9._-]/g, '_')}.json`);
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: now.toISOString(),
+    invoiceTurnId,
+    invoiceId: normalizeText(options.invoiceId),
+    billingPeriod: {
+      openedAt: normalizeText(options.openedAt),
+      closedAt: normalizeText(options.closedAt) || null
+    },
+    credits: {
+      purchased: options.creditsPurchased,
+      unitPriceUsd: options.unitPriceUsd
+    },
+    billing: {
+      currency: 'USD',
+      prepaidUsd: options.prepaidUsd,
+      pricingBasis: normalizeText(options.pricingBasis)
+    },
+    provenance: {
+      sourceKind: normalizeText(options.sourceKind),
+      sourcePath: normalizeText(options.sourcePath) || null,
+      operatorNote: normalizeText(options.operatorNote) || null
+    }
+  };
+
+  return {
+    outputPath: path.resolve(outputPath),
+    report
+  };
+}
+
+export function runAgentCostInvoiceTurn(options, now = new Date()) {
+  const result = buildAgentCostInvoiceTurn(options, now);
+  fs.mkdirSync(path.dirname(result.outputPath), { recursive: true });
+  fs.writeFileSync(result.outputPath, `${JSON.stringify(result.report, null, 2)}\n`, 'utf8');
+  return result;
+}
+
+function printUsage() {
+  console.log('Usage: node tools/priority/agent-cost-invoice-turn.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --invoice-id <value>            Invoice identifier (required).');
+  console.log('  --opened-at <date-time>         Invoice turn openedAt timestamp (required).');
+  console.log('  --closed-at <date-time>         Optional invoice turn close timestamp.');
+  console.log('  --credits-purchased <number>    Credits purchased in this invoice turn (required).');
+  console.log('  --unit-price-usd <number>       USD price per credit or usage unit (required).');
+  console.log('  --prepaid-usd <number>          Optional explicit prepaid total; defaults to credits * unit price.');
+  console.log('  --pricing-basis <mode>          prepaid-credit | usage-billed | hybrid (default: prepaid-credit).');
+  console.log('  --source-kind <kind>            operator-invoice | billing-export | manual-baseline.');
+  console.log('  --source-path <path>            Optional private/local evidence path.');
+  console.log('  --operator-note <text>          Optional note carried into the normalized receipt.');
+  console.log('  --invoice-turn-id <value>       Optional explicit invoice turn id.');
+  console.log('  --output <path>                 Output path override.');
+  console.log('  -h, --help                      Show help and exit.');
+}
+
+export async function main(argv = process.argv) {
+  try {
+    const options = parseArgs(argv);
+    if (options.help) {
+      printUsage();
+      return 0;
+    }
+    const result = runAgentCostInvoiceTurn(options);
+    console.log(`[agent-cost-invoice-turn] wrote ${result.outputPath}`);
+    return 0;
+  } catch (error) {
+    console.error(error?.message || String(error));
+    return 1;
+  }
+}
+
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+if (entrypointPath && modulePath === entrypointPath) {
+  const exitCode = await main(process.argv);
+  process.exit(exitCode);
+}

--- a/tools/priority/agent-cost-rollup.mjs
+++ b/tools/priority/agent-cost-rollup.mjs
@@ -1,0 +1,662 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+export const TURN_SCHEMA = 'priority/agent-cost-turn@v1';
+export const INVOICE_TURN_SCHEMA = 'priority/agent-cost-invoice-turn@v1';
+export const REPORT_SCHEMA = 'priority/agent-cost-rollup@v1';
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'cost', 'agent-cost-rollup.json');
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function toNonNegativeNumber(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function toNonNegativeInteger(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function roundUsd(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return Number(parsed.toFixed(6));
+}
+
+function safeRelative(filePath) {
+  return path.relative(process.cwd(), path.resolve(filePath)).replace(/\\/g, '/');
+}
+
+function parseRemoteUrl(url) {
+  if (!url) {
+    return null;
+  }
+  const sshMatch = String(url).match(/:(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const httpsMatch = String(url).match(/github\.com\/(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const repoPath = sshMatch?.groups?.repoPath ?? httpsMatch?.groups?.repoPath;
+  if (!repoPath) {
+    return null;
+  }
+  const [owner, repo] = repoPath.split('/');
+  if (!owner || !repo) {
+    return null;
+  }
+  return `${owner}/${repo.replace(/\.git$/i, '')}`;
+}
+
+function resolveRepoSlug(explicitRepo) {
+  if (normalizeText(explicitRepo).includes('/')) {
+    return normalizeText(explicitRepo);
+  }
+  if (normalizeText(process.env.GITHUB_REPOSITORY).includes('/')) {
+    return normalizeText(process.env.GITHUB_REPOSITORY);
+  }
+  for (const remote of ['upstream', 'origin']) {
+    try {
+      const raw = execSync(`git config --get remote.${remote}.url`, {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+        .toString('utf8')
+        .trim();
+      const slug = parseRemoteUrl(raw);
+      if (slug) {
+        return slug;
+      }
+    } catch {
+      // ignore missing remotes
+    }
+  }
+  return null;
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(path.resolve(filePath), 'utf8'));
+}
+
+function loadInputFile(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return { exists: false, path: resolvedPath, payload: null, error: null };
+  }
+  try {
+    return {
+      exists: true,
+      path: resolvedPath,
+      payload: readJsonFile(resolvedPath),
+      error: null
+    };
+  } catch (error) {
+    return {
+      exists: true,
+      path: resolvedPath,
+      payload: null,
+      error: error?.message || String(error)
+    };
+  }
+}
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function sum(values) {
+  return roundUsd(values.reduce((accumulator, value) => accumulator + (Number.isFinite(value) ? value : 0), 0)) ?? 0;
+}
+
+function createBlocker(code, message, inputPath = null) {
+  return { code, message, inputPath: inputPath ? safeRelative(inputPath) : null };
+}
+
+function pricingBasisFromTurn(payload) {
+  return normalizeText(payload?.billing?.rateCard?.pricingBasis) || null;
+}
+
+function computeUsdFromRateCard(payload) {
+  const rateCard = payload?.billing?.rateCard;
+  if (!rateCard || typeof rateCard !== 'object') {
+    return null;
+  }
+
+  const inputTokens = toNonNegativeInteger(payload?.usage?.inputTokens) ?? 0;
+  const cachedInputTokens = toNonNegativeInteger(payload?.usage?.cachedInputTokens) ?? 0;
+  const outputTokens = toNonNegativeInteger(payload?.usage?.outputTokens) ?? 0;
+  const usageUnitCount = toNonNegativeNumber(payload?.usage?.usageUnitCount) ?? 0;
+
+  const inputUsdPer1k = toNonNegativeNumber(rateCard.inputUsdPer1kTokens) ?? 0;
+  const cachedInputUsdPer1k = toNonNegativeNumber(rateCard.cachedInputUsdPer1kTokens) ?? 0;
+  const outputUsdPer1k = toNonNegativeNumber(rateCard.outputUsdPer1kTokens) ?? 0;
+  const usageUnitUsd = toNonNegativeNumber(rateCard.usageUnitUsd) ?? 0;
+
+  const tokenUsd =
+    (inputTokens / 1000) * inputUsdPer1k +
+    (cachedInputTokens / 1000) * cachedInputUsdPer1k +
+    (outputTokens / 1000) * outputUsdPer1k;
+  const unitUsd = usageUnitCount * usageUnitUsd;
+  const total = tokenUsd + unitUsd;
+  return total > 0 ? roundUsd(total) : null;
+}
+
+function normalizeTurnReceipt(input) {
+  const payload = input?.payload;
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 'invalid',
+      blockers: [createBlocker('turn-report-unreadable', 'Turn report could not be read as JSON.', input.path)]
+    };
+  }
+
+  if (normalizeText(payload.schema) !== TURN_SCHEMA) {
+    return {
+      status: 'invalid',
+      blockers: [
+        createBlocker(
+          'turn-schema-mismatch',
+          `Turn report schema must remain ${TURN_SCHEMA}.`,
+          input.path
+        )
+      ]
+    };
+  }
+
+  const exactness = normalizeText(payload?.billing?.exactness).toLowerCase();
+  const normalizedExactness = exactness === 'exact' ? 'exact' : exactness === 'estimated' ? 'estimated' : null;
+  const declaredAmountUsd = toNonNegativeNumber(payload?.billing?.amountUsd);
+  const computedAmountUsd = computeUsdFromRateCard(payload);
+  const preferRateCardEstimate = normalizedExactness === 'estimated' && declaredAmountUsd === 0 && computedAmountUsd != null;
+  const amountUsd = preferRateCardEstimate ? computedAmountUsd : declaredAmountUsd ?? computedAmountUsd;
+
+  const blockers = [];
+  if (!normalizedExactness) {
+    blockers.push(
+      createBlocker('billing-exactness-missing', 'Turn report billing.exactness must be exact or estimated.', input.path)
+    );
+  }
+  if (!normalizeText(payload?.provider?.id)) {
+    blockers.push(createBlocker('provider-id-missing', 'Turn report provider.id is required.', input.path));
+  }
+  if (!normalizeText(payload?.model?.effective)) {
+    blockers.push(createBlocker('model-effective-missing', 'Turn report model.effective is required.', input.path));
+  }
+  if (amountUsd == null) {
+    blockers.push(
+      createBlocker(
+        'billing-amount-unresolved',
+        'Turn report must provide billing.amountUsd or enough rate-card data to estimate cost.',
+        input.path
+      )
+    );
+  }
+
+  if (blockers.length > 0) {
+    return {
+      status: 'invalid',
+      blockers
+    };
+  }
+
+  const usageUnitKind = normalizeText(payload?.usage?.usageUnitKind) || null;
+  const usageUnitCount = toNonNegativeNumber(payload?.usage?.usageUnitCount);
+  const inputTokens = toNonNegativeInteger(payload?.usage?.inputTokens) ?? 0;
+  const cachedInputTokens = toNonNegativeInteger(payload?.usage?.cachedInputTokens) ?? 0;
+  const outputTokens = toNonNegativeInteger(payload?.usage?.outputTokens) ?? 0;
+  const totalTokens = toNonNegativeInteger(payload?.usage?.totalTokens) ?? inputTokens + cachedInputTokens + outputTokens;
+
+  return {
+    status: 'valid',
+    blockers: [],
+    turn: {
+      sourcePath: safeRelative(input.path),
+      generatedAt: normalizeText(payload.generatedAt) || null,
+      repository: normalizeText(payload?.context?.repository) || null,
+      issueNumber: toNonNegativeInteger(payload?.context?.issueNumber),
+      laneId: normalizeText(payload?.context?.laneId) || null,
+      laneBranch: normalizeText(payload?.context?.laneBranch) || null,
+      sessionId: normalizeText(payload?.context?.sessionId) || null,
+      turnId: normalizeText(payload?.context?.turnId) || null,
+      workerSlotId: normalizeText(payload?.context?.workerSlotId) || null,
+      agentRole: normalizeText(payload?.context?.agentRole) || null,
+      providerId: normalizeText(payload?.provider?.id) || null,
+      providerKind: normalizeText(payload?.provider?.kind) || null,
+      providerRuntime: normalizeText(payload?.provider?.runtime) || null,
+      executionPlane: normalizeText(payload?.provider?.executionPlane) || null,
+      requestedModel: normalizeText(payload?.model?.requested) || null,
+      effectiveModel: normalizeText(payload?.model?.effective) || null,
+      usageUnitKind,
+      usageUnitCount,
+      inputTokens,
+      cachedInputTokens,
+      outputTokens,
+      totalTokens,
+      exactness: normalizedExactness,
+      amountUsd,
+      amountSource: !preferRateCardEstimate && declaredAmountUsd != null ? 'declared-amount' : 'rate-card-estimate',
+      rateCardId: normalizeText(payload?.billing?.rateCard?.id) || null,
+      rateCardSource: normalizeText(payload?.billing?.rateCard?.source) || null,
+      rateCardRetrievedAt: normalizeText(payload?.billing?.rateCard?.retrievedAt) || null,
+      pricingBasis: pricingBasisFromTurn(payload),
+      provenance: {
+        sourceSchema: normalizeText(payload?.provenance?.sourceSchema) || null,
+        sourceReceiptPath: normalizeText(payload?.provenance?.sourceReceiptPath) || null,
+        sourceReportPath: normalizeText(payload?.provenance?.sourceReportPath) || null,
+        usageObservedAt: normalizeText(payload?.provenance?.usageObservedAt) || null
+      }
+    }
+  };
+}
+
+function normalizeInvoiceTurnReceipt(input) {
+  if (!input) {
+    return {
+      status: 'missing',
+      blockers: []
+    };
+  }
+  const payload = input?.payload;
+  if (!payload || typeof payload !== 'object') {
+    return {
+      status: 'invalid',
+      blockers: [createBlocker('invoice-turn-unreadable', 'Invoice turn report could not be read as JSON.', input.path)]
+    };
+  }
+  if (normalizeText(payload.schema) !== INVOICE_TURN_SCHEMA) {
+    return {
+      status: 'invalid',
+      blockers: [
+        createBlocker(
+          'invoice-turn-schema-mismatch',
+          `Invoice turn report schema must remain ${INVOICE_TURN_SCHEMA}.`,
+          input.path
+        )
+      ]
+    };
+  }
+
+  const creditsPurchased = toNonNegativeNumber(payload?.credits?.purchased);
+  const unitPriceUsd = toNonNegativeNumber(payload?.credits?.unitPriceUsd);
+  const prepaidUsd = toNonNegativeNumber(payload?.billing?.prepaidUsd);
+  const blockers = [];
+  if (creditsPurchased == null) {
+    blockers.push(createBlocker('invoice-turn-credits-missing', 'Invoice turn credits.purchased is required.', input.path));
+  }
+  if (unitPriceUsd == null) {
+    blockers.push(createBlocker('invoice-turn-unit-price-missing', 'Invoice turn credits.unitPriceUsd is required.', input.path));
+  }
+  if (prepaidUsd == null) {
+    blockers.push(createBlocker('invoice-turn-prepaid-missing', 'Invoice turn billing.prepaidUsd is required.', input.path));
+  }
+  if (blockers.length > 0) {
+    return {
+      status: 'invalid',
+      blockers
+    };
+  }
+
+  return {
+    status: 'valid',
+    blockers: [],
+    invoiceTurn: {
+      sourcePath: safeRelative(input.path),
+      invoiceTurnId: normalizeText(payload.invoiceTurnId) || null,
+      invoiceId: normalizeText(payload.invoiceId) || null,
+      openedAt: normalizeText(payload?.billingPeriod?.openedAt) || null,
+      closedAt: normalizeText(payload?.billingPeriod?.closedAt) || null,
+      creditsPurchased,
+      unitPriceUsd,
+      prepaidUsd,
+      pricingBasis: normalizeText(payload?.billing?.pricingBasis) || null,
+      sourceKind: normalizeText(payload?.provenance?.sourceKind) || null,
+      sourcePathEvidence: normalizeText(payload?.provenance?.sourcePath) || null,
+      operatorNote: normalizeText(payload?.provenance?.operatorNote) || null
+    }
+  };
+}
+
+function incrementCount(map, key) {
+  const normalizedKey = normalizeText(key) || 'unknown';
+  map.set(normalizedKey, (map.get(normalizedKey) ?? 0) + 1);
+}
+
+function addUsd(map, key, amountUsd) {
+  const normalizedKey = normalizeText(key) || 'unknown';
+  map.set(normalizedKey, roundUsd((map.get(normalizedKey) ?? 0) + (amountUsd ?? 0)) ?? 0);
+}
+
+function materializeBreakdown(countMap, usdMap) {
+  return [...countMap.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, turnCount]) => ({
+      key,
+      turnCount,
+      totalUsd: usdMap.get(key) ?? 0
+    }));
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    turnReportPaths: [],
+    invoiceTurnPath: null,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    repo: null,
+    failOnInvalidInputs: true,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (token === '--no-fail-on-invalid-inputs') {
+      options.failOnInvalidInputs = false;
+      continue;
+    }
+    if (token === '--fail-on-invalid-inputs') {
+      options.failOnInvalidInputs = true;
+      continue;
+    }
+    if (token === '--turn-report' || token === '--invoice-turn' || token === '--output' || token === '--repo') {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--turn-report') {
+        options.turnReportPaths.push(next);
+      } else if (token === '--invoice-turn') {
+        options.invoiceTurnPath = next;
+      } else if (token === '--output') {
+        options.outputPath = next;
+      } else {
+        options.repo = next;
+      }
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!options.help && options.turnReportPaths.length === 0) {
+    throw new Error('Missing required option: --turn-report <path>.');
+  }
+  return options;
+}
+
+export function evaluateAgentCostRollup({ turnInputs, normalizedTurns }) {
+  const blockers = [];
+
+  for (const input of turnInputs) {
+    if (!input.exists) {
+      blockers.push(createBlocker('turn-report-missing', 'Turn report is missing.', input.path));
+      continue;
+    }
+    if (input.error) {
+      blockers.push(createBlocker('turn-report-unreadable', `Turn report could not be parsed: ${input.error}`, input.path));
+    }
+  }
+
+  for (const normalized of normalizedTurns) {
+    blockers.push(...ensureArray(normalized.blockers));
+  }
+
+  const validTurns = normalizedTurns.filter((entry) => entry.status === 'valid').map((entry) => entry.turn);
+  const exactTurns = validTurns.filter((entry) => entry.exactness === 'exact');
+  const estimatedTurns = validTurns.filter((entry) => entry.exactness === 'estimated');
+
+  return {
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockerCount: blockers.length,
+    blockers,
+    recommendation:
+      blockers.length > 0
+        ? 'repair-input-receipts'
+        : estimatedTurns.length > 0
+          ? 'continue-estimated-telemetry'
+          : 'exact-cost-ready',
+    validTurns,
+    exactTurns,
+    estimatedTurns
+  };
+}
+
+export function runAgentCostRollup(options) {
+  const repo = resolveRepoSlug(options.repo);
+  const turnInputs = options.turnReportPaths.map((filePath) => loadInputFile(filePath));
+  const normalizedTurns = turnInputs.map((input) => normalizeTurnReceipt(input));
+  const invoiceTurnInput = options.invoiceTurnPath ? loadInputFile(options.invoiceTurnPath) : null;
+  const normalizedInvoiceTurn = normalizeInvoiceTurnReceipt(invoiceTurnInput);
+  const evaluation = evaluateAgentCostRollup({ turnInputs, normalizedTurns });
+  const invoiceTurnBlockers = [];
+  if (invoiceTurnInput?.exists === false) {
+    invoiceTurnBlockers.push(createBlocker('invoice-turn-missing', 'Invoice turn report is missing.', invoiceTurnInput.path));
+  } else if (invoiceTurnInput?.error) {
+    invoiceTurnBlockers.push(
+      createBlocker('invoice-turn-unreadable', `Invoice turn report could not be parsed: ${invoiceTurnInput.error}`, invoiceTurnInput.path)
+    );
+  }
+  invoiceTurnBlockers.push(...ensureArray(normalizedInvoiceTurn.blockers));
+
+  const validTurns = evaluation.validTurns;
+  const totalUsd = sum(validTurns.map((entry) => entry.amountUsd));
+  const exactUsd = sum(evaluation.exactTurns.map((entry) => entry.amountUsd));
+  const estimatedUsd = sum(evaluation.estimatedTurns.map((entry) => entry.amountUsd));
+  const totalInputTokens = validTurns.reduce((sumValue, entry) => sumValue + (entry.inputTokens ?? 0), 0);
+  const totalCachedInputTokens = validTurns.reduce((sumValue, entry) => sumValue + (entry.cachedInputTokens ?? 0), 0);
+  const totalOutputTokens = validTurns.reduce((sumValue, entry) => sumValue + (entry.outputTokens ?? 0), 0);
+  const totalTokens = validTurns.reduce((sumValue, entry) => sumValue + (entry.totalTokens ?? 0), 0);
+  const totalUsageUnits = roundUsd(validTurns.reduce((sumValue, entry) => sumValue + (entry.usageUnitCount ?? 0), 0)) ?? 0;
+
+  const byProviderCount = new Map();
+  const byProviderUsd = new Map();
+  const byModelCount = new Map();
+  const byModelUsd = new Map();
+  const byIssueCount = new Map();
+  const byIssueUsd = new Map();
+  const byLaneCount = new Map();
+  const byLaneUsd = new Map();
+  const byAgentRoleCount = new Map();
+  const byAgentRoleUsd = new Map();
+  const byRepositoryCount = new Map();
+  const byRepositoryUsd = new Map();
+
+  const rateCards = new Map();
+  const sessionIds = new Set();
+  const issueNumbers = new Set();
+  const laneIds = new Set();
+  const repositories = new Set();
+
+  for (const turn of validTurns) {
+    incrementCount(byProviderCount, turn.providerId);
+    addUsd(byProviderUsd, turn.providerId, turn.amountUsd);
+    incrementCount(byModelCount, turn.effectiveModel);
+    addUsd(byModelUsd, turn.effectiveModel, turn.amountUsd);
+    incrementCount(byIssueCount, turn.issueNumber != null ? String(turn.issueNumber) : 'unknown');
+    addUsd(byIssueUsd, turn.issueNumber != null ? String(turn.issueNumber) : 'unknown', turn.amountUsd);
+    incrementCount(byLaneCount, turn.laneId);
+    addUsd(byLaneUsd, turn.laneId, turn.amountUsd);
+    incrementCount(byAgentRoleCount, turn.agentRole);
+    addUsd(byAgentRoleUsd, turn.agentRole, turn.amountUsd);
+    incrementCount(byRepositoryCount, turn.repository);
+    addUsd(byRepositoryUsd, turn.repository, turn.amountUsd);
+    if (turn.rateCardId || turn.rateCardSource) {
+      const rateCardKey = `${turn.rateCardId || 'unknown'}|${turn.rateCardSource || 'unknown'}`;
+      if (!rateCards.has(rateCardKey)) {
+        rateCards.set(rateCardKey, {
+          id: turn.rateCardId,
+          source: turn.rateCardSource,
+          retrievedAt: turn.rateCardRetrievedAt,
+          pricingBasis: turn.pricingBasis
+        });
+      }
+    }
+    if (turn.sessionId) {
+      sessionIds.add(turn.sessionId);
+    }
+    if (turn.issueNumber != null) {
+      issueNumbers.add(turn.issueNumber);
+    }
+    if (turn.laneId) {
+      laneIds.add(turn.laneId);
+    }
+    if (turn.repository) {
+      repositories.add(turn.repository);
+    }
+  }
+
+  const invoiceTurn = normalizedInvoiceTurn.status === 'valid' ? normalizedInvoiceTurn.invoiceTurn : null;
+  const estimatedCreditsConsumed =
+    invoiceTurn && invoiceTurn.unitPriceUsd > 0 ? roundUsd(totalUsd / invoiceTurn.unitPriceUsd) : null;
+  const creditsRemaining =
+    invoiceTurn && estimatedCreditsConsumed != null
+      ? roundUsd(Math.max(invoiceTurn.creditsPurchased - estimatedCreditsConsumed, 0))
+      : null;
+  const estimatedPrepaidUsdRemaining =
+    invoiceTurn ? roundUsd(Math.max(invoiceTurn.prepaidUsd - totalUsd, 0)) : null;
+  const prepaidUsdConsumedRatio =
+    invoiceTurn && invoiceTurn.prepaidUsd > 0 ? roundUsd(totalUsd / invoiceTurn.prepaidUsd) : null;
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: new Date().toISOString(),
+    repository: repo,
+    inputs: {
+      turnReportPaths: turnInputs.map((entry) => ({
+        path: safeRelative(entry.path),
+        exists: entry.exists,
+        error: entry.error ?? null
+      })),
+      invoiceTurnPath: invoiceTurnInput
+        ? {
+            path: safeRelative(invoiceTurnInput.path),
+            exists: invoiceTurnInput.exists,
+            error: invoiceTurnInput.error ?? null
+          }
+        : null
+    },
+    turns: validTurns,
+    summary: {
+      status: evaluation.blockerCount + invoiceTurnBlockers.length === 0 ? evaluation.status : 'fail',
+      recommendation:
+        invoiceTurnBlockers.length > 0
+          ? 'repair-invoice-turn-baseline'
+          : evaluation.recommendation,
+      blockerCount: evaluation.blockerCount + invoiceTurnBlockers.length,
+      blockers: [...evaluation.blockers, ...invoiceTurnBlockers],
+      metrics: {
+        totalTurns: validTurns.length,
+        exactTurnCount: evaluation.exactTurns.length,
+        estimatedTurnCount: evaluation.estimatedTurns.length,
+        totalUsd,
+        exactUsd,
+        estimatedUsd,
+        totalInputTokens,
+        totalCachedInputTokens,
+        totalOutputTokens,
+        totalTokens,
+        totalUsageUnits,
+        estimatedCreditsConsumed,
+        creditsRemaining,
+        estimatedPrepaidUsdRemaining,
+        prepaidUsdConsumedRatio
+      },
+      provenance: {
+        sessionIds: [...sessionIds].sort(),
+        issueNumbers: [...issueNumbers].sort((left, right) => left - right),
+        laneIds: [...laneIds].sort(),
+        repositories: [...repositories].sort(),
+        rateCards: [...rateCards.values()].sort((left, right) =>
+          `${left.id || ''}|${left.source || ''}`.localeCompare(`${right.id || ''}|${right.source || ''}`)
+        ),
+        invoiceTurn
+      }
+    },
+    billingWindow: invoiceTurn
+      ? {
+          invoiceTurnId: invoiceTurn.invoiceTurnId,
+          invoiceId: invoiceTurn.invoiceId,
+          openedAt: invoiceTurn.openedAt,
+          closedAt: invoiceTurn.closedAt,
+          pricingBasis: invoiceTurn.pricingBasis,
+          sourceKind: invoiceTurn.sourceKind,
+          sourcePathEvidence: invoiceTurn.sourcePathEvidence,
+          operatorNote: invoiceTurn.operatorNote
+        }
+      : null,
+    breakdown: {
+      byProvider: materializeBreakdown(byProviderCount, byProviderUsd),
+      byModel: materializeBreakdown(byModelCount, byModelUsd),
+      byIssue: materializeBreakdown(byIssueCount, byIssueUsd),
+      byLane: materializeBreakdown(byLaneCount, byLaneUsd),
+      byAgentRole: materializeBreakdown(byAgentRoleCount, byAgentRoleUsd),
+      byRepository: materializeBreakdown(byRepositoryCount, byRepositoryUsd)
+    }
+  };
+
+  const outputPath = path.resolve(options.outputPath || DEFAULT_OUTPUT_PATH);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  const shouldFail = options.failOnInvalidInputs !== false && report.summary.blockerCount > 0;
+  return {
+    exitCode: shouldFail ? 1 : 0,
+    outputPath,
+    report
+  };
+}
+
+function printUsage() {
+  console.log('Usage: node tools/priority/agent-cost-rollup.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --turn-report <path>            Agent cost turn receipt path (repeatable, required).');
+  console.log('  --invoice-turn <path>           Optional invoice turn baseline receipt path.');
+  console.log(`  --output <path>                 Output path (default: ${DEFAULT_OUTPUT_PATH}).`);
+  console.log('  --repo <owner/repo>             Repository slug override.');
+  console.log('  --fail-on-invalid-inputs        Exit non-zero when input receipts are invalid (default true).');
+  console.log('  --no-fail-on-invalid-inputs     Emit rollup without failing process exit.');
+  console.log('  -h, --help                      Show help and exit.');
+}
+
+export async function main(argv = process.argv) {
+  try {
+    const options = parseArgs(argv);
+    if (options.help) {
+      printUsage();
+      return 0;
+    }
+    const result = runAgentCostRollup(options);
+    console.log(`[agent-cost-rollup] wrote ${path.resolve(options.outputPath || DEFAULT_OUTPUT_PATH)}`);
+    return result.exitCode;
+  } catch (error) {
+    console.error(error?.message || String(error));
+    return 1;
+  }
+}
+
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const modulePath = new URL(import.meta.url).protocol === 'file:' ? process.platform === 'win32'
+  ? path.normalize(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'))
+  : path.normalize(new URL(import.meta.url).pathname)
+  : null;
+if (entrypointPath && modulePath && modulePath === entrypointPath) {
+  const exitCode = await main(process.argv);
+  process.exit(exitCode);
+}


### PR DESCRIPTION
## Summary
- add invoice-turn, per-turn, and rollup cost telemetry contracts for #1639
- document the first invoice-turn slice and expose npm wrappers for future agent use
- harden the cost helpers with Windows-safe CLI entrypoints and zero-mask rate-card recovery

## Validation
- `node --test tools/priority/__tests__/agent-cost-rollup.test.mjs tools/priority/__tests__/agent-cost-rollup-schema.test.mjs tools/priority/__tests__/agent-cost-telemetry-surfaces.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs priority:cost:invoice-turn -- --invoice-id HQ1VJLMV-0027 --opened-at 2026-03-21T10:01:07.000-07:00 --credits-purchased 10000 --unit-price-usd 0.04 --source-kind manual-baseline --operator-note "Wrapper smoke for #1639." --output tests/results/_agent/cost/invoice-turns/wrapper-smoke.json`
- `node tools/npm/run-script.mjs priority:cost:rollup -- --turn-report tools/priority/__fixtures__/agent-cost-rollup/live-turn-estimated.json --turn-report tools/priority/__fixtures__/agent-cost-rollup/background-turn-exact.json --invoice-turn tools/priority/__fixtures__/agent-cost-rollup/invoice-turn-baseline.json --output tests/results/_agent/cost/agent-cost-rollup.wrapper-smoke.json`
- `git diff --check`
