### PR TITLE
#1691 clarify Sagan worker-pool telemetry docs

### DIFF
--- a/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
+++ b/docs/knowledgebase/Agent-Cost-Telemetry-Surfaces.md
@@ -152,7 +152,8 @@ These provide the denominator side of the question:
 
 - worker utilization
 - queue occupancy
-- concurrent-lane activity
+- concurrent-lane activity as a logical worker-pool model
+- live orchestrator identity (`liveOrchestratorLane`) alongside the pool summary
 - hosted wait escape count
 - terminal PR counts
 - effort levels and duration

--- a/tools/priority/__tests__/throughput-scorecard.test.mjs
+++ b/tools/priority/__tests__/throughput-scorecard.test.mjs
@@ -516,7 +516,7 @@ test('buildThroughputScorecard surfaces idle classification coverage from the co
   assert.equal(report.concurrentLanes.idleClassificationCoverage.stateCounts['waiting-merge'], 1);
 });
 
-test('buildThroughputScorecard warns when actionable lane demand leaves the four-slot worker pool underfilled', () => {
+test('buildThroughputScorecard warns when actionable lane demand leaves the logical worker pool underfilled', () => {
   const report = buildThroughputScorecard({
     repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
     runtimeState: {


### PR DESCRIPTION
Replacement clean lane for the capital-fabric follow-up. This keeps the remaining gap scoped to the telemetry docs and scorecard test naming so they describe the logical worker-pool model plus live orchestrator identity instead of implying a fixed four-lane set.\n\nValidation:\n- node --test tools/priority/__tests__/throughput-scorecard.test.mjs tools/priority/__tests__/throughput-scorecard-schema.test.mjs\n- node tools/npm/run-script.mjs lint:md:changed\n- git diff --check\n