### PR TITLE
[ci] prefer manager-filtered host evidence in Jarvis observer

### DIFF
--- a/docs/schemas/jarvis-session-observer-v1.schema.json
+++ b/docs/schemas/jarvis-session-observer-v1.schema.json
@@ -122,6 +122,7 @@
       "required": [
         "status",
         "provider",
+        "source",
         "reasons",
         "daemonFingerprint",
         "previousFingerprint",
@@ -129,11 +130,16 @@
         "windowsDocker",
         "wslDocker",
         "runnerServices",
-        "isolation"
+        "isolation",
+        "diagnostics"
       ],
       "properties": {
         "status": { "type": "string" },
         "provider": { "type": ["string", "null"] },
+        "source": {
+          "type": "string",
+          "enum": ["delivery-agent-manager-state", "daemon-host-signal", "unavailable"]
+        },
         "reasons": { "type": "array", "items": { "type": "string" } },
         "daemonFingerprint": { "type": ["string", "null"] },
         "previousFingerprint": { "type": ["string", "null"] },
@@ -162,6 +168,33 @@
             "lastAction": { "type": ["string", "null"] },
             "preemptedServices": { "type": "array", "items": { "type": "string" } },
             "counters": { "type": "object" }
+          }
+        },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["managerStateAvailable", "managerGeneratedAt", "hostSignalDiagnostics"],
+          "properties": {
+            "managerStateAvailable": { "type": "boolean" },
+            "managerGeneratedAt": { "type": ["string", "null"], "format": "date-time" },
+            "hostSignalDiagnostics": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "usedHostSignal",
+                "reason",
+                "hostSignalGeneratedAt",
+                "managerStartedAt",
+                "hostSignalRepository"
+              ],
+              "properties": {
+                "usedHostSignal": { "type": "boolean" },
+                "reason": { "type": ["string", "null"] },
+                "hostSignalGeneratedAt": { "type": ["string", "null"], "format": "date-time" },
+                "managerStartedAt": { "type": ["string", "null"], "format": "date-time" },
+                "hostSignalRepository": { "type": ["string", "null"] }
+              }
+            }
           }
         }
       }
@@ -361,6 +394,7 @@
         "runtimeDir",
         "deliveryStatePath",
         "concurrentLaneStatusPath",
+        "managerStatePath",
         "hostSignalPath",
         "hostIsolationPath",
         "observerHeartbeatPath",
@@ -374,6 +408,7 @@
         "runtimeDir": { "type": "string" },
         "deliveryStatePath": { "type": "string" },
         "concurrentLaneStatusPath": { "type": "string" },
+        "managerStatePath": { "type": "string" },
         "hostSignalPath": { "type": "string" },
         "hostIsolationPath": { "type": "string" },
         "observerHeartbeatPath": { "type": "string" },

--- a/tools/priority/__tests__/jarvis-session-observer.test.mjs
+++ b/tools/priority/__tests__/jarvis-session-observer.test.mjs
@@ -211,6 +211,8 @@ test('observeJarvisSessionObserver projects an active manual Windows Docker sess
   assert.equal(report.status, 'active');
   assert.equal(report.summary.activeSessionCount, 1);
   assert.equal(report.summary.totalSessionCount, 1);
+  assert.equal(report.hostRuntime.source, 'daemon-host-signal');
+  assert.equal(report.hostRuntime.diagnostics.managerStateAvailable, false);
   assert.equal(report.daemon.daemonCutover.status, 'ready');
   assert.equal(report.daemon.daemonCutover.readyForLinuxDaemon, true);
   assert.deepEqual(report.daemon.daemonCutover.requiredActions, []);
@@ -313,4 +315,125 @@ test('observeJarvisSessionObserver blocks when native-wsl daemon cutover is stil
     'Rerun priority:jarvis:status.'
   ]);
   assert.match(report.daemon.daemonCutover.reason, /cut over to a distro-owned Linux daemon/i);
