### PR TITLE
feat(priority): synthesize repo-aware wake outcomes

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -179,14 +179,20 @@
       "name": "Wake Adjudication Contracts",
       "category": "supporting",
       "status": "reference",
-      "description": "Wake adjudication schema, CLI, hosted downstream-onboarding integration, and focused tests that replay reported downstream onboarding failures against live GitHub state before reopening work.",
+      "description": "Wake adjudication and wake-work synthesis schemas, CLIs, hosted downstream-onboarding integration, checked-in policy, and focused tests that replay reported downstream onboarding failures against live GitHub state and then turn them into repo-aware work-routing decisions.",
       "files": [
         "docs/DOWNSTREAM_RELEASE_TRAIN_ONBOARDING.md",
         "docs/schemas/wake-adjudication-report-v1.schema.json",
+        "docs/schemas/wake-work-synthesis-policy-v1.schema.json",
+        "docs/schemas/wake-work-synthesis-report-v1.schema.json",
         ".github/workflows/downstream-onboarding-feedback.yml",
+        "tools/policy/wake-work-synthesis.json",
         "tools/priority/wake-adjudication.mjs",
+        "tools/priority/wake-work-synthesis.mjs",
         "tools/priority/__tests__/wake-adjudication.test.mjs",
         "tools/priority/__tests__/wake-adjudication-schema.test.mjs",
+        "tools/priority/__tests__/wake-work-synthesis.test.mjs",
+        "tools/priority/__tests__/wake-work-synthesis-schema.test.mjs",
         "tools/priority/__tests__/downstream-onboarding-contract.test.mjs"
       ]
     },

--- a/docs/schemas/wake-work-synthesis-policy-v1.schema.json
+++ b/docs/schemas/wake-work-synthesis-policy-v1.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/wake-work-synthesis-policy-v1.schema.json",
+  "title": "Wake Work Synthesis Policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "compareRepository",
+    "classificationDefaults",
+    "liveDefectRouting"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/wake-work-synthesis-policy@v1"
+    },
+    "compareRepository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "classificationDefaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stale-artifact",
+        "environment-only",
+        "branch-target-drift",
+        "platform-permission-gap",
+        "live-defect"
+      ],
+      "properties": {
+        "stale-artifact": { "$ref": "#/$defs/classificationDefault" },
+        "environment-only": { "$ref": "#/$defs/classificationDefault" },
+        "branch-target-drift": { "$ref": "#/$defs/classificationDefault" },
+        "platform-permission-gap": { "$ref": "#/$defs/classificationDefault" },
+        "live-defect": { "$ref": "#/$defs/classificationDefault" }
+      }
+    },
+    "liveDefectRouting": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "compareRepositoryDecision",
+        "consumerProvingDecision",
+        "fallbackDecision"
+      ],
+      "properties": {
+        "compareRepositoryDecision": { "$ref": "#/$defs/decision" },
+        "consumerProvingDecision": { "$ref": "#/$defs/decision" },
+        "fallbackDecision": { "$ref": "#/$defs/decision" }
+      }
+    }
+  },
+  "$defs": {
+    "classificationDefault": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision",
+        "workKind"
+      ],
+      "properties": {
+        "decision": { "$ref": "#/$defs/decision" },
+        "workKind": { "$ref": "#/$defs/workKind" }
+      }
+    },
+    "decision": {
+      "type": "string",
+      "enum": [
+        "suppress",
+        "monitor",
+        "compare-governance-work",
+        "template-work",
+        "consumer-proving-drift",
+        "investment-work"
+      ]
+    },
+    "workKind": {
+      "type": "string",
+      "enum": [
+        "suppression",
+        "monitoring",
+        "governance",
+        "defect",
+        "drift-correction",
+        "investment"
+      ]
+    }
+  }
+}

