### PR TITLE
[ci] distinguish fresh-head Validate lag from missing session-index evidence

### DIFF
--- a/tools/priority/__tests__/project-session-index-v2-promotion-decision.test.mjs
+++ b/tools/priority/__tests__/project-session-index-v2-promotion-decision.test.mjs
@@ -42,7 +42,7 @@ test('projectSessionIndexV2PromotionDecision routes the helper into the standing
           selection: {
             mode: 'latest-completed-run',
             status: 'fail',
-            failureClass: 'run-not-found',
+            failureClass: 'current-head-run-pending',
           },
           sourceRun: null,
           artifact: {
@@ -50,7 +50,7 @@ test('projectSessionIndexV2PromotionDecision routes the helper into the standing
             destinationRoot: path.join(repoRoot, DEFAULT_DESTINATION_ROOT),
           },
           decision: {
-            state: 'missing-evidence',
+            state: 'fresh-head-awaiting-validate',
             summary: 'No completed current-head Validate run exists yet.',
           },
         },
@@ -74,12 +74,12 @@ test('projectSessionIndexV2PromotionDecision routes the helper into the standing
     'LabVIEW-Community-CI-CD/compare-vi-cli-action',
   ]);
   assert.equal(result.exitCode, 0);
-  assert.equal(result.snapshot.state, 'missing-evidence');
+  assert.equal(result.snapshot.state, 'fresh-head-awaiting-validate');
   assert.equal(result.snapshot.status, 'fail');
   assert.equal(result.snapshot.path, 'tests/results/_agent/issue/session-index-v2-promotion-decision.json');
   assert.equal(result.snapshot.downloadReportPath, 'tests/results/_agent/issue/session-index-v2-promotion-decision-download.json');
   assert.equal(result.snapshot.artifactRoot, 'tests/results/_agent/issue/session-index-v2-promotion-decision-artifacts');
-  assert.match(logs.join('\n'), /state=missing-evidence status=fail run=none/);
+  assert.match(logs.join('\n'), /state=fresh-head-awaiting-validate status=fail run=none/);
 });
 
 test('projectSessionIndexV2PromotionDecision records a projection error when the helper throws', async () => {

--- a/tools/priority/__tests__/session-index-v2-promotion-decision.test.mjs
+++ b/tools/priority/__tests__/session-index-v2-promotion-decision.test.mjs
@@ -1510,7 +1510,8 @@ test('runSessionIndexV2PromotionDecision reports missing-evidence when the curre
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.sourceRun, null);
-  assert.equal(result.report.decision.state, 'missing-evidence');
+  assert.equal(result.report.selection.failureClass, 'current-head-run-pending');
+  assert.equal(result.report.decision.state, 'fresh-head-awaiting-validate');
   assert.equal(result.report.status, 'warn');
 });
 

--- a/tools/priority/session-index-v2-promotion-decision.mjs
+++ b/tools/priority/session-index-v2-promotion-decision.mjs
@@ -1027,11 +1027,14 @@ async function resolveSelectedRun(options, runGhJsonFn, getBranchHeadShaFn = def
       options.branch,
     );
     if (!run) {
+      const branchHasCompletedRuns = collectedRuns.length > 0;
       return {
         status: 'fail',
         selectionMode: 'latest-completed-run',
-        failureClass: 'run-not-found',
-        errorMessage: `No completed ${options.workflow} runs found for branch '${options.branch}' at head '${branchHeadSha}' in ${options.repo} after scanning ${WORKFLOW_RUNS_PAGE_SIZE * WORKFLOW_RUNS_MAX_PAGES} runs.`,
+        failureClass: branchHasCompletedRuns ? 'current-head-run-pending' : 'run-not-found',
+        errorMessage: branchHasCompletedRuns
+          ? `No completed ${options.workflow} runs found yet for branch '${options.branch}' at current head '${branchHeadSha}' in ${options.repo} after scanning ${WORKFLOW_RUNS_PAGE_SIZE * WORKFLOW_RUNS_MAX_PAGES} runs.`
+          : `No completed ${options.workflow} runs found for branch '${options.branch}' at head '${branchHeadSha}' in ${options.repo} after scanning ${WORKFLOW_RUNS_PAGE_SIZE * WORKFLOW_RUNS_MAX_PAGES} runs.`,
         run: null,
       };
     }
@@ -1186,13 +1189,27 @@ export async function runSessionIndexV2PromotionDecision({
     );
 
     if (selectedRun.status !== 'pass' || !selectedRun.run?.id) {
-      report.evidence.status = selectedRun.failureClass === 'run-not-found' ? 'missing' : 'invalid';
+      report.evidence.status =
+        selectedRun.failureClass === 'run-not-found' || selectedRun.failureClass === 'current-head-run-pending'
+          ? 'missing'
+          : 'invalid';
       report.evidence.errors.push(selectedRun.errorMessage ?? 'Failed to resolve a workflow run.');
       report.decision = evaluatePromotionDecision({
         evidence: report.evidence,
         policy: report.policy,
         requiredCheckName: options.requiredCheckName,
       });
+      if (
+        selectedRun.failureClass === 'current-head-run-pending' &&
+        report.decision.state === 'missing-evidence' &&
+        report.decision.status === 'warn'
+      ) {
+        report.decision = {
+          ...report.decision,
+          state: 'fresh-head-awaiting-validate',
+          summary: 'The current branch head has not produced a completed Validate run yet, so promotion evidence is temporarily pending.'
+        };
+      }
       report.status = report.decision.status;
       const reportPath = await writeReportFn(options.reportPath, report);
       return { exitCode: report.status === 'fail' ? 1 : 0, report, reportPath };


### PR DESCRIPTION
## Summary
- distinguish fresh-head Validate lag from true missing session-index promotion evidence
- keep the promotion decision fail-closed while exposing a clearer `fresh-head-awaiting-validate` state
- preserve existing missing-evidence and config-drift behavior for real proof gaps

## Testing
- node --test tools/priority/__tests__/project-session-index-v2-promotion-decision.test.mjs tools/priority/__tests__/session-index-v2-promotion-decision.test.mjs
- git diff --check
