### PR TITLE
fix: avoid detached bootstrap develop checkout collisions

### DIFF
--- a/tests/Priority.BootstrapDecision.Tests.ps1
+++ b/tests/Priority.BootstrapDecision.Tests.ps1
@@ -43,6 +43,21 @@ Describe 'Bootstrap develop checkout decision' -Tag 'Unit' {
     $decision.Action | Should -Be 'checkout-develop'
   }
 
+  It 'keeps detached HEAD when develop is already attached elsewhere' {
+    $decision = & $script:DecisionModule {
+      Get-DevelopCheckoutDecision `
+        -CurrentBranch 'HEAD' `
+        -IsDirty:$false `
+        -HasDevelop:$true `
+        -RemoteDevelopRef $null `
+        -AttachedDevelopWorktreeRoots @([pscustomobject]@{ Root = 'C:\repo\develop-helper'; IsClean = $true })
+    }
+
+    $decision.Action | Should -Be 'skip-detached-develop-attached'
+    $decision.Message | Should -Match 'develop attached'
+    $decision.Message | Should -Match 'develop-helper'
+  }
+
   It 'delegates standing-priority helpers to a develop worktree when bootstrapping from a work branch' {
     $decision = & $script:DecisionModule {
       Get-BootstrapHelperRootDecision `

--- a/tools/priority/bootstrap-decision.psm1
+++ b/tools/priority/bootstrap-decision.psm1
@@ -7,7 +7,8 @@ function Get-DevelopCheckoutDecision {
     [AllowNull()][string]$CurrentBranch,
     [bool]$IsDirty,
     [bool]$HasDevelop,
-    [AllowNull()][hashtable]$RemoteDevelopRef
+    [AllowNull()][hashtable]$RemoteDevelopRef,
+    [AllowNull()][object[]]$AttachedDevelopWorktreeRoots
   )
 
   if ([string]::IsNullOrWhiteSpace($CurrentBranch)) {
@@ -70,6 +71,27 @@ function Get-DevelopCheckoutDecision {
       Message = "[bootstrap] Creating local develop from $($RemoteDevelopRef.Ref)."
       Remote = $RemoteDevelopRef.Remote
       Ref = $RemoteDevelopRef.Ref
+    }
+  }
+
+  $normalizedAttachedDevelopRoots = @(
+    @(
+      foreach ($root in @($AttachedDevelopWorktreeRoots)) {
+        $normalizedCandidate = Normalize-BootstrapHelperCandidate -Candidate $root
+        if ($null -ne $normalizedCandidate) {
+          $normalizedCandidate.Root
+        }
+      }
+    ) | Select-Object -Unique
+  )
+
+  if ($CurrentBranch -eq 'HEAD' -and $normalizedAttachedDevelopRoots.Count -gt 0) {
+    $attachedRoot = $normalizedAttachedDevelopRoots[0]
+    return [pscustomobject]@{
+      Action = 'skip-detached-develop-attached'
+      Message = "[bootstrap] Detached HEAD already has develop attached at '$attachedRoot'; keeping the detached checkout."
+      Remote = $null
+      Ref = $null
     }
   }
 

--- a/tools/priority/bootstrap.ps1
+++ b/tools/priority/bootstrap.ps1
@@ -648,6 +648,7 @@ function Ensure-DevelopBranch {
   $isDirty = $false
   $hasDevelop = $false
   $remoteRef = $null
+  $developWorktreeRoots = @()
 
   if ($current -in @('main', 'master', 'HEAD')) {
     $dirty = @(Get-GitStatusPorcelain)
@@ -655,13 +656,20 @@ function Ensure-DevelopBranch {
 
     if (-not $isDirty) {
       $hasDevelop = Test-GitBranchExists -Name 'develop'
-      if (-not $hasDevelop) {
+      if ($hasDevelop) {
+        $developWorktreeRoots = @(Get-DevelopWorktreeRoots)
+      } else {
         $remoteRef = Resolve-RemoteDevelopRef
       }
     }
   }
 
-  $decision = Get-DevelopCheckoutDecision -CurrentBranch $current -IsDirty:$isDirty -HasDevelop:$hasDevelop -RemoteDevelopRef $remoteRef
+  $decision = Get-DevelopCheckoutDecision `
+    -CurrentBranch $current `
+    -IsDirty:$isDirty `
+    -HasDevelop:$hasDevelop `
+    -RemoteDevelopRef $remoteRef `
+    -AttachedDevelopWorktreeRoots $developWorktreeRoots
 
   switch ($decision.Action) {
     'noop-already-develop' {
@@ -685,6 +693,10 @@ function Ensure-DevelopBranch {
     }
     'skip-no-remote-develop' {
       Write-Warning $decision.Message
+      return
+    }
+    'skip-detached-develop-attached' {
+      Write-Host $decision.Message
       return
     }
     'create-develop-from-remote' {


### PR DESCRIPTION
## Summary
- avoid `git checkout develop` from bootstrap when detached `HEAD` already has `develop` attached in another worktree
- add focused bootstrap-decision coverage for the detached-worktree case
- prove the fix with a clean detached bootstrap run from `E:\comparevi-lanes\1795-detached-proof-clean`

## Testing
- `pwsh -NoLogo -NoProfile -File tests/Priority.BootstrapDecision.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1`
- `git diff --check`