--- a/docs/schemas/wake-work-synthesis-report-v1.schema.json
+++ b/docs/schemas/wake-work-synthesis-report-v1.schema.json
@@ -1,0 +1,310 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/wake-work-synthesis-report-v1.schema.json",
+  "title": "Wake Work Synthesis Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "repository",
+    "policy",
+    "inputs",
+    "wake",
+    "roles",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/wake-work-synthesis-report@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "compareRepository"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "compareRepository": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wakeAdjudicationReportPath",
+        "repoGraphTruthPath"
+      ],
+      "properties": {
+        "wakeAdjudicationReportPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repoGraphTruthPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "wake": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classification",
+        "status",
+        "recommendedOwnerRepository",
+        "nextAction",
+        "reason",
+        "suppressIssueInjection",
+        "suppressDownstreamIssueInjection",
+        "suppressTemplateIssueInjection"
+      ],
+      "properties": {
+        "classification": {
+          "type": "string",
+          "enum": [
+            "live-defect",
+            "stale-artifact",
+            "branch-target-drift",
+            "platform-permission-gap",
+            "environment-only"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "actionable",
+            "suppressed",
+            "monitoring"
+          ]
+        },
+        "recommendedOwnerRepository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nextAction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "suppressIssueInjection": {
+          "type": "boolean"
+        },
+        "suppressDownstreamIssueInjection": {
+          "type": "boolean"
+        },
+        "suppressTemplateIssueInjection": {
+          "type": "boolean"
+        }
+      }
+    },
+    "roles": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reportedRoleMatches",
+        "revalidatedRoleMatches",
+        "governingRole"
+      ],
+      "properties": {
+        "reportedRoleMatches": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/roleMatch" }
+        },
+        "revalidatedRoleMatches": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/roleMatch" }
+        },
+        "governingRole": {
+          "anyOf": [
+            { "$ref": "#/$defs/roleMatch" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision",
+        "status",
+        "workKind",
+        "recommendedOwnerRepository",
+        "reason",
+        "issueRouting"
+      ],
+      "properties": {
+        "decision": { "$ref": "#/$defs/decision" },
+        "status": {
+          "type": "string",
+          "enum": [
+            "suppressed",
+            "monitoring",
+            "actionable"
+          ]
+        },
+        "workKind": { "$ref": "#/$defs/workKind" },
+        "recommendedOwnerRepository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issueRouting": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "compareGovernanceWork",
+            "templateWork",
+            "consumerProvingDriftWork",
+            "investmentWork"
+          ],
+          "properties": {
+            "compareGovernanceWork": {
+              "type": "boolean"
+            },
+            "templateWork": {
+              "type": "boolean"
+            },
+            "consumerProvingDriftWork": {
+              "type": "boolean"
+            },
+            "investmentWork": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "decision": {
+      "type": "string",
+      "enum": [
+        "suppress",
+        "monitor",
+        "compare-governance-work",
+        "template-work",
+        "consumer-proving-drift",
+        "investment-work"
+      ]
+    },
+    "workKind": {
+      "type": "string",
+      "enum": [
+        "suppression",
+        "monitoring",
+        "governance",
+        "defect",
+        "drift-correction",
+        "investment"
+      ]
+    },
+    "roleMatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repositoryId",
+        "repository",
+        "repositoryKind",
+        "repositoryStatus",
+        "roleId",
+        "role",
+        "branch",
+        "required",
+        "roleStatus",
+        "relationshipStatus"
+      ],
+      "properties": {
+        "repositoryId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repositoryKind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repositoryStatus": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "fail",
+            "unknown"
+          ]
+        },
+        "roleId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "localRefAlias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "roleStatus": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "fail",
+            "missing",
+            "unknown"
+          ]
+        },
+        "relationshipStatus": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "pass",
+            "fail",
+            "unknown",
+            null
+          ]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "priority:monitoring:mode": "node tools/priority/handoff-monitoring-mode.mjs",
     "priority:monitoring:inject-work": "node tools/priority/monitoring-work-injection.mjs",
     "priority:wake:adjudicate": "node tools/priority/wake-adjudication.mjs",
+    "priority:wake:synthesize": "node tools/priority/wake-work-synthesis.mjs",
     "priority:handoff-tests": "node tools/priority/run-handoff-tests.mjs",
     "priority:health-snapshot": "pwsh -NoLogo -NoProfile -File tools/priority/Write-HealthSnapshot.ps1",
     "priority:lease": "node tools/priority/agent-writer-lease.mjs",

--- a/tools/policy/wake-work-synthesis.json
+++ b/tools/policy/wake-work-synthesis.json
@@ -1,0 +1,31 @@
+{
+  "schema": "priority/wake-work-synthesis-policy@v1",
+  "compareRepository": "LabVIEW-Community-CI-CD/compare-vi-cli-action",
+  "classificationDefaults": {
+    "stale-artifact": {
+      "decision": "suppress",
+      "workKind": "suppression"
+    },
+    "environment-only": {
+      "decision": "monitor",
+      "workKind": "monitoring"
+    },
+    "branch-target-drift": {
+      "decision": "compare-governance-work",
+      "workKind": "drift-correction"
+    },
+    "platform-permission-gap": {
+      "decision": "compare-governance-work",
+      "workKind": "governance"
+    },
+    "live-defect": {
+      "decision": "template-work",
+      "workKind": "defect"
+    }
+  },
+  "liveDefectRouting": {
+    "compareRepositoryDecision": "compare-governance-work",
+    "consumerProvingDecision": "consumer-proving-drift",
+    "fallbackDecision": "investment-work"
+  }
+}

