### PR TITLE
[workflow-policy]: make template verification authority explicit across worktrees

### DIFF
--- a/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
+++ b/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
@@ -16,6 +16,7 @@ It is not a second feature-development branch.
 - Proving scorecard schema: `docs/schemas/downstream-promotion-scorecard-v1.schema.json`
 - Proving scorecard output: `tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json`
 - Template-agent verification lane report: `tests/results/_agent/promotion/template-agent-verification-report.json`
+- Authoritative template verification overlay: `tests/results/_agent/promotion/template-agent-verification-report.local.json`, projected during bootstrap from the latest matching downstream proving artifact for the current `develop` source SHA
 - Selection resolver: `tools/priority/resolve-downstream-proving-artifact.mjs`
 - Selection schema: `docs/schemas/downstream-proving-selection-v1.schema.json`
 - Selection output: `tests/results/_agent/release/downstream-proving-selection.json`
@@ -57,6 +58,10 @@ always-on count.
   - `capitalFabric.maxLogicalLaneCount = 8`
 - machine-readable report:
   - `tests/results/_agent/promotion/template-agent-verification-report.json`
+  - local authoritative overlay:
+    - `tests/results/_agent/promotion/template-agent-verification-report.local.json`
+  - authority sync receipt:
+    - `tests/results/_agent/promotion/template-agent-verification-sync.json`
 
 The reserved lane renders the pinned template dependency through the hosted
 tools-image container on Ubuntu, then verifies the same pinned release on
