### PR TITLE
feat(priority): add wake adjudication for downstream signals

### DIFF
--- a/.github/workflows/downstream-onboarding-feedback.yml
+++ b/.github/workflows/downstream-onboarding-feedback.yml
@@ -239,6 +239,23 @@ jobs:
             --schema docs/schemas/downstream-onboarding-feedback-v1.schema.json \
             --data tests/results/_agent/onboarding/downstream-onboarding-feedback.json
 
+      - name: Adjudicate downstream wake against live branch truth
+        if: ${{ always() && hashFiles('tests/results/_agent/onboarding/downstream-onboarding.json') != '' }}
+        run: |
+          set -euo pipefail
+          node tools/priority/wake-adjudication.mjs \
+            --reported tests/results/_agent/onboarding/downstream-onboarding.json \
+            --revalidated-output tests/results/_agent/onboarding/downstream-onboarding-revalidated.json \
+            --output tests/results/_agent/issue/wake-adjudication.json
+
+      - name: Validate wake adjudication report schema
+        if: ${{ always() && hashFiles('tests/results/_agent/issue/wake-adjudication.json') != '' }}
+        run: |
+          set -euo pipefail
+          node tools/npm/run-script.mjs schema:validate -- \
+            --schema docs/schemas/wake-adjudication-report-v1.schema.json \
+            --data tests/results/_agent/issue/wake-adjudication.json
+
       - name: Validate template-agent verification report schema
         if: ${{ always() && hashFiles('tests/results/_agent/promotion/template-agent-verification-report.json') != '' }}
         run: |
@@ -300,6 +317,12 @@ jobs:
           } else {
             lines.push('- execution status: `feedback-report-missing`');
           }