--- a/tools/priority/__tests__/wake-work-synthesis-schema.test.mjs
+++ b/tools/priority/__tests__/wake-work-synthesis-schema.test.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import { runWakeWorkSynthesis } from '../wake-work-synthesis.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+test('wake work synthesis report matches schema', async () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-work-synthesis-schema-'));
+  const policyPath = path.join(tmpDir, 'policy.json');
+  const wakePath = path.join(tmpDir, 'wake.json');
+  const repoGraphPath = path.join(tmpDir, 'repo-graph.json');
+  const outputPath = path.join(tmpDir, 'wake-work-synthesis.json');
+
+  writeJson(policyPath, {
+    schema: 'priority/wake-work-synthesis-policy@v1',
+    compareRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    classificationDefaults: {
+      'stale-artifact': { decision: 'suppress', workKind: 'suppression' },
+      'environment-only': { decision: 'monitor', workKind: 'monitoring' },
+      'branch-target-drift': { decision: 'compare-governance-work', workKind: 'drift-correction' },
+      'platform-permission-gap': { decision: 'compare-governance-work', workKind: 'governance' },
+      'live-defect': { decision: 'template-work', workKind: 'defect' }
+    },
+    liveDefectRouting: {
+      compareRepositoryDecision: 'compare-governance-work',
+      consumerProvingDecision: 'consumer-proving-drift',
+      fallbackDecision: 'investment-work'
+    }
+  });
+  writeJson(wakePath, {
+    schema: 'priority/wake-adjudication-report@v1',
+    generatedAt: '2026-03-22T00:00:00.000Z',
+    wakeKind: 'downstream-onboarding',
+    reported: {
+      path: 'reported.json',
+      generatedAt: '2026-03-22T00:00:00.000Z',
+      downstreamRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      targetBranch: 'develop',
+      defaultBranch: 'develop',
+      summaryStatus: 'fail',
+      requiredFailCount: 1,
+      warningCount: 0,
+      workflowReferenceCount: 1,
+      successfulRunCount: 1,
+      requiredFailures: [],
+      warnings: []
+    },
+    revalidated: {
+      path: 'revalidated.json',
+      generatedAt: '2026-03-22T00:01:00.000Z',
+      downstreamRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      targetBranch: 'develop',
+      defaultBranch: 'develop',
+      summaryStatus: 'fail',
+      requiredFailCount: 1,
+      warningCount: 0,
+      workflowReferenceCount: 1,
+      successfulRunCount: 1,
+      requiredFailures: [],
+      warnings: [],
+      reran: true,
+      exitCode: 0
+    },
+    delta: {
+      targetBranchChanged: false,
+      defaultBranchChanged: false,
+      workflowReferenceCountDelta: 0,
+      successfulRunCountDelta: 0,
+      reportedRequiredFailureIds: [],
+      revalidatedRequiredFailureIds: [],
+      clearedRequiredFailureIds: [],
+      persistentRequiredFailureIds: [],
+      newRequiredFailureIds: []
+    },
+    summary: {
+      classification: 'live-defect',
+      status: 'actionable',
+      suppressIssueInjection: false,
+      suppressDownstreamIssueInjection: false,
+      suppressTemplateIssueInjection: false,
+      recommendedOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      nextAction: 'route-live-downstream-defect',
+      reason: 'Live replay still blocks required downstream onboarding checks.'
+    }
+  });
+  writeJson(repoGraphPath, {
+    schema: 'priority/downstream-repo-graph-truth@v1',
+    generatedAt: '2026-03-22T00:00:00.000Z',
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    policy: {
+      path: 'tools/policy/downstream-repo-graph.json',
+      compareRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    repositories: [
+      {
+        id: 'canonical-template',
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+        kind: 'canonical-template',
+        status: 'pass',
+        roles: [
+          {
+            id: 'template-canonical-development',
+            role: 'canonical-development',
+            branch: 'develop',
+            localRefAlias: null,
+            required: true,
+            status: 'pass',
+            branchExists: true,
+            headSha: 'tpl123',
+            relationship: null
+          }
+        ],
+        summary: {
+          requiredMissingRoleCount: 0,
+          optionalMissingRoleCount: 0,
+          alignmentFailureCount: 0,
+          unknownRoleCount: 0
+        }
+      }
+    ],
+    summary: {
+      status: 'pass',
+      repositoryCount: 1,
+      roleCount: 1,
+      requiredMissingRoleCount: 0,
+      optionalMissingRoleCount: 0,
+      alignmentFailureCount: 0,
+      unknownRoleCount: 0
+    }
+  });
+
+  const { report } = await runWakeWorkSynthesis({
+    repoRoot: tmpDir,
+    policyPath,
+    wakeAdjudicationPath: wakePath,
+    repoGraphTruthPath: repoGraphPath,
+    outputPath
+  });
+
+  const schema = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'docs', 'schemas', 'wake-work-synthesis-report-v1.schema.json'), 'utf8')
+  );
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(report), true, JSON.stringify(validate.errors, null, 2));
+});
+
+test('checked-in wake work synthesis policy matches schema', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  const policy = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'tools', 'policy', 'wake-work-synthesis.json'), 'utf8')
+  );
+  const schema = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'docs', 'schemas', 'wake-work-synthesis-policy-v1.schema.json'), 'utf8')
+  );
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  assert.equal(validate(policy), true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/wake-work-synthesis.test.mjs
+++ b/tools/priority/__tests__/wake-work-synthesis.test.mjs
@@ -1,0 +1,344 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  DEFAULT_OUTPUT_PATH,
+  parseArgs,
+  runWakeWorkSynthesis,
+  synthesizeWakeWork
+} from '../wake-work-synthesis.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function createPolicy() {
+  return {
+    schema: 'priority/wake-work-synthesis-policy@v1',
+    compareRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    classificationDefaults: {
+      'stale-artifact': { decision: 'suppress', workKind: 'suppression' },
+      'environment-only': { decision: 'monitor', workKind: 'monitoring' },
+      'branch-target-drift': { decision: 'compare-governance-work', workKind: 'drift-correction' },
+      'platform-permission-gap': { decision: 'compare-governance-work', workKind: 'governance' },
+      'live-defect': { decision: 'template-work', workKind: 'defect' }
+    },
+    liveDefectRouting: {
+      compareRepositoryDecision: 'compare-governance-work',
+      consumerProvingDecision: 'consumer-proving-drift',
+      fallbackDecision: 'investment-work'
+    }
+  };
+}
+
+function createRepoGraphTruth() {
+  return {
+    schema: 'priority/downstream-repo-graph-truth@v1',
+    generatedAt: '2026-03-22T00:00:00.000Z',
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    policy: {
+      path: 'tools/policy/downstream-repo-graph.json',
+      compareRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    repositories: [
+      {
+        id: 'compare',
+        repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        kind: 'supervisor',
+        status: 'pass',
+        roles: [
+          {
+            id: 'compare-producer-lineage',
+            role: 'producer-lineage',
+            branch: 'develop',
+            localRefAlias: 'upstream/develop',
+            required: true,
+            status: 'pass',
+            branchExists: true,
+            headSha: 'cmp123',
+            relationship: null
+          }
+        ],
+        summary: {
+          requiredMissingRoleCount: 0,
+          optionalMissingRoleCount: 0,
+          alignmentFailureCount: 0,
+          unknownRoleCount: 0
+        }
+      },
+      {
+        id: 'canonical-template',
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+        kind: 'canonical-template',
+        status: 'pass',
+        roles: [
+          {
+            id: 'template-canonical-development',
+            role: 'canonical-development',
+            branch: 'develop',
+            localRefAlias: null,
+            required: true,
+            status: 'pass',
+            branchExists: true,
+            headSha: 'tpl123',
+            relationship: null
+          },
+          {
+            id: 'template-consumer-proving-rail',
+            role: 'consumer-proving-rail',
+            branch: 'downstream/develop',
+            localRefAlias: null,
+            required: false,
+            status: 'pass',
+            branchExists: true,
+            headSha: 'cmp123',
+            relationship: {
+              tracksRoleId: 'compare-consumer-proving-source',
+              status: 'pass',
+              trackedHeadSha: 'cmp123',
+              reason: 'head-sha-match'
+            }
+          }
+        ],
+        summary: {
+          requiredMissingRoleCount: 0,
+          optionalMissingRoleCount: 0,
+          alignmentFailureCount: 0,
+          unknownRoleCount: 0
+        }
+      },
+      {
+        id: 'org-consumer-fork',
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork',
+        kind: 'consumer-fork',
+        status: 'pass',
+        roles: [
+          {
+            id: 'org-fork-canonical-development',
+            role: 'canonical-development-mirror',
+            branch: 'develop',
+            localRefAlias: null,
+            required: true,
+            status: 'pass',
+            branchExists: true,
+            headSha: 'tpl123',
+            relationship: {
+              tracksRoleId: 'template-canonical-development',
+              status: 'pass',
+              trackedHeadSha: 'tpl123',
+              reason: 'head-sha-match'
+            }
+          }
+        ],
+        summary: {
+          requiredMissingRoleCount: 0,
+          optionalMissingRoleCount: 0,
+          alignmentFailureCount: 0,
+          unknownRoleCount: 0
+        }
+      }
+    ],
+    summary: {
+      status: 'pass',
+      repositoryCount: 3,
+      roleCount: 4,
+      requiredMissingRoleCount: 0,
+      optionalMissingRoleCount: 0,
+      alignmentFailureCount: 0,
+      unknownRoleCount: 0
+    }
+  };
+}
+
+function createWakeReport({
+  classification,
+  status,
+  recommendedOwnerRepository,
+  reportedRepository = 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+  reportedBranch = 'develop',
+  revalidatedRepository = reportedRepository,
+  revalidatedBranch = reportedBranch,
+  nextAction = 'test-next-action',
+  reason = 'test reason',
+  suppressIssueInjection = false,
+  suppressDownstreamIssueInjection = false,
+  suppressTemplateIssueInjection = false
+}) {
+  return {
+    schema: 'priority/wake-adjudication-report@v1',
+    generatedAt: '2026-03-22T00:00:00.000Z',
+    wakeKind: 'downstream-onboarding',
+    reported: {
+      path: 'reported.json',
+      generatedAt: '2026-03-22T00:00:00.000Z',
+      downstreamRepository: reportedRepository,
+      targetBranch: reportedBranch,
+      defaultBranch: reportedBranch,
+      summaryStatus: classification === 'live-defect' ? 'fail' : 'warn',
+      requiredFailCount: classification === 'live-defect' ? 1 : 0,
+      warningCount: classification === 'environment-only' ? 1 : 0,
+      workflowReferenceCount: 1,
+      successfulRunCount: 1,
+      requiredFailures: [],
+      warnings: []
+    },
+    revalidated: {
+      path: 'revalidated.json',
+      generatedAt: '2026-03-22T00:01:00.000Z',
+      downstreamRepository: revalidatedRepository,
+      targetBranch: revalidatedBranch,
+      defaultBranch: revalidatedBranch,
+      summaryStatus: classification === 'live-defect' ? 'fail' : classification === 'environment-only' ? 'warn' : 'pass',
+      requiredFailCount: classification === 'live-defect' ? 1 : 0,
+      warningCount: classification === 'environment-only' ? 1 : 0,
+      workflowReferenceCount: 1,
+      successfulRunCount: 1,
+      requiredFailures: [],
+      warnings: [],
+      reran: true,
+      exitCode: 0
+    },
+    delta: {
+      targetBranchChanged: reportedBranch !== revalidatedBranch,
+      defaultBranchChanged: reportedBranch !== revalidatedBranch,
+      workflowReferenceCountDelta: 0,
+      successfulRunCountDelta: 0,
+      reportedRequiredFailureIds: [],
+      revalidatedRequiredFailureIds: [],
+      clearedRequiredFailureIds: [],
+      persistentRequiredFailureIds: [],
+      newRequiredFailureIds: []
+    },
+    summary: {
+      classification,
+      status,
+      suppressIssueInjection,
+      suppressDownstreamIssueInjection,
+      suppressTemplateIssueInjection,
+      recommendedOwnerRepository,
+      nextAction,
+      reason
+    }
+  };
+}
+
+test('parseArgs captures wake work synthesis paths', () => {
+  const parsed = parseArgs([
+    'node',
+    'wake-work-synthesis.mjs',
+    '--policy',
+    'policy.json',
+    '--wake-adjudication',
+    'wake.json',
+    '--repo-graph-truth',
+    'graph.json',
+    '--output',
+    'out.json'
+  ]);
+
+  assert.equal(parsed.policyPath, 'policy.json');
+  assert.equal(parsed.wakeAdjudicationPath, 'wake.json');
+  assert.equal(parsed.repoGraphTruthPath, 'graph.json');
+  assert.equal(parsed.outputPath, 'out.json');
+});
+
+test('synthesizeWakeWork routes branch-target drift into compare governance work', () => {
+  const report = synthesizeWakeWork(
+    createPolicy(),
+    createWakeReport({
+      classification: 'branch-target-drift',
+      status: 'suppressed',
+      recommendedOwnerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      reportedBranch: 'downstream/develop',
+      revalidatedBranch: 'develop',
+      suppressIssueInjection: true,
+      suppressDownstreamIssueInjection: true,
+      suppressTemplateIssueInjection: true
+    }),
+    createRepoGraphTruth()
+  );
+
+  assert.equal(report.summary.decision, 'compare-governance-work');
+  assert.equal(report.summary.workKind, 'drift-correction');
+  assert.equal(report.summary.recommendedOwnerRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(report.summary.issueRouting.compareGovernanceWork, true);
+  assert.equal(report.roles.governingRole.role, 'consumer-proving-rail');
+});
+
+test('synthesizeWakeWork routes canonical live defects into template work', () => {
+  const report = synthesizeWakeWork(
+    createPolicy(),
+    createWakeReport({
+      classification: 'live-defect',
+      status: 'actionable',
+      recommendedOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'
+    }),
+    createRepoGraphTruth()
+  );
+
+  assert.equal(report.summary.decision, 'template-work');
+  assert.equal(report.summary.workKind, 'defect');
+  assert.equal(report.summary.issueRouting.templateWork, true);
+});
+
+test('synthesizeWakeWork routes consumer-fork live defects into consumer proving drift work', () => {
+  const report = synthesizeWakeWork(
+    createPolicy(),
+    createWakeReport({
+      classification: 'live-defect',
+      status: 'actionable',
+      recommendedOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork',
+      reportedRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork',
+      revalidatedRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork'
+    }),
+    createRepoGraphTruth()
+  );
+
+  assert.equal(report.summary.decision, 'consumer-proving-drift');
+  assert.equal(report.summary.workKind, 'drift-correction');
+  assert.equal(report.summary.issueRouting.consumerProvingDriftWork, true);
+});
+
+test('synthesizeWakeWork falls back to investment work when no repo-graph role matches a live defect', () => {
+  const report = synthesizeWakeWork(
+    createPolicy(),
+    createWakeReport({
+      classification: 'live-defect',
+      status: 'actionable',
+      recommendedOwnerRepository: null,
+      reportedRepository: 'example/unknown',
+      revalidatedRepository: 'example/unknown'
+    }),
+    createRepoGraphTruth()
+  );
+
+  assert.equal(report.summary.decision, 'investment-work');
+  assert.equal(report.summary.workKind, 'investment');
+  assert.equal(report.summary.recommendedOwnerRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(report.summary.issueRouting.investmentWork, true);
+});
+
+test('runWakeWorkSynthesis writes the default output path', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-work-synthesis-default-output-'));
+  writeJson(path.join(tmpDir, 'tools', 'policy', 'wake-work-synthesis.json'), createPolicy());
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'issue', 'wake-adjudication.json'), createWakeReport({
+    classification: 'environment-only',
+    status: 'monitoring',
+    recommendedOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+    suppressIssueInjection: true,
+    suppressDownstreamIssueInjection: true,
+    suppressTemplateIssueInjection: true
+  }));
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'downstream-repo-graph-truth.json'), createRepoGraphTruth());
+
+  const { outputPath, report } = await runWakeWorkSynthesis({ repoRoot: tmpDir });
+
+  assert.match(outputPath, new RegExp(DEFAULT_OUTPUT_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\//g, '[\\\\/]')));
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(report.summary.decision, 'monitor');
+  assert.equal(report.summary.status, 'monitoring');
+});