@@ -99,6 +104,13 @@ The canonical hosted overwrite path is `.github/workflows/downstream-onboarding-
 When that workflow evaluates the policy target repository and policy consumer rail
 branch, it refreshes the same report with the hosted run URL, status, and
 duration so the reserved lane does not remain stale between local delivery turns.
+
+Fresh standing worktrees should not treat the checked-in `pending` seed as the
+latest authority by default. `tools/priority/project-template-agent-verification-authority.mjs`
+now resolves the current hosted downstream-proving artifact for `develop` and
+projects a local `.local.json` overlay. Local consumers such as
+`tools/priority/template-pivot-gate.mjs` must prefer that overlay when it is
+present.
 
 Generate the report with:
 

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -276,15 +276,19 @@
       "description": "Reserved template-agent verification lane policy, machine-readable report contract, generator, and focused tests for the hosted-first LabviewGitHubCiTemplate feedback loop, including the pinned LabviewGitHubCiTemplate@v0.1.0 consumer dependency and hosted container-backed verification plane.",
         "files": [
           "docs/schemas/template-agent-verification-report-v1.schema.json",
+          "docs/schemas/template-agent-verification-sync-report-v1.schema.json",
           "docs/schemas/template-pivot-gate-policy-v1.schema.json",
           "docs/schemas/template-pivot-gate-report-v1.schema.json",
           "tools/policy/template-dependency.json",
           "tools/policy/template-pivot-gate.json",
           "tools/priority/delivery-agent.policy.json",
           "tools/priority/template-agent-verification-report.mjs",
+          "tools/priority/sync-template-agent-verification-report.mjs",
           "tools/priority/template-pivot-gate.mjs",
           "tools/priority/__tests__/template-agent-verification-report.test.mjs",
           "tools/priority/__tests__/template-agent-verification-report-schema.test.mjs",
+          "tools/priority/__tests__/sync-template-agent-verification-report.test.mjs",
+          "tools/priority/__tests__/sync-template-agent-verification-report-schema.test.mjs",
           "tools/priority/__tests__/template-pivot-gate.test.mjs",
           "tools/priority/__tests__/template-pivot-gate-schema.test.mjs"
         ]

--- a/docs/schemas/delivery-agent-policy-v1.schema.json
+++ b/docs/schemas/delivery-agent-policy-v1.schema.json
@@ -174,6 +174,7 @@
         "targetRepository": { "type": "string" },
         "consumerRailBranch": { "type": "string" },
         "reportPath": { "type": "string" },
+        "authoritativeReportPath": { "type": "string" },
         "metrics": {
           "type": "object",
           "additionalProperties": true,

--- a/docs/schemas/downstream-proving-selection-v1.schema.json
+++ b/docs/schemas/downstream-proving-selection-v1.schema.json
@@ -148,24 +148,97 @@
         }
       }
     },
+    "templateAgentVerification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "schema",
+        "summaryStatus",
+        "verificationStatus",
+        "verificationProvider",
+        "verificationRunUrl",
+        "iterationHeadSha",
+        "matchedExpectedSourceSha",
+        "targetRepository",
+        "consumerRailBranch",
+        "templateRepository",
+        "templateVersion",
+        "templateRef",
+        "cookiecutterVersion"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pass", "fail"]
+        },
+        "schema": {
+          "type": ["string", "null"]
+        },
+        "summaryStatus": {
+          "type": ["string", "null"]
+        },
+        "verificationStatus": {
+          "type": ["string", "null"]
+        },
+        "verificationProvider": {
+          "type": ["string", "null"]
+        },
+        "verificationRunUrl": {
+          "type": ["string", "null"]
+        },
+        "iterationHeadSha": {
+          "type": ["string", "null"]
+        },
+        "matchedExpectedSourceSha": {
+          "type": "boolean"
+        },
+        "targetRepository": {
+          "type": ["string", "null"]
+        },
+        "consumerRailBranch": {
+          "type": ["string", "null"]
+        },
+        "templateRepository": {
+          "type": ["string", "null"]
+        },
+        "templateVersion": {
+          "type": ["string", "null"]
+        },
+        "templateRef": {
+          "type": ["string", "null"]
+        },
+        "cookiecutterVersion": {
+          "type": ["string", "null"]
+        }
+      }
+    },
     "candidate": {
       "type": "object",
       "additionalProperties": false,
       "required": [
         "run",
         "artifactName",
+        "artifactRoot",
         "downloadStatus",
         "downloadReportPath",
         "scorecardPath",
         "scorecardStatus",
         "scorecard",
-        "scorecardError"
+        "scorecardError",
+        "templateAgentVerificationReportPath",
+        "templateAgentVerificationStatus",
+        "templateAgentVerification",
+        "templateAgentVerificationError"
       ],
       "properties": {
         "run": {
           "$ref": "#/$defs/run"
         },
         "artifactName": {
+          "type": "string"
+        },
+        "artifactRoot": {
           "type": "string"
         },
         "downloadStatus": {
@@ -188,6 +261,22 @@
           ]
         },
         "scorecardError": {
+          "type": ["string", "null"]
+        },
+        "templateAgentVerificationReportPath": {
+          "type": ["string", "null"]
+        },
+        "templateAgentVerificationStatus": {
+          "type": "string",
+          "enum": ["pass", "fail", "missing"]
+        },
+        "templateAgentVerification": {
+          "anyOf": [
+            { "$ref": "#/$defs/templateAgentVerification" },
+            { "type": "null" }
+          ]
+        },
+        "templateAgentVerificationError": {
           "type": ["string", "null"]
         }
       }

--- a/docs/schemas/template-agent-verification-sync-report-v1.schema.json
+++ b/docs/schemas/template-agent-verification-sync-report-v1.schema.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/template-agent-verification-sync-report-v1.schema.json",
+  "title": "Template Agent Verification Sync Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "repoRoot",
+    "repository",
+    "branch",
+    "workflow",
+    "expectedSourceSha",
+    "policyPath",
+    "localCanonicalReportPath",
+    "localOverlayReportPath",
+    "authoritativeReportPath",
+    "provingSelectionReportPath",
+    "localReport",
+    "localOverlayReport",
+    "authorityReport",
+    "hostedAuthorityReport",
+    "provingSelectionStatus",
+    "provingSelectionError",
+    "selection"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/template-agent-verification-sync-report@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repoRoot": {
+      "type": "string"
+    },
+    "repository": {
+      "type": ["string", "null"]
+    },
+    "branch": {
+      "type": "string"
+    },
+    "workflow": {
+      "type": "string"
+    },
+    "expectedSourceSha": {
+      "type": ["string", "null"]
+    },
+    "policyPath": {
+      "type": "string"
+    },
+    "localCanonicalReportPath": {
+      "type": "string"
+    },
+    "localOverlayReportPath": {
+      "type": "string"
+    },
+    "authoritativeReportPath": {
+      "type": "string"
+    },
+    "provingSelectionReportPath": {
+      "type": "string"
+    },
+    "authorityRootSelection": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "localReport": {
+      "$ref": "#/$defs/reportRef"
+    },
+    "localOverlayReport": {
+      "$ref": "#/$defs/reportRef"
+    },
+    "authorityReport": {
+      "$ref": "#/$defs/reportRef"
+    },
+    "hostedAuthorityReport": {
+      "$ref": "#/$defs/reportRef"
+    },
+    "provingSelectionStatus": {
+      "type": "string",
+      "enum": ["pass", "fail", "missing", "error"]
+    },
+    "provingSelectionError": {
+      "type": ["string", "null"]
+    },
+    "selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "reason",
+        "selectedPath",
+        "synchronizedLocalOverlay",
+        "synchronizedAuthorityCache"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "hosted-authority",
+            "authority",
+            "none"
+          ]
+        },
+        "reason": {
+          "type": "string"
+        },
+        "selectedPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "synchronizedLocalOverlay": {
+          "type": "boolean"
+        },
+        "synchronizedAuthorityCache": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "reportRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "exists",
+        "parseError",
+        "schema",
+        "summaryStatus",
+        "verificationStatus",
+        "generatedAt",
+        "generatedAtMs",
+        "templateRepository",
+        "templateVersion",
+        "templateRef",
+        "cookiecutterVersion",
+        "runUrl",
+        "provider",
+        "valid"
+      ],
+      "properties": {
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exists": {
+          "type": "boolean"
+        },
+        "parseError": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summaryStatus": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verificationStatus": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generatedAt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "generatedAtMs": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "templateRepository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templateVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templateRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cookiecutterVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "valid": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "priority:pivot:template": "node tools/priority/template-pivot-gate.mjs",
     "priority:template:agent:verify": "node tools/priority/template-agent-verification-report.mjs",
     "priority:template:render:container": "node tools/priority/template-cookiecutter-container.mjs",
+    "priority:template:verify:sync": "node tools/priority/sync-template-agent-verification-report.mjs",
     "priority:template:verify": "node tools/priority/template-agent-verification-report.mjs",
     "priority:promote:downstream:manifest": "node tools/priority/downstream-promotion-manifest.mjs",
     "priority:promote:downstream:scorecard": "node tools/priority/downstream-promotion-scorecard.mjs",

--- a/tools/priority/__tests__/bootstrap-helper-contract.test.mjs
+++ b/tools/priority/__tests__/bootstrap-helper-contract.test.mjs
@@ -32,6 +32,10 @@ test('bootstrap routes standing-priority helper scripts through the resolved hel
   );
   assert.match(
     content,
+    /Invoke-NodeScriptFromRepoRoot[\s\S]*-ScriptRelativePath 'tools\/priority\/sync-template-agent-verification-report\.mjs'[\s\S]*-AllowFailure:\$true/
+  );
+  assert.match(
+    content,
     /\$semverOutcome = Invoke-SemVerCheck -RepoRoot \$priorityHelperRepoRoot -WorkingDirectory \$priorityWorkingDirectory/
   );
   assert.match(

--- a/tools/priority/__tests__/resolve-downstream-proving-artifact-schema.test.mjs
+++ b/tools/priority/__tests__/resolve-downstream-proving-artifact-schema.test.mjs
@@ -54,6 +54,7 @@ test('downstream proving selection schema validates generated selection payload'
       },
       async downloadNamedArtifactsFn({ destinationRoot, reportPath }) {
         const scorecardPath = path.join(destinationRoot, 'downstream-develop-promotion-scorecard.json');
+        const templateAgentVerificationReportPath = path.join(destinationRoot, 'template-agent-verification-report.json');
         writeJson(scorecardPath, {
           schema: 'priority/downstream-promotion-scorecard@v1',
           gates: {
@@ -70,6 +71,35 @@ test('downstream proving selection schema validates generated selection payload'
             blockerCount: 0,
             provenance: {
               sourceCommitSha: expectedSourceSha
+            }
+          }
+        });
+        writeJson(templateAgentVerificationReportPath, {
+          schema: 'priority/template-agent-verification-report@v1',
+          summary: {
+            status: 'pass',
+            blockerCount: 0,
+            recommendation: 'continue-template-agent-loop'
+          },
+          iteration: {
+            label: 'downstream promotion',
+            headSha: expectedSourceSha
+          },
+          lane: {
+            targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+            consumerRailBranch: 'downstream/develop'
+          },
+          verification: {
+            provider: 'hosted-github-workflow',
+            status: 'pass',
+            runUrl: 'https://example.test/runs/202'
+          },
+          provenance: {
+            templateDependency: {
+              repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+              version: 'v0.1.0',
+              ref: 'v0.1.0',
+              cookiecutterVersion: '2.7.1'
             }
           }
         });

--- a/tools/priority/__tests__/resolve-downstream-proving-artifact.test.mjs
+++ b/tools/priority/__tests__/resolve-downstream-proving-artifact.test.mjs
@@ -102,6 +102,7 @@ test('runResolveDownstreamProvingArtifact selects the first pass scorecard that 
       },
       async downloadNamedArtifactsFn({ runId, destinationRoot, reportPath }) {
         const scorecardPath = path.join(destinationRoot, 'downstream-develop-promotion-scorecard.json');
+        const templateAgentVerificationReportPath = path.join(destinationRoot, 'template-agent-verification-report.json');
         const sourceCommitSha = runId === '201'
           ? 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
           : expectedSourceSha;
@@ -124,6 +125,35 @@ test('runResolveDownstreamProvingArtifact selects the first pass scorecard that 
             }
           }
         });
+        writeJson(templateAgentVerificationReportPath, {
+          schema: 'priority/template-agent-verification-report@v1',
+          summary: {
+            status: 'pass',
+            blockerCount: 0,
+            recommendation: 'continue-template-agent-loop'
+          },
+          iteration: {
+            label: 'downstream promotion',
+            headSha: sourceCommitSha
+          },
+          lane: {
+            targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+            consumerRailBranch: 'downstream/develop'
+          },
+          verification: {
+            provider: 'hosted-github-workflow',
+            status: 'pass',
+            runUrl: `https://example.test/runs/${runId}`
+          },
+          provenance: {
+            templateDependency: {
+              repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+              version: 'v0.1.0',
+              ref: 'v0.1.0',
+              cookiecutterVersion: '2.7.1'
+            }
+          }
+        });
         writeJson(reportPath, {
           schema: 'run-artifact-download@v1',
           status: 'pass'
@@ -140,8 +170,14 @@ test('runResolveDownstreamProvingArtifact selects the first pass scorecard that 
 
   assert.equal(result.status, 'pass');
   assert.equal(result.selected.run.id, 202);
+  assert.equal(result.selected.templateAgentVerificationStatus, 'pass');
   assert.equal(result.selected.scorecardStatus, 'pass');
   assert.equal(result.selected.scorecard.sourceCommitSha, expectedSourceSha);
+  assert.equal(
+    path.basename(result.selected.templateAgentVerificationReportPath),
+    'template-agent-verification-report.json'
+  );
+  assert.equal(result.selected.templateAgentVerification.matchedExpectedSourceSha, true);
   assert.equal(result.report.selected.run.id, 202);
   assert.equal(result.report.selected.scorecard.matchedExpectedSourceSha, true);
   assert.ok(fs.existsSync(result.reportPath));
@@ -196,6 +232,35 @@ test('runResolveDownstreamProvingArtifact fails closed when no downloaded scorec
             }
           }
         });
