### PR TITLE
[workflow-policy]: bump pinned LabviewGitHubCiTemplate dependency to v0.1.1

### DIFF
--- a/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
+++ b/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
@@ -36,7 +36,7 @@ At minimum that means:
 - `comparevi-history` release identity
 - scenario-pack or corpus identity
 - cookiecutter/template identity
-- pinned `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.0` release
+- pinned `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.1` release
 - pinned `cookiecutter==2.7.1` runtime for hosted conveyor proofs
 - proving scorecard reference
 - actor and timestamp
@@ -69,7 +69,7 @@ Windows as the mirrored consumer-proof plane. The released template
 dependency is treated as a conveyor-belt input, not a floating branch:
 
 - template repository: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate`
-- template ref: `v0.1.0`
+- template ref: `v0.1.1`
 - cookiecutter runtime: `2.7.1`
 - Ubuntu execution plane: `ghcr.io/labview-community-ci-cd/comparevi-tools:latest`
 - consumer render root:
@@ -144,7 +144,7 @@ node tools/npm/run-script.mjs priority:promote:downstream:manifest -- `
   --comparevi-tools-release v0.6.3-tools.14 `
   --comparevi-history-release v1.3.24 `
   --scenario-pack-id scenario-pack@v1 `
-  --cookiecutter-template-id LabviewGitHubCiTemplate@v0.1.0 `
+  --cookiecutter-template-id LabviewGitHubCiTemplate@v0.1.1 `
   --proving-scorecard-ref tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json `
   --actor SergioVelderrain
 ```

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -273,7 +273,7 @@
       "name": "Template Agent Verification Contracts",
       "category": "supporting",
       "status": "reference",
-      "description": "Reserved template-agent verification lane policy, machine-readable report contract, generator, and focused tests for the hosted-first LabviewGitHubCiTemplate feedback loop, including the pinned LabviewGitHubCiTemplate@v0.1.0 consumer dependency and hosted container-backed verification plane.",
+      "description": "Reserved template-agent verification lane policy, machine-readable report contract, generator, and focused tests for the hosted-first LabviewGitHubCiTemplate feedback loop, including the pinned LabviewGitHubCiTemplate@v0.1.1 consumer dependency and hosted container-backed verification plane.",
         "files": [
           "docs/schemas/template-agent-verification-report-v1.schema.json",
           "docs/schemas/template-agent-verification-sync-report-v1.schema.json",
@@ -317,7 +317,7 @@
       "name": "Cookiecutter Scaffold Contracts",
       "category": "supporting",
       "status": "reference",
-        "description": "Pinned cookiecutter catalog, schemas, wrapper, focused tests, and template trees for generating reviewable scenario-pack and certification corpus scaffold outputs against the released LabviewGitHubCiTemplate@v0.1.0 dependency with a hosted container-backed render conveyor.",
+        "description": "Pinned cookiecutter catalog, schemas, wrapper, focused tests, and template trees for generating reviewable scenario-pack and certification corpus scaffold outputs against the released LabviewGitHubCiTemplate@v0.1.1 dependency with a hosted container-backed render conveyor.",
         "files": [
           "docs/knowledgebase/Cookiecutter-Certification-Scaffolds.md",
           ".github/workflows/cookiecutter-bootstrap.yml",

--- a/docs/knowledgebase/Cookiecutter-Certification-Scaffolds.md
+++ b/docs/knowledgebase/Cookiecutter-Certification-Scaffolds.md
@@ -126,7 +126,7 @@ The hosted proof runs `tools/Test-CompareVICookiecutterBootstrap.ps1`, which:
 The hosted conveyor now has a second, template-consumer proof lane:
 
 - pinned template dependency:
-  - `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.0`
+  - `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.1`
 - checked-in deterministic context:
   - `tests/fixtures/cookiecutter/template-context.json`
 - hosted Ubuntu execution plane:
@@ -154,6 +154,6 @@ the same pinned dependency provenance.
 ## Natural Follow-Ons
 
 - mirror the template family into `svelderrainruiz/cookiecutter`
-- carry the same scaffold surface into `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.0`
+- carry the same scaffold surface into `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.1`
 - use the hosted bootstrap proof as the consumer-proving install contract for
   Linux and Windows lanes

--- a/docs/schemas/template-dependency-v1.schema.json
+++ b/docs/schemas/template-dependency-v1.schema.json
@@ -38,7 +38,7 @@
     },
     "templateReleaseRef": {
       "type": "string",
-      "const": "v0.1.0"
+      "const": "v0.1.1"
     },
     "templateDirectory": {
       "anyOf": [
@@ -109,7 +109,7 @@
       "properties": {
         "checkout": {
           "type": "string",
-          "const": "v0.1.0"
+          "const": "v0.1.1"
         },
         "defaultContextPath": {
           "type": "string",

--- a/tools/policy/template-dependency.json
+++ b/tools/policy/template-dependency.json
@@ -4,7 +4,7 @@
   "schemaVersion": "1.0.0",
   "templateRepositorySlug": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
   "templateRepositoryUrl": "https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.git",
-  "templateReleaseRef": "v0.1.0",
+  "templateReleaseRef": "v0.1.1",
   "templateDirectory": null,
   "cookiecutterVersion": "2.7.1",
   "container": {
@@ -17,7 +17,7 @@
     "posix": "/tmp/comparevi-template-consumers"
   },
   "rendering": {
-    "checkout": "v0.1.0",
+    "checkout": "v0.1.1",
     "defaultContextPath": "tests/fixtures/cookiecutter/template-context.json",
     "deterministicInput": true,
     "noInput": true,

--- a/tools/policy/template-pivot-gate.json
+++ b/tools/policy/template-pivot-gate.json
@@ -6,8 +6,8 @@
   "targetBranch": "develop",
   "templateDependency": {
     "repository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
-    "version": "v0.1.0",
-    "ref": "v0.1.0",
+    "version": "v0.1.1",
+    "ref": "v0.1.1",
     "cookiecutterVersion": "2.7.1"
   },
   "queueEmpty": {

--- a/tools/priority/__tests__/downstream-promotion-manifest-schema.test.mjs
+++ b/tools/priority/__tests__/downstream-promotion-manifest-schema.test.mjs
@@ -36,7 +36,7 @@ test('downstream promotion manifest validates its schema', async () => {
       compareviToolsRelease: 'v0.6.3-tools.14',
       compareviHistoryRelease: 'v1.3.24',
       scenarioPackIdentity: 'scenario-pack@v1',
-      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0',
+      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1',
       provingScorecardRef: 'tests/results/_agent/throughput/throughput-scorecard.json',
       actor: 'SergioVelderrain',
       promotionKind: 'replay',

--- a/tools/priority/__tests__/downstream-promotion-manifest.test.mjs
+++ b/tools/priority/__tests__/downstream-promotion-manifest.test.mjs
@@ -28,7 +28,7 @@ test('parseArgs enforces immutable input flags for downstream promotion manifest
     '--scenario-pack-id',
     'scenario-pack@v1',
     '--cookiecutter-template-id',
-    'LabviewGitHubCiTemplate@v0.1.0',
+    'LabviewGitHubCiTemplate@v0.1.1',
     '--proving-scorecard-ref',
     'tests/results/_agent/throughput/throughput-scorecard.json',
     '--actor',
@@ -39,7 +39,7 @@ test('parseArgs enforces immutable input flags for downstream promotion manifest
   assert.equal(parsed.outputPath, DEFAULT_OUTPUT_PATH);
   assert.equal(parsed.promotionKind, 'promote');
   assert.equal(parsed.compareviToolsRelease, 'v0.6.3-tools.14');
-  assert.equal(parsed.cookiecutterTemplateIdentity, 'LabviewGitHubCiTemplate@v0.1.0');
+  assert.equal(parsed.cookiecutterTemplateIdentity, 'LabviewGitHubCiTemplate@v0.1.1');
 });
 
 test('parseArgs fails closed when replay and rollback lineage flags do not match promotion kind', () => {
@@ -57,7 +57,7 @@ test('parseArgs fails closed when replay and rollback lineage flags do not match
         '--scenario-pack-id',
         'scenario-pack@v1',
         '--cookiecutter-template-id',
-        'LabviewGitHubCiTemplate@v0.1.0',
+        'LabviewGitHubCiTemplate@v0.1.1',
         '--proving-scorecard-ref',
         'tests/results/_agent/throughput/throughput-scorecard.json',
         '--actor',
@@ -87,7 +87,7 @@ test('runDownstreamPromotionManifest writes a deterministic immutable manifest',
       compareviToolsRelease: 'v0.6.3-tools.14',
       compareviHistoryRelease: 'v1.3.24',
       scenarioPackIdentity: 'scenario-pack@v1',
-      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0',
+      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1',
       provingScorecardRef: 'tests/results/_agent/throughput/throughput-scorecard.json',
       actor: 'SergioVelderrain',
       promotionKind: 'promote',
@@ -132,7 +132,7 @@ test('runDownstreamPromotionManifest fails closed when local upstream/develop do
           compareviToolsRelease: 'v0.6.3-tools.14',
           compareviHistoryRelease: 'v1.3.24',
           scenarioPackIdentity: 'scenario-pack@v1',
-          cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0',
+          cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1',
           provingScorecardRef: 'tests/results/_agent/throughput/throughput-scorecard.json',
           actor: 'SergioVelderrain',
           promotionKind: 'promote',

--- a/tools/priority/__tests__/downstream-promotion-scorecard-schema.test.mjs
+++ b/tools/priority/__tests__/downstream-promotion-scorecard-schema.test.mjs
@@ -76,8 +76,8 @@ test('downstream promotion scorecard schema validates generated report payload',
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
@@ -114,7 +114,7 @@ test('downstream promotion scorecard schema validates generated report payload',
       compareviToolsRelease: 'v0.6.3-tools.14',
       compareviHistoryRelease: 'v1.3.24',
       scenarioPackIdentity: 'scenario-pack@v1',
-      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0'
+      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1'
     }
   });
 

--- a/tools/priority/__tests__/downstream-promotion-scorecard.test.mjs
+++ b/tools/priority/__tests__/downstream-promotion-scorecard.test.mjs
@@ -142,8 +142,8 @@ test('runDownstreamPromotionScorecard projects manifest provenance when present'
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
@@ -180,7 +180,7 @@ test('runDownstreamPromotionScorecard projects manifest provenance when present'
       compareviToolsRelease: 'v0.6.3-tools.14',
       compareviHistoryRelease: 'v1.3.24',
       scenarioPackIdentity: 'scenario-pack@v1',
-      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0'
+      cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1'
     }
   });
 
@@ -201,7 +201,7 @@ test('runDownstreamPromotionScorecard projects manifest provenance when present'
   assert.equal(result.report.gates.manifestReport.status, 'pass');
   assert.equal(result.report.summary.metrics.totalWarnings, 3);
   assert.equal(result.report.summary.provenance.compareviToolsRelease, 'v0.6.3-tools.14');
-  assert.equal(result.report.summary.provenance.cookiecutterTemplateIdentity, 'LabviewGitHubCiTemplate@v0.1.0');
+  assert.equal(result.report.summary.provenance.cookiecutterTemplateIdentity, 'LabviewGitHubCiTemplate@v0.1.1');
   assert.equal(
     result.report.summary.provenance.templateVerificationRepository,
     'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'
@@ -260,8 +260,8 @@ test('runDownstreamPromotionScorecard fails closed when onboarding blockers rema
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
@@ -332,8 +332,8 @@ test('runDownstreamPromotionScorecard fails closed when template verification he
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {}
@@ -356,7 +356,7 @@ test('runDownstreamPromotionScorecard fails closed when template verification he
       targetBranchClassId: 'downstream-consumer-proving-rail',
       localSourceVerification: { attempted: true, matched: true }
     },
-    inputs: { cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0' }
+    inputs: { cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1' }
   });
 
   const result = runDownstreamPromotionScorecard({
@@ -408,8 +408,8 @@ test('runDownstreamPromotionScorecard fails closed when template verification la
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {}
@@ -432,7 +432,7 @@ test('runDownstreamPromotionScorecard fails closed when template verification la
       targetBranchClassId: 'downstream-consumer-proving-rail',
       localSourceVerification: { attempted: true, matched: true }
     },
-    inputs: { cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.0' }
+    inputs: { cookiecutterTemplateIdentity: 'LabviewGitHubCiTemplate@v0.1.1' }
   });
 
   const result = runDownstreamPromotionScorecard({

--- a/tools/priority/__tests__/resolve-downstream-proving-artifact-schema.test.mjs
+++ b/tools/priority/__tests__/resolve-downstream-proving-artifact-schema.test.mjs
@@ -97,8 +97,8 @@ test('downstream proving selection schema validates generated selection payload'
           provenance: {
             templateDependency: {
               repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-              version: 'v0.1.0',
-              ref: 'v0.1.0',
+              version: 'v0.1.1',
+              ref: 'v0.1.1',
               cookiecutterVersion: '2.7.1'
             }
           }

--- a/tools/priority/__tests__/resolve-downstream-proving-artifact.test.mjs
+++ b/tools/priority/__tests__/resolve-downstream-proving-artifact.test.mjs
@@ -148,8 +148,8 @@ test('runResolveDownstreamProvingArtifact selects the first pass scorecard that 
           provenance: {
             templateDependency: {
               repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-              version: 'v0.1.0',
-              ref: 'v0.1.0',
+              version: 'v0.1.1',
+              ref: 'v0.1.1',
               cookiecutterVersion: '2.7.1'
             }
           }
@@ -255,8 +255,8 @@ test('runResolveDownstreamProvingArtifact fails closed when no downloaded scorec
           provenance: {
             templateDependency: {
               repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-              version: 'v0.1.0',
-              ref: 'v0.1.0',
+              version: 'v0.1.1',
+              ref: 'v0.1.1',
               cookiecutterVersion: '2.7.1'
             }
           }

--- a/tools/priority/__tests__/sync-template-agent-verification-report-schema.test.mjs
+++ b/tools/priority/__tests__/sync-template-agent-verification-report-schema.test.mjs
@@ -83,8 +83,8 @@ test('template agent verification sync schema validates generated sync payload',
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       }
     }

--- a/tools/priority/__tests__/sync-template-agent-verification-report.test.mjs
+++ b/tools/priority/__tests__/sync-template-agent-verification-report.test.mjs
@@ -94,8 +94,8 @@ test('syncTemplateAgentVerificationReport prefers hosted downstream proving evid
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       }
     }

--- a/tools/priority/__tests__/template-agent-verification-report-schema.test.mjs
+++ b/tools/priority/__tests__/template-agent-verification-report-schema.test.mjs
@@ -51,8 +51,8 @@ test('template-agent verification report matches the checked-in schema', () => {
       provider: 'hosted-github-workflow',
       runUrl: 'https://github.com/example/run/1',
       templateRepo: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      templateVersion: 'v0.1.0',
-      templateRef: 'v0.1.0',
+      templateVersion: 'v0.1.1',
+      templateRef: 'v0.1.1',
       cookiecutterVersion: '2.7.1',
       executionPlane: 'linux-tools-image',
       containerImage: 'ghcr.io/labview-community-ci-cd/comparevi-tools:v0.1.0',
@@ -74,7 +74,7 @@ test('template-agent verification report matches the checked-in schema', () => {
   addFormats(ajv);
   const validate = ajv.compile(schema);
   assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
-  assert.equal(report.provenance.templateDependency.version, 'v0.1.0');
+  assert.equal(report.provenance.templateDependency.version, 'v0.1.1');
   assert.equal(report.provenance.execution.executionPlane, 'linux-tools-image');
 });
 

--- a/tools/priority/__tests__/template-agent-verification-report.test.mjs
+++ b/tools/priority/__tests__/template-agent-verification-report.test.mjs
@@ -31,9 +31,9 @@ test('parseArgs captures template-agent verification report inputs', () => {
     '--template-repo',
     'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
     '--template-version',
-    'v0.1.0',
+    'v0.1.1',
     '--template-ref',
-    'v0.1.0',
+    'v0.1.1',
     '--cookiecutter-version',
     '2.7.1',
     '--execution-plane',
@@ -56,7 +56,7 @@ test('parseArgs captures template-agent verification report inputs', () => {
   assert.equal(options.durationSeconds, 240);
   assert.equal(options.runUrl, 'https://github.com/example/run/1');
   assert.match(options.templatePolicyPath, /tools[\\/]policy[\\/]template-dependency\.json$/);
-  assert.equal(options.templateVersion, 'v0.1.0');
+  assert.equal(options.templateVersion, 'v0.1.1');
   assert.equal(options.cookiecutterVersion, '2.7.1');
   assert.equal(options.executionPlane, 'linux-tools-image');
   assert.equal(options.outputPath, DEFAULT_OUTPUT_PATH);
@@ -107,8 +107,8 @@ test('evaluateTemplateAgentVerificationReport passes when the reserved hosted la
     provider: 'hosted-github-workflow',
     runUrl: 'https://github.com/example/run/1',
     templateRepo: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-    templateVersion: 'v0.1.0',
-    templateRef: 'v0.1.0',
+    templateVersion: 'v0.1.1',
+    templateRef: 'v0.1.1',
     cookiecutterVersion: '2.7.1',
     executionPlane: 'linux-tools-image',
     containerImage: 'ghcr.io/labview-community-ci-cd/comparevi-tools:v0.1.0',
@@ -125,7 +125,7 @@ test('evaluateTemplateAgentVerificationReport passes when the reserved hosted la
   assert.equal(report.metrics.durationWithinGoal, true);
   assert.equal(report.blockers.length, 0);
   assert.equal(report.provenance.templateDependency.repository, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
-  assert.equal(report.provenance.templateDependency.version, 'v0.1.0');
+  assert.equal(report.provenance.templateDependency.version, 'v0.1.1');
   assert.equal(report.provenance.templateDependency.cookiecutterVersion, '2.7.1');
   assert.equal(report.provenance.execution.agentId, 'darwin');
 });
@@ -268,8 +268,8 @@ test('runTemplateAgentVerificationReport defaults pinned template provenance fro
   );
 
   assert.equal(report.provenance.templateDependency.repository, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
-  assert.equal(report.provenance.templateDependency.version, 'v0.1.0');
-  assert.equal(report.provenance.templateDependency.ref, 'v0.1.0');
+  assert.equal(report.provenance.templateDependency.version, 'v0.1.1');
+  assert.equal(report.provenance.templateDependency.ref, 'v0.1.1');
   assert.equal(report.provenance.templateDependency.cookiecutterVersion, '2.7.1');
   assert.equal(report.provenance.execution.executionPlane, 'linux-tools-image');
   assert.equal(report.provenance.execution.containerImage, 'ghcr.io/labview-community-ci-cd/comparevi-tools:latest');

--- a/tools/priority/__tests__/template-cookiecutter-container.test.mjs
+++ b/tools/priority/__tests__/template-cookiecutter-container.test.mjs
@@ -64,7 +64,7 @@ test('build helpers produce deterministic container and workspace identities', (
       runId: 'run-1743',
       context: {
         template_name: 'LabviewGitHubCiTemplate',
-        version: 'v0.1.0'
+        version: 'v0.1.1'
       }
     },
     {
@@ -81,7 +81,7 @@ test('build helpers produce deterministic container and workspace identities', (
       runId: 'run-1743b',
       context: {
         template_name: 'LabviewGitHubCiTemplate',
-        version: 'v0.1.0'
+        version: 'v0.1.1'
       }
     },
     {
@@ -92,7 +92,7 @@ test('build helpers produce deterministic container and workspace identities', (
   );
 
   assert.equal(planA.policy.schema, 'priority/template-dependency@v1');
-  assert.equal(planA.checkout, 'v0.1.0');
+  assert.equal(planA.checkout, 'v0.1.1');
   assert.equal(planA.containerImage, policy.container.image);
   assert.equal(planA.policy.effectiveContainerImage, undefined);
   assert.match(planA.containerName, /^comparevi-template-issue-origin-1743-template-cookiecutter-conveyor-run-1743$/);
@@ -101,7 +101,7 @@ test('build helpers produce deterministic container and workspace identities', (
   assert.match(planA.containerWorkspaceRoot, /\/workspace\/issue-origin-1743-template-cookiecutter-conveyor\/run-1743$/);
   assert.match(planA.containerHomeRoot, /\/workspace\/issue-origin-1743-template-cookiecutter-conveyor\/run-1743\/\.home$/);
   assert.match(planA.dockerArgs.join(' '), /from cookiecutter\.main import cookiecutter/);
-  assert.match(planA.dockerArgs.join(' '), /checkout = "v0\.1\.0"/);
+  assert.match(planA.dockerArgs.join(' '), /checkout = "v0\.1\.1"/);
   assert.match(planA.dockerArgs.join(' '), /HOME=\/workspace\/issue-origin-1743-template-cookiecutter-conveyor\/run-1743\/\.home/);
   assert.equal(planA.containerUser, null);
   assert.notEqual(planA.containerName, planB.containerName);
@@ -143,7 +143,7 @@ test('build helpers project host uid/gid onto POSIX docker runs', () => {
       runId: 'run-1743',
       context: {
         template_name: 'LabviewGitHubCiTemplate',
-        version: 'v0.1.0'
+        version: 'v0.1.1'
       }
     },
     {
@@ -166,7 +166,7 @@ test('buildCookiecutterPythonScript wires the pinned checkout and deterministic 
   const script = buildCookiecutterPythonScript({
     templateRepositoryUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.git',
     templateDirectory: null,
-    checkout: 'v0.1.0',
+    checkout: 'v0.1.1',
     outputDir: '/workspace/template-cookiecutter/run-1/output',
     context: {
       pack_slug: 'template-cookiecutter',
@@ -175,7 +175,7 @@ test('buildCookiecutterPythonScript wires the pinned checkout and deterministic 
   });
 
   assert.match(script.script, /from cookiecutter\.main import cookiecutter/);
-  assert.match(script.script, /checkout = "v0\.1\.0"/);
+  assert.match(script.script, /checkout = "v0\.1\.1"/);
   assert.match(script.script, /"overwrite_if_exists": True/);
   assert.match(script.script, /COMPAREVI_TEMPLATE_EXTRA_CONTEXT_JSON/);
   assert.equal(script.contextJson.includes('template-cookiecutter-v1'), true);
@@ -257,7 +257,7 @@ test('runTemplateCookiecutterContainer writes a receipt and captures the spawned
   assert.equal(calls[0].command, 'docker');
   assert.match(calls[0].args.join(' '), /--name comparevi-template-issue-origin-1743-template-cookiecutter-conveyor-run-1743/);
   assert.match(calls[0].args.join(' '), /comparevi-tools:cookiecutter/);
-  assert.match(calls[0].args.join(' '), /COMPAREVI_TEMPLATE_CHECKOUT=v0\.1\.0/);
+  assert.match(calls[0].args.join(' '), /COMPAREVI_TEMPLATE_CHECKOUT=v0\.1\.1/);
   assert.match(calls[0].args.join(' '), /COMPAREVI_TEMPLATE_EXTRA_CONTEXT_JSON=/);
   assert.match(calls[0].args.join(' '), /python3/);
   assert.match(calls[0].args.join(' '), /from cookiecutter\.main import cookiecutter/);
@@ -276,7 +276,7 @@ test('runTemplateCookiecutterContainer writes a receipt and captures the spawned
   assert.equal(persisted.run.uniqueContainerName, true);
   assert.equal(persisted.run.contextSource, 'file');
   assert.equal(persisted.run.contextFilePath, contextFilePath);
-  assert.equal(plan.checkout, 'v0.1.0');
+  assert.equal(plan.checkout, 'v0.1.1');
 });
 
 test('dry-run mode writes a receipt without invoking docker', () => {

--- a/tools/priority/__tests__/template-dependency-policy.test.mjs
+++ b/tools/priority/__tests__/template-dependency-policy.test.mjs
@@ -19,12 +19,12 @@ test('template dependency policy pins the template repository release and cookie
   assert.equal(policy.schema, 'priority/template-dependency@v1');
   assert.equal(policy.schemaVersion, '1.0.0');
   assert.equal(policy.templateRepositorySlug, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
-  assert.equal(policy.templateReleaseRef, 'v0.1.0');
+  assert.equal(policy.templateReleaseRef, 'v0.1.1');
   assert.equal(policy.cookiecutterVersion, '2.7.1');
   assert.equal(policy.container.runtime, 'docker');
   assert.equal(policy.container.image, 'ghcr.io/labview-community-ci-cd/comparevi-tools:latest');
   assert.equal(policy.container.executionPlane, 'linux-tools-image');
-  assert.equal(policy.rendering.checkout, 'v0.1.0');
+  assert.equal(policy.rendering.checkout, 'v0.1.1');
   assert.equal(policy.rendering.defaultContextPath, 'tests/fixtures/cookiecutter/template-context.json');
   assert.equal(policy.rendering.deterministicInput, true);
   assert.equal(policy.rendering.noInput, true);
@@ -42,10 +42,10 @@ test('template dependency policy validates against the checked-in schema', () =>
   assert.equal(schema.$id, 'https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/template-dependency-v1.schema.json');
   assert.equal(schema.properties.schema.const, 'priority/template-dependency@v1');
   assert.equal(schema.properties.templateRepositorySlug.const, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
-  assert.equal(schema.properties.templateReleaseRef.const, 'v0.1.0');
+  assert.equal(schema.properties.templateReleaseRef.const, 'v0.1.1');
   assert.equal(schema.properties.cookiecutterVersion.const, '2.7.1');
   assert.equal(schema.properties.container.properties.runtime.const, 'docker');
-  assert.equal(schema.properties.rendering.properties.checkout.const, 'v0.1.0');
+  assert.equal(schema.properties.rendering.properties.checkout.const, 'v0.1.1');
   assert.equal(
     schema.properties.rendering.properties.defaultContextPath.const,
     'tests/fixtures/cookiecutter/template-context.json'

--- a/tools/priority/__tests__/template-pivot-gate-schema.test.mjs
+++ b/tools/priority/__tests__/template-pivot-gate-schema.test.mjs
@@ -34,8 +34,8 @@ test('template pivot gate report matches the checked-in schema', async () => {
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.0',
-      ref: 'v0.1.0',
+      version: 'v0.1.1',
+      ref: 'v0.1.1',
       cookiecutterVersion: '2.7.1'
     },
     queueEmpty: {
@@ -148,8 +148,8 @@ test('template pivot gate report matches the checked-in schema', async () => {
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {

--- a/tools/priority/__tests__/template-pivot-gate.test.mjs
+++ b/tools/priority/__tests__/template-pivot-gate.test.mjs
@@ -48,8 +48,8 @@ test('runTemplatePivotGate reports ready only when queue-empty, rc release, and 
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.0',
-      ref: 'v0.1.0',
+      version: 'v0.1.1',
+      ref: 'v0.1.1',
       cookiecutterVersion: '2.7.1'
     },
     queueEmpty: {
@@ -161,8 +161,8 @@ test('runTemplatePivotGate reports ready only when queue-empty, rc release, and 
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
@@ -235,8 +235,8 @@ test('runTemplatePivotGate prefers a local authoritative template verification o
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.0',
-      ref: 'v0.1.0',
+      version: 'v0.1.1',
+      ref: 'v0.1.1',
       cookiecutterVersion: '2.7.1'
     },
     queueEmpty: {
@@ -381,8 +381,8 @@ test('runTemplatePivotGate prefers a local authoritative template verification o
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.0',
-        ref: 'v0.1.0',
+        version: 'v0.1.1',
+        ref: 'v0.1.1',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
@@ -442,8 +442,8 @@ test('runTemplatePivotGate fails closed when the queue is not proven empty or re
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.0',
-      ref: 'v0.1.0',
+      version: 'v0.1.1',
+      ref: 'v0.1.1',
       cookiecutterVersion: '2.7.1'
     },
     queueEmpty: {
@@ -724,8 +724,8 @@ test('runTemplatePivotGate fails closed when the verification report does not ma
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.0',
-      ref: 'v0.1.0',
+      version: 'v0.1.1',
+      ref: 'v0.1.1',
       cookiecutterVersion: '2.7.1'
     },
     queueEmpty: {
@@ -838,7 +838,7 @@ test('runTemplatePivotGate fails closed when the verification report does not ma
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.1',
+        version: 'v0.1.0',
         ref: 'v0.1.0',
         cookiecutterVersion: '2.7.1'
       },


### PR DESCRIPTION
## Summary
- bump the pinned `LabviewGitHubCiTemplate` dependency from `v0.1.0` to `v0.1.1`
- align the downstream promotion, template verification, and pivot-gate contracts with the new released template tag
- refresh the template dependency tests so the proving rail tracks the released template honestly

## Validation
- `node --test tools/priority/__tests__/template-dependency-policy.test.mjs tools/priority/__tests__/template-cookiecutter-container.test.mjs tools/priority/__tests__/template-agent-verification-report.test.mjs tools/priority/__tests__/sync-template-agent-verification-report.test.mjs tools/priority/__tests__/template-pivot-gate.test.mjs tools/priority/__tests__/downstream-promotion-manifest.test.mjs tools/priority/__tests__/downstream-promotion-scorecard.test.mjs tools/priority/__tests__/resolve-downstream-proving-artifact.test.mjs`
- `node --test tools/priority/__tests__/downstream-promotion-manifest-schema.test.mjs tools/priority/__tests__/downstream-promotion-scorecard-schema.test.mjs tools/priority/__tests__/resolve-downstream-proving-artifact-schema.test.mjs tools/priority/__tests__/sync-template-agent-verification-report-schema.test.mjs tools/priority/__tests__/template-agent-verification-report-schema.test.mjs tools/priority/__tests__/template-pivot-gate-schema.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`

## Proof
- template release: `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate@v0.1.1`
- hosted template smoke run: `https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate/actions/runs/23397184210`
- local container render receipt: `tests/results/_agent/template-cookiecutter/template-cookiecutter-container.json`