### PR TITLE
#1704 Delegate dirty develop syncs to helper worktrees

### DIFF
--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -273,6 +273,69 @@ test('resolveDevelopSyncExecutionRoot degrades dirty work-branch syncs to ref-re
   );
 });
 
+test('resolveDevelopSyncExecutionRoot delegates dirty develop roots to a clean helper develop worktree', () => {
+  const repoRoot = path.join('C:', 'repo', 'dirty-develop-root');
+  const helperRoot = path.join('C:', 'repo', 'clean-develop-helper');
+  const calls = [];
+  const plan = resolveDevelopSyncExecutionRoot({
+    repoRoot,
+    spawnSyncFn: (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      if (command !== 'git') {
+        throw new Error(`Unexpected command ${command}`);
+      }
+      if (args[0] === 'branch' && args[1] === '--show-current') {
+        return { status: 0, stdout: 'develop\n', stderr: '' };
+      }
+      if (args[0] === 'status' && args[1] === '--porcelain') {
+        if (options.cwd === repoRoot) {
+          return { status: 0, stdout: ' M tests/results/_agent/issue/router.json\n?? dirty-note.txt\n', stderr: '' };
+        }
+        if (options.cwd === helperRoot) {
+          return { status: 0, stdout: '', stderr: '' };
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          status: 0,
+          stdout: [
+            `worktree ${repoRoot}`,
+            'HEAD 1111111111111111111111111111111111111111',
+            'branch refs/heads/develop',
+            '',
+            `worktree ${helperRoot}`,
+            'HEAD 2222222222222222222222222222222222222222',
+            'branch refs/heads/develop',
+            ''
+          ].join('\n'),
+          stderr: ''
+        };
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`);
+    }
+  });
+
+  assert.equal(plan.currentBranch, 'develop');
+  assert.equal(plan.executionRepoRoot, helperRoot);
+  assert.equal(plan.mode, 'full-sync');
+  assert.equal(plan.reason, 'dirty-develop-root-helper');
+  assert.equal(plan.dirtyWorktree, true);
+  assert.equal(plan.delegated, true);
+  assert.equal(plan.helperRoot, helperRoot);
+  assert.deepEqual(
+    calls.map((entry) => ({
+      args: entry.args.join(' '),
+      cwd: entry.cwd
+    })),
+    [
+      { args: 'branch --show-current', cwd: repoRoot },
+      { args: 'status --porcelain', cwd: repoRoot },
+      { args: 'worktree list --porcelain', cwd: repoRoot },
+      { args: 'status --porcelain', cwd: helperRoot }
+    ]
+  );
+});
+
 test('buildDevelopSyncBranchClassTrace classifies upstream develop to fork develop as a mirror sync', () => {
   const trace = buildDevelopSyncBranchClassTrace(repoRoot);
 

--- a/tools/priority/develop-sync.mjs
+++ b/tools/priority/develop-sync.mjs
@@ -218,6 +218,35 @@ function isDirtyWorktree({ repoRoot, env = process.env, spawnSyncFn = spawnSync 
   return statusText.length > 0;
 }
 
+function findDevelopHelperRoot({
+  repoRoot,
+  requireClean = false,
+  env = process.env,
+  spawnSyncFn = spawnSync
+} = {}) {
+  const worktreeText = runGitText(spawnSyncFn, repoRoot, ['worktree', 'list', '--porcelain'], env);
+  const helpers = parseGitWorktreeListPorcelain(worktreeText)
+    .map((entry) => ({
+      ...entry,
+      path: path.resolve(entry.path)
+    }))
+    .filter((entry) => entry.path !== repoRoot && entry.branchRef === 'refs/heads/develop');
+
+  if (!requireClean) {
+    return helpers[0]?.path ?? null;
+  }
+
+  for (const helper of helpers) {
+    try {
+      if (!isDirtyWorktree({ repoRoot: helper.path, env, spawnSyncFn })) {
+        return helper.path;
+      }
+    } catch {}
+  }
+
+  return null;
+}
+
 function writeJsonFile(filePath, payload) {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
@@ -289,6 +318,31 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
     };
   }
 
+  if (currentBranch === 'develop') {
+    try {
+      if (isDirtyWorktree({ repoRoot: normalizedRepoRoot, env, spawnSyncFn })) {
+        const helperRoot = findDevelopHelperRoot({
+          repoRoot: normalizedRepoRoot,
+          requireClean: true,
+          env,
+          spawnSyncFn
+        });
+        if (helperRoot) {
+          return {
+            repoRoot: normalizedRepoRoot,
+            executionRepoRoot: helperRoot,
+            currentBranch,
+            mode: 'full-sync',
+            reason: 'dirty-develop-root-helper',
+            dirtyWorktree: true,
+            delegated: true,
+            helperRoot
+          };
+        }
+      }
+    } catch {}
+  }
+
   if (!isWorkBranch(currentBranch)) {
     return {
       repoRoot: normalizedRepoRoot,
@@ -303,13 +357,7 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
   }
 
   try {
-    const worktreeText = runGitText(spawnSyncFn, normalizedRepoRoot, ['worktree', 'list', '--porcelain'], env);
-    const helperRoot = parseGitWorktreeListPorcelain(worktreeText)
-      .map((entry) => ({
-        ...entry,
-        path: path.resolve(entry.path)
-      }))
-      .find((entry) => entry.path !== normalizedRepoRoot && entry.branchRef === 'refs/heads/develop')?.path;
+    const helperRoot = findDevelopHelperRoot({ repoRoot: normalizedRepoRoot, env, spawnSyncFn });
     if (helperRoot) {
       return {
         repoRoot: normalizedRepoRoot,


### PR DESCRIPTION
# Summary

Delivers issue #1704 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1704
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/origin-1704-helper-delegate`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1704