+        writeJson(path.join(destinationRoot, 'template-agent-verification-report.json'), {
+          schema: 'priority/template-agent-verification-report@v1',
+          summary: {
+            status: 'pass',
+            blockerCount: 0,
+            recommendation: 'continue-template-agent-loop'
+          },
+          iteration: {
+            label: 'downstream promotion',
+            headSha: 'dddddddddddddddddddddddddddddddddddddddd'
+          },
+          lane: {
+            targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+            consumerRailBranch: 'downstream/develop'
+          },
+          verification: {
+            provider: 'hosted-github-workflow',
+            status: 'pass',
+            runUrl: 'https://example.test/runs/301'
+          },
+          provenance: {
+            templateDependency: {
+              repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+              version: 'v0.1.0',
+              ref: 'v0.1.0',
+              cookiecutterVersion: '2.7.1'
+            }
+          }
+        });
         writeJson(reportPath, {
           schema: 'run-artifact-download@v1',
           status: 'pass'
@@ -215,4 +280,5 @@ test('runResolveDownstreamProvingArtifact fails closed when no downloaded scorec
   assert.equal(result.report.selected, null);
   assert.equal(result.report.candidates.length, 1);
   assert.equal(result.report.candidates[0].scorecard.matchedExpectedSourceSha, false);
+  assert.equal(result.report.candidates[0].templateAgentVerification.matchedExpectedSourceSha, false);
 });

--- a/tools/priority/__tests__/sync-template-agent-verification-report-schema.test.mjs
+++ b/tools/priority/__tests__/sync-template-agent-verification-report-schema.test.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { syncTemplateAgentVerificationReport } from '../sync-template-agent-verification-report.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+test('template agent verification sync schema validates generated sync payload', async (t) => {
+  const schemaPath = path.join(repoRoot, 'docs', 'schemas', 'template-agent-verification-sync-report-v1.schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-agent-verification-sync-schema-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const policyPath = path.join(tmpDir, 'tools', 'priority', 'delivery-agent.policy.json');
+  const localReportPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'template-agent-verification-report.json');
+  const localOverlayReportPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'template-agent-verification-report.local.json');
+  const authorityReportPath = path.join(tmpDir, 'authority-root', 'template-agent-verification-report.json');
+  const hostedAuthorityReportPath = path.join(tmpDir, 'hosted', 'template-agent-verification-report.json');
+  const outputPath = path.join(tmpDir, 'sync.json');
+
+  writeJson(policyPath, {
+    templateAgentVerificationLane: {
+      reportPath: 'tests/results/_agent/promotion/template-agent-verification-report.json',
+      authoritativeReportPath: path.relative(tmpDir, authorityReportPath).replace(/\\/g, '/')
+    }
+  });
+  writeJson(localReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-21T22:44:32.705Z',
+    summary: {
+      status: 'pending',
+      blockerCount: 0,
+      recommendation: 'wait-for-template-verification'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pending',
+      runUrl: null
+    },
+    provenance: {
+      templateDependency: {
+        repository: null,
+        version: null,
+        ref: null,
+        cookiecutterVersion: null
+      }
+    }
+  });
+  writeJson(hostedAuthorityReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-22T05:15:00.000Z',
+    summary: {
+      status: 'pass',
+      blockerCount: 0,
+      recommendation: 'continue-template-agent-loop'
+    },
+    iteration: {
+      label: 'downstream-promotion 77',
+      headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    },
+    lane: {
+      targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      consumerRailBranch: 'downstream/develop'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pass',
+      runUrl: 'https://example.test/runs/77'
+    },
+    provenance: {
+      templateDependency: {
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+        version: 'v0.1.0',
+        ref: 'v0.1.0',
+        cookiecutterVersion: '2.7.1'
+      }
+    }
+  });
+
+  const result = await syncTemplateAgentVerificationReport(
+    {
+      repoRoot: tmpDir,
+      policyPath,
+      localReportPath,
+      localOverlayReportPath,
+      authorityReportPath,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      expectedSourceSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      outputPath
+    },
+    {
+      resolveRepoSlugFn: (value) => value,
+      runResolveDownstreamProvingArtifactFn: async ({ outputPath: selectionOutputPath }) => {
+        writeJson(selectionOutputPath, { schema: 'priority/downstream-proving-selection@v1', status: 'pass' });
+        return {
+          status: 'pass',
+          reportPath: selectionOutputPath,
+          selected: {
+            templateAgentVerificationStatus: 'pass',
+            templateAgentVerificationReportPath: hostedAuthorityReportPath
+          }
+        };
+      }
+    }
+  );
+
+  const payload = JSON.parse(await readFile(result.outputPath, 'utf8'));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(payload);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+  assert.equal(payload.selection.source, 'hosted-authority');
+  assert.equal(payload.localOverlayReport.summaryStatus, 'pass');
+});

