### PR TITLE
#1682 infer active lane branch for agent-cost turns

### DIFF
--- a/tools/priority/__tests__/agent-cost-turn.test.mjs
+++ b/tools/priority/__tests__/agent-cost-turn.test.mjs
@@ -9,76 +9,112 @@ import { spawnSync } from 'node:child_process';
 
 import { buildAgentCostTurn, parseArgs, runAgentCostTurn } from '../agent-cost-turn.mjs';
 
+function withEnv(updates, callback) {
+  const original = new Map();
+  for (const [key, value] of Object.entries(updates)) {
+    original.set(key, process.env[key]);
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of original.entries()) {
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 test('parseArgs captures reasoning-effort metadata and derives effective defaults', () => {
-  const parsed = parseArgs([
-    'node',
-    'agent-cost-turn.mjs',
-    '--provider-id', 'codex-cli',
-    '--provider-kind', 'local-codex',
-    '--provider-runtime', 'codex-cli',
-    '--execution-plane', 'wsl2',
-    '--requested-model', 'gpt-5.4',
-    '--requested-reasoning-effort', 'xhigh',
-    '--repository', 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-    '--issue-number', '1644',
-    '--lane-id', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    '--lane-branch', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    '--session-id', 'session-live-1644',
-    '--turn-id', 'turn-live-1644',
-    '--agent-role', 'live',
-    '--source-schema', 'priority/manual-live-session@v1',
-    '--usage-observed-at', '2026-03-21T18:40:00.000Z'
-  ]);
+  const parsed = withEnv(
+    {
+      GITHUB_HEAD_REF: 'issue/origin-1644-reasoning-effort-model-selection-telemetry'
+    },
+    () =>
+      parseArgs([
+        'node',
+        'agent-cost-turn.mjs',
+        '--provider-id', 'codex-cli',
+        '--provider-kind', 'local-codex',
+        '--provider-runtime', 'codex-cli',
+        '--execution-plane', 'wsl2',
+        '--requested-model', 'gpt-5.4',
+        '--requested-reasoning-effort', 'xhigh',
+        '--repository', 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        '--issue-number', '1644',
+        '--lane-id', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
+        '--session-id', 'session-live-1644',
+        '--turn-id', 'turn-live-1644',
+        '--agent-role', 'live',
+        '--source-schema', 'priority/manual-live-session@v1',
+        '--usage-observed-at', '2026-03-21T18:40:00.000Z'
+      ])
+  );
 
   assert.equal(parsed.effectiveModel, 'gpt-5.4');
   assert.equal(parsed.requestedReasoningEffort, 'xhigh');
   assert.equal(parsed.effectiveReasoningEffort, 'xhigh');
   assert.equal(parsed.usageUnitCount, 1);
   assert.equal(parsed.operatorSteered, false);
+  assert.equal(parsed.laneBranch, 'issue/origin-1644-reasoning-effort-model-selection-telemetry');
 });
 
 test('buildAgentCostTurn writes a normalized receipt with reasoning effort and steering metadata', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-cost-turn-'));
   const outputPath = path.join(tmpDir, 'turn.json');
-  const result = buildAgentCostTurn({
-    providerId: 'codex-cli',
-    providerKind: 'local-codex',
-    providerRuntime: 'codex-cli',
-    executionPlane: 'wsl2',
-    requestedModel: 'gpt-5.4',
-    effectiveModel: 'gpt-5.4',
-    requestedReasoningEffort: 'xhigh',
-    effectiveReasoningEffort: 'xhigh',
-    inputTokens: 1000,
-    cachedInputTokens: 0,
-    outputTokens: 250,
-    usageUnitKind: 'turn',
-    usageUnitCount: 1,
-    exactness: 'estimated',
-    amountUsd: 0.05,
-    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
-    issueNumber: 1644,
-    laneId: 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    laneBranch: 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-    sessionId: 'session-live-1644',
-    turnId: 'turn-live-1644',
-    workerSlotId: 'worker-slot-1',
-    agentRole: 'live',
-    sourceSchema: 'priority/manual-live-session@v1',
-    sourceReceiptPath: 'tests/results/_agent/runtime/live-turn-1644.json',
-    sourceReportPath: null,
-    usageObservedAt: '2026-03-21T18:40:00.000Z',
-    operatorSteered: true,
-    operatorSteeringKind: 'operator-prompt',
-    operatorSteeringSource: 'operator-observed',
-    operatorSteeringObservedAt: '2026-03-21T18:39:30.000Z',
-    operatorSteeringNote: 'Operator provided extra steering for this calibration turn.',
-    steeringInvoiceTurnId: 'invoice-turn-2026-03-HQ1VJLMV-0027',
-    outputPath
-  }, new Date('2026-03-21T18:41:00.000Z'));
+  const result = withEnv(
+    {
+      GITHUB_HEAD_REF: 'issue/origin-1644-reasoning-effort-model-selection-telemetry'
+    },
+    () =>
+      buildAgentCostTurn({
+        providerId: 'codex-cli',
+        providerKind: 'local-codex',
+        providerRuntime: 'codex-cli',
+        executionPlane: 'wsl2',
+        requestedModel: 'gpt-5.4',
+        effectiveModel: 'gpt-5.4',
+        requestedReasoningEffort: 'xhigh',
+        effectiveReasoningEffort: 'xhigh',
+        inputTokens: 1000,
+        cachedInputTokens: 0,
+        outputTokens: 250,
+        usageUnitKind: 'turn',
+        usageUnitCount: 1,
+        exactness: 'estimated',
+        amountUsd: 0.05,
+        repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        issueNumber: 1644,
+        laneId: 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
+        sessionId: 'session-live-1644',
+        turnId: 'turn-live-1644',
+        workerSlotId: 'worker-slot-1',
+        agentRole: 'live',
+        sourceSchema: 'priority/manual-live-session@v1',
+        sourceReceiptPath: 'tests/results/_agent/runtime/live-turn-1644.json',
+        sourceReportPath: null,
+        usageObservedAt: '2026-03-21T18:40:00.000Z',
+        operatorSteered: true,
+        operatorSteeringKind: 'operator-prompt',
+        operatorSteeringSource: 'operator-observed',
+        operatorSteeringObservedAt: '2026-03-21T18:39:30.000Z',
+        operatorSteeringNote: 'Operator provided extra steering for this calibration turn.',
+        steeringInvoiceTurnId: 'invoice-turn-2026-03-HQ1VJLMV-0027',
+        outputPath
+      }, new Date('2026-03-21T18:41:00.000Z'))
+  );
 
   assert.equal(result.report.model.requestedReasoningEffort, 'xhigh');
   assert.equal(result.report.model.effectiveReasoningEffort, 'xhigh');
+  assert.equal(result.report.context.laneBranch, 'issue/origin-1644-reasoning-effort-model-selection-telemetry');
   assert.equal(result.report.steering.operatorIntervened, true);
   assert.equal(result.report.steering.kind, 'operator-prompt');
   assert.equal(result.report.steering.invoiceTurnId, 'invoice-turn-2026-03-HQ1VJLMV-0027');
@@ -105,7 +141,6 @@ test('agent-cost-turn CLI writes a receipt directly', () => {
       '--repository', 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
       '--issue-number', '1644',
       '--lane-id', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
-      '--lane-branch', 'issue/origin-1644-reasoning-effort-model-selection-telemetry',
       '--session-id', 'session-live-1644',
       '--turn-id', 'turn-live-1644',
       '--agent-role', 'live',
@@ -118,6 +153,10 @@ test('agent-cost-turn CLI writes a receipt directly', () => {
     ],
     {
       cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_HEAD_REF: 'issue/origin-1644-reasoning-effort-model-selection-telemetry'
+      },
       encoding: 'utf8'
     }
   );
@@ -126,6 +165,7 @@ test('agent-cost-turn CLI writes a receipt directly', () => {
   assert.match(result.stdout, /\[agent-cost-turn\] wrote /);
   assert.equal(fs.existsSync(outputPath), true);
   const output = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.equal(output.context.laneBranch, 'issue/origin-1644-reasoning-effort-model-selection-telemetry');
   assert.equal(output.steering.operatorIntervened, true);
   assert.equal(output.steering.kind, 'operator-prompt');
 });

--- a/tools/priority/agent-cost-turn.mjs
+++ b/tools/priority/agent-cost-turn.mjs
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 export const REPORT_SCHEMA = 'priority/agent-cost-turn@v1';
@@ -39,6 +40,38 @@ function normalizeReasoningEffort(value) {
 function sanitizeFileSegment(value, fallback) {
   const normalized = normalizeText(value).replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
   return normalized || fallback;
+}
+
+function resolveActiveLaneBranch(explicitLaneBranch, env = process.env, execSyncFn = execSync) {
+  const explicit = normalizeText(explicitLaneBranch);
+  if (explicit) {
+    return explicit;
+  }
+
+  const headRef = normalizeText(env?.GITHUB_HEAD_REF);
+  if (headRef) {
+    return headRef;
+  }
+
+  const refName = normalizeText(env?.GITHUB_REF_NAME);
+  if (refName && refName !== 'merge') {
+    return refName;
+  }
+
+  try {
+    const currentBranch = normalizeText(
+      execSyncFn('git branch --show-current', {
+        stdio: ['ignore', 'pipe', 'ignore']
+      }).toString('utf8')
+    );
+    if (currentBranch) {
+      return currentBranch;
+    }
+  } catch {
+    // Ignore git fallback failures and surface a clear validation error below.
+  }
+
+  return '';
 }
 
 export function parseArgs(argv = process.argv) {
@@ -213,7 +246,6 @@ export function parseArgs(argv = process.argv) {
     ['requestedModel', '--requested-model'],
     ['repository', '--repository'],
     ['laneId', '--lane-id'],
-    ['laneBranch', '--lane-branch'],
     ['sessionId', '--session-id'],
     ['turnId', '--turn-id'],
     ['agentRole', '--agent-role'],
@@ -230,6 +262,7 @@ export function parseArgs(argv = process.argv) {
     throw new Error('Missing required option: --issue-number <integer>.');
   }
 
+  options.laneBranch = resolveActiveLaneBranch(options.laneBranch);
   options.inputTokens = toNonNegativeInteger(options.inputTokens) ?? 0;
   options.cachedInputTokens = toNonNegativeInteger(options.cachedInputTokens) ?? 0;
   options.outputTokens = toNonNegativeInteger(options.outputTokens) ?? 0;
@@ -246,6 +279,9 @@ export function parseArgs(argv = process.argv) {
   }
   if (!['live', 'background'].includes(normalizeText(options.agentRole).toLowerCase())) {
     throw new Error('agent-role must be live or background.');
+  }
+  if (!normalizeText(options.laneBranch)) {
+    throw new Error('Missing required option: --lane-branch <value> or a resolvable active branch.');
   }
 
   options.effectiveModel = normalizeText(options.effectiveModel) || normalizeText(options.requestedModel);
@@ -270,6 +306,7 @@ export function buildAgentCostTurn(options, now = new Date()) {
   const normalizedRequestedReasoningEffort = normalizeReasoningEffort(options.requestedReasoningEffort);
   const normalizedEffectiveReasoningEffort =
     normalizeReasoningEffort(options.effectiveReasoningEffort) ?? normalizedRequestedReasoningEffort;
+  const resolvedLaneBranch = resolveActiveLaneBranch(options.laneBranch);
   const normalizedInputTokens = toNonNegativeInteger(options.inputTokens) ?? 0;
   const normalizedCachedInputTokens = toNonNegativeInteger(options.cachedInputTokens) ?? 0;
   const normalizedOutputTokens = toNonNegativeInteger(options.outputTokens) ?? 0;
@@ -357,7 +394,7 @@ export function buildAgentCostTurn(options, now = new Date()) {
       repository: normalizeText(options.repository),
       issueNumber: options.issueNumber,
       laneId: normalizeText(options.laneId),
-      laneBranch: normalizeText(options.laneBranch),
+      laneBranch: resolvedLaneBranch,
       sessionId: normalizeText(options.sessionId),
       turnId: normalizeText(options.turnId),
       workerSlotId: normalizeText(options.workerSlotId) || null,
@@ -404,7 +441,7 @@ function printUsage() {
   console.log('  --repository <owner/repo>');
   console.log('  --issue-number <integer>');
   console.log('  --lane-id <value>');
-  console.log('  --lane-branch <value>');
+  console.log('  --lane-branch <value>    Optional; defaults to GITHUB_HEAD_REF or the current git branch.');
   console.log('  --session-id <value>');
   console.log('  --turn-id <value>');
   console.log('  --agent-role <live|background>');


### PR DESCRIPTION
This moves the branch-attributed cost turn seam into the upstream compare-vi-cli-action repo while keeping the existing commit set intact.\n\nValidation:\n- node --test tools/priority/__tests__/agent-cost-turn.test.mjs\n- git diff --check\n