### PR TITLE
[policy]: disable fork release branch protections that block RC maintenance pushes (#1799)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -95,6 +95,10 @@ promotion behavior, not the branch-class source of truth.
 "Automatic request Copilot review" setting is still a manual settings-page verification point because GitHub's REST
 ruleset/branch-protection APIs do not expose that toggle directly.
 
+Fork release exception:
+- `forkProfile.rulesets.8614172.enabled = false` keeps fork `release/*` rulesets disabled by contract.
+- Reason: fork release branches are disposable automation maintenance lanes, so follow-up RC repair pushes must not be blocked by PR-only or required-check ruleset enforcement.
+
 ## Prescriptive Protection Settings
 
 Keep GitHub’s live protections in lockstep with the repository contract below. Any delta should either be reverted or

--- a/tools/priority/__tests__/check-policy-fork-release-ruleset.test.mjs
+++ b/tools/priority/__tests__/check-policy-fork-release-ruleset.test.mjs
@@ -1,0 +1,399 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run } from '../check-policy.mjs';
+
+function createResponse(data, status = 200, statusText = 'OK') {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    async json() {
+      return data === null ? null : structuredClone(data);
+    },
+    async text() {
+      if (data === null || data === undefined) {
+        return '';
+      }
+      return typeof data === 'string' ? data : JSON.stringify(data);
+    }
+  };
+}
+
+const manifestOverride = {
+  repo: {
+    allow_squash_merge: true,
+    allow_merge_commit: false,
+    allow_rebase_merge: true,
+    allow_auto_merge: true,
+    delete_branch_on_merge: true
+  },
+  forkProfile: {
+    branches: {
+      develop: {
+        allow_force_pushes: true,
+        allow_fork_syncing: false
+      }
+    },
+    rulesets: {
+      '8614172': {
+        enabled: false
+      }
+    }
+  },
+  branches: {
+    develop: {
+      required_status_checks_strict: true,
+      required_status_checks: ['lint', 'commit-integrity'],
+      required_linear_history: true,
+      enforce_admins: false,
+      required_pull_request_reviews: null,
+      restrictions: null,
+      allow_force_pushes: false,
+      allow_deletions: false,
+      block_creations: false,
+      required_conversation_resolution: false,
+      lock_branch: false,
+      allow_fork_syncing: false
+    },
+    main: {
+      required_status_checks_strict: true,
+      required_status_checks: ['lint'],
+      required_linear_history: true,
+      enforce_admins: false,
+      required_pull_request_reviews: null,
+      restrictions: null,
+      allow_force_pushes: false,
+      allow_deletions: false,
+      block_creations: false,
+      required_conversation_resolution: false,
+      lock_branch: false,
+      allow_fork_syncing: false
+    }
+  },
+  rulesets: {
+    '8811898': {
+      name: 'develop',
+      includes: ['refs/heads/develop'],
+      required_linear_history: true,
+      required_status_checks: ['lint', 'commit-integrity'],
+      merge_queue: null,
+      pull_request: {
+        required_approving_review_count: 0,
+        dismiss_stale_reviews_on_push: false,
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_review_thread_resolution: false,
+        allowed_merge_methods: ['squash', 'rebase']
+      }
+    },
+    '8614140': {
+      name: 'main',
+      includes: ['refs/heads/main'],
+      required_status_checks: ['lint'],
+      merge_queue: null,
+      pull_request: {
+        required_approving_review_count: 0,
+        dismiss_stale_reviews_on_push: false,
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_review_thread_resolution: false,
+        allowed_merge_methods: ['squash', 'rebase']
+      }
+    },
+    '8614172': {
+      name: 'release',
+      includes: ['refs/heads/release/*'],
+      required_status_checks: ['lint', 'publish'],
+      merge_queue: null,
+      pull_request: {
+        required_approving_review_count: 0,
+        dismiss_stale_reviews_on_push: true,
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_review_thread_resolution: false,
+        allowed_merge_methods: ['rebase']
+      }
+    }
+  }
+};
+
+const branchRequiredChecksOverride = {
+  schema: 'branch-required-checks/v1',
+  schemaVersion: '1.0.0',
+  branchClassBindings: {
+    develop: 'fork-mirror',
+    main: 'upstream-release',
+    'release/*': 'upstream-release-prep'
+  },
+  branchClassRequiredChecks: {
+    'fork-mirror': ['lint', 'commit-integrity'],
+    'upstream-release': ['lint'],
+    'upstream-release-prep': ['lint', 'publish']
+  },
+  branches: {
+    develop: ['lint', 'commit-integrity'],
+    main: ['lint'],
+    'release/*': ['lint', 'publish']
+  },
+  observed: {
+    develop: [],
+    main: []
+  }
+};
+
+function createBranchProtection(requiredChecks, { allowForcePushes = false, allowForkSyncing = false } = {}) {
+  return {
+    required_status_checks: {
+      strict: true,
+      contexts: [...requiredChecks],
+      checks: requiredChecks.map((context) => ({ context }))
+    },
+    enforce_admins: { enabled: false },
+    required_pull_request_reviews: null,
+    restrictions: null,
+    required_linear_history: { enabled: true },
+    allow_force_pushes: { enabled: allowForcePushes },
+    allow_deletions: { enabled: false },
+    block_creations: { enabled: false },
+    required_conversation_resolution: { enabled: false },
+    lock_branch: { enabled: false },
+    allow_fork_syncing: { enabled: allowForkSyncing }
+  };
+}
+
+function createRuleset({
+  id,
+  name,
+  includes,
+  enforcement = 'active',
+  requiredLinearHistory = false,
+  requiredStatusChecks,
+  pullRequest
+}) {
+  const rules = [];
+  if (requiredLinearHistory) {
+    rules.push({ type: 'required_linear_history' });
+  }
+  if (requiredStatusChecks) {
+    rules.push({
+      type: 'required_status_checks',
+      parameters: {
+        strict_required_status_checks_policy: true,
+        do_not_enforce_on_create: false,
+        required_status_checks: requiredStatusChecks.map((context) => ({ context }))
+      }
+    });
+  }
+  if (pullRequest) {
+    rules.push({
+      type: 'pull_request',
+      parameters: structuredClone(pullRequest)
+    });
+  }
+  return {
+    id,
+    name,
+    target: 'branch',
+    enforcement,
+    conditions: {
+      ref_name: {
+        include: [...includes],
+        exclude: []
+      }
+    },
+    bypass_actors: [],
+    rules
+  };
+}
+
+test('priority:policy verify passes when a fork release ruleset is already disabled', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-fork';
+  const rulesets = {
+    develop: createRuleset({
+      id: 8811898,
+      name: 'develop',
+      includes: ['refs/heads/develop'],
+      requiredLinearHistory: true,
+      requiredStatusChecks: ['lint', 'commit-integrity'],
+      pullRequest: manifestOverride.rulesets['8811898'].pull_request
+    }),
+    main: createRuleset({
+      id: 8614140,
+      name: 'main',
+      includes: ['refs/heads/main'],
+      requiredStatusChecks: ['lint'],
+      pullRequest: manifestOverride.rulesets['8614140'].pull_request
+    }),
+    release: createRuleset({
+      id: 8614172,
+      name: 'release',
+      includes: ['refs/heads/release/*'],
+      enforcement: 'disabled',
+      requiredStatusChecks: ['lint', 'publish'],
+      pullRequest: manifestOverride.rulesets['8614172'].pull_request
+    })
+  };
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse({
+        allow_squash_merge: true,
+        allow_merge_commit: false,
+        allow_rebase_merge: true,
+        allow_auto_merge: true,
+        delete_branch_on_merge: true,
+        fork: true,
+        owner: { type: 'Organization', login: 'test-org' },
+        permissions: { admin: true }
+      });
+    }
+    if (method === 'GET' && url === `${repoUrl}/branches/develop/protection`) {
+      return createResponse(createBranchProtection(['lint', 'commit-integrity'], { allowForcePushes: true }));
+    }
+    if (method === 'GET' && url === `${repoUrl}/branches/main/protection`) {
+      return createResponse(createBranchProtection(['lint']));
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8811898`) {
+      return createResponse(rulesets.develop);
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8614140`) {
+      return createResponse(rulesets.main);
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8614172`) {
+      return createResponse(rulesets.release);
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets`) {
+      return createResponse(Object.values(rulesets).map((ruleset) => ({
+        id: ruleset.id,
+        name: ruleset.name,
+        target: ruleset.target,
+        enforcement: ruleset.enforcement
+      })));
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-fork',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    manifestOverride,
+    branchRequiredChecksOverride,
+    log: () => {},
+    error: () => {}
+  });
+
+  assert.equal(code, 0);
+});
+
+test('priority:policy --apply disables an active fork release ruleset instead of recreating protection drift', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-fork';
+  let releaseRuleset = createRuleset({
+    id: 8614172,
+    name: 'release',
+    includes: ['refs/heads/release/*'],
+    enforcement: 'active',
+    requiredStatusChecks: ['lint', 'publish'],
+    pullRequest: manifestOverride.rulesets['8614172'].pull_request
+  });
+  const rulesets = {
+    develop: createRuleset({
+      id: 8811898,
+      name: 'develop',
+      includes: ['refs/heads/develop'],
+      requiredLinearHistory: true,
+      requiredStatusChecks: ['lint', 'commit-integrity'],
+      pullRequest: manifestOverride.rulesets['8811898'].pull_request
+    }),
+    main: createRuleset({
+      id: 8614140,
+      name: 'main',
+      includes: ['refs/heads/main'],
+      requiredStatusChecks: ['lint'],
+      pullRequest: manifestOverride.rulesets['8614140'].pull_request
+    })
+  };
+  const appliedPayloads = [];
+
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse({
+        allow_squash_merge: true,
+        allow_merge_commit: false,
+        allow_rebase_merge: true,
+        allow_auto_merge: true,
+        delete_branch_on_merge: true,
+        fork: true,
+        owner: { type: 'Organization', login: 'test-org' },
+        permissions: { admin: true }
+      });
+    }
+    if (method === 'GET' && url === `${repoUrl}/branches/develop/protection`) {
+      return createResponse(createBranchProtection(['lint', 'commit-integrity'], { allowForcePushes: true }));
+    }
+    if (method === 'GET' && url === `${repoUrl}/branches/main/protection`) {
+      return createResponse(createBranchProtection(['lint']));
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8811898`) {
+      return createResponse(rulesets.develop);
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8614140`) {
+      return createResponse(rulesets.main);
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets/8614172`) {
+      return createResponse(releaseRuleset);
+    }
+    if (method === 'GET' && url === `${repoUrl}/rulesets`) {
+      return createResponse([
+        rulesets.develop,
+        rulesets.main,
+        releaseRuleset
+      ].map((ruleset) => ({
+        id: ruleset.id,
+        name: ruleset.name,
+        target: ruleset.target,
+        enforcement: ruleset.enforcement
+      })));
+    }
+    if (method === 'PUT' && url === `${repoUrl}/rulesets/8614172`) {
+      const payload = typeof options.body === 'string' ? JSON.parse(options.body) : structuredClone(options.body);
+      appliedPayloads.push(payload);
+      releaseRuleset = {
+        ...releaseRuleset,
+        enforcement: payload.enforcement
+      };
+      return createResponse(releaseRuleset);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs', '--apply'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-fork',
+      GITHUB_TOKEN: 'fake-token'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    manifestOverride,
+    branchRequiredChecksOverride,
+    log: () => {},
+    error: () => {}
+  });
+
+  assert.equal(code, 0);
+  assert.equal(appliedPayloads.length, 1);
+  assert.equal(appliedPayloads[0].enforcement, 'disabled');
+});

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -232,6 +232,28 @@ function applyBranchExpectationOverrides(branches, overrides) {
   return branches;
 }
 
+function mergeRulesetExpectationOverrides(baseExpectation, overrideExpectation) {
+  if (!overrideExpectation || typeof overrideExpectation !== 'object') {
+    return baseExpectation;
+  }
+  return {
+    ...(baseExpectation ?? {}),
+    ...overrideExpectation
+  };
+}
+
+function applyRulesetExpectationOverrides(rulesets, overrides) {
+  if (!rulesets || typeof rulesets !== 'object' || !overrides || typeof overrides !== 'object') {
+    return rulesets;
+  }
+
+  for (const [rulesetId, overrideExpectation] of Object.entries(overrides)) {
+    rulesets[rulesetId] = mergeRulesetExpectationOverrides(rulesets[rulesetId], overrideExpectation);
+  }
+
+  return rulesets;
+}
+
 function buildEffectiveManifest(manifest, repoData, repositorySlug) {
   const effectiveManifest = structuredClone(manifest ?? {});
   const repoProfile = resolveManifestRepoProfile(effectiveManifest, repositorySlug);
@@ -241,10 +263,18 @@ function buildEffectiveManifest(manifest, repoData, repositorySlug) {
       effectiveManifest.branches,
       effectiveManifest?.forkProfile?.branches
     );
+    applyRulesetExpectationOverrides(
+      effectiveManifest.rulesets,
+      effectiveManifest?.forkProfile?.rulesets
+    );
   }
 
   if (repoProfile?.branchOverrides && typeof repoProfile.branchOverrides === 'object') {
     applyBranchExpectationOverrides(effectiveManifest.branches, repoProfile.branchOverrides);
+  }
+
+  if (repoProfile?.rulesetOverrides && typeof repoProfile.rulesetOverrides === 'object') {
+    applyRulesetExpectationOverrides(effectiveManifest.rulesets, repoProfile.rulesetOverrides);
   }
 
   return effectiveManifest;
@@ -736,6 +766,30 @@ function comparePullRequestRule(expected, actualRule) {
   return diffs;
 }
 
+function normalizeRulesetExpectation(expected) {
+  if (expected === undefined) {
+    return { mode: 'present', expectations: {} };
+  }
+  if (expected === null || expected === false) {
+    return { mode: 'disabled', expectations: {} };
+  }
+  if (typeof expected !== 'object' || Array.isArray(expected)) {
+    return { mode: 'present', expectations: {} };
+  }
+
+  const expectations = structuredClone(expected);
+  const enabled = hasOwnProperty(expectations, 'enabled') ? Boolean(expectations.enabled) : true;
+  delete expectations.enabled;
+  return {
+    mode: enabled ? 'present' : 'disabled',
+    expectations
+  };
+}
+
+function isRulesetDisabledExpectation(expected) {
+  return normalizeRulesetExpectation(expected).mode === 'disabled';
+}
+
 function normalizeOptionalRuleExpectation(expected) {
   if (expected === undefined) {
     return { mode: 'ignore', parameters: null };
@@ -810,6 +864,18 @@ function prefixRulesetDiffs(id, diffs = []) {
 }
 
 function compareRuleset(id, expected, actual) {
+  const normalized = normalizeRulesetExpectation(expected);
+  if (normalized.mode === 'disabled') {
+    if (!actual) {
+      return [];
+    }
+    const actualEnforcement = actual.enforcement ?? 'active';
+    return actualEnforcement === 'disabled'
+      ? []
+      : [`ruleset ${id}: expected disabled, actual enforcement ${actualEnforcement}`];
+  }
+
+  expected = normalized.expectations;
   if (!actual) {
     return [`ruleset ${id}: not found`];
   }
@@ -1063,10 +1129,12 @@ function updateOptionalParameterizedRule(rules, type, expected, actualRule) {
 }
 
 function buildRulesetPayload(expectations, actual = null) {
+  const normalized = normalizeRulesetExpectation(expectations);
+  expectations = normalized.expectations;
   const updated = {
     name: actual?.name ?? expectations.name ?? 'ruleset',
     target: actual?.target ?? expectations.target ?? 'branch',
-    enforcement: actual?.enforcement ?? 'active',
+    enforcement: normalized.mode === 'disabled' ? 'disabled' : (actual?.enforcement ?? 'active'),
     conditions: structuredClone(actual?.conditions ?? {}),
     bypass_actors: sanitizeBypassActors(actual?.bypass_actors),
     rules: structuredClone(actual?.rules ?? [])
@@ -1077,6 +1145,17 @@ function buildRulesetPayload(expectations, actual = null) {
       updated.conditions.ref_name = { include: [], exclude: [] };
     }
     updated.conditions.ref_name.include = expectations.includes;
+  }
+
+  if (normalized.mode === 'disabled') {
+    return {
+      name: updated.name,
+      target: updated.target,
+      enforcement: updated.enforcement,
+      conditions: updated.conditions,
+      bypass_actors: updated.bypass_actors,
+      rules: updated.rules
+    };
   }
 
   const existingQueueRule = updated.rules.find((rule) => rule?.type === 'merge_queue');
@@ -1142,6 +1221,10 @@ async function applyRuleset(repoUrl, token, id, expectations, actual, fetchFn, l
 }
 
 async function createRuleset(repoUrl, token, expectations, fetchFn, logFn = console.log) {
+  if (isRulesetDisabledExpectation(expectations)) {
+    logFn(`[policy] ruleset ${expectations?.name ?? 'unknown'}: expected disabled; skipping create.`);
+    return null;
+  }
   const rulesetUrl = `${repoUrl}/rulesets`;
   const payload = buildRulesetPayload(expectations);
   const created = await requestJson(rulesetUrl, token, { method: 'POST', body: payload, fetchFn });
@@ -1342,6 +1425,9 @@ function evaluateDiffs(manifest, state, options = {}) {
         continue;
       }
       if (entry.error) {
+        if (isNotFoundError(entry.error) && isRulesetDisabledExpectation(entry.expectations)) {
+          continue;
+        }
         rulesetDiffs.push(
           `ruleset ${entry.id}: failed to load -> ${entry.error.message}`
         );
@@ -1655,7 +1741,7 @@ export async function run({
         }
 
         const needsUpdate = entry.error
-          ? isNotFoundError(entry.error)
+          ? (isNotFoundError(entry.error) && !isRulesetDisabledExpectation(entry.expectations))
           : compareRuleset(entry.resolvedId ?? entry.id, entry.expectations, entry.ruleset).length > 0;
         if (!needsUpdate) {
           continue;

--- a/tools/priority/policy.json
+++ b/tools/priority/policy.json
@@ -19,6 +19,11 @@
         "allow_force_pushes": true,
         "allow_fork_syncing": false
       }
+    },
+    "rulesets": {
+      "8614172": {
+        "enabled": false
+      }
     }
   },
   "branches": {


### PR DESCRIPTION
## Summary
- keep fork `release/*` rulesets disabled by contract through `forkProfile.rulesets.8614172.enabled = false`
- teach `priority:policy` to verify and apply disabled ruleset expectations instead of drifting fork release lanes back to active enforcement
- document the fork release exception and lock it with dedicated policy tests

## Why
Live evidence shows both fork `release/*` rulesets are already disabled. The remaining gap is checked-in policy drift: a future `priority:policy --apply` could re-enable fork release protection and break RC maintenance pushes again.

## Validation
- `node --test tools/priority/__tests__/check-policy-fork-release-ruleset.test.mjs`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`

## Live Evidence
- org fork ruleset report: `tests/results/_agent/policy/fork-release-policy-org-report.json`
- user fork ruleset report: `tests/results/_agent/policy/fork-release-policy-user-report.json`
- both live reports now show the remaining drift is `downstream/develop`, not fork `release/*`