+          const wakeAdjudicationPath = 'tests/results/_agent/issue/wake-adjudication.json';
+          if (fs.existsSync(wakeAdjudicationPath)) {
+            const wakeAdjudication = JSON.parse(fs.readFileSync(wakeAdjudicationPath, 'utf8'));
+            lines.push(`- wake adjudication: \`${wakeAdjudication.summary?.classification ?? 'unknown'}\``);
+            lines.push(`- wake action: \`${wakeAdjudication.summary?.nextAction ?? 'unknown'}\``);
+          }
           if (fs.existsSync(templateVerificationReportPath)) {
             const templateVerification = JSON.parse(fs.readFileSync(templateVerificationReportPath, 'utf8'));
             lines.push(
@@ -319,6 +342,7 @@ jobs:
           name: downstream-onboarding-feedback
           path: |
             tests/results/_agent/onboarding/*.json
+            tests/results/_agent/issue/wake-adjudication.json
             tests/results/_agent/promotion/downstream-develop-promotion-manifest.json
             tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json
             tests/results/_agent/promotion/template-agent-verification-report.json

--- a/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
+++ b/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
@@ -18,6 +18,9 @@ This runbook defines the controlled onboarding path for issue `#715`:
 - Feedback status report:
   - `tests/results/_agent/onboarding/downstream-onboarding-feedback.json`
   - schema: `docs/schemas/downstream-onboarding-feedback-v1.schema.json`
+- Wake adjudication report:
+  - `tests/results/_agent/issue/wake-adjudication.json`
+  - schema: `docs/schemas/wake-adjudication-report-v1.schema.json`
 - Promotion scorecard:
   - `tests/results/_agent/promotion/downstream-develop-promotion-scorecard.json`
   - schema: `docs/schemas/downstream-promotion-scorecard-v1.schema.json`
@@ -106,6 +109,40 @@ The success report includes:
 - aggregated pain points ranked by frequency and severity
 - normalized hardening backlog for follow-up planning
 
+## Wake adjudication
+
+When a downstream onboarding signal fails, replay it against current live GitHub
+state before reopening work:
+
+```bash
+node tools/npm/run-script.mjs priority:wake:adjudicate -- \
+  --reported tests/results/_agent/onboarding/downstream-onboarding.json \
+  --revalidated-output tests/results/_agent/onboarding/downstream-onboarding-revalidated.json \
+  --output tests/results/_agent/issue/wake-adjudication.json
+```
+
+Equivalent direct script invocation:
+
+```bash
+node tools/priority/wake-adjudication.mjs \
+  --reported tests/results/_agent/onboarding/downstream-onboarding.json \
+  --revalidated-output tests/results/_agent/onboarding/downstream-onboarding-revalidated.json \
+  --output tests/results/_agent/issue/wake-adjudication.json
+```
+
+The adjudicator classifies the wake as one of:
+
+- `live-defect`
+- `stale-artifact`
+- `branch-target-drift`
+- `platform-permission-gap`
+- `environment-only`
+
+This keeps the loop from minting downstream issues from stale hosted artifacts
+alone. The adjudication report carries both the originally reported branch truth
+and the revalidated live branch truth so the next issue-injection decision can
+route from evidence instead of raw failure status.
+
 Optional aggregated hardening issue creation:
 
 ```bash
@@ -151,6 +188,7 @@ It now follows the shared hosted-signal contract in [`HOSTED_SIGNAL_REPORT_FIRST
 
 - exports both `GH_TOKEN` and `GITHUB_TOKEN`
 - appends a deterministic step summary from the feedback report when present
+- emits a wake adjudication artifact so stale downstream branch/provenance signals can be suppressed before reopening work
 - builds and validates the downstream promotion scorecard before artifact upload
 - projects immutable downstream promotion manifest inputs into the scorecard when the manifest artifact is present
 - keeps schema validation and artifact upload existence-aware so missing-report cascades do not mask the primary failure

--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -176,6 +176,21 @@
       ]
     },
     {
+      "name": "Wake Adjudication Contracts",
+      "category": "supporting",
+      "status": "reference",
+      "description": "Wake adjudication schema, CLI, hosted downstream-onboarding integration, and focused tests that replay reported downstream onboarding failures against live GitHub state before reopening work.",
+      "files": [
+        "docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md",
+        "docs/schemas/wake-adjudication-report-v1.schema.json",
+        ".github/workflows/downstream-onboarding-feedback.yml",
+        "tools/priority/wake-adjudication.mjs",
+        "tools/priority/__tests__/wake-adjudication.test.mjs",
+        "tools/priority/__tests__/wake-adjudication-schema.test.mjs",
+        "tools/priority/__tests__/downstream-onboarding-contract.test.mjs"
+      ]
+    },
+    {
       "name": "GitHub Templates",
       "category": "supporting",
       "status": "reference",

--- a/docs/schemas/wake-adjudication-report-v1.schema.json
+++ b/docs/schemas/wake-adjudication-report-v1.schema.json
@@ -1,0 +1,336 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://labview-community-ci-cd.github.io/schemas/wake-adjudication-report-v1.schema.json",
+  "title": "Wake Adjudication Report v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "generatedAt",
+    "wakeKind",
+    "reported",
+    "revalidated",
+    "delta",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "priority/wake-adjudication-report@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "wakeKind": {
+      "type": "string",
+      "const": "downstream-onboarding"
+    },
+    "reported": {
+      "$ref": "#/definitions/observation"
+    },
+    "revalidated": {
+      "$ref": "#/definitions/revalidatedObservation"
+    },
+    "delta": {
+      "type": "object",
+      "required": [
+        "targetBranchChanged",
+        "defaultBranchChanged",
+        "workflowReferenceCountDelta",
+        "successfulRunCountDelta",
+        "reportedRequiredFailureIds",
+        "revalidatedRequiredFailureIds",
+        "clearedRequiredFailureIds",
+        "persistentRequiredFailureIds",
+        "newRequiredFailureIds"
+      ],
+      "properties": {
+        "targetBranchChanged": {
+          "type": "boolean"
+        },
+        "defaultBranchChanged": {
+          "type": "boolean"
+        },
+        "workflowReferenceCountDelta": {
+          "type": "integer"
+        },
+        "successfulRunCountDelta": {
+          "type": "integer"
+        },
+        "reportedRequiredFailureIds": {
+          "$ref": "#/definitions/idArray"
+        },
+        "revalidatedRequiredFailureIds": {
+          "$ref": "#/definitions/idArray"
+        },
+        "clearedRequiredFailureIds": {
+          "$ref": "#/definitions/idArray"
+        },
+        "persistentRequiredFailureIds": {
+          "$ref": "#/definitions/idArray"
+        },
+        "newRequiredFailureIds": {
+          "$ref": "#/definitions/idArray"
+        }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "classification",
+        "status",
+        "suppressIssueInjection",
+        "suppressDownstreamIssueInjection",
+        "suppressTemplateIssueInjection",
+        "recommendedOwnerRepository",
+        "nextAction",
+        "reason"
+      ],
+      "properties": {
+        "classification": {
+          "type": "string",
+          "enum": [
+            "live-defect",
+            "stale-artifact",
+            "branch-target-drift",
+            "platform-permission-gap",
+            "environment-only"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "actionable",
+            "suppressed",
+            "monitoring"
+          ]
+        },
+        "suppressIssueInjection": {
+          "type": "boolean"
+        },
+        "suppressDownstreamIssueInjection": {
+          "type": "boolean"
+        },
+        "suppressTemplateIssueInjection": {
+          "type": "boolean"
+        },
+        "recommendedOwnerRepository": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "nextAction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "definitions": {
+    "idArray": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "checklistEntry": {
+      "type": "object",
+      "required": [
+        "id",
+        "reason"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "observation": {
+      "type": "object",
+      "required": [
+        "path",
+        "downstreamRepository",
+        "targetBranch",
+        "defaultBranch",
+        "summaryStatus",
+        "requiredFailCount",
+        "warningCount",
+        "workflowReferenceCount",
+        "successfulRunCount",
+        "requiredFailures",
+        "warnings"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generatedAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "downstreamRepository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "targetBranch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summaryStatus": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "requiredFailCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warningCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workflowReferenceCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "successfulRunCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requiredFailures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/checklistEntry"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/checklistEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "revalidatedObservation": {
+      "type": "object",
+      "required": [
+        "path",
+        "downstreamRepository",
+        "targetBranch",
+        "defaultBranch",
+        "summaryStatus",
+        "requiredFailCount",
+        "warningCount",
+        "workflowReferenceCount",
+        "successfulRunCount",
+        "requiredFailures",
+        "warnings",
+        "reran",
+        "exitCode"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generatedAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "downstreamRepository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "targetBranch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summaryStatus": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "warn",
+            "fail"
+          ]
+        },
+        "requiredFailCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warningCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workflowReferenceCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "successfulRunCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requiredFailures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/checklistEntry"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/checklistEntry"
+          }
+        },
+        "reran": {
+          "type": "boolean"
+        },
+        "exitCode": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "priority:handoff": "pwsh -NoLogo -NoProfile -File tools/priority/Import-HandoffState.ps1",
     "priority:monitoring:mode": "node tools/priority/handoff-monitoring-mode.mjs",
     "priority:monitoring:inject-work": "node tools/priority/monitoring-work-injection.mjs",
+    "priority:wake:adjudicate": "node tools/priority/wake-adjudication.mjs",
     "priority:handoff-tests": "node tools/priority/run-handoff-tests.mjs",
     "priority:health-snapshot": "pwsh -NoLogo -NoProfile -File tools/priority/Write-HealthSnapshot.ps1",
     "priority:lease": "node tools/priority/agent-writer-lease.mjs",

--- a/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
+++ b/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
@@ -36,6 +36,10 @@ test('workflow executes onboarding, success, feedback, and promotion scorecard c
   assert.match(workflow, /downstream-onboarding-report-v1\.schema\.json/);
   assert.match(workflow, /downstream-onboarding-success-v1\.schema\.json/);
   assert.match(workflow, /downstream-onboarding-feedback-v1\.schema\.json/);
+  assert.match(workflow, /Adjudicate downstream wake against live branch truth/);
+  assert.match(workflow, /wake-adjudication\.mjs/);
+  assert.match(workflow, /wake-adjudication-report-v1\.schema\.json/);
+  assert.match(workflow, /tests\/results\/_agent\/issue\/wake-adjudication\.json/);
   assert.match(workflow, /Refresh template-agent verification report/);
   assert.match(workflow, /priority:template:agent:verify/);
   assert.match(workflow, /Generate downstream promotion manifest/);
@@ -59,8 +63,10 @@ test('workflow executes onboarding, success, feedback, and promotion scorecard c
   );
   assert.match(workflow, /Append onboarding feedback summary/);
   assert.match(workflow, /execution status/);
+  assert.match(workflow, /wake adjudication/);
   assert.match(workflow, /template-agent verification status/);
   assert.match(workflow, /hashFiles\('tests\/results\/_agent\/onboarding\/downstream-onboarding\.json'\)/);
+  assert.match(workflow, /hashFiles\('tests\/results\/_agent\/issue\/wake-adjudication\.json'\)/);
   assert.match(workflow, /hashFiles\('tests\/results\/_agent\/promotion\/downstream-develop-promotion-manifest\.json'\)/);
   assert.match(workflow, /hashFiles\('tests\/results\/_agent\/promotion\/downstream-develop-promotion-scorecard\.json'\)/);
 });
@@ -70,14 +76,17 @@ test('runbook and package scripts expose downstream onboarding and promotion com
   assert.equal(packageJson.scripts['priority:onboard:downstream'], 'node tools/priority/downstream-onboarding.mjs');
   assert.equal(packageJson.scripts['priority:onboard:feedback'], 'node tools/priority/downstream-onboarding-feedback.mjs');
   assert.equal(packageJson.scripts['priority:onboard:success'], 'node tools/priority/downstream-onboarding-success.mjs');
+  assert.equal(packageJson.scripts['priority:wake:adjudicate'], 'node tools/priority/wake-adjudication.mjs');
   assert.equal(packageJson.scripts['priority:promote:downstream:scorecard'], 'node tools/priority/downstream-promotion-scorecard.mjs');
 
   const runbook = read('docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md');
   assert.match(runbook, /priority:onboard:downstream/);
   assert.match(runbook, /priority:onboard:feedback/);
   assert.match(runbook, /priority:onboard:success/);
+  assert.match(runbook, /priority:wake:adjudicate/);
   assert.match(runbook, /priority:promote:downstream:scorecard/);
   assert.match(runbook, /downstream-develop-promotion-scorecard\.json/);
+  assert.match(runbook, /wake-adjudication\.json/);
   assert.match(runbook, /--issue-repo LabVIEW-Community-CI-CD\/LabviewGitHubCiTemplate/);
   assert.match(runbook, /consumer_issue_repo/);
   assert.match(runbook, /fails closed/);

--- a/tools/priority/__tests__/wake-adjudication-schema.test.mjs
+++ b/tools/priority/__tests__/wake-adjudication-schema.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+import { runWakeAdjudication } from '../wake-adjudication.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function createOnboardingReport({ targetBranch, requiredFailures = [], warnings = [] }) {
+  return {
+    schema: 'priority/downstream-onboarding-report@v1',
+    generatedAt: '2026-03-22T15:29:00.000Z',
+    upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    actionRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    downstreamRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+    targetBranch,
+    repository: {
+      ok: true,
+      error: null,
+      defaultBranch: targetBranch,
+      htmlUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      private: false
+    },
+    workflowDiscovery: {
+      scannedWorkflowCount: 1,
+      referencedWorkflowCount: 1
+    },
+    workflowReferences: [],
+    runs: {
+      total: 1,
+      successful: 1,
+      firstSuccessfulRunAt: '2026-03-20T20:47:21Z'
+    },
+    checklist: [
+      {
+        id: 'repository-accessible',
+        description: 'repo',
+        required: true,
+        severity: 'P1',
+        recommendation: 'ok',
+        status: 'pass',
+        reason: 'repository-visible'
+      },
+      ...requiredFailures.map((entry) => ({
+        id: entry.id,
+        description: entry.id,
+        required: true,
+        severity: 'P1',
+        recommendation: 'fix',
+        status: 'fail',
+        reason: entry.reason
+      })),
+      ...warnings.map((entry) => ({
+        id: entry.id,
+        description: entry.id,
+        required: false,
+        severity: 'P2',
+        recommendation: 'check',
+        status: 'warn',
+        reason: entry.reason
+      }))
+    ],
+    metrics: {
+      requiredFailures: requiredFailures.length,
+      warningCount: warnings.length,
+      frictionScore: requiredFailures.length * 3 + warnings.length
+    },
+    summary: {
+      status: requiredFailures.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass',
+      totalChecklist: 1 + requiredFailures.length + warnings.length,
+      passCount: 1,
+      warnCount: warnings.length,
+      failCount: requiredFailures.length,
+      requiredFailCount: requiredFailures.length
+    },
+    hardeningBacklog: []
+  };
+}
+
+test('wake adjudication report matches schema', async () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-adjudication-schema-'));
+  const reportedPath = path.join(tmpDir, 'reported.json');
+  const revalidatedOutputPath = path.join(tmpDir, 'revalidated.json');
+
+  writeJson(
+    reportedPath,
+    createOnboardingReport({
+      targetBranch: 'downstream/develop',
+      requiredFailures: [{ id: 'workflow-reference-present', reason: 'no-workflow-reference-found' }]
+    })
+  );
+
+  const { report } = await runWakeAdjudication(
+    {
+      repoRoot: tmpDir,
+      reportedPath,
+      revalidatedOutputPath
+    },
+    {
+      runDownstreamOnboardingFn: async () => {
+        writeJson(
+          revalidatedOutputPath,
+          createOnboardingReport({
+            targetBranch: 'develop',
+            warnings: [{ id: 'required-checks-visible', reason: 'branch-protection-api-404' }]
+          })
+        );
+        return 0;
+      }
+    }
+  );
+
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const schema = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'docs', 'schemas', 'wake-adjudication-report-v1.schema.json'), 'utf8')
+  );
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/wake-adjudication.test.mjs
+++ b/tools/priority/__tests__/wake-adjudication.test.mjs
@@ -1,0 +1,306 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  DEFAULT_OUTPUT_PATH,
+  DEFAULT_REVALIDATED_OUTPUT_PATH,
+  buildRevalidationArgv,
+  parseArgs,
+  runWakeAdjudication
+} from '../wake-adjudication.mjs';
+
+const WARNING_ONLY = new Set(['protected-environments-configured', 'required-checks-visible']);
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function createOnboardingReport({
+  targetBranch,
+  defaultBranch = targetBranch,
+  requiredFailures = [],
+  warnings = [],
+  referencedWorkflowCount = 0,
+  successfulRuns = 0
+}) {
+  const requiredFailureIds = new Set(requiredFailures.map((entry) => entry.id));
+  const warningIds = new Set(warnings.map((entry) => entry.id));
+  const checklistIds = [
+    'repository-accessible',
+    'workflow-reference-present',
+    'certified-reference-pinned',
+    'successful-consumption-run',
+    'protected-environments-configured',
+    'required-checks-visible'
+  ];
+  const checklist = checklistIds.map((id) => {
+    const required = !WARNING_ONLY.has(id);
+    const severity = required ? 'P1' : 'P2';
+    if (requiredFailureIds.has(id)) {
+      const match = requiredFailures.find((entry) => entry.id === id);
+      return {
+        id,
+        description: id,
+        required,
+        severity,
+        recommendation: 'fix',
+        status: 'fail',
+        reason: match?.reason || 'failed'
+      };
+    }
+    if (warningIds.has(id)) {
+      const match = warnings.find((entry) => entry.id === id);
+      return {
+        id,
+        description: id,
+        required,
+        severity,
+        recommendation: 'check',
+        status: 'warn',
+        reason: match?.reason || 'warn'
+      };
+    }
+    return {
+      id,
+      description: id,
+      required,
+      severity,
+      recommendation: 'ok',
+      status: 'pass',
+      reason: 'ok'
+    };
+  });
+  const requiredFailCount = requiredFailures.length;
+  const warnCount = warnings.length;
+  const status = requiredFailCount > 0 ? 'fail' : warnCount > 0 ? 'warn' : 'pass';
+  return {
+    schema: 'priority/downstream-onboarding-report@v1',
+    generatedAt: '2026-03-22T15:29:00.000Z',
+    upstreamRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    actionRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    downstreamRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+    targetBranch,
+    repository: {
+      ok: true,
+      error: null,
+      defaultBranch,
+      htmlUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      private: false
+    },
+    workflowDiscovery: {
+      scannedWorkflowCount: referencedWorkflowCount > 0 ? 1 : 0,
+      referencedWorkflowCount
+    },
+    workflowReferences: Array.from({ length: referencedWorkflowCount }, (_, index) => ({
+      workflowPath: '.github/workflows/template-smoke.yml',
+      lineNumber: index + 1,
+      ref: 'v0.6.3',
+      verified: {
+        ref: 'v0.6.3',
+        kind: 'stable-tag',
+        immutable: true,
+        certifiedCandidate: true,
+        exists: true,
+        certified: true,
+        reason: 'stable-tag-verified'
+      }
+    })),
+    runs: {
+      total: successfulRuns,
+      successful: successfulRuns,
+      firstSuccessfulRunAt: successfulRuns > 0 ? '2026-03-20T20:47:21Z' : null
+    },
+    checklist,
+    metrics: {
+      requiredFailures: requiredFailCount,
+      warningCount: warnCount,
+      frictionScore: requiredFailCount * 3 + warnCount
+    },
+    summary: {
+      status,
+      totalChecklist: checklist.length,
+      passCount: checklist.filter((entry) => entry.status === 'pass').length,
+      warnCount,
+      failCount: requiredFailCount,
+      requiredFailCount
+    },
+    hardeningBacklog: []
+  };
+}
+
+test('parseArgs exposes checked-in wake adjudication defaults', () => {
+  const parsed = parseArgs(['node', 'wake-adjudication.mjs', '--reported', 'reported.json']);
+  assert.equal(parsed.reportedPath, 'reported.json');
+  assert.equal(parsed.outputPath, DEFAULT_OUTPUT_PATH);
+  assert.equal(parsed.revalidatedOutputPath, DEFAULT_REVALIDATED_OUTPUT_PATH);
+  assert.equal(parsed.revalidatedReportPath, null);
+});
+
+test('buildRevalidationArgv replays downstream onboarding against the reported downstream repo', () => {
+  const argv = buildRevalidationArgv(
+    {
+      downstreamRepository: 'owner/downstream',
+      upstreamRepository: 'owner/upstream',
+      actionRepository: 'owner/action'
+    },
+    {
+      revalidatedOutputPath: 'tests/results/_agent/onboarding/revalidated.json',
+      revalidatedBranch: 'develop'
+    }
+  );
+
+  assert.deepEqual(argv, [
+    'node',
+    'downstream-onboarding.mjs',
+    '--repo',
+    'owner/downstream',
+    '--upstream-repo',
+    'owner/upstream',
+    '--action-repo',
+    'owner/action',
+    '--output',
+    'tests/results/_agent/onboarding/revalidated.json',
+    '--branch',
+    'develop'
+  ]);
+});
+
+test('runWakeAdjudication classifies stale downstream failures as branch-target-drift when live replay resolves a different branch', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-adjudication-branch-drift-'));
+  const reportedPath = path.join(tmpDir, 'reported.json');
+  const revalidatedOutputPath = path.join(tmpDir, 'revalidated.json');
+  const outputPath = path.join(tmpDir, 'wake-adjudication.json');
+
+  writeJson(
+    reportedPath,
+    createOnboardingReport({
+      targetBranch: 'downstream/develop',
+      defaultBranch: 'downstream/develop',
+      requiredFailures: [
+        { id: 'workflow-reference-present', reason: 'no-workflow-reference-found' },
+        { id: 'certified-reference-pinned', reason: 'no-reference-to-certify' },
+        { id: 'successful-consumption-run', reason: 'no-successful-run-observed' }
+      ]
+    })
+  );
+
+  const { report } = await runWakeAdjudication(
+    {
+      repoRoot: tmpDir,
+      reportedPath,
+      revalidatedOutputPath,
+      outputPath
+    },
+    {
+      runDownstreamOnboardingFn: async () => {
+        writeJson(
+          revalidatedOutputPath,
+          createOnboardingReport({
+            targetBranch: 'develop',
+            defaultBranch: 'develop',
+            warnings: [
+              { id: 'protected-environments-configured', reason: 'required-environments-missing' },
+              { id: 'required-checks-visible', reason: 'branch-protection-api-404' }
+            ],
+            referencedWorkflowCount: 1,
+            successfulRuns: 7
+          })
+        );
+        return 0;
+      }
+    }
+  );
+
+  assert.equal(report.summary.classification, 'branch-target-drift');
+  assert.equal(report.summary.suppressIssueInjection, true);
+  assert.equal(report.summary.recommendedOwnerRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(report.delta.targetBranchChanged, true);
+  assert.deepEqual(report.delta.clearedRequiredFailureIds.sort(), [
+    'certified-reference-pinned',
+    'successful-consumption-run',
+    'workflow-reference-present'
+  ]);
+});
+
+test('runWakeAdjudication classifies surviving required failures as live-defect', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-adjudication-live-defect-'));
+  const reportedPath = path.join(tmpDir, 'reported.json');
+  const revalidatedOutputPath = path.join(tmpDir, 'revalidated.json');
+
+  writeJson(
+    reportedPath,
+    createOnboardingReport({
+      targetBranch: 'develop',
+      requiredFailures: [{ id: 'workflow-reference-present', reason: 'no-workflow-reference-found' }]
+    })
+  );
+
+  const { report } = await runWakeAdjudication(
+    {
+      repoRoot: tmpDir,
+      reportedPath,
+      revalidatedOutputPath
+    },
+    {
+      runDownstreamOnboardingFn: async () => {
+        writeJson(
+          revalidatedOutputPath,
+          createOnboardingReport({
+            targetBranch: 'develop',
+            requiredFailures: [{ id: 'workflow-reference-present', reason: 'no-workflow-reference-found' }]
+          })
+        );
+        return 1;
+      }
+    }
+  );
+
+  assert.equal(report.summary.classification, 'live-defect');
+  assert.equal(report.summary.suppressIssueInjection, false);
+  assert.equal(report.summary.recommendedOwnerRepository, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
+  assert.deepEqual(report.delta.persistentRequiredFailureIds, ['workflow-reference-present']);
+});
+
+test('runWakeAdjudication classifies warning-only live replay as environment-only', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-adjudication-environment-only-'));
+  const reportedPath = path.join(tmpDir, 'reported.json');
+  const revalidatedOutputPath = path.join(tmpDir, 'revalidated.json');
+
+  writeJson(
+    reportedPath,
+    createOnboardingReport({
+      targetBranch: 'develop',
+      warnings: [{ id: 'protected-environments-configured', reason: 'required-environments-missing' }]
+    })
+  );
+
+  const { report } = await runWakeAdjudication(
+    {
+      repoRoot: tmpDir,
+      reportedPath,
+      revalidatedOutputPath
+    },
+    {
+      runDownstreamOnboardingFn: async () => {
+        writeJson(
+          revalidatedOutputPath,
+          createOnboardingReport({
+            targetBranch: 'develop',
+            warnings: [{ id: 'required-checks-visible', reason: 'branch-protection-api-404' }],
+            referencedWorkflowCount: 1,
+            successfulRuns: 3
+          })
+        );
+        return 0;
+      }
+    }
+  );
+
+  assert.equal(report.summary.classification, 'environment-only');
+  assert.equal(report.summary.status, 'monitoring');
+  assert.equal(report.summary.suppressDownstreamIssueInjection, true);
+});

--- a/tools/priority/wake-adjudication.mjs
+++ b/tools/priority/wake-adjudication.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { main as runDownstreamOnboarding } from './downstream-onboarding.mjs';
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(MODULE_DIR, '..', '..');
+
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'issue', 'wake-adjudication.json');
+export const DEFAULT_REVALIDATED_OUTPUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'onboarding',
+  'downstream-onboarding-revalidated.json'
+);
+
+const WARNING_ONLY_IDS = new Set(['protected-environments-configured', 'required-checks-visible']);
+
+function printUsage() {
+  console.log('Usage: node tools/priority/wake-adjudication.mjs --reported <path> [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --reported <path>              Reported downstream onboarding report to adjudicate (required).');
+  console.log(`  --output <path>                Wake adjudication report path (default: ${DEFAULT_OUTPUT_PATH}).`);
+  console.log(
+    `  --revalidated-output <path>    Where the live replay report should be written (default: ${DEFAULT_REVALIDATED_OUTPUT_PATH}).`
+  );
+  console.log('  --revalidated-report <path>    Use an existing revalidated report instead of replaying live.');
+  console.log('  --branch <name>                Override the branch used for live replay.');
+  console.log('  -h, --help                     Show this message and exit.');
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    reportedPath: null,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    revalidatedOutputPath: DEFAULT_REVALIDATED_OUTPUT_PATH,
+    revalidatedReportPath: null,
+    revalidatedBranch: null,
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    const next = args[index + 1];
+
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    if (
+      token === '--reported' ||
+      token === '--output' ||
+      token === '--revalidated-output' ||
+      token === '--revalidated-report' ||
+      token === '--branch'
+    ) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--reported') options.reportedPath = next;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--revalidated-output') options.revalidatedOutputPath = next;
+      if (token === '--revalidated-report') options.revalidatedReportPath = next;
+      if (token === '--branch') options.revalidatedBranch = next;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  if (!options.help && !options.reportedPath) {
+    throw new Error('Missing required option: --reported <path>.');
+  }
+
+  return options;
+}
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function asOptional(value) {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function resolvePath(repoRoot, candidate) {
+  return path.resolve(repoRoot, candidate);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+function ensureDownstreamOnboardingReport(payload, filePath) {
+  if (payload?.schema !== 'priority/downstream-onboarding-report@v1') {
+    throw new Error(`Expected downstream onboarding report at ${filePath}.`);
+  }
+  return payload;
+}
+
+function summarizeChecklist(report, desiredStatus) {
+  return Array.isArray(report?.checklist)
+    ? report.checklist
+        .filter((entry) => normalizeText(entry?.status) === desiredStatus)
+        .map((entry) => ({
+          id: normalizeText(entry?.id),
+          reason: normalizeText(entry?.reason),
+          required: entry?.required === true
+        }))
+        .filter((entry) => entry.id && entry.reason)
+    : [];
+}
+
+function toObservation(reportPath, report, overrides = {}) {
+  const requiredFailures = summarizeChecklist(report, 'fail')
+    .filter((entry) => entry.required)
+    .map((entry) => ({
+      id: entry.id,
+      reason: entry.reason
+    }));
+  const warnings = summarizeChecklist(report, 'warn').map((entry) => ({
+    id: entry.id,
+    reason: entry.reason
+  }));
+  return {
+    path: reportPath,
+    generatedAt: asOptional(report?.generatedAt),
+    downstreamRepository: normalizeText(report?.downstreamRepository),
+    targetBranch: normalizeText(report?.targetBranch),
+    defaultBranch: asOptional(report?.repository?.defaultBranch),
+    summaryStatus: normalizeText(report?.summary?.status) || 'fail',
+    requiredFailCount: Number.isInteger(report?.summary?.requiredFailCount) ? report.summary.requiredFailCount : requiredFailures.length,
+    warningCount: Number.isInteger(report?.summary?.warnCount) ? report.summary.warnCount : warnings.length,
+    workflowReferenceCount: Number.isInteger(report?.workflowDiscovery?.referencedWorkflowCount)
+      ? report.workflowDiscovery.referencedWorkflowCount
+      : Array.isArray(report?.workflowReferences)
+        ? report.workflowReferences.length
+        : 0,
+    successfulRunCount: Number.isInteger(report?.runs?.successful) ? report.runs.successful : 0,
+    requiredFailures,
+    warnings,
+    ...overrides
+  };
+}
+
+function uniqueIds(entries) {
+  return [...new Set((Array.isArray(entries) ? entries : []).map((entry) => normalizeText(entry?.id)).filter(Boolean))];
+}
+
+function diffIds(beforeEntries, afterEntries) {
+  const before = new Set(uniqueIds(beforeEntries));
+  const after = new Set(uniqueIds(afterEntries));
+  return {
+    cleared: [...before].filter((entry) => !after.has(entry)),
+    persistent: [...before].filter((entry) => after.has(entry)),
+    added: [...after].filter((entry) => !before.has(entry))
+  };
+}
+
+function isPermissionGapReason(reason) {
+  const normalized = normalizeText(reason).toLowerCase();
+  return (
+    normalized.includes('api-401') ||
+    normalized.includes('api-403') ||
+    normalized.includes('api-404') ||
+    normalized.includes('unavailable') ||
+    normalized.includes('visibility')
+  );
+}
+
+function classifyWake({ reported, revalidated, reportedReport }) {
+  const targetBranchChanged = normalizeText(reported.targetBranch) !== normalizeText(revalidated.targetBranch);
+  const defaultBranchChanged = normalizeText(reported.defaultBranch) !== normalizeText(revalidated.defaultBranch);
+  const liveWarnings = Array.isArray(revalidated.warnings) ? revalidated.warnings : [];
+  const liveWarningIds = uniqueIds(liveWarnings);
+  const warningsOnly = liveWarnings.length > 0 && liveWarningIds.every((entry) => WARNING_ONLY_IDS.has(entry));
+  const liveRequiredFailures = Array.isArray(revalidated.requiredFailures) ? revalidated.requiredFailures : [];
+  const livePermissionOnly =
+    liveRequiredFailures.length > 0 && liveRequiredFailures.every((entry) => isPermissionGapReason(entry.reason));
+
+  if (reported.requiredFailCount > 0 && revalidated.requiredFailCount === 0) {
+    if (targetBranchChanged || defaultBranchChanged) {
+      return {
+        classification: 'branch-target-drift',
+        status: 'suppressed',
+        suppressIssueInjection: true,
+        suppressDownstreamIssueInjection: true,
+        suppressTemplateIssueInjection: true,
+        recommendedOwnerRepository: normalizeText(reportedReport?.upstreamRepository) || null,
+        nextAction: 'reconcile-downstream-branch-target-provenance',
+        reason:
+          'The reported wake failed against stale downstream branch truth, while live replay resolved a different current branch and cleared all required blockers.'
+      };
+    }
+    if (warningsOnly || revalidated.summaryStatus === 'warn') {
+      return {
+        classification: 'environment-only',
+        status: 'monitoring',
+        suppressIssueInjection: true,
+        suppressDownstreamIssueInjection: true,
+        suppressTemplateIssueInjection: true,
+        recommendedOwnerRepository: normalizeText(revalidated.downstreamRepository) || null,
+        nextAction: 'monitor-warning-only-downstream-surface',
+        reason:
+          'Required blockers cleared on live replay; only warning-level environment or branch-protection gaps remain.'
+      };
+    }
+    return {
+      classification: 'stale-artifact',
+      status: 'suppressed',
+      suppressIssueInjection: true,
+      suppressDownstreamIssueInjection: true,
+      suppressTemplateIssueInjection: true,
+      recommendedOwnerRepository: null,
+      nextAction: 'suppress-stale-reported-wake',
+      reason:
+        'The reported failure no longer reproduces on live replay and should not reopen work by itself.'
+    };
+  }
+
+  if (revalidated.requiredFailCount > 0) {
+    if (livePermissionOnly) {
+      return {
+        classification: 'platform-permission-gap',
+        status: 'actionable',
+        suppressIssueInjection: false,
+        suppressDownstreamIssueInjection: true,
+        suppressTemplateIssueInjection: true,
+        recommendedOwnerRepository: normalizeText(reportedReport?.upstreamRepository) || null,
+        nextAction: 'route-platform-governance-gap',
+        reason:
+          'Live replay still fails, but only through platform or permission visibility gaps rather than a downstream consumer defect.'
+      };
+    }
+    return {
+      classification: 'live-defect',
+      status: 'actionable',
+      suppressIssueInjection: false,
+      suppressDownstreamIssueInjection: false,
+      suppressTemplateIssueInjection: false,
+      recommendedOwnerRepository: normalizeText(revalidated.downstreamRepository) || null,
+      nextAction: 'route-live-downstream-defect',
+      reason:
+        'The reported failure survives live replay and still blocks required downstream onboarding checks.'
+    };
+  }
+
+  return {
+    classification: warningsOnly ? 'environment-only' : 'stale-artifact',
+    status: warningsOnly ? 'monitoring' : 'suppressed',
+    suppressIssueInjection: true,
+    suppressDownstreamIssueInjection: true,
+    suppressTemplateIssueInjection: true,
+    recommendedOwnerRepository: warningsOnly ? normalizeText(revalidated.downstreamRepository) || null : null,
+    nextAction: warningsOnly ? 'monitor-warning-only-downstream-surface' : 'suppress-stale-reported-wake',
+    reason: warningsOnly
+      ? 'Live replay reports warning-only downstream conditions with no required blockers.'
+      : 'Live replay cleared the reported failure.'
+  };
+}
+
+export function buildRevalidationArgv(reportedReport, options) {
+  const argv = [
+    'node',
+    'downstream-onboarding.mjs',
+    '--repo',
+    normalizeText(reportedReport?.downstreamRepository),
+    '--upstream-repo',
+    normalizeText(reportedReport?.upstreamRepository),
+    '--action-repo',
+    normalizeText(reportedReport?.actionRepository),
+    '--output',
+    normalizeText(options.revalidatedOutputPath)
+  ];
+  const branchOverride = asOptional(options.revalidatedBranch);
+  if (branchOverride) {
+    argv.push('--branch', branchOverride);
+  }
+  return argv;
+}
+
+export async function runWakeAdjudication(options = {}, deps = {}) {
+  const repoRoot = path.resolve(options.repoRoot || DEFAULT_REPO_ROOT);
+  const reportedPath = resolvePath(repoRoot, options.reportedPath);
+  const outputPath = resolvePath(repoRoot, options.outputPath || DEFAULT_OUTPUT_PATH);
+  const revalidatedOutputPath = resolvePath(repoRoot, options.revalidatedOutputPath || DEFAULT_REVALIDATED_OUTPUT_PATH);
+  const revalidatedReportPath = options.revalidatedReportPath
+    ? resolvePath(repoRoot, options.revalidatedReportPath)
+    : revalidatedOutputPath;
+
+  const reportedReport = ensureDownstreamOnboardingReport(readJson(reportedPath), reportedPath);
+
+  let revalidatedExitCode = null;
+  let reran = false;
+  if (!options.revalidatedReportPath) {
+    reran = true;
+    const argv = buildRevalidationArgv(reportedReport, {
+      ...options,
+      revalidatedOutputPath
+    });
+    const runFn = deps.runDownstreamOnboardingFn || runDownstreamOnboarding;
+    revalidatedExitCode = await runFn(argv);
+  }
+
+  const revalidatedReport = ensureDownstreamOnboardingReport(readJson(revalidatedReportPath), revalidatedReportPath);
+  const reported = toObservation(reportedPath, reportedReport);
+  const revalidated = toObservation(revalidatedReportPath, revalidatedReport, {
+    reran,
+    exitCode: revalidatedExitCode
+  });
+  const failureDiff = diffIds(reported.requiredFailures, revalidated.requiredFailures);
+  const summary = classifyWake({ reported, revalidated, reportedReport });
+
+  const report = {
+    schema: 'priority/wake-adjudication-report@v1',
+    generatedAt: new Date().toISOString(),
+    wakeKind: 'downstream-onboarding',
+    reported,
+    revalidated,
+    delta: {
+      targetBranchChanged: normalizeText(reported.targetBranch) !== normalizeText(revalidated.targetBranch),
+      defaultBranchChanged: normalizeText(reported.defaultBranch) !== normalizeText(revalidated.defaultBranch),
+      workflowReferenceCountDelta: revalidated.workflowReferenceCount - reported.workflowReferenceCount,
+      successfulRunCountDelta: revalidated.successfulRunCount - reported.successfulRunCount,
+      reportedRequiredFailureIds: uniqueIds(reported.requiredFailures),
+      revalidatedRequiredFailureIds: uniqueIds(revalidated.requiredFailures),
+      clearedRequiredFailureIds: failureDiff.cleared,
+      persistentRequiredFailureIds: failureDiff.persistent,
+      newRequiredFailureIds: failureDiff.added
+    },
+    summary
+  };
+
+  writeJson(outputPath, report);
+  console.log(
+    `[wake-adjudication] wrote ${outputPath} (${report.summary.classification}, action=${report.summary.nextAction})`
+  );
+  return { report, outputPath, revalidatedReportPath };
+}
+
+export async function main(argv = process.argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+  await runWakeAdjudication(options);
+  return 0;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((code) => {
+      if (code !== 0) process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(error?.stack ?? error?.message ?? String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary
- add a wake adjudication surface that replays reported downstream onboarding failures against live GitHub state before work injection
- wire the hosted downstream onboarding workflow to emit `tests/results/_agent/issue/wake-adjudication.json`
- document and test the new adjudication contract across the runbook, workflow contract, and schema surface

## Validation
- `node --test tools/priority/__tests__/wake-adjudication.test.mjs tools/priority/__tests__/wake-adjudication-schema.test.mjs tools/priority/__tests__/downstream-onboarding-contract.test.mjs`
- `node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/wake-adjudication-report-v1.schema.json --data tests/results/_agent/issue/wake-adjudication-23406267865.json`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`

## Proof
- real replay of compare run `23406267865` wrote `tests/results/_agent/issue/wake-adjudication-23406267865.json`
- that report classified the wake as `branch-target-drift`
- downstream/template issue injection stays suppressed until live revalidation says otherwise
