### PR TITLE
Align usage export receipts with rollup contract (#1671)

### DIFF
--- a/docs/schemas/agent-cost-usage-export-v1.schema.json
+++ b/docs/schemas/agent-cost-usage-export-v1.schema.json
@@ -7,409 +7,85 @@
   "required": [
     "schema",
     "generatedAt",
-    "source",
-    "account",
-    "period",
-    "summary",
-    "windows",
-    "transitions",
+    "reportWindow",
+    "usageType",
+    "totals",
+    "sourceKind",
+    "sourcePathEvidence",
+    "operatorNote",
     "provenance",
     "confidence"
   ],
   "properties": {
     "schema": { "const": "priority/agent-cost-usage-export@v1" },
     "generatedAt": { "type": "string", "format": "date-time" },
-    "source": { "$ref": "#/$defs/rollupSource" },
-    "account": { "$ref": "#/$defs/account" },
-    "period": { "$ref": "#/$defs/rollupPeriod" },
-    "summary": { "$ref": "#/$defs/rollupSummary" },
-    "windows": {
-      "type": "array",
-      "minItems": 1,
-      "items": { "$ref": "#/$defs/windowReceipt" }
-    },
-    "transitions": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/transition" }
-    },
-    "provenance": { "$ref": "#/$defs/rollupProvenance" },
-    "confidence": { "$ref": "#/$defs/rollupConfidence" }
-  },
-  "$defs": {
-    "nullableString": {
-      "type": ["string", "null"]
-    },
-    "account": {
+    "reportWindow": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["accountId", "accountUserId", "email", "name", "publicId"],
+      "required": ["startDate", "endDate", "rowCount"],
       "properties": {
-        "accountId": { "type": "string" },
-        "accountUserId": { "type": "string" },
-        "email": { "type": "string" },
-        "name": { "type": "string" },
-        "publicId": { "type": "string" }
-      }
-    },
-    "windowSource": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["kind", "path", "fileName", "sha256", "header", "rowCount"],
-      "properties": {
-        "kind": { "type": "string" },
-        "path": { "$ref": "#/$defs/nullableString" },
-        "fileName": { "$ref": "#/$defs/nullableString" },
-        "sha256": { "$ref": "#/$defs/nullableString" },
-        "header": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 10,
-          "maxItems": 10
-        },
+        "startDate": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+        "endDate": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "rowCount": { "type": "integer", "minimum": 1 }
       }
     },
-    "usageTypeTotal": {
+    "usageType": { "type": "string", "minLength": 1 },
+    "totals": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["usageType", "rowCount", "usageCredits", "usageQuantity"],
+      "required": ["usageCredits", "usageQuantity"],
       "properties": {
-        "usageType": { "type": "string" },
-        "rowCount": { "type": "integer", "minimum": 1 },
         "usageCredits": { "type": "number", "minimum": 0 },
         "usageQuantity": { "type": "number", "minimum": 0 }
       }
     },
