### PR TITLE
#1751 Prefer clean attached develop helpers during develop sync

### DIFF
--- a/tools/priority/__tests__/develop-sync.test.mjs
+++ b/tools/priority/__tests__/develop-sync.test.mjs
@@ -214,6 +214,11 @@ test('resolveDevelopSyncExecutionRoot delegates work-branch syncs to an existing
           stderr: ''
         };
       }
+      if (args[0] === 'status' && args[1] === '--porcelain') {
+        if (options.cwd === helperRoot) {
+          return { status: 0, stdout: '', stderr: '' };
+        }
+      }
       throw new Error(`Unexpected git args: ${args.join(' ')}`);
     }
   });
@@ -224,7 +229,70 @@ test('resolveDevelopSyncExecutionRoot delegates work-branch syncs to an existing
   assert.equal(plan.delegated, true);
   assert.deepEqual(
     calls.map((entry) => entry.args.join(' ')),
-    ['branch --show-current', 'worktree list --porcelain']
+    ['branch --show-current', 'worktree list --porcelain', 'status --porcelain']
+  );
+});
+
+test('resolveDevelopSyncExecutionRoot degrades clean work-branch syncs to ref-refresh when the only attached develop helper is dirty', () => {
+  const repoRoot = path.join('C:', 'repo', 'issue-root');
+  const helperRoot = path.join('C:', 'repo', 'develop-root');
+  const calls = [];
+  const plan = resolveDevelopSyncExecutionRoot({
+    repoRoot,
+    spawnSyncFn: (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      if (command !== 'git') {
+        throw new Error(`Unexpected command ${command}`);
+      }
+      if (args[0] === 'branch' && args[1] === '--show-current') {
+        return { status: 0, stdout: 'issue/origin-1751-sync-helper\n', stderr: '' };
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          status: 0,
+          stdout: [
+            `worktree ${repoRoot}`,
+            'HEAD 1111111111111111111111111111111111111111',
+            'branch refs/heads/issue/origin-1751-sync-helper',
+            '',
+            `worktree ${helperRoot}`,
+            'HEAD 2222222222222222222222222222222222222222',
+            'branch refs/heads/develop',
+            ''
+          ].join('\n'),
+          stderr: ''
+        };
+      }
+      if (args[0] === 'status' && args[1] === '--porcelain') {
+        if (options.cwd === helperRoot) {
+          return { status: 0, stdout: ' M tests/results/_agent/promotion/template-agent-verification-report.json\n', stderr: '' };
+        }
+        if (options.cwd === repoRoot) {
+          return { status: 0, stdout: '', stderr: '' };
+        }
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`);
+    }
+  });
+
+  assert.equal(plan.executionRepoRoot, repoRoot);
+  assert.equal(plan.currentBranch, 'issue/origin-1751-sync-helper');
+  assert.equal(plan.mode, 'ref-refresh');
+  assert.equal(plan.reason, 'dirty-develop-helper');
+  assert.equal(plan.dirtyWorktree, false);
+  assert.equal(plan.delegated, false);
+  assert.equal(plan.helperRoot, null);
+  assert.deepEqual(
+    calls.map((entry) => ({
+      args: entry.args.join(' '),
+      cwd: entry.cwd
+    })),
+    [
+      { args: 'branch --show-current', cwd: repoRoot },
+      { args: 'worktree list --porcelain', cwd: repoRoot },
+      { args: 'status --porcelain', cwd: helperRoot },
+      { args: 'worktree list --porcelain', cwd: repoRoot }
+    ]
   );
 });
 
@@ -269,7 +337,7 @@ test('resolveDevelopSyncExecutionRoot degrades dirty work-branch syncs to ref-re
   assert.equal(plan.helperRoot, null);
   assert.deepEqual(
     calls.map((entry) => entry.args.join(' ')),
-    ['branch --show-current', 'worktree list --porcelain', 'status --porcelain']
+    ['branch --show-current', 'worktree list --porcelain', 'worktree list --porcelain', 'status --porcelain']
   );
 });
 
@@ -485,6 +553,11 @@ test('runDevelopSync launches the sync script from the delegated develop helper 
             ].join('\n'),
             stderr: ''
           };
+        }
+        if (args[0] === 'status' && args[1] === '--porcelain') {
+          if (options.cwd === helperRoot) {
+            return { status: 0, stdout: '', stderr: '' };
+          }
         }
         if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
           return { status: 0, stdout: `${helperRoot}\n`, stderr: '' };

--- a/tools/priority/develop-sync.mjs
+++ b/tools/priority/develop-sync.mjs
@@ -247,6 +247,19 @@ function findDevelopHelperRoot({
   return null;
 }
 
+function hasDevelopHelperRoot({
+  repoRoot,
+  env = process.env,
+  spawnSyncFn = spawnSync
+} = {}) {
+  return findDevelopHelperRoot({
+    repoRoot,
+    requireClean: false,
+    env,
+    spawnSyncFn
+  }) !== null;
+}
+
 function writeJsonFile(filePath, payload) {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
@@ -357,7 +370,12 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
   }
 
   try {
-    const helperRoot = findDevelopHelperRoot({ repoRoot: normalizedRepoRoot, env, spawnSyncFn });
+    const helperRoot = findDevelopHelperRoot({
+      repoRoot: normalizedRepoRoot,
+      requireClean: true,
+      env,
+      spawnSyncFn
+    });
     if (helperRoot) {
       return {
         repoRoot: normalizedRepoRoot,
@@ -368,6 +386,18 @@ export function resolveDevelopSyncExecutionRoot({ repoRoot, env = process.env, s
         dirtyWorktree: false,
         delegated: true,
         helperRoot
+      };
+    }
+    if (hasDevelopHelperRoot({ repoRoot: normalizedRepoRoot, env, spawnSyncFn })) {
+      return {
+        repoRoot: normalizedRepoRoot,
+        executionRepoRoot: normalizedRepoRoot,
+        currentBranch,
+        mode: 'ref-refresh',
+        reason: 'dirty-develop-helper',
+        dirtyWorktree: false,
+        delegated: false,
+        helperRoot: null
       };
     }
   } catch {}


### PR DESCRIPTION
# Summary

Delivers issue #1751 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1751
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/origin-1751-develop-sync-reuse-attached-clean-worktrees`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1751