--- a/tools/priority/__tests__/sync-template-agent-verification-report.test.mjs
+++ b/tools/priority/__tests__/sync-template-agent-verification-report.test.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_LOCAL_OVERLAY_REPORT_PATH,
+  DEFAULT_LOCAL_REPORT_PATH,
+  DEFAULT_OUTPUT_PATH,
+  DEFAULT_POLICY_PATH,
+  DEFAULT_PROVING_SELECTION_DESTINATION_ROOT,
+  DEFAULT_PROVING_SELECTION_OUTPUT_PATH,
+  parseArgs,
+  syncTemplateAgentVerificationReport
+} from '../sync-template-agent-verification-report.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+test('parseArgs exposes the checked-in template verification sync defaults', () => {
+  const parsed = parseArgs(['node', 'sync-template-agent-verification-report.mjs']);
+  assert.equal(parsed.policyPath, DEFAULT_POLICY_PATH);
+  assert.equal(parsed.localReportPath, DEFAULT_LOCAL_REPORT_PATH);
+  assert.equal(parsed.localOverlayReportPath, DEFAULT_LOCAL_OVERLAY_REPORT_PATH);
+  assert.equal(parsed.provingSelectionOutputPath, DEFAULT_PROVING_SELECTION_OUTPUT_PATH);
+  assert.equal(parsed.provingSelectionDestinationRoot, DEFAULT_PROVING_SELECTION_DESTINATION_ROOT);
+  assert.equal(parsed.outputPath, DEFAULT_OUTPUT_PATH);
+});
+
+test('syncTemplateAgentVerificationReport prefers hosted downstream proving evidence and writes a local overlay', async (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-agent-verification-sync-pass-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const policyPath = path.join(tmpDir, 'tools', 'priority', 'delivery-agent.policy.json');
+  const localReportPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'template-agent-verification-report.json');
+  const localOverlayReportPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'template-agent-verification-report.local.json');
+  const authorityReportPath = path.join(tmpDir, 'authority-root', 'template-agent-verification-report.json');
+  const hostedAuthorityReportPath = path.join(tmpDir, 'hosted', 'template-agent-verification-report.json');
+  const provingSelectionOutputPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'selection.json');
+
+  writeJson(policyPath, {
+    templateAgentVerificationLane: {
+      reportPath: 'tests/results/_agent/promotion/template-agent-verification-report.json',
+      authoritativeReportPath: path.relative(tmpDir, authorityReportPath).replace(/\\/g, '/')
+    }
+  });
+  writeJson(localReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-21T22:44:32.705Z',
+    summary: {
+      status: 'pending',
+      blockerCount: 0,
+      recommendation: 'wait-for-template-verification'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pending',
+      runUrl: null
+    },
+    provenance: {
+      templateDependency: {
+        repository: null,
+        version: null,
+        ref: null,
+        cookiecutterVersion: null
+      }
+    }
+  });
+  writeJson(hostedAuthorityReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-22T05:15:00.000Z',
+    summary: {
+      status: 'pass',
+      blockerCount: 0,
+      recommendation: 'continue-template-agent-loop'
+    },
+    iteration: {
+      label: 'downstream-promotion 77',
+      headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    },
+    lane: {
+      targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      consumerRailBranch: 'downstream/develop'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pass',
+      runUrl: 'https://example.test/runs/77'
+    },
+    provenance: {
+      templateDependency: {
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+        version: 'v0.1.0',
+        ref: 'v0.1.0',
+        cookiecutterVersion: '2.7.1'
+      }
+    }
+  });
+
+  const result = await syncTemplateAgentVerificationReport(
+    {
+      repoRoot: tmpDir,
+      policyPath,
+      localReportPath,
+      localOverlayReportPath,
+      authorityReportPath,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      expectedSourceSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      provingSelectionOutputPath
+    },
+    {
+      resolveRepoSlugFn: (value) => value,
+      runResolveDownstreamProvingArtifactFn: async ({ outputPath }) => {
+        writeJson(outputPath, { schema: 'priority/downstream-proving-selection@v1', status: 'pass' });
+        return {
+          status: 'pass',
+          reportPath: outputPath,
+          selected: {
+            templateAgentVerificationStatus: 'pass',
+            templateAgentVerificationReportPath: hostedAuthorityReportPath
+          }
+        };
+      }
+    }
+  );
+
+  assert.equal(result.report.selection.source, 'hosted-authority');
+  assert.equal(result.report.selection.synchronizedAuthorityCache, true);
+  assert.equal(result.report.selection.synchronizedLocalOverlay, true);
+  assert.equal(result.report.localReport.summaryStatus, 'pending');
+  assert.equal(result.report.localOverlayReport.summaryStatus, 'pass');
+  assert.equal(result.report.authorityReport.summaryStatus, 'pass');
+  assert.equal(fs.existsSync(localOverlayReportPath), true);
+  assert.equal(fs.existsSync(authorityReportPath), true);
+});
+
+test('syncTemplateAgentVerificationReport clears stale overlays when no authoritative evidence is available', async (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-agent-verification-sync-fail-'));
+  t.after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const policyPath = path.join(tmpDir, 'tools', 'priority', 'delivery-agent.policy.json');
+  const localReportPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'template-agent-verification-report.json');
+  const localOverlayReportPath = path.join(tmpDir, 'tests', 'results', '_agent', 'promotion', 'template-agent-verification-report.local.json');
+  const authorityReportPath = path.join(tmpDir, 'authority-root', 'template-agent-verification-report.json');
+
+  writeJson(policyPath, {
+    templateAgentVerificationLane: {
+      reportPath: 'tests/results/_agent/promotion/template-agent-verification-report.json',
+      authoritativeReportPath: path.relative(tmpDir, authorityReportPath).replace(/\\/g, '/')
+    }
+  });
+  writeJson(localReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-21T22:44:32.705Z',
+    summary: {
+      status: 'pending',
+      blockerCount: 0,
+      recommendation: 'wait-for-template-verification'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pending',
+      runUrl: null
+    },
+    provenance: {
+      templateDependency: {
+        repository: null,
+        version: null,
+        ref: null,
+        cookiecutterVersion: null
+      }
+    }
+  });
+  writeJson(localOverlayReportPath, {
+    stale: true
+  });
+
+  const result = await syncTemplateAgentVerificationReport(
+    {
+      repoRoot: tmpDir,
+      policyPath,
+      localReportPath,
+      localOverlayReportPath,
+      authorityReportPath,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      expectedSourceSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    },
+    {
+      resolveRepoSlugFn: (value) => value,
+      runResolveDownstreamProvingArtifactFn: async ({ outputPath }) => {
+        writeJson(outputPath, { schema: 'priority/downstream-proving-selection@v1', status: 'fail' });
+        return {
+          status: 'fail',
+          reportPath: outputPath,
+          selected: null
+        };
+      }
+    }
+  );
+
+  assert.equal(result.report.selection.source, 'none');
+  assert.equal(result.report.selection.synchronizedLocalOverlay, false);
+  assert.equal(fs.existsSync(localOverlayReportPath), false);
+  assert.equal(result.report.localReport.summaryStatus, 'pending');
+});

--- a/tools/priority/__tests__/template-conveyor-command-contract.test.mjs
+++ b/tools/priority/__tests__/template-conveyor-command-contract.test.mjs
@@ -20,6 +20,10 @@ test('package scripts expose the pinned template conveyor entrypoints', () => {
     'node tools/priority/template-agent-verification-report.mjs'
   );
   assert.equal(
+    packageJson.scripts['priority:template:verify:sync'],
+    'node tools/priority/sync-template-agent-verification-report.mjs'
+  );
+  assert.equal(
     packageJson.scripts['priority:pivot:template'],
     'node tools/priority/template-pivot-gate.mjs'
   );

--- a/tools/priority/__tests__/template-pivot-gate.test.mjs
+++ b/tools/priority/__tests__/template-pivot-gate.test.mjs
@@ -217,6 +217,215 @@ test('runTemplatePivotGate reports ready only when queue-empty, rc release, and 
   assert.equal(fs.existsSync(outputPath), true);
 });
 