-    "windowPeriod": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["firstDatePartition", "lastDatePartition", "datePartitionCount"],
-      "properties": {
-        "firstDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "lastDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "datePartitionCount": { "type": "integer", "minimum": 1 }
-      }
-    },
-    "windowSummary": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["rowCount", "usageUnits", "totalUsageCredits", "totalUsageQuantity", "usageTypes", "usageTypeTotals"],
-      "properties": {
-        "rowCount": { "type": "integer", "minimum": 1 },
-        "usageUnits": { "type": "string" },
-        "totalUsageCredits": { "type": "number", "minimum": 0 },
-        "totalUsageQuantity": { "type": "number", "minimum": 0 },
-        "usageTypes": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1
-        },
-        "usageTypeTotals": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/usageTypeTotal" }
-        }
-      }
-    },
-    "windowRow": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "rowIndex",
-        "datePartition",
-        "accountId",
-        "accountUserId",
-        "email",
-        "name",
-        "publicId",
-        "usageType",
-        "usageCredits",
-        "usageQuantity",
-        "usageUnits"
-      ],
-      "properties": {
-        "rowIndex": { "type": "integer", "minimum": 1 },
-        "datePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "accountId": { "type": "string" },
-        "accountUserId": { "type": "string" },
-        "email": { "type": "string" },
-        "name": { "type": "string" },
-        "publicId": { "type": "string" },
-        "usageType": { "type": "string" },
-        "usageCredits": { "type": "number", "minimum": 0 },
-        "usageQuantity": { "type": "number", "minimum": 0 },
-        "usageUnits": { "type": "string" }
-      }
-    },
-    "windowConfidence": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["level", "basis", "rowCoverage", "accountCoverage"],
-      "properties": {
-        "level": { "enum": ["low", "medium", "high"] },
-        "basis": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1
-        },
-        "rowCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
-        "accountCoverage": { "type": "number", "minimum": 0, "maximum": 1 }
-      }
-    },
-    "windowContinuity": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "windowIndex",
-        "windowCount",
-        "previousWindowId",
-        "nextWindowId",
-        "previousWindowLastDatePartition",
-        "nextWindowFirstDatePartition",
-        "gapDaysFromPrevious",
-        "gapDaysToNext",
-        "isContiguousWithPrevious",
-        "isContiguousWithNext",
-        "isFirstWindow",
-        "isLastWindow"
-      ],
-      "properties": {
-        "windowIndex": { "type": "integer", "minimum": 1 },
-        "windowCount": { "type": "integer", "minimum": 1 },
-        "previousWindowId": { "$ref": "#/$defs/nullableString" },
-        "nextWindowId": { "$ref": "#/$defs/nullableString" },
-        "previousWindowLastDatePartition": { "$ref": "#/$defs/nullableString" },
-        "nextWindowFirstDatePartition": { "$ref": "#/$defs/nullableString" },
-        "gapDaysFromPrevious": { "type": ["integer", "null"], "minimum": 0 },
-        "gapDaysToNext": { "type": ["integer", "null"], "minimum": 0 },
-        "isContiguousWithPrevious": { "type": ["boolean", "null"] },
-        "isContiguousWithNext": { "type": ["boolean", "null"] },
-        "isFirstWindow": { "type": "boolean" },
-        "isLastWindow": { "type": "boolean" }
-      }
-    },
-    "windowProvenance": {
+    "sourceKind": { "type": "string" },
+    "sourcePathEvidence": { "type": ["string", "null"] },
+    "operatorNote": { "type": "string" },
+    "provenance": {
       "type": "object",
       "additionalProperties": false,
       "required": [
         "sourceKind",
         "sourcePath",
+        "sourcePathEvidence",
         "sourceSha256",
         "sourceFileName",
         "accountId",
         "accountUserId",
-        "publicId",
         "email",
-        "windowId",
-        "windowIndex",
-        "windowCount"
+        "name",
+        "publicId",
+        "usageUnits",
+        "usageType",
+        "rowCount",
+        "datePartitionCount",
+        "windowId"
       ],
       "properties": {
         "sourceKind": { "type": "string" },
-        "sourcePath": { "$ref": "#/$defs/nullableString" },
-        "sourceSha256": { "$ref": "#/$defs/nullableString" },
-        "sourceFileName": { "$ref": "#/$defs/nullableString" },
+        "sourcePath": { "type": ["string", "null"] },
+        "sourcePathEvidence": { "type": ["string", "null"] },
+        "sourceSha256": { "type": ["string", "null"] },
+        "sourceFileName": { "type": ["string", "null"] },
         "accountId": { "type": "string" },
         "accountUserId": { "type": "string" },
-        "publicId": { "type": "string" },
         "email": { "type": "string" },
-        "windowId": { "type": "string" },
-        "windowIndex": { "type": "integer", "minimum": 1 },
-        "windowCount": { "type": "integer", "minimum": 1 }
-      }
-    },
-    "windowReceipt": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["windowId", "schema", "generatedAt", "source", "account", "period", "summary", "rows", "provenance", "confidence", "continuity"],
-      "properties": {
-        "windowId": { "type": "string", "minLength": 1 },
-        "schema": { "const": "priority/agent-cost-usage-export@v1" },
-        "generatedAt": { "type": "string", "format": "date-time" },
-        "source": { "$ref": "#/$defs/windowSource" },
-        "account": { "$ref": "#/$defs/account" },
-        "period": { "$ref": "#/$defs/windowPeriod" },
-        "summary": { "$ref": "#/$defs/windowSummary" },
-        "rows": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/windowRow" }
-        },
-        "provenance": { "$ref": "#/$defs/windowProvenance" },
-        "confidence": { "$ref": "#/$defs/windowConfidence" },
-        "continuity": { "$ref": "#/$defs/windowContinuity" }
-      }
-    },
-    "transition": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "fromWindowId",
-        "fromWindowIndex",
-        "toWindowId",
-        "toWindowIndex",
-        "fromLastDatePartition",
-        "toFirstDatePartition",
-        "gapDays",
-        "overlapDays",
-        "status",
-        "isContiguous"
-      ],
-      "properties": {
-        "fromWindowId": { "type": "string", "minLength": 1 },
-        "fromWindowIndex": { "type": "integer", "minimum": 1 },
-        "toWindowId": { "type": "string", "minLength": 1 },
-        "toWindowIndex": { "type": "integer", "minimum": 1 },
-        "fromLastDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "toFirstDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "gapDays": { "type": "integer", "minimum": 0 },
-        "overlapDays": { "type": "integer", "minimum": 0 },
-        "status": { "type": "string", "enum": ["adjacent", "gap"] },
-        "isContiguous": { "type": "boolean" }
-      }
-    },
-    "rollupSource": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["kind", "inputCount", "windowCount", "rowCount", "files"],
-      "properties": {
-        "kind": { "type": "string" },
-        "inputCount": { "type": "integer", "minimum": 1 },
-        "windowCount": { "type": "integer", "minimum": 1 },
-        "rowCount": { "type": "integer", "minimum": 1 },
-        "files": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["path", "fileName", "sha256", "header", "rowCount", "windowId", "firstDatePartition", "lastDatePartition"],
-            "properties": {
-              "path": { "$ref": "#/$defs/nullableString" },
-              "fileName": { "$ref": "#/$defs/nullableString" },
-              "sha256": { "$ref": "#/$defs/nullableString" },
-              "header": {
-                "type": "array",
-                "items": { "type": "string" },
-                "minItems": 10,
-                "maxItems": 10
-              },
-              "rowCount": { "type": "integer", "minimum": 1 },
-              "windowId": { "type": "string", "minLength": 1 },
-              "firstDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-              "lastDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" }
-            }
-          }
-        }
-      }
-    },
-    "rollupPeriod": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "firstDatePartition",
-        "lastDatePartition",
-        "datePartitionCount",
-        "windowCount",
-        "transitionCount",
-        "contiguousTransitionCount",
-        "gapTransitionCount",
-        "overlapTransitionCount"
-      ],
-      "properties": {
-        "firstDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "lastDatePartition": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-        "datePartitionCount": { "type": "integer", "minimum": 1 },
-        "windowCount": { "type": "integer", "minimum": 1 },
-        "transitionCount": { "type": "integer", "minimum": 0 },
-        "contiguousTransitionCount": { "type": "integer", "minimum": 0 },
-        "gapTransitionCount": { "type": "integer", "minimum": 0 },
-        "overlapTransitionCount": { "type": "integer", "minimum": 0 }
-      }
-    },
-    "rollupSummary": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "windowCount",
-        "transitionCount",
-        "contiguousTransitionCount",
-        "gapTransitionCount",
-        "overlapTransitionCount",
-        "rowCount",
-        "totalUsageCredits",
-        "totalUsageQuantity",
-        "usageUnits",
-        "usageTypes",
-        "usageTypeTotals",
-        "continuityStatus"
-      ],
-      "properties": {
-        "windowCount": { "type": "integer", "minimum": 1 },
-        "transitionCount": { "type": "integer", "minimum": 0 },
-        "contiguousTransitionCount": { "type": "integer", "minimum": 0 },
-        "gapTransitionCount": { "type": "integer", "minimum": 0 },
-        "overlapTransitionCount": { "type": "integer", "minimum": 0 },
-        "rowCount": { "type": "integer", "minimum": 1 },
-        "totalUsageCredits": { "type": "number", "minimum": 0 },
-        "totalUsageQuantity": { "type": "number", "minimum": 0 },
+        "name": { "type": "string" },
+        "publicId": { "type": "string" },
         "usageUnits": { "type": "string" },
-        "usageTypes": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1
-        },
-        "usageTypeTotals": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/usageTypeTotal" }
-        },
-        "continuityStatus": { "type": "string", "enum": ["single-window", "contiguous", "gapped"] }
+        "usageType": { "type": "string" },
+        "rowCount": { "type": "integer", "minimum": 1 },
+        "datePartitionCount": { "type": "integer", "minimum": 1 },
+        "windowId": { "type": "string", "minLength": 1 },
+        "windowIndex": { "type": ["integer", "null"], "minimum": 1 },
+        "windowCount": { "type": ["integer", "null"], "minimum": 1 }
       }
     },
-    "rollupProvenance": {
+    "confidence": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "sourceKind",
-        "sourcePaths",
-        "sourceSha256s",
-        "sourceFileNames",
-        "accountId",
-        "accountUserId",
-        "publicId",
-        "email",
-        "windowCount",
-        "windowIds"
-      ],
-      "properties": {
-        "sourceKind": { "type": "string" },
-        "sourcePaths": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/nullableString" }
-        },
-        "sourceSha256s": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/nullableString" }
-        },
-        "sourceFileNames": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/nullableString" }
-        },
-        "accountId": { "$ref": "#/$defs/nullableString" },
-        "accountUserId": { "$ref": "#/$defs/nullableString" },
-        "publicId": { "$ref": "#/$defs/nullableString" },
-        "email": { "$ref": "#/$defs/nullableString" },
-        "windowCount": { "type": "integer", "minimum": 1 },
-        "windowIds": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1
-        }
-      }
-    },
-    "rollupConfidence": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["level", "basis", "rowCoverage", "accountCoverage", "windowCoverage", "continuityCoverage"],
+      "required": ["level", "basis", "rowCoverage", "accountCoverage", "windowCoverage"],
       "properties": {
         "level": { "enum": ["low", "medium", "high"] },
         "basis": {
@@ -419,10 +95,45 @@
         },
         "rowCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
         "accountCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
-        "windowCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
-        "continuityCoverage": { "type": "number", "minimum": 0, "maximum": 1 }
+        "windowCoverage": { "type": "number", "minimum": 0, "maximum": 1 }
       }
