### PR TITLE
#1725 Exclude the last standing issue from auto-select loopbacks

### DIFF
--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -10,6 +10,7 @@ import {
   selectAutoStandingPriorityCandidate,
   selectAutoStandingPriorityCandidateForRepo,
   autoSelectStandingPriorityIssue,
+  resolveAutoSelectExcludedIssueNumbers,
   classifyNoStandingPriorityCondition,
   buildNoStandingPriorityReport,
   buildAutoPromotedStandingPriorityReport,
@@ -369,6 +370,16 @@ test('selectAutoStandingPriorityCandidate skips excluded standing issues and dep
 
   assert.equal(selected?.number, 315);
   assert.equal(selected?.cadence, false);
+});
+
+test('resolveAutoSelectExcludedIssueNumbers unions prior standing numbers from cache and router state', () => {
+  const result = resolveAutoSelectExcludedIssueNumbers(
+    { number: 1497 },
+    { issue: 1482 },
+    [1497, 1725]
+  );
+
+  assert.deepEqual(result, [1482, 1497, 1725]);
 });
 
 test('selectAutoStandingPriorityCandidate keeps comparevi demo rollout issues in scope', () => {
@@ -1197,6 +1208,32 @@ test('autoSelectStandingPriorityIssue selects and labels next issue via injected
   assert.equal(result.candidateSource, 'gh');
   assert.equal(result.labelAssignmentSource, 'gh');
   assert.deepEqual(calls, [911]);
+});
+
+test('autoSelectStandingPriorityIssue respects excluded previous standing issues', async () => {
+  const calls = [];
+  const result = await autoSelectStandingPriorityIssue('/tmp/repo', 'owner/repo', {
+    targetSlug: 'owner/repo',
+    excludeIssueNumbers: [1497],
+    runGhList: () => ({
+      status: 0,
+      stdout: JSON.stringify([
+        { number: 1497, title: '[P0] Previous standing umbrella', labels: [{ name: 'governance' }], createdAt: '2026-03-06T09:00:00Z' },
+        { number: 1482, title: '[P1] Next actionable lane', labels: [{ name: 'ci' }], createdAt: '2026-03-06T10:00:00Z' }
+      ])
+    }),
+    runGhAddLabel: ({ issueNumber }) => {
+      calls.push(issueNumber);
+      return { status: 0, stdout: '' };
+    },
+    runRestList: async () => ({ status: 'error', error: 'not-used' }),
+    runRestAddLabel: async () => ({ status: 'error', error: 'not-used' }),
+    warn: () => {}
+  });
+
+  assert.equal(result.status, 'selected');
+  assert.equal(result.issue?.number, 1482);
+  assert.deepEqual(calls, [1482]);
 });
 
 test('autoSelectStandingPriorityIssue reports empty when only out-of-scope demo issues remain', async () => {

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -853,6 +853,28 @@ function readJson(file) {
   }
 }
 
+export function resolveAutoSelectExcludedIssueNumbers(cache = {}, router = null, existing = []) {
+  const excluded = new Set(
+    Array.isArray(existing)
+      ? existing
+          .map((value) => Number(value))
+          .filter((value) => Number.isInteger(value) && value > 0)
+      : []
+  );
+
+  const cacheNumber = Number(cache?.number);
+  if (Number.isInteger(cacheNumber) && cacheNumber > 0) {
+    excluded.add(cacheNumber);
+  }
+
+  const routerIssue = Number(router?.issue);
+  if (Number.isInteger(routerIssue) && routerIssue > 0) {
+    excluded.add(routerIssue);
+  }
+
+  return Array.from(excluded).sort((left, right) => left - right);
+}
+
 export function shouldWriteJsonFile(file, nextObject) {
   const currentObject = readJson(file);
   if (currentObject == null) {
@@ -2600,6 +2622,7 @@ export async function main(options = {}) {
   const cache = readJson(cachePath) || {};
   const resultsDir = path.join(repoRoot, 'tests', 'results', '_agent', 'issue');
   fs.mkdirSync(resultsDir, { recursive: true });
+  const existingRouter = readJson(path.join(resultsDir, 'router.json')) || {};
 
   let standingPriority;
   let autoPromotedStandingReport = null;
@@ -2623,8 +2646,14 @@ export async function main(options = {}) {
       }
       if (autoSelectNext) {
         if (noStandingReason !== 'queue-empty') {
+          const autoSelectExcludedIssueNumbers = resolveAutoSelectExcludedIssueNumbers(
+            cache,
+            existingRouter,
+            options.excludeIssueNumbers
+          );
           const autoSelect = await autoSelectStandingPriorityIssue(repoRoot, slug, {
-            env: options.env || process.env
+            env: options.env || process.env,
+            excludeIssueNumbers: autoSelectExcludedIssueNumbers
           });
           if (autoSelect.status === 'selected' && autoSelect.issue?.number) {
             standingPriority = {


### PR DESCRIPTION
# Summary

Delivers issue #1725 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1725
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/origin-1725-auto-select-exclude-last-standing`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1725