+});
+
+test('observeJarvisSessionObserver honors manager state when stale host-signal evidence was rejected', async () => {
+  const repoRoot = createTempDir();
+  const runtimeDir = path.join(repoRoot, 'tests', 'results', '_agent', 'runtime');
+  writeJson(path.join(repoRoot, 'tools', 'priority', 'delivery-agent.policy.json'), {
+    schema: 'priority/delivery-agent-policy@v1',
+    capitalFabric: {
+      specialtyLanes: [
+        {
+          id: 'jarvis',
+          enabled: true,
+          primaryRecordedResponsibility: 'Sagan',
+          maxInstanceCount: 2,
+          preferredExecutionPlane: 'local-docker-windows',
+          preferredContainerImage: 'nationalinstruments/labview:2026q1-windows'
+        }
+      ]
+    },
+    dockerRuntime: {
+      provider: 'native-wsl',
+      dockerHost: 'unix:///var/run/docker.sock',
+      expectedOsType: 'linux',
+      expectedContext: '',
+      manageDockerEngine: false,
+      allowHostEngineMutation: false
+    }
+  });
+  writeJson(path.join(runtimeDir, 'delivery-agent-state.json'), {
+    schema: 'priority/delivery-agent-runtime-state@v1',
+    generatedAt: '2026-03-21T01:00:00.000Z',
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+  });
+  writeJson(path.join(runtimeDir, 'delivery-agent-manager-state.json'), {
+    schema: 'priority/unattended-delivery-agent-manager-report@v1',
+    generatedAt: '2026-03-21T01:20:00.000Z',
+    hostSignal: null,
+    hostSignalDiagnostics: {
+      usedHostSignal: false,
+      reason: 'stale-before-current-manager',
+      hostSignalGeneratedAt: '2026-03-21T01:00:00.000Z',
+      managerStartedAt: '2026-03-21T01:15:00.000Z',
+      hostSignalRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    hostIsolation: {
+      lastStatus: 'native-wsl',
+      lastAction: 'collect',
+      preemptedServices: [],
+      counters: {
+        runnerPreemptionCount: 0
+      }
+    }
+  });
+  writeJson(path.join(runtimeDir, 'daemon-host-signal.json'), {
+    schema: 'priority/delivery-agent-host-signal@v1',
+    generatedAt: '2026-03-21T01:10:00.000Z',
+    status: 'native-wsl',
+    provider: 'native-wsl',
+    daemonFingerprint: 'stale-host-signal-fingerprint',
+    previousFingerprint: 'stale-host-signal-fingerprint',
+    fingerprintChanged: false,
+    reasons: [],
+    windowsDocker: {
+      available: true,
+      context: 'desktop-windows',
+      osType: 'windows',
+      operatingSystem: 'Docker Desktop',
+      serverName: 'docker-desktop',
+      platformName: 'Docker Desktop',
+      serverVersion: '29.2.0',
+      labels: [],
+      error: null
+    },
+    wslDocker: {
+      distro: 'Ubuntu',
+      dockerHost: 'unix:///var/run/docker.sock',
+      available: true,
+      socketPath: '/var/run/docker.sock',
+      socketPresent: true,
+      socketOwner: 'root:docker',
+      socketMode: '660',
+      systemdState: 'running',
+      serviceState: 'active',
+      context: 'default',
+      osType: 'linux',
+      operatingSystem: 'Ubuntu 24.04.2 LTS',
+      serverName: 'ubuntu-native',
+      platformName: 'Docker Engine - Community',
+      serverVersion: '28.1.1',
+      labels: [],
+      isDockerDesktop: false,
+      error: null
+    },
+    runnerServices: {
+      running: [],
+      stopped: []
+    }
+  });
+
+  const { report } = await observeJarvisSessionObserver({
+    repoRoot,
+    runtimeDir,
+    policyPath: path.join(repoRoot, 'tools', 'priority', 'delivery-agent.policy.json'),
+    outputPath: path.join(runtimeDir, 'jarvis-session-observer.json'),
+    tailLines: 2
+  });
+
+  assert.equal(report.hostRuntime.source, 'delivery-agent-manager-state');
+  assert.equal(report.hostRuntime.status, 'unknown');
+  assert.equal(report.hostRuntime.provider, null);
+  assert.equal(report.hostRuntime.diagnostics.managerStateAvailable, true);
+  assert.equal(report.hostRuntime.diagnostics.hostSignalDiagnostics.usedHostSignal, false);
+  assert.equal(report.hostRuntime.diagnostics.hostSignalDiagnostics.reason, 'stale-before-current-manager');
+  assert.equal(report.daemon.daemonCutover.status, 'unknown');
+  assert.match(report.daemon.daemonCutover.reason, /could not determine whether the Linux daemon plane is reusable/i);
+  assert.ok(
+    report.warnings.includes(
+      'delivery-agent manager rejected daemon-host-signal.json (stale-before-current-manager).'
+    )
+  );
+  assert.equal(report.artifacts.managerStatePath, path.join(runtimeDir, 'delivery-agent-manager-state.json'));
 });

--- a/tools/priority/jarvis-session-observer.mjs
+++ b/tools/priority/jarvis-session-observer.mjs
@@ -160,13 +160,29 @@ function normalizeJarvisPolicy(policy = {}, runtimeState = {}) {
   };
 }
 