+    },
+    "continuity": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "windowIndex",
+            "windowCount",
+            "previousWindowId",
+            "nextWindowId",
+            "previousReportWindowEndDate",
+            "nextReportWindowStartDate",
+            "gapDaysFromPrevious",
+            "gapDaysToNext",
+            "isContiguousWithPrevious",
+            "isContiguousWithNext",
+            "isFirstWindow",
+            "isLastWindow"
+          ],
+          "properties": {
+            "windowIndex": { "type": "integer", "minimum": 1 },
+            "windowCount": { "type": "integer", "minimum": 1 },
+            "previousWindowId": { "type": ["string", "null"] },
+            "nextWindowId": { "type": ["string", "null"] },
+            "previousReportWindowEndDate": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+            "nextReportWindowStartDate": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+            "gapDaysFromPrevious": { "type": ["integer", "null"], "minimum": 0 },
+            "gapDaysToNext": { "type": ["integer", "null"], "minimum": 0 },
+            "isContiguousWithPrevious": { "type": ["boolean", "null"] },
+            "isContiguousWithNext": { "type": ["boolean", "null"] },
+            "isFirstWindow": { "type": "boolean" },
+            "isLastWindow": { "type": "boolean" }
+          }
+        },
+        { "type": "null" }
+      ]
     }
   }
 }
-

--- a/tools/priority/__tests__/agent-cost-usage-export-normalize-schema.test.mjs
+++ b/tools/priority/__tests__/agent-cost-usage-export-normalize-schema.test.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 
-import { buildNormalizedUsageExportRollupFromCsvInputs } from '../agent-cost-usage-export-normalize.mjs';
+import { buildNormalizedUsageExportReceiptFromCsv, buildNormalizedUsageExportReceiptsFromCsvInputs } from '../agent-cost-usage-export-normalize.mjs';
 
 const repoRoot = path.resolve(process.cwd());
 const fixturePath = path.join(repoRoot, 'tools', 'priority', '__fixtures__', 'agent-cost-rollup', 'usage-export-sample.csv');
@@ -64,10 +64,31 @@ function writeUsageExportCsv(filePath, csvText) {
   fs.writeFileSync(filePath, `${csvText}\n`, 'utf8');
 }
 
