### PR TITLE
Refine merge-queue continuity flow (#1683)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Feature Branch Enforcement & Merge Queue
 
-| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
+| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 1-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
 
 ## Purpose
 
@@ -84,8 +84,8 @@ promotion behavior, not the branch-class source of truth.
 ### GitHub rulesets
 | Ruleset ID | Scope                | Highlights                                                                                   |
 |------------|----------------------|----------------------------------------------------------------------------------------------|
-| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
-| `8614140`  | `refs/heads/main`    | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`, `commit-integrity`. Required approving reviews: `0`. |
+| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 1-minute quiet window). Required checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `agent-review-policy`, `hook-parity`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
+| `8614140`  | `refs/heads/main`    | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 1-minute quiet window). Required checks: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`, `commit-integrity`. Required approving reviews: `0`. |
 | `8614172`  | `refs/heads/release/*` | No merge queue; protects against force-push/deletion. Required checks: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`. Required approving reviews: `0`. |
 
 `node tools/npm/run-script.mjs priority:policy` queries these rulesets and fails if the live configuration drifts from
@@ -266,7 +266,7 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   `grouping_strategy=ALLGREEN`):
   - `grouping_strategy=ALLGREEN`
   - `max_entries_to_build=5`, `min_entries_to_merge=1`, `max_entries_to_merge=5`
-  - `min_entries_to_merge_wait_minutes=5`
+  - `min_entries_to_merge_wait_minutes=1`
   - `check_response_timeout_minutes=60`
 - **Required checks**: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`, `commit-integrity`.
 - **Workflow triggers**: Ensure those required checks run on both `pull_request` and `merge_group` so queued entries can merge.
@@ -309,11 +309,11 @@ to confirm each workflow includes both triggers.
    deletion once the merge materializes. When the PR remains queued after the current helper turn, `priority:queue:supervisor`
    reconciles that deferred cleanup and records the outcome under `deferredBranchCleanup` in
    `tests/results/_agent/queue/queue-supervisor-report.json`.
-   When a queued `develop` PR needs to be amended, run the dedicated helper from a clean checkout of that PR head:
-   `node tools/npm/run-script.mjs priority:queue:refresh -- --pr <number> --repo $REPO`. It is the supported
-   dequeue -> amend -> requeue flow: the helper dequeues the PR through GraphQL, rebases the checked-out branch onto
-   current `develop`, force-pushes with lease, re-arms queue admission via `priority:merge-sync`, and writes
-   `tests/results/_agent/queue/queue-refresh-<pr>.json` as the machine-readable receipt.
+   When a queued `develop` PR needs a base refresh or a safe amendment turn, run the dedicated helper from a clean checkout of that PR head:
+   `node tools/npm/run-script.mjs priority:queue:refresh -- --pr <number> --repo $REPO`. It dequeues the PR through
+   GraphQL, then either rebases the checked-out branch onto current `develop` or, with `--skip-rebase`, force-pushes
+   the already-checked-out PR head as-is for queued amendment flows. It then re-arms queue admission via
+   `priority:merge-sync` and writes `tests/results/_agent/queue/queue-refresh-<pr>.json` as the machine-readable receipt.
 5. For autonomous queueing, run `node tools/npm/run-script.mjs priority:queue:supervisor -- --dry-run` first, then
    `--apply` when trunk health is green. The supervisor enforces required checks, dependency ordering, and queue caps.
    Use `QUEUE_AUTOPILOT_MAX_INFLIGHT` for cap tuning and keep `QUEUE_AUTOPILOT_ADAPTIVE_CAP=1`

--- a/docs/schemas/queue-refresh-receipt-v1.schema.json
+++ b/docs/schemas/queue-refresh-receipt-v1.schema.json
@@ -183,11 +183,15 @@
         {
           "type": "object",
           "required": [
+            "mode",
             "baseRemoteRef",
             "forcePushTarget",
             "rebasedHeadSha"
           ],
           "properties": {
+            "mode": {
+              "enum": ["rebase", "amend", null]
+            },
             "baseRemoteRef": {
               "type": ["string", "null"]
             },

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -596,6 +596,8 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   );
   const developMergeQueueRule = rulesetDevelop.rules.find((rule) => rule.type === 'merge_queue');
   assert.ok(developMergeQueueRule, 'merge_queue rule expected on develop');
+  assert.equal(developMergeQueueRule.parameters.max_entries_to_build, 5);
+  assert.equal(developMergeQueueRule.parameters.max_entries_to_merge, 5);
   assert.equal(developMergeQueueRule.parameters.min_entries_to_merge_wait_minutes, 1);
   const developPullRule = rulesetDevelop.rules.find((rule) => rule.type === 'pull_request');
   assert.deepEqual(

--- a/tools/priority/__tests__/queue-refresh-pr.test.mjs
+++ b/tools/priority/__tests__/queue-refresh-pr.test.mjs
@@ -63,6 +63,7 @@ test('parseArgs accepts queue refresh receipt and merge-summary flags', () => {
     'owner/repo',
     '--head-remote',
     'origin',
+    '--skip-rebase',
     '--summary-path',
     'tests/results/_agent/queue/queue-refresh-1568.json',
     '--merge-summary-path',
@@ -74,6 +75,7 @@ test('parseArgs accepts queue refresh receipt and merge-summary flags', () => {
     pr: 1568,
     repo: 'owner/repo',
     headRemote: 'origin',
+    skipRebase: true,
     summaryPath: 'tests/results/_agent/queue/queue-refresh-1568.json',
     mergeSummaryPath: 'tests/results/_agent/queue/merge-sync-1568.json',
     dryRun: true
@@ -92,6 +94,7 @@ test('runQueueRefresh skips non-queued PRs without dequeueing, rebasing, or requ
       pr: 123,
       repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
       headRemote: null,
+      skipRebase: false,
       summaryPath: 'memory://queue-refresh-123.json',
       mergeSummaryPath: 'memory://merge-sync-123.json',
       dryRun: false
@@ -144,6 +147,7 @@ test('runQueueRefresh dequeues, rebases, force-pushes, and re-arms merge queue a
       pr: 123,
       repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
       headRemote: null,
+      skipRebase: false,
       summaryPath: 'memory://queue-refresh-123.json',
       mergeSummaryPath: 'memory://merge-sync-123.json',
       dryRun: false
@@ -204,6 +208,7 @@ test('runQueueRefresh dequeues, rebases, force-pushes, and re-arms merge queue a
   assert.equal(receipt.dequeue.status, 'completed');
   assert.equal(receipt.dequeue.finalIsInMergeQueue, false);
   assert.equal(receipt.refresh.status, 'completed');
+  assert.equal(receipt.refresh.mode, 'rebase');
   assert.equal(receipt.refresh.rebasedHeadSha, 'fedcba9876543210fedcba9876543210fedcba98');
   assert.equal(receipt.requeue.status, 'completed');
   assert.equal(receipt.requeue.promotionStatus, 'queued');
@@ -244,6 +249,7 @@ test('runQueueRefresh aborts the rebase and records a failed receipt when local 
         pr: 123,
         repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
         headRemote: null,
+        skipRebase: false,
         summaryPath: 'memory://queue-refresh-123.json',
         mergeSummaryPath: 'memory://merge-sync-123.json',
         dryRun: false
@@ -296,4 +302,108 @@ test('runQueueRefresh aborts the rebase and records a failed receipt when local 
     ['rebase', 'upstream/develop'],
     ['rebase', '--abort']
   ]);
+});
+
+test('runQueueRefresh can amend a queued PR without rebasing when local head is already checked out', async () => {
+  const gitCalls = [];
+  const mergeSyncCalls = [];
+  let queueReads = 0;
+
+  const { receipt } = await runQueueRefresh({
+    repoRoot: process.cwd(),
+    args: {
+      pr: 123,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      headRemote: null,
+      skipRebase: true,
+      summaryPath: 'memory://queue-refresh-123.json',
+      mergeSummaryPath: 'memory://merge-sync-123.json',
+      dryRun: false
+    },
+    ensureGhCliFn: () => {},
+    readPolicyFn: async () => buildQueuePolicy(),
+    readPullRequestViewFn: async () => buildPullRequestView(),
+    readPullRequestQueueStateFn: async () => {
+      queueReads += 1;
+      return queueReads === 1 ? buildQueueState({ isInMergeQueue: true }) : buildQueueState({ isInMergeQueue: false });
+    },
+    dequeuePullRequestFn: async () => ({}),
+    runGitCommandFn: (_repoRoot, args) => {
+      gitCalls.push(args);
+      if (args[0] === 'status') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return { status: 0, stdout: 'fedcba9876543210fedcba9876543210fedcba98\n', stderr: '' };
+      }
+      if (args[0] === 'push') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`);
+    },
+    readCurrentBranchFn: () => 'issue/origin-123-queue-refresh',
+    readTrackingRemoteFn: () => 'origin',
+    resolveHeadRemoteNameFn: () => ({ remoteName: 'origin', source: 'test' }),
+    runMergeSyncFn: async (payload) => {
+      mergeSyncCalls.push(payload);
+      return {
+        promotion: {
+          status: 'queued',
+          materialized: true
+        },
+        finalMode: 'auto',
+        finalReason: 'merge-state-blocked'
+      };
+    },
+    sleepFn: async () => {},
+    writeReceiptFn: async (receiptPath) => receiptPath
+  });
+
+  assert.equal(receipt.refresh.status, 'completed');
+  assert.equal(receipt.refresh.mode, 'amend');
+  assert.equal(receipt.refresh.reason, 'amended-and-pushed');
+  assert.deepEqual(gitCalls, [
+    ['status', '--porcelain'],
+    ['rev-parse', 'HEAD'],
+    ['push', '--force-with-lease', 'origin', 'HEAD:issue/origin-123-queue-refresh']
+  ]);
+  assert.equal(mergeSyncCalls.length, 1);
+});
+
+test('runQueueRefresh amend mode fails closed when the checked-out branch is not the PR head', async () => {
+  let queueReads = 0;
+  await assert.rejects(
+    runQueueRefresh({
+      repoRoot: process.cwd(),
+      args: {
+        pr: 123,
+        repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        headRemote: null,
+        skipRebase: true,
+        summaryPath: 'memory://queue-refresh-123.json',
+        mergeSummaryPath: 'memory://merge-sync-123.json',
+        dryRun: false
+      },
+      ensureGhCliFn: () => {},
+      readPolicyFn: async () => buildQueuePolicy(),
+      readPullRequestViewFn: async () => buildPullRequestView(),
+      readPullRequestQueueStateFn: async () => {
+        queueReads += 1;
+        return queueReads === 1 ? buildQueueState({ isInMergeQueue: true }) : buildQueueState({ isInMergeQueue: false });
+      },
+      dequeuePullRequestFn: async () => ({}),
+      runGitCommandFn: (_repoRoot, args) => {
+        if (args[0] === 'status') {
+          return { status: 0, stdout: '', stderr: '' };
+        }
+        throw new Error(`Unexpected git args: ${args.join(' ')}`);
+      },
+      readCurrentBranchFn: () => 'develop',
+      readTrackingRemoteFn: () => 'origin',
+      resolveHeadRemoteNameFn: () => ({ remoteName: 'origin', source: 'test' }),
+      runMergeSyncFn: async () => ({}),
+      writeReceiptFn: async (receiptPath) => receiptPath
+    }),
+    /Queue amend mode requires the checked-out branch/
+  );
 });

--- a/tools/priority/queue-refresh-pr.mjs
+++ b/tools/priority/queue-refresh-pr.mjs
@@ -22,6 +22,7 @@ const USAGE_LINES = [
   '  --pr <number>             Pull request number to refresh/amend safely (required)',
   '  --repo <owner/repo>       Target repository (defaults to upstream remote)',
   '  --head-remote <name>      Explicit remote for the PR head branch (default: infer from checkout/remotes)',
+  '  --skip-rebase             Dequeue, force-push the checked-out PR head branch as-is, and requeue without rebasing',
   '  --summary-path <path>     Write queue-refresh receipt JSON (default: tests/results/_agent/queue/queue-refresh-<pr>.json)',
   '  --merge-summary-path <path>',
   '                            Write nested merge-sync summary JSON (default: tests/results/_agent/queue/merge-sync-<pr>.json)',
@@ -70,6 +71,7 @@ export function parseArgs(argv = process.argv) {
     pr: null,
     repo: null,
     headRemote: null,
+    skipRebase: false,
     summaryPath: null,
     mergeSummaryPath: null,
     dryRun: false
@@ -83,6 +85,10 @@ export function parseArgs(argv = process.argv) {
     }
     if (arg === '--dry-run') {
       options.dryRun = true;
+      continue;
+    }
+    if (arg === '--skip-rebase') {
+      options.skipRebase = true;
       continue;
     }
     if (
@@ -416,6 +422,7 @@ function createReceipt({
       status: 'skipped',
       reason: null,
       helperCallsExecuted: [],
+      mode: null,
       baseRemoteRef: baseRefName ? `upstream/${baseRefName}` : null,
       forcePushTarget: headRemote && headRefName ? `${headRemote}:${headRefName}` : null,
       rebasedHeadSha: null
@@ -543,6 +550,12 @@ export async function runQueueRefresh(options = {}) {
 
     ensureCleanWorkingTree(repoRoot, { runGitCommandFn });
 
+    if (args.skipRebase && currentBranch !== headRefName) {
+      throw new Error(
+        `Queue amend mode requires the checked-out branch '${headRefName}', but found '${currentBranch || 'HEAD'}'.`
+      );
+    }
+
     if (args.dryRun) {
       receipt.dequeue = {
         ...receipt.dequeue,
@@ -556,7 +569,8 @@ export async function runQueueRefresh(options = {}) {
         ...receipt.refresh,
         attempted: true,
         status: 'dry-run',
-        reason: 'dry-run'
+        reason: 'dry-run',
+        mode: args.skipRebase ? 'amend' : 'rebase'
       };
       receipt.requeue = {
         ...receipt.requeue,
@@ -596,42 +610,45 @@ export async function runQueueRefresh(options = {}) {
 
     currentStep = 'refresh';
     receipt.refresh.attempted = true;
-    receipt.refresh.helperCallsExecuted.push(`git fetch upstream ${baseRefName}`);
-    const upstreamFetch = runGitCommandFn(repoRoot, ['fetch', 'upstream', baseRefName], { allowFailure: true });
-    if (upstreamFetch.status !== 0) {
-      throw new Error(formatCommandError('git', ['fetch', 'upstream', baseRefName], upstreamFetch));
-    }
-
-    receipt.refresh.helperCallsExecuted.push(`git fetch ${headRemote.remoteName} ${headRefName}`);
-    const headFetch = runGitCommandFn(repoRoot, ['fetch', headRemote.remoteName, headRefName], { allowFailure: true });
-    if (headFetch.status !== 0) {
-      throw new Error(formatCommandError('git', ['fetch', headRemote.remoteName, headRefName], headFetch));
-    }
-
-    if (currentBranch !== headRefName) {
-      receipt.refresh.helperCallsExecuted.push(`git checkout ${headRefName}`);
-      let checkout = runGitCommandFn(repoRoot, ['checkout', headRefName], { allowFailure: true });
-      if (checkout.status !== 0) {
-        receipt.refresh.helperCallsExecuted.push(
-          `git checkout -b ${headRefName} --track ${headRemote.remoteName}/${headRefName}`
-        );
-        checkout = runGitCommandFn(
-          repoRoot,
-          ['checkout', '-b', headRefName, '--track', `${headRemote.remoteName}/${headRefName}`],
-          { allowFailure: true }
-        );
+    receipt.refresh.mode = args.skipRebase ? 'amend' : 'rebase';
+    if (!args.skipRebase) {
+      receipt.refresh.helperCallsExecuted.push(`git fetch upstream ${baseRefName}`);
+      const upstreamFetch = runGitCommandFn(repoRoot, ['fetch', 'upstream', baseRefName], { allowFailure: true });
+      if (upstreamFetch.status !== 0) {
+        throw new Error(formatCommandError('git', ['fetch', 'upstream', baseRefName], upstreamFetch));
       }
-      if (checkout.status !== 0) {
-        throw new Error(formatCommandError('git', ['checkout', headRefName], checkout));
-      }
-    }
 
-    receipt.refresh.helperCallsExecuted.push(`git rebase upstream/${baseRefName}`);
-    const rebase = runGitCommandFn(repoRoot, ['rebase', `upstream/${baseRefName}`], { allowFailure: true });
-    if (rebase.status !== 0) {
-      receipt.refresh.helperCallsExecuted.push('git rebase --abort');
-      runGitCommandFn(repoRoot, ['rebase', '--abort'], { allowFailure: true });
-      throw new Error(formatCommandError('git', ['rebase', `upstream/${baseRefName}`], rebase));
+      receipt.refresh.helperCallsExecuted.push(`git fetch ${headRemote.remoteName} ${headRefName}`);
+      const headFetch = runGitCommandFn(repoRoot, ['fetch', headRemote.remoteName, headRefName], { allowFailure: true });
+      if (headFetch.status !== 0) {
+        throw new Error(formatCommandError('git', ['fetch', headRemote.remoteName, headRefName], headFetch));
+      }
+
+      if (currentBranch !== headRefName) {
+        receipt.refresh.helperCallsExecuted.push(`git checkout ${headRefName}`);
+        let checkout = runGitCommandFn(repoRoot, ['checkout', headRefName], { allowFailure: true });
+        if (checkout.status !== 0) {
+          receipt.refresh.helperCallsExecuted.push(
+            `git checkout -b ${headRefName} --track ${headRemote.remoteName}/${headRefName}`
+          );
+          checkout = runGitCommandFn(
+            repoRoot,
+            ['checkout', '-b', headRefName, '--track', `${headRemote.remoteName}/${headRefName}`],
+            { allowFailure: true }
+          );
+        }
+        if (checkout.status !== 0) {
+          throw new Error(formatCommandError('git', ['checkout', headRefName], checkout));
+        }
+      }
+
+      receipt.refresh.helperCallsExecuted.push(`git rebase upstream/${baseRefName}`);
+      const rebase = runGitCommandFn(repoRoot, ['rebase', `upstream/${baseRefName}`], { allowFailure: true });
+      if (rebase.status !== 0) {
+        receipt.refresh.helperCallsExecuted.push('git rebase --abort');
+        runGitCommandFn(repoRoot, ['rebase', '--abort'], { allowFailure: true });
+        throw new Error(formatCommandError('git', ['rebase', `upstream/${baseRefName}`], rebase));
+      }
     }
 
     const rebasedHeadSha = normalizeText(runGitCommandFn(repoRoot, ['rev-parse', 'HEAD']).stdout) || null;
@@ -645,7 +662,7 @@ export async function runQueueRefresh(options = {}) {
       );
     }
     receipt.refresh.status = 'completed';
-    receipt.refresh.reason = 'rebased-and-pushed';
+    receipt.refresh.reason = args.skipRebase ? 'amended-and-pushed' : 'rebased-and-pushed';
     receipt.refresh.rebasedHeadSha = rebasedHeadSha;
 
     currentStep = 'requeue';


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1683
- Issue title: [program]: refine develop merge-queue continuity and queued-branch amendment flow
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1683
- Standing priority at PR creation: Yes (#1683)
- Base branch: `develop`
- Head branch: `issue/origin-1683-merge-queue-continuity`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
