### PR TITLE
[governance]: execute runtime repo-context pivot from portfolio handoff

### DIFF
--- a/tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs
@@ -167,6 +167,44 @@ test('planCompareviRuntimeStep keeps queue-empty compare ownership as idle with 
   );
 });
 
+test('planCompareviRuntimeStep describes repo-context pivot preparation when compare remains current owner but template is next', async () => {
+  const decision = await compareviRuntimeTest.planCompareviRuntimeStep({
+    repoRoot: '/tmp/repo',
+    env: { GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action' },
+    options: {},
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({ implementationRemote: 'origin' }),
+      runMonitoringWorkInjectionFn: async () => ({
+        issueNumber: null,
+        outputPath: '/tmp/repo/tests/results/_agent/issue/monitoring-work-injection.json',
+        ledgerPath: '/tmp/repo/tests/results/_agent/ops/ops-decision-ledger.json'
+      }),
+      classifyNoStandingPriorityConditionFn: async () => ({
+        status: 'classified',
+        reason: 'queue-empty',
+        openIssueCount: 0,
+        message: 'queue empty'
+      }),
+      resolveStandingPriorityForRepoFn: async () => ({ found: null }),
+      readGovernorPortfolioSummaryFn: async () =>
+        createGovernorPortfolioSummary({
+          nextOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+          nextAction: 'future-agent-may-pivot',
+          ownerDecisionSource: 'compare-monitoring-mode',
+          governorMode: 'monitoring-active'
+        })
+    }
+  });
+
+  assert.equal(decision.outcome, 'idle');
+  assert.match(decision.reason, /preparing repo-context pivot/i);
+  assert.equal(decision.artifacts.governorPortfolioHandoff.status, 'owner-match');
+  assert.equal(
+    decision.artifacts.governorPortfolioHandoff.nextOwnerRepository,
+    'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'
+  );
+});
+
 test('planCompareviRuntimeStep reports queue-empty external-owner handoff metadata when portfolio points at template', async () => {
   const decision = await compareviRuntimeTest.planCompareviRuntimeStep({
     repoRoot: '/tmp/repo',

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -122,6 +122,47 @@ function makeLaneBranchClassContract() {
   };
 }
 
+function createMonitoringEntrypoints({
+  comparePath = 'E:\\comparevi-lanes\\compare-monitoring-canonical',
+  templatePath = 'E:\\comparevi-lanes\\LabviewGitHubCiTemplate-monitoring-canonical'
+} = {}) {
+  return {
+    schema: 'local/monitoring-entrypoints-v1',
+    generatedAt: '2026-03-23T04:30:00.000Z',
+    compare: {
+      authoritative: true,
+      path: comparePath,
+      checkoutState: 'branch-monitoring/upstream-develop',
+      headSha: 'e0acdbfd445cafcc7257a2b740fdb4cce4da12bb',
+      receipts: {
+        queueEmpty: `${comparePath}\\tests\\results\\_agent\\issue\\no-standing-priority.json`
+      },
+      currentState: {
+        standingQueue: 'queue-empty',
+        continuity: 'maintained',
+        turnBoundary: 'safe-idle',
+        monitoringMode: 'active',
+        futureAgentAction: 'future-agent-may-pivot'
+      }
+    },
+    template: {
+      authoritative: true,
+      path: templatePath,
+      checkoutState: 'branch-monitoring/origin-develop',
+      headSha: '7c09c6fc989a25d79b9ae73135aa2403f77d6df6',
+      currentState: {
+        canonicalOpenIssues: 0,
+        orgForkOpenIssues: 0,
+        personalForkOpenIssues: 0
+      },
+      supportedProofRuns: {
+        orgFork: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork/actions/runs/23405232217',
+        personalFork: 'https://github.com/svelderrainruiz/LabviewGitHubCiTemplate/actions/runs/23405232554'
+      }
+    }
+  };
+}
+
 test('parseArgs accepts runtime action, lane metadata, and lease options', () => {
   const parsed = parseArgs([
     'node',
@@ -3597,6 +3638,165 @@ test('comparevi canonical execution delegates to the delivery broker instead of 
   assert.equal(execution.outcome, 'coding-command-finished');
   assert.equal(execution.source, 'delivery-agent-broker');
   assert.equal(execution.details.actionType, 'execute-coding-turn');
+});
+
+test('comparevi runtime executes repo-context pivot when queue-empty portfolio handoff targets canonical template', async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'comparevi-runtime-portfolio-pivot-'));
+  const execution = await compareviRuntimeTest.executeCompareviTurn({
+    options: {
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    env: {
+      GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      AGENT_PRIORITY_UPSTREAM_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    repoRoot: '/tmp/repo',
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    schedulerDecision: {
+      outcome: 'idle',
+      reason:
+        'standing queue is empty; governor portfolio keeps ownership in LabVIEW-Community-CI-CD/compare-vi-cli-action while preparing repo-context pivot to LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.',
+      artifacts: {
+        governorPortfolioHandoff: {
+          summaryPath: 'tests/results/_agent/handoff/autonomous-governor-portfolio-summary.json',
+          status: 'owner-match',
+          currentOwnerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          nextOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+          nextAction: 'future-agent-may-pivot',
+          ownerDecisionSource: 'compare-monitoring-mode',
+          governorMode: 'monitoring-active',
+          reason: 'Governor portfolio keeps current ownership in LabVIEW-Community-CI-CD/compare-vi-cli-action.'
+        }
+      }
+    },
+    taskPacket: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      objective: {
+        summary:
+          'standing queue is empty; governor portfolio keeps ownership in LabVIEW-Community-CI-CD/compare-vi-cli-action while preparing repo-context pivot to LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.'
+      }
+    },
+    taskPacketArtifacts: {
+      latestPath: path.join(runtimeDir, 'task-packet.json')
+    },
+    runtimeArtifactPaths: {
+      runtimeDir
+    },
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({
+        schema: 'priority/delivery-agent-policy@v1',
+        implementationRemote: 'origin',
+        maxActiveCodingLanes: 4
+      }),
+      readMonitoringEntrypointsFn: async () => createMonitoringEntrypoints(),
+      collectMarketplaceSnapshotFn: async () => ({
+        schema: 'priority/lane-marketplace-snapshot@v1',
+        generatedAt: '2026-03-23T04:31:00.000Z',
+        summary: {
+          repositoryCount: 0,
+          eligibleLaneCount: 0,
+          topEligibleLane: null
+        },
+        entries: []
+      }),
+      writeMarketplaceSnapshotFn: async () => path.join(runtimeDir, 'lane-marketplace-snapshot.json'),
+      selectMarketplaceRecommendationFn: () => null,
+      runTemplateAgentVerificationReportFn: async () => null
+    }
+  });
+
+  assert.equal(execution.outcome, 'repo-context-pivot');
+  assert.equal(execution.details.actionType, 'repo-context-pivot');
+  assert.equal(execution.details.nextWakeCondition, 'target-repository-cycle');
+  assert.equal(execution.details.nextOwnerRepository, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
+  assert.equal(
+    execution.details.targetEntrypointPath,
+    'E:\\comparevi-lanes\\LabviewGitHubCiTemplate-monitoring-canonical'
+  );
+  assert.equal(
+    execution.artifacts.governorPortfolioPivot.status,
+    'ready'
+  );
+
+  const persisted = await readJson(path.join(runtimeDir, 'delivery-agent-state.json'));
+  assert.equal(persisted.activeLane.actionType, 'repo-context-pivot');
+  assert.equal(persisted.activeLane.outcome, 'repo-context-pivot');
+  assert.equal(persisted.activeLane.nextWakeCondition, 'target-repository-cycle');
+});
+
+test('comparevi runtime keeps idle when repo-context pivot target registry is unavailable', async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'comparevi-runtime-portfolio-pending-'));
+  const execution = await compareviRuntimeTest.executeCompareviTurn({
+    options: {
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    env: {
+      GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      AGENT_PRIORITY_UPSTREAM_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    repoRoot: '/tmp/repo',
+    repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    schedulerDecision: {
+      outcome: 'idle',
+      reason:
+        'standing queue is empty; governor portfolio keeps ownership in LabVIEW-Community-CI-CD/compare-vi-cli-action while preparing repo-context pivot to LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.',
+      artifacts: {
+        governorPortfolioHandoff: {
+          summaryPath: 'tests/results/_agent/handoff/autonomous-governor-portfolio-summary.json',
+          status: 'owner-match',
+          currentOwnerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          nextOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+          nextAction: 'future-agent-may-pivot',
+          ownerDecisionSource: 'compare-monitoring-mode',
+          governorMode: 'monitoring-active',
+          reason: 'Governor portfolio keeps current ownership in LabVIEW-Community-CI-CD/compare-vi-cli-action.'
+        }
+      }
+    },
+    taskPacket: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      objective: {
+        summary:
+          'standing queue is empty; governor portfolio keeps ownership in LabVIEW-Community-CI-CD/compare-vi-cli-action while preparing repo-context pivot to LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate.'
+      }
+    },
+    taskPacketArtifacts: {
+      latestPath: path.join(runtimeDir, 'task-packet.json')
+    },
+    runtimeArtifactPaths: {
+      runtimeDir
+    },
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({
+        schema: 'priority/delivery-agent-policy@v1',
+        implementationRemote: 'origin',
+        maxActiveCodingLanes: 4
+      }),
+      readMonitoringEntrypointsFn: async () => null,
+      collectMarketplaceSnapshotFn: async () => ({
+        schema: 'priority/lane-marketplace-snapshot@v1',
+        generatedAt: '2026-03-23T04:31:00.000Z',
+        summary: {
+          repositoryCount: 0,
+          eligibleLaneCount: 0,
+          topEligibleLane: null
+        },
+        entries: []
+      }),
+      writeMarketplaceSnapshotFn: async () => path.join(runtimeDir, 'lane-marketplace-snapshot.json'),
+      selectMarketplaceRecommendationFn: () => null,
+      runTemplateAgentVerificationReportFn: async () => null
+    }
+  });
+
+  assert.equal(execution.outcome, 'idle');
+  assert.equal(execution.details.actionType, 'repo-context-pivot-pending');
+  assert.equal(execution.details.pivotStatus, 'missing');
+  assert.match(execution.reason, /unavailable \(missing\)/i);
+
+  const persisted = await readJson(path.join(runtimeDir, 'delivery-agent-state.json'));
+  assert.equal(persisted.activeLane.actionType, 'repo-context-pivot-pending');
+  assert.equal(persisted.activeLane.outcome, 'idle');
 });
 
 test('comparevi canonical execution consumes the broker receipt file when stdout includes helper chatter', async () => {

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -114,6 +114,7 @@ const DEFAULT_AUTONOMOUS_GOVERNOR_PORTFOLIO_SUMMARY_PATH = path.join(
   'handoff',
   'autonomous-governor-portfolio-summary.json'
 );
+const DEFAULT_MONITORING_ENTRYPOINTS_PATH = path.join('..', 'monitoring-entrypoints.json');
 const execFileAsync = promisify(execFile);
 const COMPAREVI_PREFERRED_HELPERS = [
   'node tools/npm/run-script.mjs priority:github:metadata:apply',
@@ -160,6 +161,19 @@ function coercePositiveInteger(value) {
     return null;
   }
   return parsed;
+}
+
+function toDisplayPath(repoRoot, candidatePath) {
+  const normalized = normalizeText(candidatePath);
+  if (!normalized) {
+    return null;
+  }
+  const resolved = path.resolve(normalized);
+  const relative = path.relative(repoRoot, resolved);
+  if (!relative || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    return relative.replace(/\\/g, '/');
+  }
+  return resolved;
 }
 
 function resolveLiveAgentModelSelectionEvidence({
@@ -463,6 +477,184 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
       currentOwnerRepository === repository
         ? `Governor portfolio keeps current ownership in ${currentOwnerRepository}.`
         : `Governor portfolio assigns current ownership to ${currentOwnerRepository}.`
+  };
+}
+
+function resolveMonitoringEntrypointByRepository(payload, repository) {
+  const normalizedRepository = normalizeText(repository).toLowerCase();
+  if (!normalizedRepository) {
+    return null;
+  }
+  if (normalizedRepository === COMPAREVI_UPSTREAM_REPOSITORY.toLowerCase()) {
+    return payload?.compare ?? null;
+  }
+  if (normalizedRepository === 'labview-community-ci-cd/labviewgithubcitemplate') {
+    return payload?.template ?? null;
+  }
+  return null;
+}
+
+async function resolveGovernorPortfolioPivotExecution({
+  repoRoot,
+  repository,
+  governorPortfolioHandoff,
+  env = {},
+  deps = {}
+}) {
+  const currentRepository =
+    normalizeText(repository) || normalizeText(env.GITHUB_REPOSITORY) || COMPAREVI_UPSTREAM_REPOSITORY;
+  const currentOwnerRepository = normalizeText(governorPortfolioHandoff?.currentOwnerRepository) || currentRepository;
+  const nextOwnerRepository = normalizeText(governorPortfolioHandoff?.nextOwnerRepository) || currentOwnerRepository;
+  const nextAction = normalizeText(governorPortfolioHandoff?.nextAction) || null;
+  const ownerDecisionSource = normalizeText(governorPortfolioHandoff?.ownerDecisionSource) || null;
+  const governorMode = normalizeText(governorPortfolioHandoff?.governorMode) || null;
+
+  if (!nextOwnerRepository || nextOwnerRepository.toLowerCase() === currentRepository.toLowerCase()) {
+    return {
+      status: 'same-repository',
+      registryPath: null,
+      currentRepository,
+      currentOwnerRepository,
+      nextOwnerRepository,
+      nextAction,
+      ownerDecisionSource,
+      governorMode,
+      targetEntrypointPath: null,
+      targetHeadSha: null,
+      targetCheckoutState: null,
+      targetReceipts: null,
+      targetCurrentState: null,
+      reason: `Governor portfolio keeps repo-context ownership in ${currentRepository}.`
+    };
+  }
+
+  if (!['future-agent-may-pivot', 'reopen-template-monitoring-work'].includes(nextAction)) {
+    return {
+      status: 'unsupported-action',
+      registryPath: null,
+      currentRepository,
+      currentOwnerRepository,
+      nextOwnerRepository,
+      nextAction,
+      ownerDecisionSource,
+      governorMode,
+      targetEntrypointPath: null,
+      targetHeadSha: null,
+      targetCheckoutState: null,
+      targetReceipts: null,
+      targetCurrentState: null,
+      reason: `Governor portfolio requested '${nextAction || 'unknown'}', which is not a supported runtime pivot action.`
+    };
+  }
+
+  const entrypointsPath = path.resolve(
+    repoRoot,
+    deps.monitoringEntrypointsPath ||
+      env.AGENT_MONITORING_ENTRYPOINTS_PATH ||
+      env.COMPAREVI_MONITORING_ENTRYPOINTS_PATH ||
+      DEFAULT_MONITORING_ENTRYPOINTS_PATH
+  );
+  const registryPath = toDisplayPath(repoRoot, entrypointsPath);
+
+  let payload = null;
+  try {
+    if (typeof deps.readMonitoringEntrypointsFn === 'function') {
+      payload = await deps.readMonitoringEntrypointsFn({ repoRoot, entrypointsPath, repository: nextOwnerRepository });
+    } else {
+      payload = await readJsonIfPresent(entrypointsPath);
+    }
+  } catch (error) {
+    return {
+      status: 'invalid',
+      registryPath,
+      currentRepository,
+      currentOwnerRepository,
+      nextOwnerRepository,
+      nextAction,
+      ownerDecisionSource,
+      governorMode,
+      targetEntrypointPath: null,
+      targetHeadSha: null,
+      targetCheckoutState: null,
+      targetReceipts: null,
+      targetCurrentState: null,
+      reason: `Unable to read monitoring entrypoints registry: ${error?.message || String(error)}`
+    };
+  }
+
+  if (!payload) {
+    return {
+      status: 'missing',
+      registryPath,
+      currentRepository,
+      currentOwnerRepository,
+      nextOwnerRepository,
+      nextAction,
+      ownerDecisionSource,
+      governorMode,
+      targetEntrypointPath: null,
+      targetHeadSha: null,
+      targetCheckoutState: null,
+      targetReceipts: null,
+      targetCurrentState: null,
+      reason: 'Monitoring entrypoints registry is unavailable for runtime repo-context pivot.'
+    };
+  }
+
+  if (normalizeText(payload?.schema) !== 'local/monitoring-entrypoints-v1') {
+    return {
+      status: 'invalid',
+      registryPath,
+      currentRepository,
+      currentOwnerRepository,
+      nextOwnerRepository,
+      nextAction,
+      ownerDecisionSource,
+      governorMode,
+      targetEntrypointPath: null,
+      targetHeadSha: null,
+      targetCheckoutState: null,
+      targetReceipts: null,
+      targetCurrentState: null,
+      reason: 'Monitoring entrypoints registry does not match the expected schema.'
+    };
+  }
+
+  const entrypoint = resolveMonitoringEntrypointByRepository(payload, nextOwnerRepository);
+  if (!entrypoint) {
+    return {
+      status: 'unsupported-target',
+      registryPath,
+      currentRepository,
+      currentOwnerRepository,
+      nextOwnerRepository,
+      nextAction,
+      ownerDecisionSource,
+      governorMode,
+      targetEntrypointPath: null,
+      targetHeadSha: null,
+      targetCheckoutState: null,
+      targetReceipts: null,
+      targetCurrentState: null,
+      reason: `Monitoring entrypoints registry does not expose a supported target for ${nextOwnerRepository}.`
+    };
+  }
+
+  return {
+    status: 'ready',
+    registryPath,
+    currentRepository,
+    currentOwnerRepository,
+    nextOwnerRepository,
+    nextAction,
+    ownerDecisionSource,
+    governorMode,
+    targetEntrypointPath: normalizeText(entrypoint.path) || null,
+    targetHeadSha: normalizeText(entrypoint.headSha) || null,
+    targetCheckoutState: normalizeText(entrypoint.checkoutState) || null,
+    targetReceipts: entrypoint.receipts ?? null,
+    targetCurrentState: entrypoint.currentState ?? null,
+    reason: `Runtime repo-context pivot is ready for ${nextOwnerRepository}.`
   };
 }
 
@@ -882,7 +1074,19 @@ async function planCompareviRuntimeStepFromLiveStanding({ repoRoot, targetReposi
 
       let reason = classification.message;
       if (governorPortfolioHandoff.status === 'owner-match') {
-        reason = `standing queue is empty; governor portfolio keeps ownership in ${governorPortfolioHandoff.currentOwnerRepository}.`;
+        if (
+          normalizeText(governorPortfolioHandoff.nextOwnerRepository) &&
+          normalizeText(governorPortfolioHandoff.nextOwnerRepository).toLowerCase() !== targetRepository.toLowerCase() &&
+          ['future-agent-may-pivot', 'reopen-template-monitoring-work'].includes(
+            normalizeText(governorPortfolioHandoff.nextAction)
+          )
+        ) {
+          reason =
+            `standing queue is empty; governor portfolio keeps ownership in ${governorPortfolioHandoff.currentOwnerRepository} ` +
+            `while preparing repo-context pivot to ${governorPortfolioHandoff.nextOwnerRepository}.`;
+        } else {
+          reason = `standing queue is empty; governor portfolio keeps ownership in ${governorPortfolioHandoff.currentOwnerRepository}.`;
+        }
       } else if (governorPortfolioHandoff.status === 'external-owner') {
         reason = `standing queue is empty; governor portfolio hands ownership to ${governorPortfolioHandoff.currentOwnerRepository}.`;
       } else if (governorPortfolioHandoff.status === 'missing') {
@@ -1418,6 +1622,102 @@ async function executeCompareviTurn({
   }
 
   if (!standingRepository || !Number.isInteger(standingIssueNumber) || standingIssueNumber <= 0) {
+    const governorPortfolioPivot = await resolveGovernorPortfolioPivotExecution({
+      repoRoot,
+      repository: repository || options.repo || env.GITHUB_REPOSITORY || upstreamRepository,
+      governorPortfolioHandoff: schedulerDecision?.artifacts?.governorPortfolioHandoff ?? null,
+      env,
+      deps
+    });
+    if (governorPortfolioPivot.status === 'ready') {
+      const receipt = {
+        status: 'completed',
+        outcome: 'repo-context-pivot',
+        reason: `Standing queue is empty; runtime repo-context pivots to ${governorPortfolioPivot.nextOwnerRepository}.`,
+        source: 'comparevi-runtime',
+        details: {
+          laneLifecycle: 'idle',
+          blockerClass: 'none',
+          actionType: 'repo-context-pivot',
+          retryable: true,
+          nextWakeCondition: 'target-repository-cycle',
+          currentRepository: governorPortfolioPivot.currentRepository,
+          currentOwnerRepository: governorPortfolioPivot.currentOwnerRepository,
+          nextOwnerRepository: governorPortfolioPivot.nextOwnerRepository,
+          nextAction: governorPortfolioPivot.nextAction,
+          ownerDecisionSource: governorPortfolioPivot.ownerDecisionSource,
+          governorMode: governorPortfolioPivot.governorMode,
+          monitoringEntrypointsPath: governorPortfolioPivot.registryPath,
+          targetEntrypointPath: governorPortfolioPivot.targetEntrypointPath,
+          targetHeadSha: governorPortfolioPivot.targetHeadSha,
+          targetCheckoutState: governorPortfolioPivot.targetCheckoutState,
+          targetCurrentState: governorPortfolioPivot.targetCurrentState,
+          targetReceipts: governorPortfolioPivot.targetReceipts
+        },
+        artifacts: {
+          governorPortfolioHandoff: schedulerDecision?.artifacts?.governorPortfolioHandoff ?? null,
+          governorPortfolioPivot
+        }
+      };
+      await persistCompareviDeliveryRuntime({
+        repository: repository || standingRepository || options.repo || env.GITHUB_REPOSITORY || 'unknown/unknown',
+        runtimeArtifactPaths,
+        schedulerDecision,
+        taskPacket,
+        executionReceipt: receipt,
+        repoRoot,
+        deps,
+        now
+      });
+      return receipt;
+    }
+
+    if (governorPortfolioPivot.status !== 'same-repository') {
+      const receipt = {
+        status: 'completed',
+        outcome: 'idle',
+        reason:
+          `Standing queue is empty; runtime repo-context pivot to ${governorPortfolioPivot.nextOwnerRepository || 'the next owner'} ` +
+          `is unavailable (${governorPortfolioPivot.status}).`,
+        source: 'comparevi-runtime',
+        details: {
+          laneLifecycle: 'idle',
+          blockerClass: governorPortfolioPivot.status === 'invalid' ? 'helper' : 'none',
+          actionType: 'repo-context-pivot-pending',
+          retryable: true,
+          nextWakeCondition: 'portfolio-handoff-refreshed',
+          currentRepository: governorPortfolioPivot.currentRepository,
+          currentOwnerRepository: governorPortfolioPivot.currentOwnerRepository,
+          nextOwnerRepository: governorPortfolioPivot.nextOwnerRepository,
+          nextAction: governorPortfolioPivot.nextAction,
+          ownerDecisionSource: governorPortfolioPivot.ownerDecisionSource,
+          governorMode: governorPortfolioPivot.governorMode,
+          monitoringEntrypointsPath: governorPortfolioPivot.registryPath,
+          targetEntrypointPath: governorPortfolioPivot.targetEntrypointPath,
+          targetHeadSha: governorPortfolioPivot.targetHeadSha,
+          targetCheckoutState: governorPortfolioPivot.targetCheckoutState,
+          targetCurrentState: governorPortfolioPivot.targetCurrentState,
+          targetReceipts: governorPortfolioPivot.targetReceipts,
+          pivotStatus: governorPortfolioPivot.status
+        },
+        artifacts: {
+          governorPortfolioHandoff: schedulerDecision?.artifacts?.governorPortfolioHandoff ?? null,
+          governorPortfolioPivot
+        }
+      };
+      await persistCompareviDeliveryRuntime({
+        repository: repository || standingRepository || options.repo || env.GITHUB_REPOSITORY || 'unknown/unknown',
+        runtimeArtifactPaths,
+        schedulerDecision,
+        taskPacket,
+        executionReceipt: receipt,
+        repoRoot,
+        deps,
+        now
+      });
+      return receipt;
+    }
+
     const receipt = {
       status: 'completed',
       outcome: 'idle',


### PR DESCRIPTION
## Summary
- execute runtime repo-context pivot from governor portfolio handoff during queue-empty idle
- resolve the clean monitoring entrypoint registry when template becomes the next repository owner
- keep runtime honest when the registry is missing or invalid instead of pretending a pivot occurred

## Testing
- node --test tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs
- node tools/npm/run-script.mjs docs:manifest:validate
- git diff --check
