### PR TITLE
fix(priority): launch detached manager from current source

### DIFF
--- a/tools/priority/__tests__/delivery-agent-manager-contract.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-manager-contract.test.mjs
@@ -222,6 +222,16 @@ test('delivery-agent manager injects monitoring work before sleeping on host-run
   assert.match(manager, /if \(blockedByHostConflict\)\s*\{\s*monitoringWorkInjection = await invokeMonitoringWorkInjection/s);
 });
 
+test('delivery-agent manager launches the detached loop through run-local-typescript instead of a stale dist path', async () => {
+  const manager = await readText('tools/priority/lib/delivery-agent-manager.ts');
+
+  assert.match(manager, /buildManagerChildCommand/);
+  assert.match(manager, /tools', 'npm', 'run-local-typescript\.mjs/);
+  assert.match(manager, /'--entry',\s*'tools\/priority\/delivery-agent\.ts'/);
+  assert.match(manager, /'--fallback-dist',\s*'dist\/tools\/priority\/delivery-agent\.js'/);
+  assert.doesNotMatch(manager, /const distScriptPath = path\.join\(repoRoot, 'dist', 'tools', 'priority', 'delivery-agent\.js'\);/);
+});
+
 test('delivery-agent manager status ignores stale heartbeat state from before the current manager start', async (t) => {
   const runtimeDirPath = await mkdtemp(path.join(repoRoot, 'tests', 'results', '_agent', 'tmp-manager-status-stale-'));
   const relativeRuntimeDir = path.relative(repoRoot, runtimeDirPath);

--- a/tools/priority/lib/delivery-agent-manager.ts
+++ b/tools/priority/lib/delivery-agent-manager.ts
@@ -67,6 +67,33 @@ async function invokeDeliveryMemory({ repoRoot, repo, runtimeDir, outPath }) {
   }
 }
 
+function buildManagerChildCommand({ repoRoot, options }) {
+  const localTypescriptRunnerPath = path.join(repoRoot, 'tools', 'npm', 'run-local-typescript.mjs');
+  return [
+    localTypescriptRunnerPath,
+    '--project',
+    'tsconfig.json',
+    '--entry',
+    'tools/priority/delivery-agent.ts',
+    '--fallback-dist',
+    'dist/tools/priority/delivery-agent.js',
+    '--',
+    'run',
+    '--repo',
+    options.repo,
+    '--runtime-dir',
+    options.runtimeDir,
+    '--daemon-poll-interval-seconds',
+    String(options.daemonPollIntervalSeconds),
+    '--cycle-interval-seconds',
+    String(options.cycleIntervalSeconds),
+    '--max-cycles',
+    String(options.maxCycles),
+    '--wsl-distro',
+    options.wslDistro,
+  ];
+}
+
 async function invokeMonitoringWorkInjection({
   cycle,
   repoRoot,
@@ -357,23 +384,7 @@ export async function ensureManagerCommand(options, dependencies = {}) {
   mkdirSync(path.dirname(paths.runnerLogPath), { recursive: true });
   const stdoutFd = openSync(paths.runnerLogPath, 'a');
   const stderrFd = openSync(paths.runnerErrorPath, 'a');
-  const distScriptPath = path.join(repoRoot, 'dist', 'tools', 'priority', 'delivery-agent.js');
-  const childArgs = [
-    distScriptPath,
-    'run',
-    '--repo',
-    options.repo,
-    '--runtime-dir',
-    options.runtimeDir,
-    '--daemon-poll-interval-seconds',
-    String(options.daemonPollIntervalSeconds),
-    '--cycle-interval-seconds',
-    String(options.cycleIntervalSeconds),
-    '--max-cycles',
-    String(options.maxCycles),
-    '--wsl-distro',
-    options.wslDistro,
-  ];
+  const childArgs = buildManagerChildCommand({ repoRoot, options });
   if (options.stopWhenNoOpenIssues || options.sleepMode) {
     childArgs.push('--stop-when-no-open-issues');
   }


### PR DESCRIPTION
## Summary
- launch the detached delivery manager through `run-local-typescript` so the unattended loop runs the current TypeScript source instead of stale local `dist`
- lock the launch path with a manager contract regression test
- keep monitoring work injection reachable during `runner-conflict` host states

## Validation
- `node --test tools/priority/__tests__/delivery-agent-manager-contract.test.mjs`
- `node tools/npm/run-local-typescript.mjs --project tsconfig.json --entry tools/priority/delivery-agent.ts --fallback-dist dist/tools/priority/delivery-agent.js -- ensure --sleep-mode --runtime-dir tests/results/_agent/runtime-1808`
- `node tools/npm/run-local-typescript.mjs --project tsconfig.json --entry tools/priority/delivery-agent.ts --fallback-dist dist/tools/priority/delivery-agent.js -- stop --runtime-dir tests/results/_agent/runtime-1808`

## Proof
- `tests/results/_agent/runtime-1808/delivery-agent-manager-trace.ndjson` now records `monitoring-work-injection`
- `tests/results/_agent/runtime-1808/delivery-agent-manager-state.json` now includes `monitoringWorkInjection`
