### PR TITLE
Add priority:queue:update alias for queued PR refreshes

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "priority:validation:proof": "node tools/npm/run-script.mjs build && node tools/priority/validation-approval-proof.mjs",
     "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
     "priority:queue:refresh": "node tools/priority/queue-refresh-pr.mjs",
+    "priority:queue:update": "node tools/priority/queue-refresh-pr.mjs",
     "priority:event:ingest": "node tools/priority/event-ingest.mjs",
     "priority:decision:ledger": "node tools/priority/decision-ledger.mjs",
     "priority:commit-integrity": "node tools/priority/commit-integrity.mjs",

--- a/tools/priority/__tests__/queue-update-command-surface.test.mjs
+++ b/tools/priority/__tests__/queue-update-command-surface.test.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+test('package.json exposes queue:update as a first-class alias to queue-refresh-pr', async () => {
+  const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8'));
+  assert.equal(packageJson.scripts['priority:queue:refresh'], 'node tools/priority/queue-refresh-pr.mjs');
+  assert.equal(packageJson.scripts['priority:queue:update'], 'node tools/priority/queue-refresh-pr.mjs');
+});
+


### PR DESCRIPTION
# Summary

Add a first-class `priority:queue:update` alias for the existing safe queued-PR refresh helper.

## Change Surface

- Primary issue or standing-priority context: #1397
- Fresh evidence driver: #1764
- Files touched: `package.json`, `tools/priority/__tests__/queue-update-command-surface.test.mjs`
- Behavior: exposes the existing dequeue-update-requeue helper under a clearer command-surface alias without changing the helper logic.

## Validation

- `node --test tools/priority/__tests__/queue-update-command-surface.test.mjs tools/priority/__tests__/queue-refresh-pr.test.mjs tools/priority/__tests__/queue-refresh-pr-schema.test.mjs`
- `git diff --check`

## Notes

- The underlying helper already dequeues by PR node id, rebases or amends, force-pushes, and re-arms merge-queue admission.
- This PR only makes that path first-class and easier to discover.

Refs #1397