--- a/tools/priority/wake-work-synthesis.mjs
+++ b/tools/priority/wake-work-synthesis.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(MODULE_DIR, '..', '..');
+export const DEFAULT_POLICY_PATH = path.join('tools', 'policy', 'wake-work-synthesis.json');
+export const DEFAULT_WAKE_ADJUDICATION_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'issue',
+  'wake-adjudication.json'
+);
+export const DEFAULT_REPO_GRAPH_TRUTH_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'downstream-repo-graph-truth.json'
+);
+export const DEFAULT_OUTPUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'issue',
+  'wake-work-synthesis.json'
+);
+
+function normalizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function asOptional(value) {
+  const normalized = normalizeText(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.resolve(filePath), 'utf8'));
+}
+
+function writeJson(filePath, payload) {
+  const resolvedPath = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+function toRelative(repoRoot, targetPath) {
+  return path.relative(repoRoot, path.resolve(targetPath)).replace(/\\/g, '/');
+}
+
+function ensureWakeAdjudicationReport(payload, filePath) {
+  if (payload?.schema !== 'priority/wake-adjudication-report@v1') {
+    throw new Error(`Expected wake adjudication report at ${filePath}.`);
+  }
+  return payload;
+}
+
+function ensureRepoGraphTruthReport(payload, filePath) {
+  if (payload?.schema !== 'priority/downstream-repo-graph-truth@v1') {
+    throw new Error(`Expected downstream repo graph truth report at ${filePath}.`);
+  }
+  return payload;
+}
+
+function ensurePolicy(payload, filePath) {
+  if (payload?.schema !== 'priority/wake-work-synthesis-policy@v1') {
+    throw new Error(`Expected wake work synthesis policy at ${filePath}.`);
+  }
+  return payload;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
+    policyPath: DEFAULT_POLICY_PATH,
+    wakeAdjudicationPath: DEFAULT_WAKE_ADJUDICATION_PATH,
+    repoGraphTruthPath: DEFAULT_REPO_GRAPH_TRUTH_PATH,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    help: false
+  };
+
+  const stringFlags = new Map([
+    ['--repo-root', 'repoRoot'],
+    ['--policy', 'policyPath'],
+    ['--wake-adjudication', 'wakeAdjudicationPath'],
+    ['--repo-graph-truth', 'repoGraphTruthPath'],
+    ['--output', 'outputPath']
+  ]);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+    if (stringFlags.has(token)) {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      options[stringFlags.get(token)] = next;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+function printHelp() {
+  [
+    'Usage: node tools/priority/wake-work-synthesis.mjs [options]',
+    '',
+    'Options:',
+    `  --repo-root <path>         Repository root override (default: ${DEFAULT_REPO_ROOT}).`,
+    `  --policy <path>            Work synthesis policy path (default: ${DEFAULT_POLICY_PATH}).`,
+    `  --wake-adjudication <path> Wake adjudication report path (default: ${DEFAULT_WAKE_ADJUDICATION_PATH}).`,
+    `  --repo-graph-truth <path>  Repo graph truth report path (default: ${DEFAULT_REPO_GRAPH_TRUTH_PATH}).`,
+    `  --output <path>            Output path (default: ${DEFAULT_OUTPUT_PATH}).`,
+    '  -h, --help                 Show help.'
+  ].forEach((line) => console.log(line));
+}
+
+function buildRoleMatches(repoGraphTruth, repository, branch) {
+  const repositorySlug = asOptional(repository);
+  const targetBranch = normalizeText(branch);
+  if (!repositorySlug || !targetBranch) {
+    return [];
+  }
+
+  const matches = [];
+  for (const repositoryEntry of repoGraphTruth.repositories || []) {
+    if (normalizeText(repositoryEntry.repository) !== repositorySlug) {
+      continue;
+    }
+    for (const role of repositoryEntry.roles || []) {
+      if (normalizeText(role.branch) !== targetBranch) {
+        continue;
+      }
+      matches.push({
+        repositoryId: normalizeText(repositoryEntry.id),
+        repository: repositorySlug,
+        repositoryKind: normalizeText(repositoryEntry.kind),
+        repositoryStatus: normalizeText(repositoryEntry.status) || 'unknown',
+        roleId: normalizeText(role.id),
+        role: normalizeText(role.role),
+        branch: normalizeText(role.branch),
+        localRefAlias: asOptional(role.localRefAlias),
+        required: role.required === true,
+        roleStatus: normalizeText(role.status) || 'unknown',
+        relationshipStatus: asOptional(role.relationship?.status)
+      });
+    }
+  }
+  return matches;
+}
+
+function selectRole(matches) {
+  return (
+    matches.find((entry) => entry.roleStatus === 'pass' && (entry.relationshipStatus == null || entry.relationshipStatus === 'pass')) ||
+    matches.find((entry) => entry.roleStatus === 'pass') ||
+    matches[0] ||
+    null
+  );
+}
+
+function selectFallbackRole(repoGraphTruth, repository) {
+  const repositorySlug = asOptional(repository);
+  if (!repositorySlug) {
+    return null;
+  }
+  const repositoryEntry = (repoGraphTruth.repositories || []).find(
+    (entry) => normalizeText(entry.repository) === repositorySlug
+  );
+  if (!repositoryEntry) {
+    return null;
+  }
+  return (
+    selectRole(
+      (repositoryEntry.roles || []).map((role) => ({
+        repositoryId: normalizeText(repositoryEntry.id),
+        repository: repositorySlug,
+        repositoryKind: normalizeText(repositoryEntry.kind),
+        repositoryStatus: normalizeText(repositoryEntry.status) || 'unknown',
+        roleId: normalizeText(role.id),
+        role: normalizeText(role.role),
+        branch: normalizeText(role.branch),
+        localRefAlias: asOptional(role.localRefAlias),
+        required: role.required === true,
+        roleStatus: normalizeText(role.status) || 'unknown',
+        relationshipStatus: asOptional(role.relationship?.status)
+      }))
+    ) || null
+  );
+}
+
+function createIssueRouting(decision) {
+  return {
+    compareGovernanceWork: decision === 'compare-governance-work',
+    templateWork: decision === 'template-work',
+    consumerProvingDriftWork: decision === 'consumer-proving-drift',
+    investmentWork: decision === 'investment-work'
+  };
+}
+
+function determineLiveDefectDecision(policy, compareRepository, governingRole, ownerRepository) {
+  if (normalizeText(governingRole?.repository) === compareRepository || normalizeText(ownerRepository) === compareRepository) {
+    return policy.liveDefectRouting.compareRepositoryDecision;
+  }
+  if (
+    normalizeText(governingRole?.repositoryKind) === 'consumer-fork' ||
+    normalizeText(governingRole?.role) === 'consumer-proving-rail' ||
+    normalizeText(governingRole?.role) === 'canonical-development-mirror'
+  ) {
+    return policy.liveDefectRouting.consumerProvingDecision;
+  }
+  if (asOptional(ownerRepository) || asOptional(governingRole?.repository)) {
+    return policy.classificationDefaults['live-defect'].decision;
+  }
+  return policy.liveDefectRouting.fallbackDecision;
+}
+
+function determineWorkKind(policy, classification, decision) {
+  if (classification !== 'live-defect') {
+    return policy.classificationDefaults[classification].workKind;
+  }
+  if (decision === 'compare-governance-work') {
+    return 'governance';
+  }
+  if (decision === 'consumer-proving-drift') {
+    return 'drift-correction';
+  }
+  if (decision === 'investment-work') {
+    return 'investment';
+  }
+  return policy.classificationDefaults['live-defect'].workKind;
+}
+
+function determineStatus(decision) {
+  if (decision === 'suppress') {
+    return 'suppressed';
+  }
+  if (decision === 'monitor') {
+    return 'monitoring';
+  }
+  return 'actionable';
+}
+
+function determineOwnerRepository(policy, decision, wakeSummary, governingRole) {
+  if (decision === 'compare-governance-work' || decision === 'investment-work') {
+    return policy.compareRepository;
+  }
+  return asOptional(wakeSummary.recommendedOwnerRepository) || asOptional(governingRole?.repository);
+}
+
+export function synthesizeWakeWork(policy, wakeReport, repoGraphTruth) {
+  const wakeSummary = wakeReport.summary;
+  const reportedRoleMatches = buildRoleMatches(
+    repoGraphTruth,
+    wakeReport.reported?.downstreamRepository,
+    wakeReport.reported?.targetBranch
+  );
+  const revalidatedRoleMatches = buildRoleMatches(
+    repoGraphTruth,
+    wakeReport.revalidated?.downstreamRepository,
+    wakeReport.revalidated?.targetBranch
+  );
+
+  const compareRepository = normalizeText(policy.compareRepository);
+  const governingRole =
+    (wakeSummary.classification === 'branch-target-drift' ? selectRole(reportedRoleMatches) : null) ||
+    selectRole(revalidatedRoleMatches) ||
+    selectFallbackRole(repoGraphTruth, wakeSummary.recommendedOwnerRepository) ||
+    selectRole(reportedRoleMatches);
+
+  let decision = policy.classificationDefaults[wakeSummary.classification]?.decision;
+  if (!decision) {
+    throw new Error(`Unsupported wake classification: ${wakeSummary.classification}`);
+  }
+
+  if (wakeSummary.classification === 'live-defect') {
+    decision = determineLiveDefectDecision(
+      policy,
+      compareRepository,
+      governingRole,
+      wakeSummary.recommendedOwnerRepository
+    );
+  }
+
+  const workKind = determineWorkKind(policy, wakeSummary.classification, decision);
+  const recommendedOwnerRepository = determineOwnerRepository(policy, decision, wakeSummary, governingRole);
+  const status = determineStatus(decision);
+
+  return {
+    wake: {
+      classification: wakeSummary.classification,
+      status: wakeSummary.status,
+      recommendedOwnerRepository: asOptional(wakeSummary.recommendedOwnerRepository),
+      nextAction: normalizeText(wakeSummary.nextAction),
+      reason: normalizeText(wakeSummary.reason),
+      suppressIssueInjection: wakeSummary.suppressIssueInjection === true,
+      suppressDownstreamIssueInjection: wakeSummary.suppressDownstreamIssueInjection === true,
+      suppressTemplateIssueInjection: wakeSummary.suppressTemplateIssueInjection === true
+    },
+    roles: {
+      reportedRoleMatches,
+      revalidatedRoleMatches,
+      governingRole: governingRole ?? null
+    },
+    summary: {
+      decision,
+      status,
+      workKind,
+      recommendedOwnerRepository,
+      reason:
+        decision === 'investment-work'
+          ? `${normalizeText(wakeSummary.reason)} No live repo-graph role matched the wake, so the next work should improve the control plane instead of reopening the wrong repo.`
+          : normalizeText(wakeSummary.reason),
+      issueRouting: createIssueRouting(decision)
+    }
+  };
+}
+
+export async function runWakeWorkSynthesis(
+  options = {},
+  {
+    now = new Date(),
+    readJsonFn = readJson,
+    writeJsonFn = writeJson
+  } = {}
+) {
+  const repoRoot = path.resolve(options.repoRoot || DEFAULT_REPO_ROOT);
+  const policyPath = path.resolve(repoRoot, options.policyPath || DEFAULT_POLICY_PATH);
+  const wakeAdjudicationPath = path.resolve(repoRoot, options.wakeAdjudicationPath || DEFAULT_WAKE_ADJUDICATION_PATH);
+  const repoGraphTruthPath = path.resolve(repoRoot, options.repoGraphTruthPath || DEFAULT_REPO_GRAPH_TRUTH_PATH);
+  const outputPath = path.resolve(repoRoot, options.outputPath || DEFAULT_OUTPUT_PATH);
+
+  const policy = ensurePolicy(readJsonFn(policyPath), policyPath);
+  const wakeReport = ensureWakeAdjudicationReport(readJsonFn(wakeAdjudicationPath), wakeAdjudicationPath);
+  const repoGraphTruth = ensureRepoGraphTruthReport(readJsonFn(repoGraphTruthPath), repoGraphTruthPath);
+
+  const synthesized = synthesizeWakeWork(policy, wakeReport, repoGraphTruth);
+  const report = {
+    schema: 'priority/wake-work-synthesis-report@v1',
+    generatedAt: now.toISOString(),
+    repository: normalizeText(repoGraphTruth.repository) || normalizeText(policy.compareRepository),
+    policy: {
+      path: toRelative(repoRoot, policyPath),
+      compareRepository: normalizeText(policy.compareRepository)
+    },
+    inputs: {
+      wakeAdjudicationReportPath: toRelative(repoRoot, wakeAdjudicationPath),
+      repoGraphTruthPath: toRelative(repoRoot, repoGraphTruthPath)
+    },
+    ...synthesized
+  };
+
+  const writtenPath = writeJsonFn(outputPath, report);
+  return { report, outputPath: writtenPath };
+}
+
+export async function main(argv = process.argv) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    console.error(`[wake-work-synthesis] ${error.message}`);
+    printHelp();
+    return 1;
+  }
+
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  try {
+    const { report, outputPath } = await runWakeWorkSynthesis(options);
+    console.log(
+      `[wake-work-synthesis] wrote ${outputPath} (${report.summary.decision}, status=${report.summary.status})`
+    );
+    return 0;
+  } catch (error) {
+    console.error(`[wake-work-synthesis] ${error.message}`);
+    return 1;
+  }
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  const exitCode = await main(process.argv);
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+}