+test('runTemplatePivotGate prefers a local authoritative template verification overlay over the checked-in pending seed', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-pivot-gate-local-overlay-'));
+  const policyPath = path.join(tmpDir, 'template-pivot-gate.json');
+  const queueEmptyReportPath = path.join(tmpDir, 'no-standing-priority.json');
+  const releaseSummaryPath = path.join(tmpDir, 'release-summary.json');
+  const handoffEntrypointStatusPath = path.join(tmpDir, 'entrypoint-status.json');
+  const templateAgentVerificationReportPath = path.join(tmpDir, 'template-agent-verification-report.json');
+  const templateAgentVerificationLocalReportPath = path.join(tmpDir, 'template-agent-verification-report.local.json');
+  const outputPath = path.join(tmpDir, 'template-pivot-gate-report.json');
+
+  writeJson(policyPath, {
+    schema: 'priority/template-pivot-gate-policy@v1',
+    schemaVersion: '1.0.0',
+    sourceRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+    targetBranch: 'develop',
+    templateDependency: {
+      repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      version: 'v0.1.0',
+      ref: 'v0.1.0',
+      cookiecutterVersion: '2.7.1'
+    },
+    queueEmpty: {
+      requiredSchema: 'standing-priority/no-standing@v1',
+      requiredReason: 'queue-empty',
+      requiredOpenIssueCount: 0
+    },
+    releaseCandidate: {
+      requiredSchema: 'agent-handoff/release-v1',
+      requireValid: true,
+      versionPattern: '^\\d+\\.\\d+\\.\\d+-rc\\.\\d+$',
+      versionPatternDescription: 'X.Y.Z-rc.N'
+    },
+    handoffEntrypoint: {
+      requiredSchema: 'agent-handoff/entrypoint-status-v1',
+      requiredStatus: 'pass'
+    },
+    decision: {
+      futureAgentOnly: true,
+      operatorSteeringAllowed: false,
+      requirePreciseSessionFeedback: true
+    },
+    artifacts: {
+      policySchema: 'docs/schemas/template-pivot-gate-policy-v1.schema.json',
+      reportSchema: 'docs/schemas/template-pivot-gate-report-v1.schema.json',
+      defaultOutputPath: outputPath,
+      queueEmptyReportPath,
+      releaseSummaryPath,
+      handoffEntrypointStatusPath,
+      templateAgentVerificationReportPath
+    }
+  });
+  writeJson(queueEmptyReportPath, {
+    schema: 'standing-priority/no-standing@v1',
+    message: 'queue empty',
+    reason: 'queue-empty',
+    openIssueCount: 0
+  });
+  writeJson(releaseSummaryPath, {
+    schema: 'agent-handoff/release-v1',
+    version: '0.6.3-rc.1',
+    valid: true,
+    issues: [],
+    checkedAt: '2026-03-21T18:00:00.000Z'
+  });
+  writeJson(handoffEntrypointStatusPath, {
+    schema: 'agent-handoff/entrypoint-status-v1',
+    generatedAt: '2026-03-21T18:01:00.000Z',
+    handoffPath: 'AGENT_HANDOFF.txt',
+    maxLines: 80,
+    actualLineCount: 42,
+    status: 'pass',
+    checks: {
+      primaryHeading: true,
+      lineBudget: true,
+      requiredHeadings: true,
+      liveArtifactGuidance: true,
+      stableEntrypointGuidance: true,
+      noStatusLogGuidance: true,
+      machineGeneratedArtifactGuidance: true,
+      noDatedHistorySections: true
+    },
+    commands: {
+      bootstrap: 'pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1',
+      standingPriority: 'pwsh -NoLogo -NoProfile -File tools/Get-StandingPriority.ps1 -Plain',
+      printHandoff: 'pwsh -NoLogo -NoProfile -File tools/Print-AgentHandoff.ps1 -ApplyToggles',
+      projectPortfolio: 'node tools/npm/run-script.mjs priority:project:portfolio:check',
+      developSync: 'node tools/npm/run-script.mjs priority:develop:sync'
+    },
+    artifacts: {
+      priorityCache: '.agent_priority_cache.json',
+      router: 'tests/results/_agent/issue/router.json',
+      noStandingPriority: 'tests/results/_agent/issue/no-standing-priority.json',
+      dockerReviewLoopSummary: 'tests/results/_agent/verification/docker-review-loop-summary.json',
+      entrypointStatus: 'tests/results/_agent/handoff/entrypoint-status.json',
+      handoffGlob: 'tests/results/_agent/handoff/*.json',
+      sessionGlob: 'tests/results/_agent/sessions/*.json'
+    },
+    violations: []
+  });
+  writeJson(templateAgentVerificationReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    summary: {
+      status: 'pending',
+      blockerCount: 0,
+      recommendation: 'wait-for-template-verification'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pending',
+      runUrl: null
+    },
+    lane: {
+      targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      consumerRailBranch: 'downstream/develop'
+    },
+    provenance: {
+      templateDependency: {
+        repository: null,
+        version: null,
+        ref: null,
+        cookiecutterVersion: null
+      },
+      execution: {
+        executionPlane: null,
+        containerImage: null,
+        generatedConsumerWorkspaceRoot: null,
+        laneId: null,
+        agentId: null,
+        fundingWindowId: null
+      }
+    }
+  });
+  writeJson(templateAgentVerificationLocalReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-21T18:02:00.000Z',
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    summary: {
+      status: 'pass',
+      blockerCount: 0,
+      recommendation: 'continue-template-agent-loop'
+    },
+    iteration: {
+      label: 'downstream-promotion 1',
+      headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    },
+    lane: {
+      enabled: true,
+      reservedSlotCount: 1,
+      minimumImplementationSlots: 3,
+      implementationSlotsRemaining: 3,
+      executionMode: 'hosted-first',
+      targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      consumerRailBranch: 'downstream/develop'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pass',
+      durationSeconds: 240,
+      runUrl: 'https://example.test/runs/2'
+    },
+    provenance: {
+      templateDependency: {
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+        version: 'v0.1.0',
+        ref: 'v0.1.0',
+        cookiecutterVersion: '2.7.1'
+      },
+      execution: {
+        executionPlane: 'linux-tools-image',
+        containerImage: 'ghcr.io/labview-community-ci-cd/comparevi-tools:v0.1.0',
+        generatedConsumerWorkspaceRoot: 'E:\\comparevi-template-consumers\\run-1',
+        laneId: 'lane-template-verify',
+        agentId: 'darwin',
+        fundingWindowId: 'HQ1VJLMV-0027'
+      }
+    },
+    goals: {},
+    metrics: {
+      targetSlotCount: 4,
+      reservedSlotCount: 1,
+      implementationSlotsRemaining: 3,
+      durationWithinGoal: true,
+      recommendationPresent: true
+    },
+    blockers: []
+  });
+
+  const { report } = await runTemplatePivotGate(
+    {
+      policyPath,
+      queueEmptyReportPath,
+      releaseSummaryPath,
+      handoffEntrypointStatusPath,
+      templateAgentVerificationReportPath,
+      outputPath,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    {
+      now: new Date('2026-03-21T18:05:00.000Z'),
+      resolveRepoSlugFn: (value) => value
+    }
+  );
+
+  assert.equal(report.summary.status, 'ready');
+  assert.equal(report.inputs.templateAgentVerificationReportPath, path.relative(process.cwd(), templateAgentVerificationLocalReportPath).replace(/\\/g, '/'));
+  assert.equal(report.evidence.templateAgentVerification.summaryStatus, 'pass');
+});
+
 test('runTemplatePivotGate fails closed when the queue is not proven empty or release is not an rc build', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-pivot-gate-blocked-'));
   const policyPath = path.join(tmpDir, 'template-pivot-gate.json');

--- a/tools/priority/bootstrap.ps1
+++ b/tools/priority/bootstrap.ps1
@@ -849,6 +849,12 @@ if (-not $PreflightOnly) {
     -ScriptRelativePath 'tools/priority/project-session-index-v2-promotion-decision.mjs' `
     -RequiredPackages @('ajv', 'ajv-formats') `
     -AllowFailure:$true
+  Write-Host '[bootstrap] Syncing authoritative template verification evidence into the local overlay report…'
+  Invoke-NodeScriptFromRepoRoot `
+    -RepoRoot $priorityHelperRepoRoot `
+    -WorkingDirectory $priorityWorkingDirectory `
+    -ScriptRelativePath 'tools/priority/sync-template-agent-verification-report.mjs' `
+    -AllowFailure:$true
   Write-Host '[bootstrap] Showing router plan…'
   $routerPath = Join-Path $priorityWorkingDirectory 'tests/results/_agent/issue/router.json'
   if (Test-Path -LiteralPath $routerPath -PathType Leaf) {

--- a/tools/priority/delivery-agent.policy.json
+++ b/tools/priority/delivery-agent.policy.json
@@ -152,6 +152,7 @@
     "targetRepository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
     "consumerRailBranch": "downstream/develop",
     "reportPath": "tests/results/_agent/promotion/template-agent-verification-report.json",
+    "authoritativeReportPath": "template-verification/template-agent-verification-report.json",
     "metrics": {
       "maxVerificationLagIterations": 1,
       "maxHostedDurationMinutes": 30,

--- a/tools/priority/resolve-downstream-proving-artifact.mjs
+++ b/tools/priority/resolve-downstream-proving-artifact.mjs
@@ -225,6 +225,48 @@ function classifyScorecard(scorecard, expectedSourceSha) {
   };
 }
 
+function classifyTemplateAgentVerificationReport(report, expectedSourceSha) {
+  const schema = normalizeText(report?.schema);
+  const summaryStatus = normalizeLower(report?.summary?.status);
+  const verificationStatus = normalizeLower(report?.verification?.status);
+  const verificationProvider = normalizeText(report?.verification?.provider);
+  const verificationRunUrl = normalizeText(report?.verification?.runUrl);
+  const iterationHeadSha = normalizeText(report?.iteration?.headSha);
+  const matchedExpectedSourceSha = iterationHeadSha === normalizeText(expectedSourceSha);
+  const targetRepository = normalizeText(report?.lane?.targetRepository);
+  const consumerRailBranch = normalizeText(report?.lane?.consumerRailBranch);
+  const templateRepository = normalizeText(report?.provenance?.templateDependency?.repository);
+  const templateVersion = normalizeText(report?.provenance?.templateDependency?.version);
+  const templateRef = normalizeText(report?.provenance?.templateDependency?.ref);
+  const cookiecutterVersion = normalizeText(report?.provenance?.templateDependency?.cookiecutterVersion);
+  const pass =
+    schema === 'priority/template-agent-verification-report@v1' &&
+    summaryStatus === 'pass' &&
+    verificationStatus === 'pass' &&
+    verificationProvider === 'hosted-github-workflow' &&
+    verificationRunUrl != null &&
+    matchedExpectedSourceSha &&
+    targetRepository === 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate' &&
+    consumerRailBranch === 'downstream/develop';
+
+  return {
+    status: pass ? 'pass' : 'fail',
+    schema,
+    summaryStatus,
+    verificationStatus,
+    verificationProvider,
+    verificationRunUrl,
+    iterationHeadSha,
+    matchedExpectedSourceSha,
+    targetRepository,
+    consumerRailBranch,
+    templateRepository,
+    templateVersion,
+    templateRef,
+    cookiecutterVersion
+  };
+}
+
 function buildGitHubOutputs(result) {
   return [
     ['downstream_proving_selection_status', result.status],
@@ -332,9 +374,13 @@ export async function runResolveDownstreamProvingArtifact(
         reportPath: downloadReportPath
       });
       const scorecardPath = findArtifactFile(candidateRoot, 'downstream-develop-promotion-scorecard.json');
+      const templateAgentVerificationReportPath = findArtifactFile(candidateRoot, 'template-agent-verification-report.json');
       let scorecard = null;
       let scorecardGate = null;
       let scorecardError = null;
+      let templateAgentVerificationReport = null;
+      let templateAgentVerificationGate = null;
+      let templateAgentVerificationError = null;
       if (scorecardPath) {
         try {
           scorecard = readJson(scorecardPath);
@@ -343,16 +389,34 @@ export async function runResolveDownstreamProvingArtifact(
           scorecardError = error instanceof Error ? error.message : String(error);
         }
       }
+      if (templateAgentVerificationReportPath) {
+        try {
+          templateAgentVerificationReport = readJson(templateAgentVerificationReportPath);
+          templateAgentVerificationGate = classifyTemplateAgentVerificationReport(
+            templateAgentVerificationReport,
+            options.expectedSourceSha
+          );
+        } catch (error) {
+          templateAgentVerificationError = error instanceof Error ? error.message : String(error);
+        }
+      }
 
       const candidate = {
         run,
         artifactName,
+        artifactRoot: path.resolve(candidateRoot),
         downloadStatus: downloadResult.report.status,
         downloadReportPath: downloadResult.reportPath,
         scorecardPath: scorecardPath ? path.resolve(scorecardPath) : null,
         scorecardStatus: scorecardGate?.status ?? 'missing',
         scorecard: scorecardGate,
-        scorecardError
+        scorecardError,
+        templateAgentVerificationReportPath: templateAgentVerificationReportPath
+          ? path.resolve(templateAgentVerificationReportPath)
+          : null,
+        templateAgentVerificationStatus: templateAgentVerificationGate?.status ?? 'missing',
+        templateAgentVerification: templateAgentVerificationGate,
+        templateAgentVerificationError
       };
       candidates.push(candidate);
 

--- a/tools/priority/sync-template-agent-verification-report.mjs
+++ b/tools/priority/sync-template-agent-verification-report.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolveArtifactDestinationRoot } from './lib/storage-root-policy.mjs';
+import { runResolveDownstreamProvingArtifact } from './resolve-downstream-proving-artifact.mjs';
+
+export const REPORT_SCHEMA = 'priority/template-agent-verification-sync-report@v1';
+export const DEFAULT_POLICY_PATH = path.join('tools', 'priority', 'delivery-agent.policy.json');
+export const DEFAULT_LOCAL_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'promotion',
+  'template-agent-verification-report.json'
+);
+export const DEFAULT_LOCAL_OVERLAY_REPORT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'promotion',
+  'template-agent-verification-report.local.json'
+);
+export const DEFAULT_AUTHORITY_REPORT_PATH = path.join(
+  'template-verification',
+  'template-agent-verification-report.json'
+);
+export const DEFAULT_PROVING_SELECTION_OUTPUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'promotion',
+  'template-agent-verification-downstream-proving-selection.json'
+);
+export const DEFAULT_PROVING_SELECTION_DESTINATION_ROOT = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'promotion',
+  'template-agent-verification-downstream-proving-artifacts'
+);
+export const DEFAULT_PROVING_BRANCH = 'develop';
+export const DEFAULT_PROVING_WORKFLOW = 'downstream-promotion.yml';
+export const DEFAULT_OUTPUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'promotion',
+  'template-agent-verification-sync.json'
+);
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function asOptional(value) {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseRemoteUrl(url) {
+  if (!url) {
+    return null;
+  }
+  const sshMatch = String(url).match(/:(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const httpsMatch = String(url).match(/github\.com\/(?<repoPath>[^/]+\/[^/]+?)(?:\.git)?$/);
+  const repoPath = sshMatch?.groups?.repoPath ?? httpsMatch?.groups?.repoPath;
+  if (!repoPath) {
+    return null;
+  }
+  const [owner, repo] = repoPath.split('/');
+  if (!owner || !repo) {
+    return null;
+  }
+  return `${owner}/${repo.replace(/\.git$/i, '')}`;
+}
+
+function resolveRepoSlug(explicitRepo, execSyncFn = execSync) {
+  if (asOptional(explicitRepo)?.includes('/')) {
+    return asOptional(explicitRepo);
+  }
+  if (asOptional(process.env.GITHUB_REPOSITORY)?.includes('/')) {
+    return asOptional(process.env.GITHUB_REPOSITORY);
+  }
+  for (const remote of ['upstream', 'origin']) {
+    try {
+      const raw = execSyncFn(`git config --get remote.${remote}.url`, {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+        .toString('utf8')
+        .trim();
+      const slug = parseRemoteUrl(raw);
+      if (slug) {
+        return slug;
+      }
+    } catch {
+      // ignore missing remotes
+    }
+  }
+  return null;
+}
+
+function resolveGitSha(revision, execSyncFn = execSync) {
+  try {
+    return asOptional(
+      execSyncFn(`git rev-parse ${revision}`, {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+        .toString('utf8')
+        .trim()
+    );
+  } catch {
+    return null;
+  }
+}
+
+function resolveExpectedSourceSha(explicitSourceSha, execSyncFn = execSync) {
+  return (
+    asOptional(explicitSourceSha) ||
+    resolveGitSha('upstream/develop', execSyncFn) ||
+    resolveGitSha('origin/develop', execSyncFn) ||
+    resolveGitSha('HEAD', execSyncFn)
+  );
+}
+
+async function defaultRunGhJson(args) {
+  const result = spawnSync('gh', args, {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.error || result.status !== 0) {
+    const message =
+      asOptional(result.stderr) ||
+      asOptional(result.stdout) ||
+      result.error?.message ||
+      `gh ${args.join(' ')} failed`;
+    throw new Error(message);
+  }
+  return JSON.parse(result.stdout || 'null');
+}
+
+function parseDate(value) {
+  const normalized = asOptional(value);
+  if (!normalized) {
+    return null;
+  }
+  const parsed = Date.parse(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function readOptionalJson(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return {
+      path: resolvedPath,
+      exists: false,
+      payload: null,
+      error: null
+    };
+  }
+  try {
+    return {
+      path: resolvedPath,
+      exists: true,
+      payload: JSON.parse(fs.readFileSync(resolvedPath, 'utf8')),
+      error: null
+    };
+  } catch (error) {
+    return {
+      path: resolvedPath,
+      exists: true,
+      payload: null,
+      error: error?.message ?? String(error)
+    };
+  }
+}
+
+function writeJson(filePath, payload) {
+  const resolvedPath = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+function copyFile(sourcePath, destinationPath) {
+  const resolvedSourcePath = path.resolve(sourcePath);
+  const resolvedDestinationPath = path.resolve(destinationPath);
+  fs.mkdirSync(path.dirname(resolvedDestinationPath), { recursive: true });
+  fs.copyFileSync(resolvedSourcePath, resolvedDestinationPath);
+  return resolvedDestinationPath;
+}
+
+function describeReport(input) {
+  const payload = input?.payload;
+  return {
+    path: input?.path ?? null,
+    exists: input?.exists === true,
+    parseError: asOptional(input?.error),
+    schema: asOptional(payload?.schema),
+    summaryStatus: asOptional(payload?.summary?.status),
+    verificationStatus: asOptional(payload?.verification?.status),
+    generatedAt: asOptional(payload?.generatedAt),
+    generatedAtMs: parseDate(payload?.generatedAt),
+    templateRepository: asOptional(payload?.provenance?.templateDependency?.repository),
+    templateVersion: asOptional(payload?.provenance?.templateDependency?.version),
+    templateRef: asOptional(payload?.provenance?.templateDependency?.ref),
+    cookiecutterVersion: asOptional(payload?.provenance?.templateDependency?.cookiecutterVersion),
+    runUrl: asOptional(payload?.verification?.runUrl),
+    provider: asOptional(payload?.verification?.provider),
+    valid:
+      payload?.schema === 'priority/template-agent-verification-report@v1' &&
+      typeof payload === 'object' &&
+      payload != null
+  };
+}
+
+export function resolveAuthorityReportPath(repoRoot, policy, env = process.env) {
+  const authorityRelativePath =
+    asOptional(policy?.templateAgentVerificationLane?.authoritativeReportPath) ?? DEFAULT_AUTHORITY_REPORT_PATH;
+  const authorityRootSelection = resolveArtifactDestinationRoot({
+    repoRoot,
+    destinationRoot: path.dirname(authorityRelativePath),
+    destinationRootExplicit: false,
+    policy: policy?.storageRoots,
+    env
+  });
+
+  return {
+    authorityReportPath: path.join(
+      authorityRootSelection.destinationRoot,
+      path.basename(authorityRelativePath)
+    ),
+    authorityRootSelection
+  };
+}
+
+async function resolveHostedAuthorityReport({
+  repoRoot,
+  repository,
+  branch,
+  workflow,
+  expectedSourceSha,
+  destinationRoot,
+  outputPath,
+  env,
+  runGhJsonFn = defaultRunGhJson,
+  runResolveDownstreamProvingArtifactFn = runResolveDownstreamProvingArtifact
+}) {
+  const selectionResult = await runResolveDownstreamProvingArtifactFn(
+    {
+      repo: repository,
+      workflow,
+      branch,
+      expectedSourceSha,
+      destinationRoot,
+      destinationRootExplicit: true,
+      outputPath
+    },
+    {
+      env,
+      runGhJsonFn
+    }
+  );
+  const hostedAuthoritySourcePath =
+    selectionResult?.selected?.templateAgentVerificationStatus === 'pass'
+      ? selectionResult.selected.templateAgentVerificationReportPath
+      : null;
+  const hostedAuthorityReport = hostedAuthoritySourcePath
+    ? describeReport(readOptionalJson(hostedAuthoritySourcePath))
+    : describeReport(null);
+  return {
+    selectionResult,
+    hostedAuthorityReport
+  };
+}
+
+function selectAuthoritySource(authorityReport, hostedAuthorityReport) {
+  if (!authorityReport.valid && !hostedAuthorityReport.valid) {
+    return {
+      source: 'none',
+      reason: 'no-valid-report',
+      selectedPath: null
+    };
+  }
+
+  if (hostedAuthorityReport.valid && !authorityReport.valid) {
+    return {
+      source: 'hosted-authority',
+      reason: 'shared-authority-missing-or-invalid',
+      selectedPath: hostedAuthorityReport.path
+    };
+  }
+
+  if (authorityReport.valid && !hostedAuthorityReport.valid) {
+    return {
+      source: 'authority',
+      reason: 'shared-authority-current',
+      selectedPath: authorityReport.path
+    };
+  }
+
+  if ((hostedAuthorityReport.generatedAtMs ?? -1) > (authorityReport.generatedAtMs ?? -1)) {
+    return {
+      source: 'hosted-authority',
+      reason: 'hosted-authority-newer-than-shared',
+      selectedPath: hostedAuthorityReport.path
+    };
+  }
+
+  return {
+    source: 'authority',
+    reason: 'shared-authority-current',
+    selectedPath: authorityReport.path
+  };
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    policyPath: DEFAULT_POLICY_PATH,
+    localReportPath: DEFAULT_LOCAL_REPORT_PATH,
+    localOverlayReportPath: DEFAULT_LOCAL_OVERLAY_REPORT_PATH,
+    authorityReportPath: null,
+    repo: null,
+    branch: DEFAULT_PROVING_BRANCH,
+    workflow: DEFAULT_PROVING_WORKFLOW,
+    expectedSourceSha: null,
+    provingSelectionOutputPath: DEFAULT_PROVING_SELECTION_OUTPUT_PATH,
+    provingSelectionDestinationRoot: DEFAULT_PROVING_SELECTION_DESTINATION_ROOT,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    repoRoot: process.cwd(),
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    if (
+      token === '--policy' ||
+      token === '--local-report' ||
+      token === '--local-overlay-report' ||
+      token === '--authority-report' ||
+      token === '--repo' ||
+      token === '--branch' ||
+      token === '--workflow' ||
+      token === '--expected-source-sha' ||
+      token === '--proving-selection-output' ||
+      token === '--proving-selection-destination-root' ||
+      token === '--output' ||
+      token === '--repo-root'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--policy') options.policyPath = next;
+      if (token === '--local-report') options.localReportPath = next;
+      if (token === '--local-overlay-report') options.localOverlayReportPath = next;
+      if (token === '--authority-report') options.authorityReportPath = next;
+      if (token === '--repo') options.repo = next;
+      if (token === '--branch') options.branch = next;
+      if (token === '--workflow') options.workflow = next;
+      if (token === '--expected-source-sha') options.expectedSourceSha = next;
+      if (token === '--proving-selection-output') options.provingSelectionOutputPath = next;
+      if (token === '--proving-selection-destination-root') options.provingSelectionDestinationRoot = next;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--repo-root') options.repoRoot = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+export async function syncTemplateAgentVerificationReport(
+  options,
+  {
+    env = process.env,
+    execSyncFn = execSync,
+    resolveRepoSlugFn = resolveRepoSlug,
+    readOptionalJsonFn = readOptionalJson,
+    writeJsonFn = writeJson,
+    copyFileFn = copyFile,
+    runResolveDownstreamProvingArtifactFn = runResolveDownstreamProvingArtifact,
+    runGhJsonFn = defaultRunGhJson
+  } = {}
+) {
+  const repoRoot = path.resolve(options.repoRoot || process.cwd());
+  const policyPath = path.resolve(repoRoot, options.policyPath || DEFAULT_POLICY_PATH);
+  const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+  const repository = resolveRepoSlugFn(options.repo, execSyncFn);
+  const branch = asOptional(options.branch) || DEFAULT_PROVING_BRANCH;
+  const workflow = asOptional(options.workflow) || DEFAULT_PROVING_WORKFLOW;
+  const expectedSourceSha = resolveExpectedSourceSha(options.expectedSourceSha, execSyncFn);
+  const localReportPath = path.resolve(
+    repoRoot,
+    options.localReportPath ||
+      asOptional(policy?.templateAgentVerificationLane?.reportPath) ||
+      DEFAULT_LOCAL_REPORT_PATH
+  );
+  const localOverlayReportPath = path.resolve(
+    repoRoot,
+    options.localOverlayReportPath || DEFAULT_LOCAL_OVERLAY_REPORT_PATH
+  );
+  const { authorityReportPath, authorityRootSelection } = options.authorityReportPath
+    ? {
+        authorityReportPath: path.resolve(options.authorityReportPath),
+        authorityRootSelection: null
+      }
+    : resolveAuthorityReportPath(repoRoot, policy, env);
+  const provingSelectionOutputPath = path.resolve(
+    repoRoot,
+    options.provingSelectionOutputPath || DEFAULT_PROVING_SELECTION_OUTPUT_PATH
+  );
+  const provingSelectionDestinationRoot = path.resolve(
+    repoRoot,
+    options.provingSelectionDestinationRoot || DEFAULT_PROVING_SELECTION_DESTINATION_ROOT
+  );
+
+  const localReport = describeReport(readOptionalJsonFn(localReportPath));
+  let authorityReport = describeReport(readOptionalJsonFn(authorityReportPath));
+  let hostedAuthorityReport = describeReport(null);
+  let provingSelection = null;
+  let provingSelectionStatus = 'missing';
+  let provingSelectionError = null;
+
+  if (repository && expectedSourceSha) {
+    try {
+      const hostedAuthority = await resolveHostedAuthorityReport({
+        repoRoot,
+        repository,
+        branch,
+        workflow,
+        expectedSourceSha,
+        destinationRoot: provingSelectionDestinationRoot,
+        outputPath: provingSelectionOutputPath,
+        env,
+        runGhJsonFn,
+        runResolveDownstreamProvingArtifactFn
+      });
+      provingSelection = hostedAuthority.selectionResult;
+      provingSelectionStatus = hostedAuthority.selectionResult?.status ?? 'fail';
+      hostedAuthorityReport = hostedAuthority.hostedAuthorityReport;
+    } catch (error) {
+      provingSelectionStatus = 'error';
+      provingSelectionError = error?.message ?? String(error);
+    }
+  }
+
+  const selection = selectAuthoritySource(authorityReport, hostedAuthorityReport);
+  let synchronizedAuthorityCache = false;
+  if (selection.source === 'hosted-authority' && hostedAuthorityReport.valid) {
+    copyFileFn(hostedAuthorityReport.path, authorityReportPath);
+    authorityReport = describeReport(readOptionalJsonFn(authorityReportPath));
+    synchronizedAuthorityCache = true;
+  }
+
+  const effectiveAuthoritativeReport = selection.source === 'hosted-authority' ? hostedAuthorityReport : authorityReport;
+  let synchronizedLocalOverlay = false;
+  if (effectiveAuthoritativeReport.valid && effectiveAuthoritativeReport.path) {
+    copyFileFn(effectiveAuthoritativeReport.path, localOverlayReportPath);
+    synchronizedLocalOverlay = true;
+  } else {
+    fs.rmSync(localOverlayReportPath, { force: true });
+  }
+  const localOverlayReport = describeReport(readOptionalJsonFn(localOverlayReportPath));
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    generatedAt: new Date().toISOString(),
+    repoRoot,
+    repository,
+    branch,
+    workflow,
+    expectedSourceSha,
+    policyPath,
+    localCanonicalReportPath: localReportPath,
+    localOverlayReportPath,
+    authoritativeReportPath: authorityReportPath,
+    provingSelectionReportPath: provingSelectionOutputPath,
+    authorityRootSelection,
+    localReport,
+    localOverlayReport,
+    authorityReport,
+    hostedAuthorityReport,
+    provingSelectionStatus,
+    provingSelectionError,
+    selection: {
+      ...selection,
+      synchronizedLocalOverlay,
+      synchronizedAuthorityCache
+    }
+  };
+
+  const outputPath = writeJsonFn(options.outputPath || DEFAULT_OUTPUT_PATH, report);
+  return {
+    report,
+    outputPath,
+    localReportPath,
+    localOverlayReportPath,
+    authorityReportPath
+  };
+}
+
+function printHelp() {
+  [
+    'Usage: node tools/priority/sync-template-agent-verification-report.mjs [options]',
+    '',
+    'Options:',
+    `  --policy <path>            Delivery policy path (default: ${DEFAULT_POLICY_PATH}).`,
+    `  --local-report <path>      Checked-in local seed report path (default: ${DEFAULT_LOCAL_REPORT_PATH}).`,
+    `  --local-overlay-report <path> Local authoritative overlay path (default: ${DEFAULT_LOCAL_OVERLAY_REPORT_PATH}).`,
+    '  --authority-report <path>  Explicit shared authoritative report path override.',
+    '  --repo <owner/repo>        Repository slug for downstream proving selection.',
+    `  --branch <name>            Downstream proving workflow branch (default: ${DEFAULT_PROVING_BRANCH}).`,
+    `  --workflow <file>          Downstream proving workflow file (default: ${DEFAULT_PROVING_WORKFLOW}).`,
+    '  --expected-source-sha <sha> Exact develop source sha to prove.',
+    `  --proving-selection-output <path> Selection report path (default: ${DEFAULT_PROVING_SELECTION_OUTPUT_PATH}).`,
+    `  --proving-selection-destination-root <path> Artifact download root (default: ${DEFAULT_PROVING_SELECTION_DESTINATION_ROOT}).`,
+    `  --output <path>            Sync report output path (default: ${DEFAULT_OUTPUT_PATH}).`,
+    '  --repo-root <path>         Repository root override (default: cwd).',
+    '  -h, --help                 Show help.'
+  ].forEach((line) => console.log(line));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const options = parseArgs(process.argv);
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    const { report, outputPath } = await syncTemplateAgentVerificationReport(options);
+    console.log(
+      `[template-agent-verification-sync] wrote ${outputPath} (source=${report.selection.source}, overlay=${report.selection.synchronizedLocalOverlay}, authority=${report.selection.synchronizedAuthorityCache})`
+    );
+  } catch (error) {
+    console.error(`[template-agent-verification-sync] ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/tools/priority/template-pivot-gate.mjs
+++ b/tools/priority/template-pivot-gate.mjs
@@ -144,6 +144,16 @@ function createBlocker(code, message) {
   return { code, message };
 }
 
+function resolvePreferredTemplateAgentVerificationReportPath(filePath) {
+  const resolved = path.resolve(filePath);
+  const parsed = path.parse(resolved);
+  const localOverlayPath = path.join(parsed.dir, `${parsed.name}.local${parsed.ext}`);
+  if (fs.existsSync(localOverlayPath)) {
+    return localOverlayPath;
+  }
+  return resolved;
+}
+
 function normalizeTemplateDependency(value) {
   return {
     repository: asOptional(value?.repository),
@@ -237,10 +247,13 @@ export async function runTemplatePivotGate(
       policy.artifacts?.handoffEntrypointStatusPath ||
       DEFAULT_HANDOFF_ENTRYPOINT_STATUS_PATH
   );
-  const templateAgentVerificationReportPath = path.resolve(
+  const requestedTemplateAgentVerificationReportPath = path.resolve(
     options.templateAgentVerificationReportPath ||
       policy.artifacts?.templateAgentVerificationReportPath ||
       DEFAULT_TEMPLATE_AGENT_VERIFICATION_REPORT_PATH
+  );
+  const templateAgentVerificationReportPath = resolvePreferredTemplateAgentVerificationReportPath(
+    requestedTemplateAgentVerificationReportPath
   );
 
   const queueEmpty = readOptionalJsonFn(queueEmptyReportPath);


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1770
- Issue title: Make template verification evidence authoritative across standing worktrees
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1770
- Standing priority at PR creation: No
- Base branch: `develop`
- Head branch: `issue/origin-1770-template-verification-authority`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
