### PR TITLE
#1717 seed 20 logical lane identities with adaptive activation

### DIFF
--- a/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
+++ b/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
@@ -63,9 +63,12 @@ future agents can decide whether template verification is improving, regressing,
 or stalling.
 
 The checked-in capital-fabric policy also declares `Jarvis` as a Windows Docker
-specialty lane family. `Jarvis` can grow to multiple instances when the host RAM
-budget leaves headroom, while the first recorded responsibility stays attached
-to a named agent for stakeholder-facing traceability.
+specialty lane family. The same policy now seeds `20` logical-lane identities
+through `capitalFabric.logicalLaneCatalog`, while `logicalLaneActivation`
+reports which identities are active versus merely seeded on the current host.
+`Jarvis` can grow to multiple instances when the host RAM budget leaves
+headroom, while the first recorded responsibility stays attached to a named
+agent for stakeholder-facing traceability.
 
 The checked-in report is expected to capture the landed iteration label,
 iteration ref, and landed iteration head SHA so the evidence can be tied back

--- a/docs/schemas/delivery-agent-policy-v1.schema.json
+++ b/docs/schemas/delivery-agent-policy-v1.schema.json
@@ -37,6 +37,20 @@
         "logicalLaneAllocationFloorRatio": { "type": "number", "minimum": 0, "maximum": 1 },
         "reservedLaneCount": { "type": "integer", "minimum": 0 },
         "hostRamBudgetPath": { "type": "string" },
+        "logicalLaneCatalog": {
+          "type": "array",
+          "maxItems": 20,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["id", "label"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 },
+              "seededOrdinal": { "type": "integer", "minimum": 1 }
+            }
+          }
+        },
         "specialtyLanes": {
           "type": "array",
           "items": {

--- a/docs/schemas/delivery-agent-runtime-state-v1.schema.json
+++ b/docs/schemas/delivery-agent-runtime-state-v1.schema.json
@@ -47,6 +47,42 @@
       }
     },
     "workerPool": { "$ref": "#/$defs/workerPool" },
+    "logicalLaneActivation": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": [
+        "capacityMode",
+        "capacitySource",
+        "effectiveLogicalLaneCount",
+        "seededLaneCount",
+        "activeLaneCount",
+        "inactiveLaneCount",
+        "catalog"
+      ],
+      "properties": {
+        "capacityMode": { "enum": ["fixed-target", "host-ram-adaptive"] },
+        "capacitySource": { "enum": ["policy-ceiling", "host-ram-budget"] },
+        "effectiveLogicalLaneCount": { "type": "integer", "minimum": 0 },
+        "seededLaneCount": { "type": "integer", "minimum": 0 },
+        "activeLaneCount": { "type": "integer", "minimum": 0 },
+        "inactiveLaneCount": { "type": "integer", "minimum": 0 },
+        "catalog": {
+          "type": "array",
+          "maxItems": 20,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "label", "seededOrdinal", "activationState"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 },
+              "seededOrdinal": { "type": "integer", "minimum": 1 },
+              "activationState": { "enum": ["seeded", "active"] }
+            }
+          }
+        }
+      }
+    },
     "marketplace": {
       "type": ["object", "null"],
       "additionalProperties": true,

--- a/docs/schemas/throughput-scorecard-v1.schema.json
+++ b/docs/schemas/throughput-scorecard-v1.schema.json
@@ -83,6 +83,42 @@
         "capacitySource": { "enum": ["policy-ceiling", "host-ram-budget"] }
       }
     },
