### PR TITLE
#1691 expose Sagan in runtime telemetry

### DIFF
--- a/docs/schemas/delivery-agent-runtime-state-v1.schema.json
+++ b/docs/schemas/delivery-agent-runtime-state-v1.schema.json
@@ -385,6 +385,7 @@
         "occupiedSlotCount": { "type": "integer", "minimum": 0 },
         "availableSlotCount": { "type": "integer", "minimum": 0 },
         "releasedLaneCount": { "type": "integer", "minimum": 0 },
+        "liveOrchestratorLane": { "type": "string" },
         "releasedLanes": {
           "type": "array",
           "items": { "$ref": "#/$defs/releasedLane" }

--- a/docs/schemas/throughput-scorecard-v1.schema.json
+++ b/docs/schemas/throughput-scorecard-v1.schema.json
@@ -37,7 +37,8 @@
         "availableSlotCount",
         "releasedLaneCount",
         "utilizationRatio",
-        "activeCodingLanes"
+        "activeCodingLanes",
+        "liveOrchestratorLane"
       ],
       "properties": {
         "targetSlotCount": { "type": "integer", "minimum": 0 },
@@ -45,7 +46,8 @@
         "availableSlotCount": { "type": "integer", "minimum": 0 },
         "releasedLaneCount": { "type": "integer", "minimum": 0 },
         "utilizationRatio": { "type": "number", "minimum": 0 },
-        "activeCodingLanes": { "type": "integer", "minimum": 0 }
+        "activeCodingLanes": { "type": "integer", "minimum": 0 },
+        "liveOrchestratorLane": { "type": "string" }
       }
     },
     "queue": {

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -3576,6 +3576,7 @@ test('comparevi canonical execution persists a broker-managed ready-for-review r
   const persistedState = await readJson(path.join(runtimeDir, 'delivery-agent-state.json'));
   assert.equal(persistedState.status, 'running');
   assert.equal(persistedState.laneLifecycle, 'waiting-review');
+  assert.equal(persistedState.workerPool.liveOrchestratorLane, 'Sagan');
   assert.equal(persistedState.activeLane.laneId, 'origin-1012');
   assert.equal(persistedState.activeLane.prUrl, 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1015');
   assert.equal(persistedState.activeLane.blockerClass, 'review');

--- a/tools/priority/__tests__/throughput-scorecard.test.mjs
+++ b/tools/priority/__tests__/throughput-scorecard.test.mjs
@@ -66,6 +66,7 @@ test('buildThroughputScorecard warns when actionable work exists while the worke
   assert.deepEqual(report.summary.reasons, ['actionable-work-with-idle-worker-pool', 'merge-queue-occupancy-below-floor']);
   assert.equal(report.summary.metrics.readyPrInventory, 2);
   assert.equal(report.summary.metrics.currentWorkerUtilizationRatio, 0);
+  assert.equal(report.workerPool.liveOrchestratorLane, 'Sagan');
   assert.equal(report.mergeQueueUtilization.status, 'warn');
   assert.equal(report.mergeQueueUtilization.observed.occupancyRatio, 0);
   assert.deepEqual(report.mergeQueueUtilization.reasons, ['merge-queue-occupancy-below-floor']);
@@ -185,6 +186,7 @@ test('runThroughputScorecard writes a pass report when queue pressure and worker
   assert.equal(result.report.mergeQueueUtilization.status, 'pass');
   assert.equal(result.report.concurrentLanes.status, 'active');
   assert.equal(result.report.concurrentLanes.workerDisposition, 'retain');
+  assert.equal(result.report.workerPool.liveOrchestratorLane, 'Sagan');
   assert.equal(result.report.concurrentLanes.deferredLaneCount, 1);
   assert.equal(result.report.summary.metrics.concurrentLaneActiveCount, 2);
   assert.equal(result.report.summary.metrics.concurrentLaneDeferredCount, 1);

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -49,6 +49,7 @@ export const DELIVERY_AGENT_POLICY_SCHEMA = 'priority/delivery-agent-policy@v1';
 export const DELIVERY_AGENT_RUNTIME_STATE_SCHEMA = 'priority/delivery-agent-runtime-state@v1';
 export const DELIVERY_AGENT_LANE_STATE_SCHEMA = 'priority/delivery-agent-lane-state@v1';
 export const READY_VALIDATION_CLEARANCE_SCHEMA = 'priority/ready-validation-clearance@v1';
+export const LIVE_ORCHESTRATOR_LANE_NAME = 'Sagan';
 export const DELIVERY_AGENT_POLICY_RELATIVE_PATH = path.join('tools', 'priority', 'delivery-agent.policy.json');
 export const DELIVERY_AGENT_STATE_FILENAME = 'delivery-agent-state.json';
 export const DELIVERY_AGENT_LANES_DIRNAME = 'delivery-agent-lanes';
@@ -2310,6 +2311,7 @@ function buildWorkerPoolRuntimeState({ policy, laneId, issue, laneLifecycle, pre
     prewarmSlotCount: workerPoolPolicy.prewarmSlotCount,
     releaseWaitingStates: [...workerPoolPolicy.releaseWaitingStates],
     providers: workerPoolPolicy.providers.map((provider) => ({ ...provider })),
+    liveOrchestratorLane: LIVE_ORCHESTRATOR_LANE_NAME,
     slots,
     occupiedSlotCount,
     availableSlotCount,

--- a/tools/priority/throughput-scorecard.mjs
+++ b/tools/priority/throughput-scorecard.mjs
@@ -229,7 +229,8 @@ export function buildThroughputScorecard({
     availableSlotCount: Number(workerPool.availableSlotCount ?? 0) || 0,
     releasedLaneCount: Number(workerPool.releasedLaneCount ?? 0) || 0,
     utilizationRatio: coerceNonNegativeNumber(workerPool.utilizationRatio) ?? 0,
-    activeCodingLanes: Number(runtimeState?.activeCodingLanes ?? 0) || 0
+    activeCodingLanes: Number(runtimeState?.activeCodingLanes ?? 0) || 0,
+    liveOrchestratorLane: normalizeText(workerPool.liveOrchestratorLane) || 'Sagan'
   };
   const queueSummary = {
     readyPrInventory: readySet.length,


### PR DESCRIPTION
Expose the live orchestrator coding lane explicitly as Sagan in the machine-readable runtime telemetry surfaces without changing slot counts or tool limits.\n\nValidation:\n- node --test tools/priority/__tests__/runtime-supervisor.test.mjs tools/priority/__tests__/throughput-scorecard.test.mjs tools/priority/__tests__/throughput-scorecard-schema.test.mjs\n- git diff --check\n