### PR TITLE
[ci]: clarify daemon cutover actions in Jarvis observer

### DIFF
--- a/docs/schemas/jarvis-session-observer-v1.schema.json
+++ b/docs/schemas/jarvis-session-observer-v1.schema.json
@@ -251,6 +251,7 @@
             "canReuseLinuxDaemon",
             "readyForLinuxDaemon",
             "requiresOperatorCutover",
+            "requiredActions",
             "reason"
           ],
           "properties": {
@@ -269,6 +270,12 @@
             "canReuseLinuxDaemon": { "type": "boolean" },
             "readyForLinuxDaemon": { "type": "boolean" },
             "requiresOperatorCutover": { "type": "boolean" },
+            "requiredActions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "reason": { "type": "string" }
           }
         },

--- a/tools/priority/__tests__/jarvis-session-observer.test.mjs
+++ b/tools/priority/__tests__/jarvis-session-observer.test.mjs
@@ -148,7 +148,7 @@ test('observeJarvisSessionObserver projects an active manual Windows Docker sess
       error: null
     },
     runnerServices: {
-      running: [],
+      running: ['actions.runner.compare-vi-cli-action.develop.1', 'actions.runner.compare-vi-cli-action.develop.2'],
       stopped: []
     }
   });
@@ -213,6 +213,7 @@ test('observeJarvisSessionObserver projects an active manual Windows Docker sess
   assert.equal(report.summary.totalSessionCount, 1);
   assert.equal(report.daemon.daemonCutover.status, 'ready');
   assert.equal(report.daemon.daemonCutover.readyForLinuxDaemon, true);
+  assert.deepEqual(report.daemon.daemonCutover.requiredActions, []);
   assert.equal(report.sessions[0].source, 'concurrent-lane-status');
   assert.equal(report.sessions[0].dockerContext, 'desktop-windows');
   assert.equal(report.sessions[0].dockerServerOs, 'windows');
@@ -288,7 +289,7 @@ test('observeJarvisSessionObserver blocks when native-wsl daemon cutover is stil
       error: null
     },
     runnerServices: {
-      running: [],
+      running: ['actions.runner.compare-vi-cli-action.develop.1', 'actions.runner.compare-vi-cli-action.develop.2'],
       stopped: []
     }
   });
@@ -305,5 +306,11 @@ test('observeJarvisSessionObserver blocks when native-wsl daemon cutover is stil
   assert.equal(report.summary.activeSessionCount, 0);
   assert.equal(report.daemon.daemonCutover.status, 'cutover-required');
   assert.equal(report.daemon.daemonCutover.requiresOperatorCutover, true);
+  assert.deepEqual(report.daemon.daemonCutover.requiredActions, [
+    'Stop or explicitly govern the 2 running actions.runner.* services on this host.',
+    'Switch WSL Docker to a distro-owned Linux daemon before reusing the daemon-first Linux plane.',
+    'Rerun priority:delivery:host:signal.',
+    'Rerun priority:jarvis:status.'
+  ]);
   assert.match(report.daemon.daemonCutover.reason, /cut over to a distro-owned Linux daemon/i);
 });

--- a/tools/priority/jarvis-session-observer.mjs
+++ b/tools/priority/jarvis-session-observer.mjs
@@ -224,6 +224,10 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
   const observedContext = toOptionalText(hostRuntime?.wslDocker?.context) ?? toOptionalText(hostRuntime?.windowsDocker?.context);
   const observedOsType = toOptionalText(hostRuntime?.wslDocker?.osType) ?? toOptionalText(hostRuntime?.windowsDocker?.osType);
   const hostStatus = normalizeLower(hostRuntime?.status);
+  const runningRunnerServices = Array.isArray(hostRuntime?.runnerServices?.running) ? hostRuntime.runnerServices.running : [];
+  const runnerServiceCount = runningRunnerServices.length;
+
+  const buildRequiredActions = (...actions) => actions.filter((action) => normalizeText(action).length > 0);
 
   if (runtimeProvider !== 'native-wsl') {
     return {
@@ -239,6 +243,7 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
       canReuseLinuxDaemon: false,
       readyForLinuxDaemon: false,
       requiresOperatorCutover: false,
+      requiredActions: [],
       reason: 'Delivery policy does not require native-wsl daemon reuse.'
     };
   }