### PR DESCRIPTION
## Summary
- add a checked-in wake-work synthesis policy and report contract
- turn wake adjudication plus repo-graph truth into explicit repo-aware routing decisions
- prove the new helper on the real `23406267865` branch-target drift wake chain

## Testing
- node --test tools/priority/__tests__/wake-work-synthesis.test.mjs tools/priority/__tests__/wake-work-synthesis-schema.test.mjs
- node tools/npm/run-script.mjs priority:repo-graph:truth
- node tools/npm/run-script.mjs priority:wake:adjudicate -- --reported E:\comparevi-lanes\compare-monitoring-canonical\run23406267865-artifacts\downstream-onboarding-feedback\onboarding\downstream-onboarding.json --revalidated-report E:\comparevi-lanes\1810-wake-adjudication\tests\results\_agent\onboarding\downstream-onboarding-23406267865-revalidated.json --output tests/results/_agent/issue/wake-adjudication.json
- node tools/npm/run-script.mjs priority:wake:synthesize
- node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/wake-work-synthesis-policy-v1.schema.json --data tools/policy/wake-work-synthesis.json
- node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/wake-work-synthesis-report-v1.schema.json --data tests/results/_agent/issue/wake-work-synthesis.json
- node tools/npm/run-script.mjs docs:manifest:validate
- node tools/npm/run-script.mjs lint:md:changed
- git diff --check