-test('normalized usage export rollup matches the checked-in schema', () => {
+test('normalized usage export receipt matches the checked-in schema', () => {
+  const csv = fs.readFileSync(fixturePath, 'utf8');
+  const { report } = buildNormalizedUsageExportReceiptFromCsv(csv, {
+    inputPath: fixturePath,
+    sourcePath: fixturePath,
+    sourceSha256: 'local-private-fingerprint'
+  }, new Date('2026-03-21T20:10:00.000Z'));
+
+  const schema = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'docs', 'schemas', 'agent-cost-usage-export-v1.schema.json'), 'utf8')
+  );
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+  assert.equal(report.reportWindow.startDate, '2026-03-15');
+  assert.equal(report.reportWindow.endDate, '2026-03-20');
+  assert.equal(report.usageType, 'codex');
+});
+
+test('adjacent usage export receipts retain explicit continuity metadata', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-usage-export-schema-'));
   const janPath = path.join(tmpDir, 'usage-export-2026-01-15.csv');
   const febPath = path.join(tmpDir, 'usage-export-2026-02-15.csv');
+  const marPath = path.join(tmpDir, 'usage-export-2026-03-15.csv');
 
   writeUsageExportCsv(
     janPath,
@@ -93,7 +114,6 @@ test('normalized usage export rollup matches the checked-in schema', () => {
       baseUsageQuantity: 20000
     })
   );
-  const marPath = path.join(tmpDir, 'usage-export-2026-03-15.csv');
   fs.copyFileSync(fixturePath, marPath);
 
   const inputs = [janPath, febPath, marPath].map((inputPath) => ({
@@ -101,7 +121,7 @@ test('normalized usage export rollup matches the checked-in schema', () => {
     raw: fs.readFileSync(inputPath, 'utf8'),
     sourceSha256: `sha256-${path.basename(inputPath)}`
   }));
-  const { report } = buildNormalizedUsageExportRollupFromCsvInputs(inputs, {
+  const { reports } = buildNormalizedUsageExportReceiptsFromCsvInputs(inputs, {
     sourceKind: 'operator-private-usage-export-csv'
   }, new Date('2026-03-21T20:10:00.000Z'));
 
@@ -111,8 +131,13 @@ test('normalized usage export rollup matches the checked-in schema', () => {
   const ajv = new Ajv2020({ allErrors: true, strict: false });
   addFormats(ajv);
   const validate = ajv.compile(schema);
-  assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
-  assert.equal(report.windows.length, 3);
-  assert.equal(report.transitions[0].status, 'adjacent');
-});
 
+  for (const report of reports) {
+    assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+  }
+  assert.equal(reports.length, 3);
+  assert.equal(reports[0].continuity.isContiguousWithNext, true);
+  assert.equal(reports[1].continuity.isContiguousWithPrevious, true);
+  assert.equal(reports[1].continuity.isContiguousWithNext, true);
+  assert.equal(reports[2].continuity.isContiguousWithPrevious, true);
+});

--- a/tools/priority/__tests__/agent-cost-usage-export-normalize.test.mjs
+++ b/tools/priority/__tests__/agent-cost-usage-export-normalize.test.mjs
@@ -9,7 +9,7 @@ import { spawnSync } from 'node:child_process';
 
 import {
   buildNormalizedUsageExportReceiptFromCsv,
-  buildNormalizedUsageExportRollupFromCsvInputs,
+  buildNormalizedUsageExportReceiptsFromCsvInputs,
   deriveDefaultOutputPath,
   parseArgs,
   runAgentCostUsageExportNormalize
@@ -114,32 +114,27 @@ test('parseArgs captures repeated usage export inputs and optional overrides', (
     '--input',
     'b.csv',
     '--output',
-    'tests/results/_agent/cost/usage-export/custom.json',
+    'tests/results/_agent/cost/usage-exports/custom.json',
     '--source-kind',
-    'operator-private-usage-export-csv'
+    'operator-private-usage-export-csv',
+    '--operator-note',
+    'checked from local export'
   ]);
 
   assert.deepEqual(options.inputPaths, ['a.csv', 'b.csv']);
-  assert.equal(options.outputPath, 'tests/results/_agent/cost/usage-export/custom.json');
+  assert.equal(options.outputPath, 'tests/results/_agent/cost/usage-exports/custom.json');
   assert.equal(options.sourceKind, 'operator-private-usage-export-csv');
+  assert.equal(options.operatorNote, 'checked from local export');
 });
 
-test('deriveDefaultOutputPath keeps usage export rollups under the local cost namespace', () => {
-  const derived = deriveDefaultOutputPath([fixturePath], {
-    period: {
-      firstDatePartition: '2026-01-15',
-      lastDatePartition: '2026-03-20'
-    },
-    summary: {
-      windowCount: 3
-    }
-  });
+test('deriveDefaultOutputPath keeps usage export receipts under the local cost namespace', () => {
+  const derived = deriveDefaultOutputPath(fixturePath);
 
-  assert.ok(derived.includes(path.join('tests', 'results', '_agent', 'cost', 'usage-export')));
-  assert.match(path.basename(derived), /usage-export-2026-01-15_to_2026-03-20-3-windows\.json$/);
+  assert.ok(derived.includes(path.join('tests', 'results', '_agent', 'cost', 'usage-exports')));
+  assert.match(path.basename(derived), /usage-export-sample\.json$/);
 });
 
-test('buildNormalizedUsageExportReceiptFromCsv normalizes a single window receipt deterministically', () => {
+test('buildNormalizedUsageExportReceiptFromCsv normalizes a single usage export receipt deterministically', () => {
   const csv = fs.readFileSync(fixturePath, 'utf8');
   const { report, outputPath } = buildNormalizedUsageExportReceiptFromCsv(csv, {
     inputPath: fixturePath,
@@ -147,22 +142,22 @@ test('buildNormalizedUsageExportReceiptFromCsv normalizes a single window receip
     sourceSha256: 'local-private-fingerprint'
   }, new Date('2026-03-21T20:10:00.000Z'));
 
-  assert.equal(report.windowId, '2026-03-15..2026-03-20');
-  assert.equal(report.summary.rowCount, 6);
-  assert.equal(report.summary.totalUsageCredits, 10559.88);
-  assert.equal(report.summary.totalUsageQuantity, 211197.6);
-  assert.deepEqual(report.summary.usageTypes, ['codex']);
-  assert.equal(report.summary.usageTypeTotals[0].rowCount, 6);
-  assert.equal(report.account.accountId, 'acct-001');
-  assert.equal(report.account.publicId, 'user-example-001');
+  assert.equal(report.schema, 'priority/agent-cost-usage-export@v1');
+  assert.deepEqual(report.reportWindow, { startDate: '2026-03-15', endDate: '2026-03-20', rowCount: 6 });
+  assert.equal(report.usageType, 'codex');
+  assert.deepEqual(report.totals, { usageCredits: 10559.88, usageQuantity: 211197.6 });
+  assert.equal(report.sourceKind, 'operator-private-usage-export-csv');
+  assert.equal(report.sourcePathEvidence, fixturePath);
+  assert.equal(report.operatorNote, 'Normalized from a local private account usage export CSV.');
   assert.equal(report.provenance.sourceSha256, 'local-private-fingerprint');
+  assert.equal(report.provenance.windowId, '2026-03-15..2026-03-20');
   assert.equal(report.confidence.level, 'high');
   assert.equal(report.continuity.windowIndex, 1);
-  assert.equal(report.rows[0].rowIndex, 1);
-  assert.equal(outputPath, deriveDefaultOutputPath([fixturePath]));
+  assert.equal(report.rows, undefined);
+  assert.equal(outputPath, deriveDefaultOutputPath(fixturePath));
 });
 
-test('buildNormalizedUsageExportRollupFromCsvInputs preserves three adjacent windows without double counting', () => {
+test('buildNormalizedUsageExportReceiptsFromCsvInputs preserves three adjacent windows without double counting', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-usage-export-rollup-'));
   const [janPath, febPath, marPath] = createContiguousUsageExportInputs(tmpDir);
   const inputs = [janPath, febPath, marPath].map((inputPath) => {
@@ -174,55 +169,47 @@ test('buildNormalizedUsageExportRollupFromCsvInputs preserves three adjacent win
     };
   });
 
-  const { report, outputPath } = buildNormalizedUsageExportRollupFromCsvInputs(inputs, {
+  const { reports, outputPaths } = buildNormalizedUsageExportReceiptsFromCsvInputs(inputs, {
     sourceKind: 'operator-private-usage-export-csv'
   }, new Date('2026-03-21T20:10:00.000Z'));
 
-  assert.equal(report.windows.length, 3);
-  assert.equal(report.period.firstDatePartition, '2026-01-15');
-  assert.equal(report.period.lastDatePartition, '2026-03-20');
-  assert.equal(report.period.transitionCount, 2);
-  assert.equal(report.period.contiguousTransitionCount, 2);
-  assert.equal(report.period.gapTransitionCount, 0);
-  assert.equal(report.summary.windowCount, 3);
-  assert.equal(report.summary.transitionCount, 2);
-  assert.equal(report.summary.totalUsageCredits, 45640.2);
-  assert.equal(report.summary.totalUsageQuantity, 912804);
-  assert.deepEqual(report.summary.usageTypes, ['codex']);
-  assert.equal(report.summary.usageTypeTotals[0].rowCount, 49);
-  assert.equal(report.summary.continuityStatus, 'contiguous');
-  assert.equal(report.transitions.length, 2);
-  assert.equal(report.transitions[0].status, 'adjacent');
-  assert.equal(report.transitions[0].gapDays, 0);
-  assert.equal(report.transitions[1].status, 'adjacent');
-  assert.equal(report.transitions[1].gapDays, 0);
-  assert.equal(report.windows[0].continuity.isContiguousWithNext, true);
-  assert.equal(report.windows[1].continuity.isContiguousWithPrevious, true);
-  assert.equal(report.windows[1].continuity.isContiguousWithNext, true);
-  assert.equal(report.windows[2].continuity.isContiguousWithPrevious, true);
-  assert.equal(report.confidence.level, 'high');
-  assert.equal(report.confidence.continuityCoverage, 1);
-  assert.equal(outputPath, deriveDefaultOutputPath(inputs.map((entry) => entry.resolvedPath), report));
+  assert.equal(reports.length, 3);
+  assert.equal(reports[0].reportWindow.startDate, '2026-01-15');
+  assert.equal(reports[2].reportWindow.endDate, '2026-03-20');
+  assert.equal(reports[0].continuity.isContiguousWithNext, true);
+  assert.equal(reports[1].continuity.isContiguousWithPrevious, true);
+  assert.equal(reports[1].continuity.isContiguousWithNext, true);
+  assert.equal(reports[2].continuity.isContiguousWithPrevious, true);
+  assert.equal(reports[0].continuity.windowCount, 3);
+  assert.equal(reports[2].continuity.windowIndex, 3);
+  assert.equal(reports[0].totals.usageCredits, 5599.02);
+  assert.equal(reports[1].totals.usageCredits, 29481.3);
+  assert.equal(reports[2].totals.usageCredits, 10559.88);
+  assert.equal(outputPaths.length, 3);
+  const totalUsageCredits = reports.reduce((sum, report) => sum + report.totals.usageCredits, 0);
+  const totalUsageQuantity = reports.reduce((sum, report) => sum + report.totals.usageQuantity, 0);
+  assert.equal(totalUsageCredits, 45640.2);
+  assert.equal(totalUsageQuantity, 912804);
 });
 
-test('runAgentCostUsageExportNormalize writes a multi-window receipt to the requested output path', () => {
+test('runAgentCostUsageExportNormalize writes receipts to the requested output directory for multiple windows', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-usage-export-run-'));
-  const outputPath = path.join(tmpDir, 'usage-export.json');
+  const outputDir = path.join(tmpDir, 'usage-exports');
   const [janPath, febPath, marPath] = createContiguousUsageExportInputs(tmpDir);
   const result = runAgentCostUsageExportNormalize({
     inputPaths: [janPath, febPath, marPath],
-    outputPath
+    outputPath: outputDir
   }, new Date('2026-03-21T20:10:00.000Z'));
 
-  assert.equal(result.report.summary.windowCount, 3);
-  assert.equal(fs.existsSync(outputPath), true);
-  const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
-  assert.equal(output.windows.length, 3);
+  assert.equal(result.reports.length, 3);
+  assert.equal(fs.existsSync(path.join(outputDir, 'usage-export-2026-01-15.json')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'usage-export-2026-02-15.json')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'usage-export-2026-03-15.json')), true);
 });
 
-test('CLI entrypoint writes the usage export rollup on repeated window inputs', () => {
+test('CLI entrypoint writes the usage export receipts on repeated window inputs', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-usage-export-cli-'));
-  const outputPath = path.join(tmpDir, 'usage-export.json');
+  const outputDir = path.join(tmpDir, 'usage-exports');
   const [janPath, febPath, marPath] = createContiguousUsageExportInputs(tmpDir);
   const result = spawnSync(
     process.execPath,
@@ -235,7 +222,7 @@ test('CLI entrypoint writes the usage export rollup on repeated window inputs', 
       '--input',
       marPath,
       '--output',
-      outputPath
+      outputDir
     ],
     {
       cwd: repoRoot,
@@ -245,6 +232,5 @@ test('CLI entrypoint writes the usage export rollup on repeated window inputs', 
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /\[agent-cost-usage-export-normalize\] wrote /);
-  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(outputDir), true);
 });
-

--- a/tools/priority/agent-cost-usage-export-normalize.mjs
+++ b/tools/priority/agent-cost-usage-export-normalize.mjs
@@ -6,8 +6,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export const REPORT_SCHEMA = 'priority/agent-cost-usage-export@v1';
-export const DEFAULT_OUTPUT_DIR = path.join('tests', 'results', '_agent', 'cost', 'usage-export');
+export const DEFAULT_OUTPUT_DIR = path.join('tests', 'results', '_agent', 'cost', 'usage-exports');
 export const DEFAULT_SOURCE_KIND = 'operator-private-usage-export-csv';
+export const DEFAULT_OPERATOR_NOTE = 'Normalized from a local private account usage export CSV.';
 export const REQUIRED_HEADERS = [
   'date_partition',
   'account_id',
@@ -63,9 +64,9 @@ function parseDatePartition(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function datePartitionDifferenceInDays(leftValue, rightValue) {
-  const left = parseDatePartition(leftValue);
-  const right = parseDatePartition(rightValue);
+function daysBetweenDates(leftDate, rightDate) {
+  const left = parseDatePartition(leftDate);
+  const right = parseDatePartition(rightDate);
   if (left == null || right == null) {
     return null;
   }
@@ -202,96 +203,86 @@ function createUsageTypeTotals(rows) {
   return Array.from(totals.values());
 }
 
-function resolveSourceKind(value) {
-  return normalizeText(value) || DEFAULT_SOURCE_KIND;
+function ensureSingleValue(rows, fieldName, errorMessage) {
+  const firstValue = normalizeText(rows[0][fieldName]);
+  for (const row of rows) {
+    if (normalizeText(row[fieldName]) !== firstValue) {
+      throw new Error(errorMessage);
+    }
+  }
+  return firstValue;
 }
 
-function createWindowReceipt(rows, sourceMeta, now = new Date()) {
+function createReceiptFromRows(rows, sourceMeta, now = new Date()) {
   if (rows.length === 0) {
     throw new Error('Usage export CSV must contain at least one normalized row.');
   }
 
-  const firstRow = rows[0];
-  const accountFields = ['accountId', 'accountUserId', 'email', 'name', 'publicId', 'usageUnits'];
-  for (const row of rows) {
-    for (const field of accountFields) {
-      if (normalizeText(row[field]) !== normalizeText(firstRow[field])) {
-        throw new Error('Usage export CSV must describe one account identity and one usage-units family.');
-      }
-    }
-  }
+  const usageType = ensureSingleValue(rows, 'usageType', 'Usage export CSV must describe one usage type per receipt.');
+  const usageUnits = ensureSingleValue(rows, 'usageUnits', 'Usage export CSV must describe one usage-units family per receipt.');
+  const accountId = ensureSingleValue(rows, 'accountId', 'Usage export CSV must describe one account identity per receipt.');
+  const accountUserId = ensureSingleValue(rows, 'accountUserId', 'Usage export CSV must describe one account identity per receipt.');
+  const email = ensureSingleValue(rows, 'email', 'Usage export CSV must describe one account identity per receipt.');
+  const name = ensureSingleValue(rows, 'name', 'Usage export CSV must describe one account identity per receipt.');
+  const publicId = ensureSingleValue(rows, 'publicId', 'Usage export CSV must describe one account identity per receipt.');
 
   const sortedDatePartitions = [...new Set(rows.map((row) => row.datePartition))].sort();
-  const totalUsageCredits = roundNumber(rows.reduce((sum, row) => sum + row.usageCredits, 0)) ?? 0;
-  const totalUsageQuantity = roundNumber(rows.reduce((sum, row) => sum + row.usageQuantity, 0)) ?? 0;
-  const usageTypeTotals = createUsageTypeTotals(rows);
+  const reportWindow = {
+    startDate: sortedDatePartitions[0],
+    endDate: sortedDatePartitions[sortedDatePartitions.length - 1],
+    rowCount: rows.length
+  };
+  const windowId = `${reportWindow.startDate}..${reportWindow.endDate}`;
+  const totals = {
+    usageCredits: roundNumber(rows.reduce((sum, row) => sum + row.usageCredits, 0)) ?? 0,
+    usageQuantity: roundNumber(rows.reduce((sum, row) => sum + row.usageQuantity, 0)) ?? 0
+  };
   const sourcePath = normalizeText(sourceMeta.sourcePath) || null;
   const sourceFileName = sourcePath ? path.basename(sourcePath) : null;
   const sourceSha256 = normalizeText(sourceMeta.sourceSha256) || null;
-  const sourceKind = resolveSourceKind(sourceMeta.sourceKind);
-  const firstDatePartition = sortedDatePartitions[0];
-  const lastDatePartition = sortedDatePartitions[sortedDatePartitions.length - 1];
-  const windowId = `${firstDatePartition}..${lastDatePartition}`;
+  const sourceKind = normalizeText(sourceMeta.sourceKind) || DEFAULT_SOURCE_KIND;
+  const operatorNote = normalizeText(sourceMeta.operatorNote) || DEFAULT_OPERATOR_NOTE;
 
   return {
-    windowId,
     schema: REPORT_SCHEMA,
     generatedAt: now.toISOString(),
-    source: {
-      kind: sourceKind,
-      path: sourcePath,
-      fileName: sourceFileName,
-      sha256: sourceSha256,
-      header: [...REQUIRED_HEADERS],
-      rowCount: rows.length
-    },
-    account: {
-      accountId: firstRow.accountId,
-      accountUserId: firstRow.accountUserId,
-      email: firstRow.email,
-      name: firstRow.name,
-      publicId: firstRow.publicId
-    },
-    period: {
-      firstDatePartition,
-      lastDatePartition,
-      datePartitionCount: sortedDatePartitions.length
-    },
-    summary: {
-      rowCount: rows.length,
-      usageUnits: firstRow.usageUnits,
-      totalUsageCredits,
-      totalUsageQuantity,
-      usageTypes: usageTypeTotals.map((entry) => entry.usageType),
-      usageTypeTotals
-    },
-    rows,
+    reportWindow,
+    usageType,
+    totals,
+    sourceKind,
+    sourcePathEvidence: sourcePath,
+    operatorNote,
     provenance: {
       sourceKind,
       sourcePath,
+      sourcePathEvidence: sourcePath,
       sourceSha256,
       sourceFileName,
-      accountId: firstRow.accountId,
-      accountUserId: firstRow.accountUserId,
-      publicId: firstRow.publicId,
-      email: firstRow.email,
-      windowId,
-      windowIndex: 1,
-      windowCount: 1
+      accountId,
+      accountUserId,
+      email,
+      name,
+      publicId,
+      usageUnits,
+      usageType,
+      rowCount: rows.length,
+      datePartitionCount: sortedDatePartitions.length,
+      windowId
     },
     confidence: {
       level: 'high',
-      basis: ['csv-header-match', 'row-count-match', 'uniform-account-identity', 'uniform-usage-units', 'numeric-field-parse'],
+      basis: ['csv-header-match', 'row-count-match', 'uniform-account-identity', 'uniform-usage-units', 'uniform-usage-type', 'numeric-field-parse'],
       rowCoverage: 1,
-      accountCoverage: 1
+      accountCoverage: 1,
+      windowCoverage: 1
     },
     continuity: {
       windowIndex: 1,
       windowCount: 1,
       previousWindowId: null,
       nextWindowId: null,
-      previousWindowLastDatePartition: null,
-      nextWindowFirstDatePartition: null,
+      previousReportWindowEndDate: null,
+      nextReportWindowStartDate: null,
       gapDaysFromPrevious: null,
       gapDaysToNext: null,
       isContiguousWithPrevious: null,
@@ -302,7 +293,7 @@ function createWindowReceipt(rows, sourceMeta, now = new Date()) {
   };
 }
 
-function buildWindowReceiptFromCsv(csvText, options = {}, now = new Date()) {
+function buildReceiptFromCsv(csvText, options = {}, now = new Date()) {
   const records = parseCsv(csvText);
   if (records.length < 2) {
     throw new Error('Usage export CSV must contain a header and at least one data row.');
@@ -318,207 +309,76 @@ function buildWindowReceiptFromCsv(csvText, options = {}, now = new Date()) {
     return normalizeRow(header, record, index + 1);
   });
 
-  return createWindowReceipt(rows, options, now);
+  return createReceiptFromRows(rows, options, now);
 }
 
-function buildTransition(prevWindow, nextWindow) {
-  const dayDifference = datePartitionDifferenceInDays(prevWindow.period.lastDatePartition, nextWindow.period.firstDatePartition);
-  if (dayDifference == null) {
-    throw new Error(`Usage export windows ${prevWindow.windowId} and ${nextWindow.windowId} contain invalid dates.`);
-  }
-  if (dayDifference <= 0) {
-    const overlapDays = Math.abs(dayDifference) + 1;
-    throw new Error(
-      `Usage export windows overlap between ${prevWindow.windowId} and ${nextWindow.windowId} by ${overlapDays} day(s).`
-    );
-  }
-
-  const gapDays = dayDifference - 1;
-  return {
-    fromWindowId: prevWindow.windowId,
-    fromWindowIndex: prevWindow.continuity.windowIndex,
-    toWindowId: nextWindow.windowId,
-    toWindowIndex: nextWindow.continuity.windowIndex,
-    fromLastDatePartition: prevWindow.period.lastDatePartition,
-    toFirstDatePartition: nextWindow.period.firstDatePartition,
-    gapDays,
-    overlapDays: 0,
-    status: gapDays === 0 ? 'adjacent' : 'gap',
-    isContiguous: gapDays === 0
-  };
+function readReceiptPath(filePath) {
+  const receipt = buildReceiptFromCsv(fs.readFileSync(path.resolve(filePath), 'utf8'), {
+    sourcePath: path.resolve(filePath),
+    sourceKind: DEFAULT_SOURCE_KIND
+  });
+  return { filePath: path.resolve(filePath), receipt };
 }
 
-function decorateWindowsWithContinuity(windows) {
-  const windowCount = windows.length;
-  if (windowCount === 0) {
-    return { windows: [], transitions: [], contiguousTransitionCount: 0, gapTransitionCount: 0, overlapTransitionCount: 0 };
+function decorateContinuity(receipts) {
+  if (receipts.length === 0) {
+    return [];
   }
 
-  const decorated = windows.map((window, index) => ({
-    ...window,
-    continuity: {
-      windowIndex: index + 1,
-      windowCount,
-      previousWindowId: index > 0 ? windows[index - 1].windowId : null,
-      nextWindowId: index < windowCount - 1 ? windows[index + 1].windowId : null,
-      previousWindowLastDatePartition: index > 0 ? windows[index - 1].period.lastDatePartition : null,
-      nextWindowFirstDatePartition: index < windowCount - 1 ? windows[index + 1].period.firstDatePartition : null,
-      gapDaysFromPrevious: null,
-      gapDaysToNext: null,
-      isContiguousWithPrevious: null,
-      isContiguousWithNext: null,
-      isFirstWindow: index === 0,
-      isLastWindow: index === windowCount - 1
-    },
-    provenance: {
-      ...window.provenance,
-      windowIndex: index + 1,
-      windowCount
+  const ordered = [...receipts].sort((left, right) => {
+    const dateCompare = left.reportWindow.startDate.localeCompare(right.reportWindow.startDate);
+    if (dateCompare !== 0) {
+      return dateCompare;
     }
-  }));
+    return normalizeText(left.sourcePathEvidence).localeCompare(normalizeText(right.sourcePathEvidence));
+  });
 
-  const transitions = [];
-  let contiguousTransitionCount = 0;
-  let gapTransitionCount = 0;
-  let overlapTransitionCount = 0;
+  return ordered.map((receipt, index) => {
+    const previous = index > 0 ? ordered[index - 1] : null;
+    const next = index < ordered.length - 1 ? ordered[index + 1] : null;
 
-  for (let index = 0; index < decorated.length - 1; index += 1) {
-    const transition = buildTransition(decorated[index], decorated[index + 1]);
-    transitions.push(transition);
-    if (transition.isContiguous) {
-      contiguousTransitionCount += 1;
-    } else {
-      gapTransitionCount += 1;
+    if (previous) {
+      const dayDifference = daysBetweenDates(previous.reportWindow.endDate, receipt.reportWindow.startDate);
+      if (dayDifference == null) {
+        throw new Error(`Usage export receipts ${previous.provenance.windowId} and ${receipt.provenance.windowId} contain invalid dates.`);
+      }
+      if (dayDifference <= 0) {
+        throw new Error(`Usage export receipts overlap between ${previous.provenance.windowId} and ${receipt.provenance.windowId}.`);
+      }
     }
-    decorated[index].continuity.gapDaysToNext = transition.gapDays;
-    decorated[index].continuity.isContiguousWithNext = transition.isContiguous;
-    decorated[index + 1].continuity.gapDaysFromPrevious = transition.gapDays;
-    decorated[index + 1].continuity.isContiguousWithPrevious = transition.isContiguous;
-  }
 
-  return { windows: decorated, transitions, contiguousTransitionCount, gapTransitionCount, overlapTransitionCount };
+    const previousGapDays = previous ? Math.max(daysBetweenDates(previous.reportWindow.endDate, receipt.reportWindow.startDate) - 1, 0) : null;
+    const nextGapDays = next ? Math.max(daysBetweenDates(receipt.reportWindow.endDate, next.reportWindow.startDate) - 1, 0) : null;
+
+    return {
+      ...receipt,
+      continuity: {
+        windowIndex: index + 1,
+        windowCount: ordered.length,
+        previousWindowId: previous?.provenance?.windowId || null,
+        nextWindowId: next?.provenance?.windowId || null,
+        previousReportWindowEndDate: previous?.reportWindow?.endDate || null,
+        nextReportWindowStartDate: next?.reportWindow?.startDate || null,
+        gapDaysFromPrevious: previousGapDays,
+        gapDaysToNext: nextGapDays,
+        isContiguousWithPrevious: previous ? previousGapDays === 0 : null,
+        isContiguousWithNext: next ? nextGapDays === 0 : null,
+        isFirstWindow: index === 0,
+        isLastWindow: index === ordered.length - 1
+      },
+      provenance: {
+        ...receipt.provenance,
+        windowIndex: index + 1,
+        windowCount: ordered.length
+      }
+    };
+  });
 }
 
-function aggregateWindows(windows, transitions) {
-  const usageTypeTotals = new Map();
-  const usageUnits = windows[0]?.summary?.usageUnits || null;
-  const account = windows[0]?.account || null;
-  const uniqueDates = new Set();
-  let totalUsageCredits = 0;
-  let totalUsageQuantity = 0;
-  let totalRowCount = 0;
-
-  for (const window of windows) {
-    totalUsageCredits = roundNumber(totalUsageCredits + window.summary.totalUsageCredits) ?? totalUsageCredits;
-    totalUsageQuantity = roundNumber(totalUsageQuantity + window.summary.totalUsageQuantity) ?? totalUsageQuantity;
-    totalRowCount += window.summary.rowCount;
-    for (const row of window.rows) {
-      uniqueDates.add(row.datePartition);
-    }
-    for (const usageTypeTotal of window.summary.usageTypeTotals) {
-      const existing = usageTypeTotals.get(usageTypeTotal.usageType) || {
-        usageType: usageTypeTotal.usageType,
-        rowCount: 0,
-        usageCredits: 0,
-        usageQuantity: 0
-      };
-      existing.rowCount += usageTypeTotal.rowCount;
-      existing.usageCredits = roundNumber(existing.usageCredits + usageTypeTotal.usageCredits) ?? existing.usageCredits;
-      existing.usageQuantity = roundNumber(existing.usageQuantity + usageTypeTotal.usageQuantity) ?? existing.usageQuantity;
-      usageTypeTotals.set(usageTypeTotal.usageType, existing);
-    }
-  }
-
-  const firstWindow = windows[0] || null;
-  const lastWindow = windows[windows.length - 1] || null;
-  const firstDatePartition = firstWindow?.period.firstDatePartition || null;
-  const lastDatePartition = lastWindow?.period.lastDatePartition || null;
-  const transitionCount = transitions.length;
-  const contiguousTransitionCount = transitions.filter((transition) => transition.isContiguous).length;
-  const gapTransitionCount = transitions.filter((transition) => transition.status === 'gap').length;
-  const overlapTransitionCount = 0;
-
-  return {
-    account,
-    period: {
-      firstDatePartition,
-      lastDatePartition,
-      datePartitionCount: uniqueDates.size,
-      windowCount: windows.length,
-      transitionCount,
-      contiguousTransitionCount,
-      gapTransitionCount,
-      overlapTransitionCount
-    },
-    summary: {
-      windowCount: windows.length,
-      transitionCount,
-      contiguousTransitionCount,
-      gapTransitionCount,
-      overlapTransitionCount,
-      rowCount: totalRowCount,
-      totalUsageCredits,
-      totalUsageQuantity,
-      usageUnits,
-      usageTypes: [...usageTypeTotals.keys()],
-      usageTypeTotals: [...usageTypeTotals.values()],
-      continuityStatus: gapTransitionCount === 0 ? 'contiguous' : 'gapped'
-    },
-    source: {
-      kind: windows[0]?.source?.kind || DEFAULT_SOURCE_KIND,
-      inputCount: windows.length,
-      windowCount: windows.length,
-      rowCount: totalRowCount,
-      files: windows.map((window) => ({
-        path: window.source.path,
-        fileName: window.source.fileName,
-        sha256: window.source.sha256,
-        header: [...window.source.header],
-        rowCount: window.source.rowCount,
-        windowId: window.windowId,
-        firstDatePartition: window.period.firstDatePartition,
-        lastDatePartition: window.period.lastDatePartition
-      }))
-    },
-    provenance: {
-      sourceKind: windows[0]?.provenance?.sourceKind || DEFAULT_SOURCE_KIND,
-      sourcePaths: windows.map((window) => window.provenance.sourcePath),
-      sourceSha256s: windows.map((window) => window.provenance.sourceSha256),
-      sourceFileNames: windows.map((window) => window.provenance.sourceFileName),
-      accountId: account?.accountId || null,
-      accountUserId: account?.accountUserId || null,
-      publicId: account?.publicId || null,
-      email: account?.email || null,
-      windowCount: windows.length,
-      windowIds: windows.map((window) => window.windowId)
-    },
-    confidence: {
-      level: gapTransitionCount === 0 ? 'high' : 'medium',
-      basis: gapTransitionCount === 0
-        ? ['csv-header-match', 'row-count-match', 'uniform-account-identity', 'uniform-usage-units', 'numeric-field-parse', 'adjacent-window-continuity']
-        : ['csv-header-match', 'row-count-match', 'uniform-account-identity', 'uniform-usage-units', 'numeric-field-parse', 'window-gap-observed'],
-      rowCoverage: 1,
-      accountCoverage: 1,
-      windowCoverage: 1,
-      continuityCoverage: windows.length <= 1 ? 1 : contiguousTransitionCount / transitions.length
-    },
-    transitions
-  };
-}
-
-export function deriveDefaultOutputPath(inputPaths = [], report = null) {
-  const normalizedPaths = Array.isArray(inputPaths) ? inputPaths.filter((entry) => normalizeText(entry)) : [];
-  if (report?.period?.firstDatePartition && report?.period?.lastDatePartition) {
-    const windowCount = report?.summary?.windowCount ?? report?.windows?.length ?? normalizedPaths.length;
-    const label = `usage-export-${report.period.firstDatePartition}_to_${report.period.lastDatePartition}-${windowCount || 0}-windows.json`;
-    return path.resolve(DEFAULT_OUTPUT_DIR, label);
-  }
-  if (normalizedPaths.length > 0) {
-    const stems = normalizedPaths.map((entry) => sanitizeFileStem(path.basename(entry)) || 'usage-export');
-    const label = `${stems.join('__') || 'usage-export-rollup'}.json`;
-    return path.resolve(DEFAULT_OUTPUT_DIR, label);
-  }
-  return path.resolve(DEFAULT_OUTPUT_DIR, 'usage-export-rollup.json');
+export function deriveDefaultOutputPath(inputPath) {
+  const resolvedPath = normalizeText(inputPath) ? path.resolve(inputPath) : null;
+  const stem = resolvedPath ? sanitizeFileStem(path.basename(resolvedPath)) || 'usage-export' : 'usage-export';
+  return path.resolve(DEFAULT_OUTPUT_DIR, `${stem}.json`);
 }
 
 export function parseArgs(argv = process.argv) {
@@ -527,6 +387,7 @@ export function parseArgs(argv = process.argv) {
     inputPaths: [],
     outputPath: null,
     sourceKind: DEFAULT_SOURCE_KIND,
+    operatorNote: DEFAULT_OPERATOR_NOTE,
     help: false
   };
 
@@ -538,7 +399,7 @@ export function parseArgs(argv = process.argv) {
       options.help = true;
       continue;
     }
-    if (['--input', '--output', '--source-kind'].includes(token)) {
+    if (['--input', '--output', '--source-kind', '--operator-note'].includes(token)) {
       if (!next || next.startsWith('-')) {
         throw new Error(`Missing value for ${token}.`);
       }
@@ -546,6 +407,7 @@ export function parseArgs(argv = process.argv) {
       if (token === '--input') options.inputPaths.push(next);
       if (token === '--output') options.outputPath = next;
       if (token === '--source-kind') options.sourceKind = next;
+      if (token === '--operator-note') options.operatorNote = next;
       continue;
     }
     throw new Error(`Unknown option: ${token}`);
@@ -559,74 +421,66 @@ export function parseArgs(argv = process.argv) {
 }
 
 export function buildNormalizedUsageExportReceiptFromCsv(csvText, options = {}, now = new Date()) {
-  const report = buildWindowReceiptFromCsv(csvText, options, now);
+  const report = buildReceiptFromCsv(csvText, options, now);
   return {
     report,
-    outputPath: deriveDefaultOutputPath([options.inputPath || options.sourcePath || 'usage-export.csv'])
+    outputPath: deriveDefaultOutputPath(options.inputPath || options.sourcePath || 'usage-export.csv')
   };
 }
 
-export function buildNormalizedUsageExportRollupFromCsvInputs(inputs, options = {}, now = new Date()) {
+export function buildNormalizedUsageExportReceiptsFromCsvInputs(inputs, options = {}, now = new Date()) {
   if (!Array.isArray(inputs) || inputs.length === 0) {
     throw new Error('Usage export normalization requires at least one input file.');
   }
 
-  const windows = inputs.map((input) => {
-    const report = buildWindowReceiptFromCsv(input.raw, {
-      sourceKind: options.sourceKind || input.sourceKind || DEFAULT_SOURCE_KIND,
+  const receipts = inputs.map((input) => {
+    const csvText = typeof input.raw === 'string' ? input.raw : fs.readFileSync(path.resolve(input.resolvedPath), 'utf8');
+    return buildReceiptFromCsv(csvText, {
       sourcePath: input.resolvedPath,
+      sourceKind: options.sourceKind || DEFAULT_SOURCE_KIND,
+      operatorNote: options.operatorNote || DEFAULT_OPERATOR_NOTE,
       sourceSha256: input.sourceSha256
     }, now);
-    return report;
   });
 
-  windows.sort((left, right) => {
-    const dateCompare = left.period.firstDatePartition.localeCompare(right.period.firstDatePartition);
-    if (dateCompare !== 0) {
-      return dateCompare;
-    }
-    return (left.source.fileName || left.source.path || '').localeCompare(right.source.fileName || right.source.path || '');
-  });
-
-  const firstWindow = windows[0];
-  const accountFields = ['accountId', 'accountUserId', 'email', 'name', 'publicId'];
-  const usageUnits = firstWindow.summary.usageUnits;
-  for (const window of windows) {
-    for (const field of accountFields) {
-      if (normalizeText(window.account[field]) !== normalizeText(firstWindow.account[field])) {
-        throw new Error('Usage export windows must describe the same account identity.');
-      }
-    }
-    if (normalizeText(window.summary.usageUnits) !== normalizeText(usageUnits)) {
-      throw new Error('Usage export windows must use the same usage-units family.');
-    }
-  }
-
-  const continuity = decorateWindowsWithContinuity(windows);
-  const report = {
-    schema: REPORT_SCHEMA,
-    generatedAt: now.toISOString(),
-    ...aggregateWindows(continuity.windows, continuity.transitions),
-    transitions: continuity.transitions,
-    windows: continuity.windows
+  const decorated = decorateContinuity(receipts);
+  return {
+    reports: decorated,
+    outputPaths: decorated.map((receipt) => path.resolve(DEFAULT_OUTPUT_DIR, `usage-export-${receipt.reportWindow.startDate}.json`))
   };
-  const outputPath = deriveDefaultOutputPath(inputs.map((input) => input.resolvedPath), report);
-  return { report, outputPath };
 }
+
+export const buildNormalizedUsageExportRollupFromCsvInputs = buildNormalizedUsageExportReceiptsFromCsvInputs;
 
 export function runAgentCostUsageExportNormalize(options, now = new Date()) {
   const inputs = options.inputPaths.map((inputPath) => readCsv(inputPath));
-  const result = buildNormalizedUsageExportRollupFromCsvInputs(inputs, {
-    outputPath: options.outputPath,
-    sourceKind: options.sourceKind
+  const result = buildNormalizedUsageExportReceiptsFromCsvInputs(inputs, {
+    sourceKind: options.sourceKind,
+    operatorNote: options.operatorNote
   }, now);
 
-  const outputPath = path.resolve(options.outputPath || result.outputPath);
-  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, `${JSON.stringify(result.report, null, 2)}\n`, 'utf8');
+  const isSingleInput = result.reports.length === 1;
+  const outputBasePath = options.outputPath
+    ? path.resolve(options.outputPath)
+    : isSingleInput
+      ? result.outputPaths[0]
+      : path.resolve(DEFAULT_OUTPUT_DIR);
+
+  fs.mkdirSync(isSingleInput ? path.dirname(outputBasePath) : outputBasePath, { recursive: true });
+
+  if (isSingleInput) {
+    fs.writeFileSync(outputBasePath, `${JSON.stringify(result.reports[0], null, 2)}\n`, 'utf8');
+  } else {
+    for (const receipt of result.reports) {
+      const fileStem = `usage-export-${receipt.reportWindow.startDate}`;
+      const receiptPath = path.join(outputBasePath, `${fileStem}.json`);
+      fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+    }
+  }
+
   return {
     ...result,
-    outputPath
+    outputPath: outputBasePath
   };
 }
 
@@ -634,10 +488,11 @@ function printUsage() {
   console.log('Usage: node tools/priority/agent-cost-usage-export-normalize.mjs [options]');
   console.log('');
   console.log('Options:');
-  console.log('  --input <csv>      Private account usage export CSV path (repeatable, required).');
-  console.log('  --output <path>    Optional receipt output override.');
-  console.log(`  --source-kind <id> Source kind for provenance (default: ${DEFAULT_SOURCE_KIND}).`);
-  console.log('  -h, --help         Show help and exit.');
+  console.log('  --input <csv>         Private account usage export CSV path (repeatable, required).');
+  console.log('  --output <path>       Output receipt file path for one input, or output directory for many inputs.');
+  console.log(`  --source-kind <id>    Source kind for provenance (default: ${DEFAULT_SOURCE_KIND}).`);
+  console.log(`  --operator-note <msg> Operator note recorded on the receipt (default: ${DEFAULT_OPERATOR_NOTE}).`);
+  console.log('  -h, --help            Show help and exit.');
 }
 
 export async function main(argv = process.argv) {
@@ -662,5 +517,3 @@ if (entrypointPath && modulePath === entrypointPath) {
   const exitCode = await main(process.argv);
   process.exit(exitCode);
 }
-
-


### PR DESCRIPTION
## Summary
- align normalized usage export receipts to the rollup-facing standalone contract
- keep contiguous monthly windows separate so Jan, Feb, and Mar private exports can calibrate spend without double counting
- write helper defaults into the canonical `usage-exports` discovery directory used by rollup

## Testing
- node --test tools/priority/__tests__/agent-cost-usage-export-normalize.test.mjs tools/priority/__tests__/agent-cost-usage-export-normalize-schema.test.mjs
- git diff --check