@@ -257,6 +262,7 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
       canReuseLinuxDaemon: true,
       readyForLinuxDaemon: true,
       requiresOperatorCutover: false,
+      requiredActions: [],
       reason: 'Pinned WSL Docker host resolves to a distro-owned Linux daemon.'
     };
   }
@@ -275,6 +281,14 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
       canReuseLinuxDaemon: false,
       readyForLinuxDaemon: false,
       requiresOperatorCutover: true,
+      requiredActions: buildRequiredActions(
+        runnerServiceCount > 0
+          ? `Stop or explicitly govern the ${runnerServiceCount} running actions.runner.* service${runnerServiceCount === 1 ? '' : 's'} on this host.`
+          : 'Verify the host has no unmanaged actions.runner.* services running.',
+        'Switch WSL Docker to a distro-owned Linux daemon before reusing the daemon-first Linux plane.',
+        'Rerun priority:delivery:host:signal.',
+        'Rerun priority:jarvis:status.'
+      ),
       reason: 'WSL Docker still resolves to Docker Desktop; cut over to a distro-owned Linux daemon before reusing the daemon-first Linux plane.'
     };
   }
@@ -293,6 +307,11 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
       canReuseLinuxDaemon: false,
       readyForLinuxDaemon: false,
       requiresOperatorCutover: false,
+      requiredActions: buildRequiredActions(
+        'Reconcile the WSL Docker daemon fingerprint.',
+        'Rerun priority:delivery:host:signal.',
+        'Rerun priority:jarvis:status.'
+      ),
       reason: 'WSL Docker daemon fingerprint drifted and must be reconciled before Linux daemon reuse.'
     };
   }
@@ -311,6 +330,13 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
       canReuseLinuxDaemon: false,
       readyForLinuxDaemon: false,
       requiresOperatorCutover: false,
+      requiredActions: buildRequiredActions(
+        runnerServiceCount > 0
+          ? `Stop or explicitly govern the ${runnerServiceCount} running actions.runner.* service${runnerServiceCount === 1 ? '' : 's'} on this host.`
+          : 'Verify the host has no unmanaged actions.runner.* services running.',
+        'Rerun priority:delivery:host:signal.',
+        'Rerun priority:jarvis:status.'
+      ),
       reason: 'Runner-service isolation is still required before Linux daemon reuse.'
     };
   }
@@ -328,6 +354,10 @@ function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
     canReuseLinuxDaemon: false,
     readyForLinuxDaemon: false,
     requiresOperatorCutover: false,
+    requiredActions: buildRequiredActions(
+      'Re-run priority:delivery:host:signal to capture the current host state.',
+      'Re-run priority:jarvis:status to re-evaluate daemon cutover readiness.'
+    ),
     reason: 'Jarvis could not determine whether the Linux daemon plane is reusable.'
   };
 }
@@ -506,6 +536,12 @@ function printHumanSummary(report) {
       `expectedDockerHost=${report.daemon.daemonCutover.expectedDockerHost ?? '<none>'} ` +
       `observedDockerHost=${report.daemon.daemonCutover.observedDockerHost ?? '<none>'}`
   );
+  if (Array.isArray(report.daemon.daemonCutover.requiredActions) && report.daemon.daemonCutover.requiredActions.length > 0) {
+    lines.push('Required actions:');
+    for (const action of report.daemon.daemonCutover.requiredActions) {
+      lines.push(`- ${action}`);
+    }
+  }
   if (report.sessions.length > 0) {
     lines.push('Sessions:');
     for (const session of report.sessions) {


### PR DESCRIPTION
Cutover-readiness clarity slice for #1741.

Changed:
- added daemon-cutover required actions to the Jarvis observer report
- surfaced actions.runner isolation guidance in the human summary
- locked the report shape with schema/test updates

Validation:
- node --test tools/priority/__tests__/jarvis-session-observer.test.mjs
- node --check tools/priority/jarvis-session-observer.mjs

Remaining risk:
- schema test is blocked in this clean lane because ajv is not installed locally.