### PR TITLE
#1426 security alert reconciliation register

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -68,6 +68,7 @@
         "docs/knowledgebase/GitHub-Wiki-Portal.md",
         "docs/knowledgebase/Headless-SampleVI-Corpus.md",
         "docs/knowledgebase/PrintToSingleFileHtml-Provenance.md",
+        "docs/knowledgebase/Security-Alert-Reconciliation-Register.md",
         "docs/knowledgebase/Offline-RealHistory-Corpus.md",
         "docs/knowledgebase/Unattended-Delivery-Daemon-Surfaces.md",
         "docs/knowledgebase/Unattended-Delivery-Daemon-Debt-Register.md",

--- a/docs/knowledgebase/Security-Alert-Reconciliation-Register.md
+++ b/docs/knowledgebase/Security-Alert-Reconciliation-Register.md
@@ -1,0 +1,44 @@
+<!-- markdownlint-disable-next-line MD041 -->
+# Security Alert Reconciliation Register
+
+This register tracks only security-alert reconciliation debt that still matters
+for RC determinism on current `develop`.
+
+It is intentionally narrower than the general security intake surface. Use it
+to keep the live Dependabot / dependency-graph lag explicit without inventing
+new remediation work when the repository manifests are already fixed.
+
+## Current State
+
+- The live security intake report remains `platform-stale`.
+- The repo manifests are already remediated locally to `js-yaml@4.1.1`.
+- GitHub still reports open Dependabot alerts `#3` and `#4` for the same
+  package.
+- The machine-readable report lives at
+  `tests/results/_agent/security/security-intake-report.json`.
+
+## RC-Relevant Finding
+
+### Dependabot / dependency-graph lag after npm remediation
+
+- Why it matters: RC reviewers should not infer an unremediated dependency from
+  a stale upstream alert if the repo manifests are already fixed.
+- Current seam: `tools/priority/security-intake.mjs` correctly classifies the
+  current state as `platform-stale`, but the repository cannot force GitHub to
+  reconcile the alert state immediately.
+- Evidence surfaces:
+  - code: `tools/priority/security-intake.mjs`
+  - receipt: `tests/results/_agent/security/security-intake-report.json`
+  - manifest proof: `package.json`, `package-lock.json`
+  - tests: `tools/priority/__tests__/security-intake.test.mjs`,
+    `tools/priority/__tests__/security-intake-schema.test.mjs`
+- Follow-up issue: `#1426`
+
+## Exit Criteria
+
+Close or demote this register entry when GitHub Dependabot alerts `#3` and `#4`
+either auto-close or stop reporting the repository as `platform-stale`.
+
+If `priority:security:intake` starts failing again because of an API-400 or
+similar tooling regression, that is a separate follow-up issue and should not be
+folded into the external platform-lag tracker.

--- a/tools/priority/__tests__/security-alert-reconciliation-register.test.mjs
+++ b/tools/priority/__tests__/security-alert-reconciliation-register.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('security alert reconciliation register is checked in and anchored to the live intake receipt', () => {
+  const manifest = JSON.parse(readText('docs/documentation-manifest.json'));
+  const docsEntry = manifest.entries.find((entry) => entry.name === 'Docs Tree');
+  const register = readText('docs/knowledgebase/Security-Alert-Reconciliation-Register.md');
+  const report = JSON.parse(readText('tests/results/_agent/security/security-intake-report.json'));
+
+  assert.ok(docsEntry);
+  assert.ok(docsEntry.files.includes('docs/knowledgebase/Security-Alert-Reconciliation-Register.md'));
+  assert.match(register, /security-intake-report\.json/);
+  assert.match(register, /platform-stale/);
+  assert.match(register, /#1426/);
+  assert.match(register, /security-intake\.mjs/);
+  assert.match(register, /security-intake\.test\.mjs/);
+  assert.match(register, /security-intake-schema\.test\.mjs/);
+  assert.equal(report.status, 'platform-stale');
+  assert.equal(report.verification.platformStale, true);
+  assert.deepEqual(report.verification.verifiedAlertNumbers, [3, 4]);
+});


### PR DESCRIPTION
Bounded #1426 audit slice for stale security/alert reconciliation.\n\nWhat landed:\n- checked-in security alert reconciliation register\n- docs manifest registration\n- focused contract test tying the register to the live security intake receipt\n\nValidation:\n- node --test tools/priority/__tests__/security-alert-reconciliation-register.test.mjs tools/priority/__tests__/security-intake.test.mjs tools/priority/__tests__/security-intake-schema.test.mjs\n- node tools/npm/run-script.mjs docs:manifest:validate\n\nLive evidence remains platform-stale rather than remediated, so this lane documents the RC-relevant debt instead of pretending the alerts are closed.