### PR TITLE
fix(priority): separate downstream onboarding branch provenance

### DIFF
--- a/.github/workflows/downstream-onboarding-feedback.yml
+++ b/.github/workflows/downstream-onboarding-feedback.yml
@@ -116,20 +116,22 @@ jobs:
           NODE
           )
           policy_repo="${policy_values[0]}"
-          policy_branch="${policy_values[1]}"
+          policy_consumer_rail_branch="${policy_values[1]}"
           repo="${DOWNSTREAM_REPO}"
           if [ -z "$repo" ]; then
             repo="${policy_repo:-${DOWNSTREAM_PILOT_REPO:-$GITHUB_REPOSITORY}}"
           fi
           branch="${DOWNSTREAM_BRANCH}"
+          branch_source="explicit-override"
           if [ -z "$branch" ]; then
-            branch="${policy_branch:-}"
+            branch_source="live-repository-default-branch"
           fi
           {
             printf 'policy_template_repo=%s\n' "$policy_repo"
-            printf 'policy_template_branch=%s\n' "$policy_branch"
+            printf 'policy_consumer_rail_branch=%s\n' "$policy_consumer_rail_branch"
             printf 'resolved_repo=%s\n' "$repo"
-            printf 'resolved_branch=%s\n' "$branch"
+            printf 'resolved_branch_override=%s\n' "$branch"
+            printf 'resolved_branch_source=%s\n' "$branch_source"
           } >> "$GITHUB_OUTPUT"
           args=(
             --repo "$repo"
@@ -165,7 +167,7 @@ jobs:
           exit "$status"
 
       - name: Refresh template-agent verification report
-        if: ${{ always() && steps.feedback.outputs.resolved_repo == steps.feedback.outputs.policy_template_repo && steps.feedback.outputs.resolved_branch == steps.feedback.outputs.policy_template_branch }}
+        if: ${{ always() && steps.feedback.outputs.resolved_repo == steps.feedback.outputs.policy_template_repo }}
         shell: bash
         run: |
           set -euo pipefail
@@ -288,24 +290,34 @@ jobs:
         shell: bash
         env:
           RESOLVED_REPO: ${{ steps.feedback.outputs.resolved_repo }}
-          RESOLVED_BRANCH: ${{ steps.feedback.outputs.resolved_branch }}
+          POLICY_CONSUMER_RAIL_BRANCH: ${{ steps.feedback.outputs.policy_consumer_rail_branch }}
+          RESOLVED_BRANCH_OVERRIDE: ${{ steps.feedback.outputs.resolved_branch_override }}
+          RESOLVED_BRANCH_SOURCE: ${{ steps.feedback.outputs.resolved_branch_source }}
         run: |
           node <<'NODE'
           const fs = require('fs');
           const reportPath = 'tests/results/_agent/onboarding/downstream-onboarding-feedback.json';
+          const onboardingReportPath = 'tests/results/_agent/onboarding/downstream-onboarding.json';
           const templateVerificationReportPath = 'tests/results/_agent/promotion/template-agent-verification-report.json';
           const hasFeedbackReport = fs.existsSync(reportPath);
+          const hasOnboardingReport = fs.existsSync(onboardingReportPath);
           const hasTemplateVerificationReport = fs.existsSync(templateVerificationReportPath);
-          if (!hasFeedbackReport && !hasTemplateVerificationReport) {
-            console.log('downstream onboarding feedback and template-agent verification reports missing');
+          if (!hasFeedbackReport && !hasOnboardingReport && !hasTemplateVerificationReport) {
+            console.log('downstream onboarding and template-agent verification reports missing');
             process.exit(0);
           }
           const feedbackReport = hasFeedbackReport ? JSON.parse(fs.readFileSync(reportPath, 'utf8')) : null;
+          const onboardingReport = hasOnboardingReport ? JSON.parse(fs.readFileSync(onboardingReportPath, 'utf8')) : null;
           const lines = [
             '## Downstream Onboarding Feedback',
             `- downstream repository: \`${process.env.RESOLVED_REPO || feedbackReport?.inputs?.downstreamRepository || 'unknown'}\``,
-            `- downstream branch: \`${process.env.RESOLVED_BRANCH || 'default'}\``,
+            `- requested branch override: \`${process.env.RESOLVED_BRANCH_OVERRIDE || feedbackReport?.inputs?.targetBranchOverride || 'default'}\``,
+            `- branch resolution source: \`${onboardingReport?.branchResolution?.source || process.env.RESOLVED_BRANCH_SOURCE || 'unknown'}\``,
+            `- evaluated branch: \`${onboardingReport?.branchResolution?.evaluatedBranch || onboardingReport?.targetBranch || 'unknown'}\``,
+            `- repository default branch: \`${onboardingReport?.branchResolution?.repositoryDefaultBranch || onboardingReport?.repository?.defaultBranch || 'unknown'}\``,
+            `- policy consumer rail branch: \`${process.env.POLICY_CONSUMER_RAIL_BRANCH || 'unknown'}\``,
             `- feedback report present: \`${hasFeedbackReport}\``,
+            `- onboarding report present: \`${hasOnboardingReport}\``,
             `- template-agent verification report present: \`${hasTemplateVerificationReport}\``
           ];
           if (hasFeedbackReport) {

--- a/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
+++ b/docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md
@@ -58,6 +58,16 @@ What it evaluates:
 - protected production environment presence
 - visibility of policy-required branch checks
 
+Branch provenance matters here:
+
+- `upstream/develop` is the compare producer lineage ref
+- `develop` is the canonical live branch for the current template repo
+- `downstream/develop` is the consumer-proving rail when the conveyor chooses to maintain one
+
+The onboarding report now records all three branch concepts separately so a
+future wake can distinguish live repo truth from compare-side proving-rail
+policy instead of collapsing them into one branch string.
+
 ## Pilot stabilization loop
 
 Repeat the onboarding run after each remediation cycle:
@@ -188,6 +198,7 @@ It now follows the shared hosted-signal contract in [`HOSTED_SIGNAL_REPORT_FIRST
 
 - exports both `GH_TOKEN` and `GITHUB_TOKEN`
 - appends a deterministic step summary from the feedback report when present
+- records requested branch override, resolved live default branch, evaluated branch, and policy consumer rail branch separately
 - emits a wake adjudication artifact so stale downstream branch/provenance signals can be suppressed before reopening work
 - builds and validates the downstream promotion scorecard before artifact upload
 - projects immutable downstream promotion manifest inputs into the scorecard when the manifest artifact is present

--- a/docs/schemas/downstream-onboarding-feedback-v1.schema.json
+++ b/docs/schemas/downstream-onboarding-feedback-v1.schema.json
@@ -23,6 +23,7 @@
       "type": "object",
       "required": [
         "downstreamRepository",
+        "targetBranchOverride",
         "startedAt",
         "parentIssue",
         "createHardeningIssues",
@@ -32,6 +33,13 @@
         "downstreamRepository": {
           "type": "string",
           "pattern": "^[^/]+/[^/]+$"
+        },
+        "targetBranchOverride": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         },
         "startedAt": {
           "type": [

--- a/docs/schemas/downstream-onboarding-report-v1.schema.json
+++ b/docs/schemas/downstream-onboarding-report-v1.schema.json
@@ -10,6 +10,8 @@
     "actionRepository",
     "downstreamRepository",
     "targetBranch",
+    "branchResolution",
+    "repository",
     "checklist",
     "metrics",
     "summary",
@@ -40,6 +42,44 @@
       "type": "string",
       "minLength": 1
     },
+    "branchResolution": {
+      "type": "object",
+      "required": [
+        "requestedBranchOverride",
+        "repositoryDefaultBranch",
+        "evaluatedBranch",
+        "source"
+      ],
+      "properties": {
+        "requestedBranchOverride": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "repositoryDefaultBranch": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "evaluatedBranch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "explicit-override",
+            "live-repository-default-branch",
+            "fallback-default-branch"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "pilot": {
       "type": "object",
       "properties": {
@@ -59,6 +99,54 @@
         }
       },
       "additionalProperties": false
+    },
+    "repository": {
+      "type": "object",
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "defaultBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "evaluatedBranch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branchResolutionSource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "explicit-override",
+            "live-repository-default-branch",
+            "fallback-default-branch",
+            null
+          ]
+        },
+        "htmlUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "private": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
     },
     "checklist": {
       "type": "array",

--- a/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
+++ b/tools/priority/__tests__/downstream-onboarding-contract.test.mjs
@@ -30,6 +30,11 @@ test('workflow executes onboarding, success, feedback, and promotion scorecard c
   assert.match(workflow, /tools\/policy\/template-dependency\.json/);
   assert.match(workflow, /Resolve immutable upstream source/);
   assert.match(workflow, /git fetch --no-tags origin '\+refs\/heads\/develop:refs\/remotes\/upstream\/develop'/);
+  assert.match(workflow, /policy_consumer_rail_branch/);
+  assert.match(workflow, /resolved_branch_override/);
+  assert.match(workflow, /resolved_branch_source/);
+  assert.match(workflow, /branch="\$\{DOWNSTREAM_BRANCH\}"/);
+  assert.doesNotMatch(workflow, /branch="\$\{policy_consumer_rail_branch/);
   assert.match(workflow, /downstream-onboarding-feedback\.mjs/);
   assert.match(workflow, /args\+=\(--branch "\$branch"\)/);
   assert.match(workflow, /--issue-repo "\$issue_repo"/);
@@ -42,6 +47,10 @@ test('workflow executes onboarding, success, feedback, and promotion scorecard c
   assert.match(workflow, /tests\/results\/_agent\/issue\/wake-adjudication\.json/);
   assert.match(workflow, /Refresh template-agent verification report/);
   assert.match(workflow, /priority:template:agent:verify/);
+  assert.doesNotMatch(
+    workflow,
+    /resolved_branch == steps\.feedback\.outputs\.policy_template_branch/
+  );
   assert.match(workflow, /Generate downstream promotion manifest/);
   assert.match(workflow, /downstream-promotion-manifest\.mjs/);
   assert.match(workflow, /--source-sha '\$\{\{ steps\.source\.outputs\.source_sha \}\}'/);
@@ -62,6 +71,11 @@ test('workflow executes onboarding, success, feedback, and promotion scorecard c
     workflow.indexOf('Generate downstream promotion manifest') < workflow.indexOf('Build downstream promotion scorecard')
   );
   assert.match(workflow, /Append onboarding feedback summary/);
+  assert.match(workflow, /requested branch override/);
+  assert.match(workflow, /branch resolution source/);
+  assert.match(workflow, /evaluated branch/);
+  assert.match(workflow, /repository default branch/);
+  assert.match(workflow, /policy consumer rail branch/);
   assert.match(workflow, /execution status/);
   assert.match(workflow, /wake adjudication/);
   assert.match(workflow, /template-agent verification status/);

--- a/tools/priority/__tests__/downstream-onboarding-feedback.test.mjs
+++ b/tools/priority/__tests__/downstream-onboarding-feedback.test.mjs
@@ -47,6 +47,7 @@ test('buildFeedbackReport captures deterministic output existence and exit codes
   const report = buildFeedbackReport({
     options: {
       downstreamRepo: 'owner/downstream',
+      targetBranch: 'downstream/develop',
       startedAt: '2026-03-09T19:16:18Z',
       parentIssue: 715,
       createHardeningIssues: true,
@@ -63,6 +64,7 @@ test('buildFeedbackReport captures deterministic output existence and exit codes
 
   assert.equal(report.schema, 'priority/downstream-onboarding-feedback@v1');
   assert.equal(report.inputs.downstreamRepository, 'owner/downstream');
+  assert.equal(report.inputs.targetBranchOverride, 'downstream/develop');
   assert.equal(report.outputs.onboardingReportExists, true);
   assert.equal(report.outputs.successReportExists, true);
   assert.equal(report.execution.evaluateExitCode, 1);

--- a/tools/priority/__tests__/downstream-onboarding.test.mjs
+++ b/tools/priority/__tests__/downstream-onboarding.test.mjs
@@ -5,6 +5,7 @@ import {
   DEFAULT_OUTPUT_PATH,
   DEFAULT_POLICY_PATH,
   parseArgs,
+  resolveBranchResolution,
   extractActionReferencesFromWorkflow,
   classifyActionReference,
   evaluateChecklist,
@@ -65,6 +66,34 @@ test('parseArgs applies defaults and parses explicit values', () => {
   assert.deepEqual(parsed.issueLabels, ['program', 'enhancement']);
   assert.equal(parsed.issuePrefix, '[onboarding-x]');
   assert.equal(parsed.failOnGap, true);
+});
+
+test('resolveBranchResolution distinguishes explicit overrides from live repository defaults', () => {
+  assert.deepEqual(
+    resolveBranchResolution({
+      requestedBranchOverride: 'downstream/develop',
+      repositoryDefaultBranch: 'develop'
+    }),
+    {
+      requestedBranchOverride: 'downstream/develop',
+      repositoryDefaultBranch: 'develop',
+      evaluatedBranch: 'downstream/develop',
+      source: 'explicit-override'
+    }
+  );
+
+  assert.deepEqual(
+    resolveBranchResolution({
+      requestedBranchOverride: null,
+      repositoryDefaultBranch: 'develop'
+    }),
+    {
+      requestedBranchOverride: null,
+      repositoryDefaultBranch: 'develop',
+      evaluatedBranch: 'develop',
+      source: 'live-repository-default-branch'
+    }
+  );
 });
 
 test('extractActionReferencesFromWorkflow finds compare-vi uses entries', () => {
@@ -264,6 +293,9 @@ test('buildInfrastructureFailureReport produces a schema-valid fail envelope', (
   assert.equal(report.schema, 'priority/downstream-onboarding-report@v1');
   assert.equal(report.summary.status, 'fail');
   assert.equal(report.repository.ok, false);
+  assert.equal(report.repository.defaultBranch, null);
+  assert.equal(report.repository.evaluatedBranch, 'develop');
+  assert.equal(report.branchResolution.source, 'explicit-override');
   assert.equal(report.infrastructureFailure.stage, 'runtime');
   assert.match(report.infrastructureFailure.message, /GitHub token not found/);
   assert.equal(report.hardeningBacklog.length > 0, true);

--- a/tools/priority/downstream-onboarding-feedback.mjs
+++ b/tools/priority/downstream-onboarding-feedback.mjs
@@ -154,6 +154,7 @@ export function buildFeedbackReport({
     generatedAt,
     inputs: {
       downstreamRepository: options.downstreamRepo,
+      targetBranchOverride: options.targetBranch ?? null,
       startedAt: options.startedAt ?? null,
       parentIssue: options.parentIssue ?? null,
       createHardeningIssues: options.createHardeningIssues,

--- a/tools/priority/downstream-onboarding.mjs
+++ b/tools/priority/downstream-onboarding.mjs
@@ -192,6 +192,31 @@ export function resolveRepositorySlug(explicitRepo) {
   throw new Error('Unable to resolve repository slug. Set GITHUB_REPOSITORY or pass --upstream-repo.');
 }
 
+export function resolveBranchResolution({
+  requestedBranchOverride,
+  repositoryDefaultBranch,
+  fallbackBranch = 'develop'
+} = {}) {
+  const normalizedRequestedBranch = requestedBranchOverride ? String(requestedBranchOverride).trim() : null;
+  const normalizedRepositoryDefaultBranch = repositoryDefaultBranch ? String(repositoryDefaultBranch).trim() : null;
+  const normalizedFallbackBranch = fallbackBranch ? String(fallbackBranch).trim() : 'develop';
+
+  const evaluatedBranch =
+    normalizedRequestedBranch || normalizedRepositoryDefaultBranch || normalizedFallbackBranch;
+  const source = normalizedRequestedBranch
+    ? 'explicit-override'
+    : normalizedRepositoryDefaultBranch
+      ? 'live-repository-default-branch'
+      : 'fallback-default-branch';
+
+  return {
+    requestedBranchOverride: normalizedRequestedBranch,
+    repositoryDefaultBranch: normalizedRepositoryDefaultBranch,
+    evaluatedBranch,
+    source
+  };
+}
+
 export function resolveToken() {
   for (const value of [process.env.GH_TOKEN, process.env.GITHUB_TOKEN]) {
     if (value && value.trim()) {
@@ -572,6 +597,8 @@ export function evaluateChecklist(policy, context) {
       context.repository?.ok ? 'repository-visible' : context.repository?.error || 'repository-unavailable',
       {
         defaultBranch: context.repository?.defaultBranch ?? null,
+        evaluatedBranch: context.repository?.evaluatedBranch ?? null,
+        branchResolutionSource: context.repository?.branchResolutionSource ?? null,
         htmlUrl: context.repository?.htmlUrl ?? null
       }
     )
@@ -808,10 +835,16 @@ export function buildInfrastructureFailureReport({
   error,
   stage = 'runtime'
 }) {
+  const branchResolution = resolveBranchResolution({
+    requestedBranchOverride: options.targetBranch,
+    repositoryDefaultBranch: null
+  });
   const repositoryContext = {
     ok: false,
     error: error?.message || String(error),
-    defaultBranch: options.targetBranch || 'develop',
+    defaultBranch: branchResolution.repositoryDefaultBranch,
+    evaluatedBranch: branchResolution.evaluatedBranch,
+    branchResolutionSource: branchResolution.source,
     htmlUrl: null
   };
   const environments = {
@@ -848,7 +881,8 @@ export function buildInfrastructureFailureReport({
     upstreamRepository,
     actionRepository,
     downstreamRepository,
-    targetBranch: repositoryContext.defaultBranch,
+    targetBranch: branchResolution.evaluatedBranch,
+    branchResolution,
     pilot: {
       startedAt: options.startedAt ?? null,
       parentIssue: options.parentIssue ?? null
@@ -1021,7 +1055,9 @@ export async function main(argv = process.argv) {
     const repositoryContext = {
       ok: false,
       error: null,
-      defaultBranch: options.targetBranch || null,
+      defaultBranch: null,
+      evaluatedBranch: null,
+      branchResolutionSource: null,
       htmlUrl: null
     };
 
@@ -1043,17 +1079,23 @@ export async function main(argv = process.argv) {
     };
 
     const repoMetadata = await fetchRepositoryMetadata(downstreamRepository, token);
+    const branchResolution = resolveBranchResolution({
+      requestedBranchOverride: options.targetBranch,
+      repositoryDefaultBranch: repoMetadata?.default_branch || null
+    });
     repositoryContext.ok = true;
-    repositoryContext.defaultBranch = options.targetBranch || repoMetadata?.default_branch || 'develop';
+    repositoryContext.defaultBranch = branchResolution.repositoryDefaultBranch;
+    repositoryContext.evaluatedBranch = branchResolution.evaluatedBranch;
+    repositoryContext.branchResolutionSource = branchResolution.source;
     repositoryContext.htmlUrl = repoMetadata?.html_url || null;
     repositoryContext.private = repoMetadata?.private === true;
 
-    workflowEntries = await fetchWorkflowEntries(downstreamRepository, repositoryContext.defaultBranch, token);
+    workflowEntries = await fetchWorkflowEntries(downstreamRepository, branchResolution.evaluatedBranch, token);
     for (const entry of workflowEntries) {
       const content = await fetchWorkflowContent(
         downstreamRepository,
         entry.path,
-        repositoryContext.defaultBranch,
+        branchResolution.evaluatedBranch,
         token
       );
       if (!content) continue;
@@ -1070,7 +1112,7 @@ export async function main(argv = process.argv) {
       const runs = await fetchWorkflowRuns(
         downstreamRepository,
         workflowPath,
-        repositoryContext.defaultBranch,
+        branchResolution.evaluatedBranch,
         options.lookbackRuns,
         token
       );
@@ -1080,7 +1122,7 @@ export async function main(argv = process.argv) {
     environments = await fetchEnvironmentStatus(downstreamRepository, token, policy.requiredEnvironments);
     branchProtection = await fetchBranchProtectionStatus(
       downstreamRepository,
-      repositoryContext.defaultBranch,
+      branchResolution.evaluatedBranch,
       token,
       policy.requiredBranchChecks
     );
@@ -1109,7 +1151,8 @@ export async function main(argv = process.argv) {
       upstreamRepository,
       actionRepository,
       downstreamRepository,
-      targetBranch: repositoryContext.defaultBranch || options.targetBranch || 'develop',
+      targetBranch: branchResolution.evaluatedBranch,
+      branchResolution,
       pilot: {
         startedAt: options.startedAt ?? null,
         parentIssue: options.parentIssue ?? null


### PR DESCRIPTION
## Summary
- separate downstream onboarding branch provenance from compare's consumer proving rail
- stop the hosted onboarding feedback workflow from defaulting template onboarding to `downstream/develop`
- surface producer lineage, canonical template development, and consumer proving rail as distinct concepts in the runbook and hosted summary

## Testing
- node --test tools/priority/__tests__/downstream-onboarding.test.mjs tools/priority/__tests__/downstream-onboarding-feedback.test.mjs tools/priority/__tests__/downstream-onboarding-contract.test.mjs
- node tools/priority/downstream-onboarding-feedback.mjs --repo LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate --parent-issue 715 --report tests/results/_agent/onboarding/downstream-onboarding.live-template-1812.json --success-output tests/results/_agent/onboarding/downstream-onboarding-success.live-template-1812.json --feedback-output tests/results/_agent/onboarding/downstream-onboarding-feedback.live-template-1812.json
- node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/downstream-onboarding-report-v1.schema.json --data tests/results/_agent/onboarding/downstream-onboarding.live-template-1812.json
- node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/downstream-onboarding-feedback-v1.schema.json --data tests/results/_agent/onboarding/downstream-onboarding-feedback.live-template-1812.json
- node tools/npm/run-script.mjs docs:manifest:validate
- node tools/npm/run-script.mjs lint:md:changed
- git diff --check