-function normalizeHostSignal(hostSignal = null, hostIsolation = null) {
+function normalizeHostSignalDiagnostics(diagnostics = null) {
+  return {
+    usedHostSignal: diagnostics?.usedHostSignal === true,
+    reason: toOptionalText(diagnostics?.reason),
+    hostSignalGeneratedAt: toOptionalText(diagnostics?.hostSignalGeneratedAt),
+    managerStartedAt: toOptionalText(diagnostics?.managerStartedAt),
+    hostSignalRepository: toOptionalText(diagnostics?.hostSignalRepository)
+  };
+}
+
+function normalizeHostSignal(hostSignal = null, hostIsolation = null, options = {}) {
   const reasons = Array.isArray(hostSignal?.reasons)
     ? hostSignal.reasons.map((entry) => normalizeText(entry)).filter(Boolean)
     : [];
+  const diagnostics = {
+    managerStateAvailable: options.managerStateAvailable === true,
+    managerGeneratedAt: toOptionalText(options.managerGeneratedAt),
+    hostSignalDiagnostics: normalizeHostSignalDiagnostics(options.hostSignalDiagnostics)
+  };
   return {
     status: toOptionalText(hostSignal?.status) ?? 'unknown',
     provider: toOptionalText(hostSignal?.provider),
+    source: toOptionalText(options.source) ?? 'unavailable',
     reasons,
     daemonFingerprint: toOptionalText(hostSignal?.daemonFingerprint),
     previousFingerprint: toOptionalText(hostSignal?.previousFingerprint),
@@ -211,8 +227,52 @@ function normalizeHostSignal(hostSignal = null, hostIsolation = null) {
       lastAction: toOptionalText(hostIsolation?.lastAction),
       preemptedServices: Array.isArray(hostIsolation?.preemptedServices) ? hostIsolation.preemptedServices : [],
       counters: hostIsolation?.counters ?? {}
-    }
+    },
+    diagnostics
   };
+}
+
+function resolveHostRuntimeEvidence(managerState, hostSignal, hostIsolation, warnings) {
+  const managerStateAvailable = Boolean(managerState);
+  const managerGeneratedAt = toOptionalText(managerState?.generatedAt);
+  const managerHostSignalDiagnostics = managerState?.hostSignalDiagnostics ?? null;
+  const managerHostSignal = managerState && Object.hasOwn(managerState, 'hostSignal')
+    ? managerState.hostSignal
+    : null;
+  const managerHostIsolation = managerState && Object.hasOwn(managerState, 'hostIsolation')
+    ? managerState.hostIsolation
+    : hostIsolation;
+  const normalizedManagerDiagnostics = normalizeHostSignalDiagnostics(managerHostSignalDiagnostics);
+
+  if (managerStateAvailable && normalizedManagerDiagnostics.usedHostSignal === false) {
+    if (normalizedManagerDiagnostics.reason) {
+      warnings.push(
+        `delivery-agent manager rejected daemon-host-signal.json (${normalizedManagerDiagnostics.reason}).`
+      );
+    }
+    return normalizeHostSignal(null, managerHostIsolation, {
+      source: 'delivery-agent-manager-state',
+      managerStateAvailable,
+      managerGeneratedAt,
+      hostSignalDiagnostics: managerHostSignalDiagnostics
+    });
+  }
+
+  if (managerHostSignal) {
+    return normalizeHostSignal(managerHostSignal, managerHostIsolation, {
+      source: 'delivery-agent-manager-state',
+      managerStateAvailable,
+      managerGeneratedAt,
+      hostSignalDiagnostics: managerHostSignalDiagnostics
+    });
+  }
+
+  return normalizeHostSignal(hostSignal, hostIsolation, {
+    source: hostSignal ? 'daemon-host-signal' : 'unavailable',
+    managerStateAvailable,
+    managerGeneratedAt,
+    hostSignalDiagnostics: managerHostSignalDiagnostics
+  });
 }
 
 function buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime) {
@@ -505,6 +565,7 @@ function createWatchPaths(paths) {
     paths.deliveryStatePath,
     paths.concurrentLaneStatusPath,
     paths.deliveryMemoryPath,
+    paths.managerStatePath,
     paths.hostSignalPath,
     paths.hostIsolationPath,
     paths.observerHeartbeatPath,
@@ -590,6 +651,7 @@ export async function buildJarvisSessionObserverReport({
     deliveryStatePath: path.join(resolvedRuntimeDir, 'delivery-agent-state.json'),
     concurrentLaneStatusPath: path.join(resolvedRuntimeDir, 'concurrent-lane-status-receipt.json'),
     deliveryMemoryPath: path.join(resolvedRuntimeDir, 'delivery-memory.json'),
+    managerStatePath: path.join(resolvedRuntimeDir, 'delivery-agent-manager-state.json'),
     hostSignalPath: path.join(resolvedRuntimeDir, 'daemon-host-signal.json'),
     hostIsolationPath: path.join(resolvedRuntimeDir, 'delivery-agent-host-isolation.json'),
     observerHeartbeatPath: path.join(resolvedRuntimeDir, 'observer-heartbeat.json'),
@@ -604,6 +666,7 @@ export async function buildJarvisSessionObserverReport({
     runtimeState,
     concurrentLaneStatus,
     deliveryMemory,
+    managerState,
     hostSignal,
     hostIsolation,
     observerHeartbeat,
@@ -616,6 +679,7 @@ export async function buildJarvisSessionObserverReport({
     readJsonIfPresent(paths.deliveryStatePath),
     readJsonIfPresent(paths.concurrentLaneStatusPath),
     readJsonIfPresent(paths.deliveryMemoryPath),
+    readJsonIfPresent(paths.managerStatePath),
     readJsonIfPresent(paths.hostSignalPath),
     readJsonIfPresent(paths.hostIsolationPath),
     readJsonIfPresent(paths.observerHeartbeatPath),
@@ -631,7 +695,7 @@ export async function buildJarvisSessionObserverReport({
   if (!runtimeState) warnings.push('delivery-agent-state.json is missing.');
 
   const jarvisPolicy = normalizeJarvisPolicy(policy ?? {}, runtimeState ?? {});
-  const hostRuntime = normalizeHostSignal(hostSignal, hostIsolation);
+  const hostRuntime = resolveHostRuntimeEvidence(managerState, hostSignal, hostIsolation, warnings);
   const daemonCutover = buildDaemonCutoverAssessment(jarvisPolicy, hostRuntime);
   const concurrentSessions = collectConcurrentLaneSessions(concurrentLaneStatus ?? {}, jarvisPolicy);
   const runtimeFallbackSession = buildRuntimeFallbackSession(runtimeState ?? {}, hostRuntime, jarvisPolicy);
@@ -699,6 +763,7 @@ export async function buildJarvisSessionObserverReport({
       runtimeDir: resolvedRuntimeDir,
       deliveryStatePath: paths.deliveryStatePath,
       concurrentLaneStatusPath: paths.concurrentLaneStatusPath,
+      managerStatePath: paths.managerStatePath,
       hostSignalPath: paths.hostSignalPath,
       hostIsolationPath: paths.hostIsolationPath,
       observerHeartbeatPath: paths.observerHeartbeatPath,


### PR DESCRIPTION
## Summary
- prefer delivery-agent manager host-runtime evidence when Jarvis observes daemon cutover state
- fail closed when the manager marks raw daemon-host-signal data as stale-before-current-manager
- expose manager-state receipt provenance in the Jarvis observer schema and tests

## Testing
- node --test tools/priority/__tests__/jarvis-session-observer.test.mjs tools/priority/__tests__/jarvis-session-observer-schema.test.mjs
- git diff --check

Refs #1741