+    "logicalLaneActivation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capacityMode",
+        "capacitySource",
+        "effectiveLogicalLaneCount",
+        "seededLaneCount",
+        "activeLaneCount",
+        "inactiveLaneCount",
+        "catalog"
+      ],
+      "properties": {
+        "capacityMode": { "enum": ["fixed-target", "host-ram-adaptive"] },
+        "capacitySource": { "enum": ["policy-ceiling", "host-ram-budget"] },
+        "effectiveLogicalLaneCount": { "type": "integer", "minimum": 0 },
+        "seededLaneCount": { "type": "integer", "minimum": 0 },
+        "activeLaneCount": { "type": "integer", "minimum": 0 },
+        "inactiveLaneCount": { "type": "integer", "minimum": 0 },
+        "catalog": {
+          "type": "array",
+          "maxItems": 20,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "label", "seededOrdinal", "activationState"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 },
+              "seededOrdinal": { "type": "integer", "minimum": 1 },
+              "activationState": { "enum": ["seeded", "active"] }
+            }
+          }
+        }
+      }
+    },
     "queue": {
       "type": "object",
       "additionalProperties": false,
@@ -276,6 +312,9 @@
             "logicalLaneAllocationRatio",
             "logicalLaneAllocationFloorRatio",
             "effectiveLogicalLaneCount",
+            "seededLogicalLaneCount",
+            "activeLogicalLaneCount",
+            "inactiveLogicalLaneCount",
             "concurrentLaneActiveCount",
             "concurrentLaneDeferredCount",
             "idleClassificationManagedLaneCount",
@@ -295,6 +334,9 @@
             "logicalLaneAllocationRatio": { "type": "number", "minimum": 0, "maximum": 1 },
             "logicalLaneAllocationFloorRatio": { "type": "number", "minimum": 0, "maximum": 1 },
             "effectiveLogicalLaneCount": { "type": "integer", "minimum": 0 },
+            "seededLogicalLaneCount": { "type": "integer", "minimum": 0 },
+            "activeLogicalLaneCount": { "type": "integer", "minimum": 0 },
+            "inactiveLogicalLaneCount": { "type": "integer", "minimum": 0 },
             "concurrentLaneActiveCount": { "type": "integer", "minimum": 0 },
             "concurrentLaneDeferredCount": { "type": "integer", "minimum": 0 },
             "idleClassificationManagedLaneCount": { "type": "integer", "minimum": 0 },

--- a/tools/priority/__tests__/delivery-agent-manager-contract.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-manager-contract.test.mjs
@@ -126,13 +126,24 @@ test('package scripts expose delivery-agent commands and keep unattended aliases
 test('delivery-agent policy wires coding turns to the Codex runner', async () => {
   const policy = JSON.parse(await readText('tools/priority/delivery-agent.policy.json'));
   assert.deepEqual(policy.codingTurnCommand, ['node', 'dist/tools/priority/run-delivery-turn-with-codex.js']);
-  assert.equal(policy.maxActiveCodingLanes, 8);
+  assert.equal(policy.maxActiveCodingLanes, 20);
   assert.equal(policy.capitalFabric.capacityMode, 'host-ram-adaptive');
-  assert.equal(policy.capitalFabric.maxLogicalLaneCount, 8);
+  assert.equal(policy.capitalFabric.maxLogicalLaneCount, 20);
+  assert.equal(policy.capitalFabric.logicalLaneCatalog.length, 20);
+  assert.deepEqual(policy.capitalFabric.logicalLaneCatalog[0], {
+    id: 'logical-lane-01',
+    label: 'Lane 01',
+    seededOrdinal: 1
+  });
+  assert.deepEqual(policy.capitalFabric.logicalLaneCatalog[19], {
+    id: 'logical-lane-20',
+    label: 'Lane 20',
+    seededOrdinal: 20
+  });
   assert.equal(policy.capitalFabric.specialtyLanes[0].id, 'jarvis');
   assert.equal(policy.capitalFabric.specialtyLanes[0].primaryRecordedResponsibility, 'Sagan');
   assert.equal(policy.capitalFabric.specialtyLanes[0].maxInstanceCount, 2);
-  assert.equal(policy.workerPool.targetSlotCount, 8);
+  assert.equal(policy.workerPool.targetSlotCount, 20);
   assert.deepEqual(
     policy.workerPool.providers.map((provider) => provider.id),
     ['local-codex', 'hosted-github-workflow', 'remote-copilot-lane', 'local-shadow-native']

--- a/tools/priority/__tests__/delivery-agent-schema.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-schema.test.mjs
@@ -29,6 +29,18 @@ function makeAjv() {
   return ajv;
 }
 
+function buildLogicalLaneCatalog(count = 20) {
+  return Array.from({ length: count }, (_, index) => {
+    const seededOrdinal = index + 1;
+    const ordinal = String(seededOrdinal).padStart(2, '0');
+    return {
+      id: `logical-lane-${ordinal}`,
+      label: `Lane ${ordinal}`,
+      seededOrdinal
+    };
+  });
+}
+
 test('delivery-agent policy schema validates the checked-in policy contract', async () => {
   const schema = await loadSchema('docs/schemas/delivery-agent-policy-v1.schema.json');
   const data = JSON.parse(await readFile(path.join(repoRoot, 'tools/priority/delivery-agent.policy.json'), 'utf8'));
@@ -36,14 +48,15 @@ test('delivery-agent policy schema validates the checked-in policy contract', as
   const validate = ajv.compile(schema);
   assert.equal(validate(data), true, JSON.stringify(validate.errors, null, 2));
   assert.equal(data.copilotReviewStrategy, 'draft-only-explicit');
-  assert.equal(data.maxActiveCodingLanes, 8);
+  assert.equal(data.maxActiveCodingLanes, 20);
   assert.deepEqual(data.capitalFabric, {
     schema: 'priority/capital-deployment-fabric@v1',
     capacityMode: 'host-ram-adaptive',
-    maxLogicalLaneCount: 8,
+    maxLogicalLaneCount: 20,
     logicalLaneAllocationFloorRatio: 0.5,
     reservedLaneCount: 1,
     hostRamBudgetPath: 'tests/results/_agent/runtime/host-ram-budget.json',
+    logicalLaneCatalog: buildLogicalLaneCatalog(),
     specialtyLanes: [
       {
         id: 'jarvis',
@@ -58,7 +71,7 @@ test('delivery-agent policy schema validates the checked-in policy contract', as
     ]
   });
   assert.deepEqual(data.workerPool, {
-    targetSlotCount: 8,
+    targetSlotCount: 20,
     prewarmSlotCount: 1,
     releaseWaitingStates: ['waiting-ci', 'waiting-review', 'ready-merge'],
     providers: [
@@ -152,7 +165,7 @@ test('delivery-agent policy schema validates the checked-in policy contract', as
   });
   assert.equal(
     data.workerPool.targetSlotCount - data.templateAgentVerificationLane.reservedSlotCount,
-    7
+    19
   );
   assert.deepEqual(data.hostIsolation, {
     mode: 'hard-cutover',
@@ -896,6 +909,15 @@ test('delivery-agent runtime state schema validates persisted runtime state', as
   assert.equal(state.policy.maxActiveCodingLanes, 4);
   assert.equal(state.policy.capitalFabric.capacityMode, 'fixed-target');
   assert.equal(state.policy.capitalFabric.maxLogicalLaneCount, 4);
+  assert.equal(state.logicalLaneActivation.seededLaneCount, 4);
+  assert.equal(state.logicalLaneActivation.activeLaneCount, 4);
+  assert.equal(state.logicalLaneActivation.catalog.length, 4);
+  assert.deepEqual(state.logicalLaneActivation.catalog[0], {
+    id: 'logical-lane-01',
+    label: 'Lane 01',
+    seededOrdinal: 1,
+    activationState: 'active'
+  });
   assert.equal(state.policy.capitalFabric.specialtyLanes.length, 0);
   assert.equal(state.workerPool.targetSlotCount, 4);
   assert.equal(state.workerPool.configuredTargetSlotCount, 4);

--- a/tools/priority/__tests__/throughput-scorecard-schema.test.mjs
+++ b/tools/priority/__tests__/throughput-scorecard-schema.test.mjs
@@ -94,4 +94,8 @@ test('throughput-scorecard schema validates generated report payloads', () => {
   });
 
   assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+  assert.equal(report.logicalLaneActivation.seededLaneCount, 20);
+  assert.equal(report.logicalLaneActivation.activeLaneCount, 4);
+  assert.equal(report.summary.metrics.seededLogicalLaneCount, 20);
+  assert.equal(report.summary.metrics.activeLogicalLaneCount, 4);
 });

--- a/tools/priority/__tests__/throughput-scorecard.test.mjs
+++ b/tools/priority/__tests__/throughput-scorecard.test.mjs
@@ -72,6 +72,13 @@ test('buildThroughputScorecard warns when actionable work exists while the worke
   assert.equal(report.summary.metrics.readyPrInventory, 2);
   assert.equal(report.summary.metrics.currentWorkerUtilizationRatio, 0);
   assert.equal(report.workerPool.liveOrchestratorLane, 'Sagan');
+  assert.equal(report.logicalLaneActivation.seededLaneCount, 20);
+  assert.equal(report.logicalLaneActivation.activeLaneCount, 4);
+  assert.equal(report.logicalLaneActivation.catalog[0].activationState, 'active');
+  assert.equal(report.logicalLaneActivation.catalog[4].activationState, 'seeded');
+  assert.equal(report.summary.metrics.seededLogicalLaneCount, 20);
+  assert.equal(report.summary.metrics.activeLogicalLaneCount, 4);
+  assert.equal(report.summary.metrics.inactiveLogicalLaneCount, 16);
   assert.equal(report.summary.metrics.logicalLaneAllocationRatio, 0);
   assert.equal(report.summary.metrics.logicalLaneAllocationFloorRatio, 0.5);
   assert.equal(report.summary.metrics.effectiveLogicalLaneCount, 4);
@@ -190,6 +197,8 @@ test('runThroughputScorecard writes a pass report when queue pressure and worker
   assert.equal(result.report.summary.status, 'pass');
   assert.equal(result.report.workerPool.utilizationRatio, 0.5);
   assert.equal(result.report.logicalLaneAllocation.effectiveLogicalLaneCount, 4);
+  assert.equal(result.report.logicalLaneActivation.seededLaneCount, 20);
+  assert.equal(result.report.logicalLaneActivation.activeLaneCount, 4);
   assert.equal(result.report.logicalLaneAllocation.allocationRatio, 0.5);
   assert.equal(result.report.delivery.hostedWaitEscapeCount, 3);
   assert.equal(result.report.queue.readySetTop[0], 1511);
@@ -662,7 +671,7 @@ test('buildThroughputScorecard derives the effective logical lane cap from the h
       policy: {
         capitalFabric: {
           capacityMode: 'host-ram-adaptive',
-          maxLogicalLaneCount: 8,
+          maxLogicalLaneCount: 20,
           logicalLaneAllocationFloorRatio: 0.5,
           reservedLaneCount: 1
         }
@@ -716,10 +725,12 @@ test('buildThroughputScorecard derives the effective logical lane cap from the h
   });
 
   assert.equal(report.logicalLaneAllocation.capacityMode, 'host-ram-adaptive');
-  assert.equal(report.logicalLaneAllocation.maxLogicalLaneCount, 8);
+  assert.equal(report.logicalLaneAllocation.maxLogicalLaneCount, 20);
   assert.equal(report.logicalLaneAllocation.effectiveLogicalLaneCount, 3);
+  assert.equal(report.logicalLaneActivation.activeLaneCount, 3);
   assert.equal(report.logicalLaneAllocation.hostRamProfile, 'windows-mirror-heavy');
   assert.equal(report.logicalLaneAllocation.hostRamRecommendedParallelism, 3);
   assert.equal(report.logicalLaneAllocation.capacitySource, 'host-ram-budget');
   assert.equal(report.summary.metrics.effectiveLogicalLaneCount, 3);
+  assert.equal(report.summary.metrics.seededLogicalLaneCount, 20);
 });

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -179,17 +179,18 @@ const DEFAULT_POLICY = {
   copilotReviewStrategy: 'draft-only-explicit',
   autoSlice: true,
   autoMerge: true,
-  maxActiveCodingLanes: 8,
+  maxActiveCodingLanes: 20,
   allowPolicyMutations: false,
   allowReleaseAdmin: false,
   stopWhenNoOpenEpics: true,
   capitalFabric: {
     schema: 'priority/capital-deployment-fabric@v1',
     capacityMode: 'host-ram-adaptive',
-    maxLogicalLaneCount: 8,
+    maxLogicalLaneCount: 20,
     logicalLaneAllocationFloorRatio: 0.5,
     reservedLaneCount: 1,
     hostRamBudgetPath: DEFAULT_HOST_RAM_BUDGET_PATH,
+    logicalLaneCatalog: buildDefaultLogicalLaneCatalog(),
     specialtyLanes: [
       {
         id: 'jarvis',
@@ -204,7 +205,7 @@ const DEFAULT_POLICY = {
     ]
   },
   workerPool: {
-    targetSlotCount: 8,
+    targetSlotCount: 20,
     prewarmSlotCount: 1,
     releaseWaitingStates: [...DEFAULT_WORKER_RELEASE_WAITING_STATES],
     providers: DEFAULT_WORKER_PROVIDER_BLUEPRINTS.map((provider) =>
@@ -529,6 +530,44 @@ function buildDefaultWorkerPoolProviders() {
   );
 }
 
+function buildDefaultLogicalLaneCatalog(count = 20) {
+  return Array.from({ length: Math.max(1, count) }, (_, index) => {
+    const seededOrdinal = index + 1;
+    const ordinalLabel = String(seededOrdinal).padStart(2, '0');
+    return {
+      id: `logical-lane-${ordinalLabel}`,
+      label: `Lane ${ordinalLabel}`,
+      seededOrdinal
+    };
+  });
+}
+
+function normalizeCapitalFabricLogicalLaneCatalog(value, { defaultCount = 20 } = {}) {
+  const sourceCatalog =
+    Array.isArray(value) && value.length > 0 ? value : buildDefaultLogicalLaneCatalog(defaultCount);
+  if (sourceCatalog.length > 20) {
+    throw new Error(`capitalFabric.logicalLaneCatalog cannot exceed 20 entries.`);
+  }
+  const catalog = sourceCatalog.map((entry, index) => {
+    const seededOrdinal = coercePositiveInteger(entry?.seededOrdinal) ?? index + 1;
+    const ordinalLabel = String(seededOrdinal).padStart(2, '0');
+    return {
+      id: normalizeText(entry?.id) || `logical-lane-${ordinalLabel}`,
+      label: normalizeText(entry?.label) || `Lane ${ordinalLabel}`,
+      seededOrdinal
+    };
+  });
+  const ids = new Set();
+  for (const lane of catalog) {
+    const laneKey = lane.id.toLowerCase();
+    if (ids.has(laneKey)) {
+      throw new Error(`Duplicate capitalFabric.logicalLaneCatalog id: ${lane.id}`);
+    }
+    ids.add(laneKey);
+  }
+  return catalog;
+}
+
 function normalizeWorkerProviderPolicy(value, { fallbackIndex = 0 } = {}) {
   const provider = value && typeof value === 'object' ? value : {};
   const fallbackBlueprint =
@@ -611,6 +650,15 @@ function normalizeCapitalFabricPolicy(
       DEFAULT_POLICY.maxActiveCodingLanes,
     1
   );
+  const logicalLaneCatalog = normalizeCapitalFabricLogicalLaneCatalog(
+    capitalFabric.logicalLaneCatalog ?? capitalFabric.logicalLanes,
+    { defaultCount: configuredCeiling }
+  );
+  if (logicalLaneCatalog.length > configuredCeiling) {
+    throw new Error(
+      `capitalFabric.logicalLaneCatalog has ${logicalLaneCatalog.length} entries but the logical lane ceiling is ${configuredCeiling}.`
+    );
+  }
   const reservedLaneCount = Math.min(
     coercePositiveInteger(capitalFabric.reservedLaneCount) ?? 1,
     configuredCeiling
@@ -628,7 +676,42 @@ function normalizeCapitalFabricPolicy(
     logicalLaneAllocationFloorRatio: coerceRatio(capitalFabric.logicalLaneAllocationFloorRatio, 0.5) ?? 0.5,
     reservedLaneCount,
     hostRamBudgetPath: normalizeText(capitalFabric.hostRamBudgetPath) || DEFAULT_HOST_RAM_BUDGET_PATH,
+    logicalLaneCatalog,
     specialtyLanes
+  };
+}
+
+export function summarizeLogicalLaneActivation({
+  capitalFabric = {},
+  effectiveLogicalLaneCount = null,
+  capacitySource = null
+} = {}) {
+  const fallbackCount =
+    coercePositiveInteger(capitalFabric.maxLogicalLaneCount) ??
+    coercePositiveInteger(capitalFabric.targetLogicalLaneCount) ??
+    20;
+  const logicalLaneCatalog = normalizeCapitalFabricLogicalLaneCatalog(
+    capitalFabric.logicalLaneCatalog ?? capitalFabric.logicalLanes,
+    { defaultCount: fallbackCount }
+  );
+  const seededLaneCount = logicalLaneCatalog.length;
+  const activeLaneCount = Math.max(
+    0,
+    Math.min(coercePositiveInteger(effectiveLogicalLaneCount) ?? seededLaneCount, seededLaneCount)
+  );
+  const inactiveLaneCount = Math.max(seededLaneCount - activeLaneCount, 0);
+  const catalog = logicalLaneCatalog.map((lane, index) => ({
+    ...lane,
+    activationState: index < activeLaneCount ? 'active' : 'seeded'
+  }));
+  return {
+    capacityMode: normalizeText(capitalFabric.capacityMode) || 'fixed-target',
+    capacitySource: normalizeText(capacitySource) || normalizeText(capitalFabric.capacitySource) || 'policy-ceiling',
+    effectiveLogicalLaneCount: activeLaneCount,
+    seededLaneCount,
+    activeLaneCount,
+    inactiveLaneCount,
+    catalog
   };
 }
 
@@ -651,6 +734,23 @@ function resolveCapitalFabricRuntimePolicy({
       ? Math.max(1, Math.min(capitalFabric.maxLogicalLaneCount, hostRamRecommendedParallelism))
       : capitalFabric.maxLogicalLaneCount;
   const implementationLaneBudget = Math.max(effectiveLogicalLaneCount - capitalFabric.reservedLaneCount, 0);
+  const logicalLaneActivation = summarizeLogicalLaneActivation({
+    capitalFabric: {
+      ...capitalFabric,
+      hostRamProfile: normalizeText(hostRamBudget?.selectedProfile?.id) || null,
+      hostRamRecommendedParallelism,
+      effectiveLogicalLaneCount,
+      capacitySource:
+        capitalFabric.capacityMode === 'host-ram-adaptive' && hostRamRecommendedParallelism != null
+          ? 'host-ram-budget'
+          : 'policy-ceiling'
+    },
+    effectiveLogicalLaneCount,
+    capacitySource:
+      capitalFabric.capacityMode === 'host-ram-adaptive' && hostRamRecommendedParallelism != null
+        ? 'host-ram-budget'
+        : 'policy-ceiling'
+  });
   return {
     ...capitalFabric,
     hostRamBudgetPath: toRepoRelativePath(repoRoot, capitalFabric.hostRamBudgetPath) || capitalFabric.hostRamBudgetPath,
@@ -668,7 +768,8 @@ function resolveCapitalFabricRuntimePolicy({
         lane.enabled === true
           ? Math.min(lane.maxInstanceCount, implementationLaneBudget)
           : 0
-    }))
+    })),
+    logicalLaneActivation
   };
 }
 
@@ -3150,6 +3251,7 @@ export function buildDeliveryAgentRuntimeRecord({
     hostRamBudget,
     repoRoot
   });
+  const { logicalLaneActivation, ...capitalFabricPolicy } = capitalFabric;
   const normalizedMaxActiveCodingLanes = Math.max(
     coercePositiveInteger(policy?.maxActiveCodingLanes) ?? workerPoolPolicy.targetSlotCount,
     workerPoolPolicy.targetSlotCount,
@@ -3275,13 +3377,14 @@ export function buildDeliveryAgentRuntimeRecord({
       allowPolicyMutations: policy.allowPolicyMutations === true,
       allowReleaseAdmin: policy.allowReleaseAdmin === true,
       stopWhenNoOpenEpics: policy.stopWhenNoOpenEpics === true,
-      capitalFabric,
+      capitalFabric: capitalFabricPolicy,
       workerPool: workerPoolPolicy
     },
     status: laneLifecycle === 'blocked' ? 'blocked' : laneLifecycle === 'idle' ? 'idle' : 'running',
     laneLifecycle,
     activeCodingLanes,
     workerPool,
+    logicalLaneActivation,
     localReviewLoop,
     concurrentLaneApply,
     concurrentLaneStatus,

--- a/tools/priority/delivery-agent.policy.json
+++ b/tools/priority/delivery-agent.policy.json
@@ -5,17 +5,39 @@
   "copilotReviewStrategy": "draft-only-explicit",
   "autoSlice": true,
   "autoMerge": true,
-  "maxActiveCodingLanes": 8,
+  "maxActiveCodingLanes": 20,
   "allowPolicyMutations": false,
   "allowReleaseAdmin": false,
   "stopWhenNoOpenEpics": true,
   "capitalFabric": {
     "schema": "priority/capital-deployment-fabric@v1",
     "capacityMode": "host-ram-adaptive",
-    "maxLogicalLaneCount": 8,
+    "maxLogicalLaneCount": 20,
     "logicalLaneAllocationFloorRatio": 0.5,
     "reservedLaneCount": 1,
     "hostRamBudgetPath": "tests/results/_agent/runtime/host-ram-budget.json",
+    "logicalLaneCatalog": [
+      {"id": "logical-lane-01", "label": "Lane 01", "seededOrdinal": 1},
+      {"id": "logical-lane-02", "label": "Lane 02", "seededOrdinal": 2},
+      {"id": "logical-lane-03", "label": "Lane 03", "seededOrdinal": 3},
+      {"id": "logical-lane-04", "label": "Lane 04", "seededOrdinal": 4},
+      {"id": "logical-lane-05", "label": "Lane 05", "seededOrdinal": 5},
+      {"id": "logical-lane-06", "label": "Lane 06", "seededOrdinal": 6},
+      {"id": "logical-lane-07", "label": "Lane 07", "seededOrdinal": 7},
+      {"id": "logical-lane-08", "label": "Lane 08", "seededOrdinal": 8},
+      {"id": "logical-lane-09", "label": "Lane 09", "seededOrdinal": 9},
+      {"id": "logical-lane-10", "label": "Lane 10", "seededOrdinal": 10},
+      {"id": "logical-lane-11", "label": "Lane 11", "seededOrdinal": 11},
+      {"id": "logical-lane-12", "label": "Lane 12", "seededOrdinal": 12},
+      {"id": "logical-lane-13", "label": "Lane 13", "seededOrdinal": 13},
+      {"id": "logical-lane-14", "label": "Lane 14", "seededOrdinal": 14},
+      {"id": "logical-lane-15", "label": "Lane 15", "seededOrdinal": 15},
+      {"id": "logical-lane-16", "label": "Lane 16", "seededOrdinal": 16},
+      {"id": "logical-lane-17", "label": "Lane 17", "seededOrdinal": 17},
+      {"id": "logical-lane-18", "label": "Lane 18", "seededOrdinal": 18},
+      {"id": "logical-lane-19", "label": "Lane 19", "seededOrdinal": 19},
+      {"id": "logical-lane-20", "label": "Lane 20", "seededOrdinal": 20}
+    ],
     "specialtyLanes": [
       {
         "id": "jarvis",
@@ -30,7 +52,7 @@
     ]
   },
   "workerPool": {
-    "targetSlotCount": 8,
+    "targetSlotCount": 20,
     "prewarmSlotCount": 1,
     "releaseWaitingStates": [
       "waiting-ci",

--- a/tools/priority/throughput-scorecard.mjs
+++ b/tools/priority/throughput-scorecard.mjs
@@ -6,6 +6,7 @@ import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_HOST_RAM_BUDGET_PATH } from './concurrent-lane-plan.mjs';
 import { summarizeIdleClassificationCoverage } from './concurrent-lane-status.mjs';
+import { summarizeLogicalLaneActivation } from './delivery-agent.mjs';
 
 export const REPORT_SCHEMA = 'priority/throughput-scorecard@v1';
 export const DEFAULT_RUNTIME_STATE_PATH = path.join('tests', 'results', '_agent', 'runtime', 'delivery-agent-state.json');
@@ -315,6 +316,13 @@ export function buildThroughputScorecard({
     viHistorySuitePullRequestCount: Number(deliveryMemory?.summary?.viHistorySuitePullRequestCount ?? 0) || 0
   };
   const logicalLaneAllocation = summarizeLogicalLaneAllocation(runtimeState, hostRamBudget);
+  const logicalLaneActivation = summarizeLogicalLaneActivation({
+    capitalFabric: runtimeState?.policy?.capitalFabric && typeof runtimeState.policy.capitalFabric === 'object'
+      ? runtimeState.policy.capitalFabric
+      : {},
+    effectiveLogicalLaneCount: logicalLaneAllocation.effectiveLogicalLaneCount,
+    capacitySource: logicalLaneAllocation.capacitySource
+  });
   const mergeQueueUtilization = evaluateMergeQueueUtilization(queueSummary, utilizationPolicy);
   const concurrentLanes = summarizeConcurrentLaneStatus(
     concurrentLaneStatusInput ?? {
@@ -375,6 +383,7 @@ export function buildThroughputScorecard({
     },
     workerPool: workerPoolSummary,
     logicalLaneAllocation,
+    logicalLaneActivation,
     queue: queueSummary,
     mergeQueueUtilization,
     concurrentLanes,
@@ -392,6 +401,9 @@ export function buildThroughputScorecard({
         logicalLaneAllocationRatio: logicalLaneAllocation.allocationRatio,
         logicalLaneAllocationFloorRatio: logicalLaneAllocation.allocationFloorRatio,
         effectiveLogicalLaneCount: logicalLaneAllocation.effectiveLogicalLaneCount,
+        seededLogicalLaneCount: logicalLaneActivation.seededLaneCount,
+        activeLogicalLaneCount: logicalLaneActivation.activeLaneCount,
+        inactiveLogicalLaneCount: logicalLaneActivation.inactiveLaneCount,
         concurrentLaneActiveCount: concurrentLanes.activeLaneCount,
         concurrentLaneDeferredCount: concurrentLanes.deferredLaneCount,
         idleClassificationManagedLaneCount: concurrentLanes.idleClassificationCoverage.managedLaneCount,


### PR DESCRIPTION
Implements the seeded-20 logical lane identity model for #1717.

Scope:
- adds a 20-entry logical lane catalog to the capital-fabric policy
- exposes deterministic seeded vs active lane activation in runtime and throughput telemetry
- keeps the adaptive host-RAM ceiling as the activation driver
- adds focused schema and contract tests

Validation:
- node --test tools/priority/__tests__/delivery-agent-schema.test.mjs tools/priority/__tests__/delivery-agent-manager-contract.test.mjs tools/priority/__tests__/throughput-scorecard.test.mjs tools/priority/__tests__/throughput-scorecard-schema.test.mjs
- git diff --check