### PR TITLE
[governance]: remove draft PR merge-sync friction from automated PR flow

### DIFF
--- a/tools/priority/__tests__/create-pr.test.mjs
+++ b/tools/priority/__tests__/create-pr.test.mjs
@@ -392,10 +392,16 @@ test('parseArgs accepts explicit PR helper overrides', () => {
     title: 'Explicit title',
     body: null,
     bodyFile: 'pr-body.md',
+    draft: null,
     reportDir: path.join('tests', 'results', '_agent', 'issue'),
     headRemote: null,
     help: false
   });
+});
+
+test('parseArgs accepts an explicit draft override', () => {
+  const options = parseArgs(['node', 'create-pr.mjs', '--draft']);
+  assert.equal(options.draft, true);
 });
 
 test('parseArgs rejects conflicting body inputs', () => {
@@ -439,6 +445,46 @@ test('parseArgs accepts an explicit head remote override', () => {
 test('parseArgs accepts an explicit report directory override', () => {
   const options = parseArgs(['node', 'create-pr.mjs', '--report-dir', '.tmp/pr-reports']);
   assert.equal(options.reportDir, '.tmp/pr-reports');
+});
+
+test('createPriorityPr forwards an explicit draft override to PR creation', () => {
+  const draftCalls = [];
+  createPriorityPrWithNoMergedHistory({
+    env: {},
+    options: {
+      issue: 1861,
+      branch: 'issue/upstream-1861-draft-pr-merge-sync-friction',
+      draft: true
+    },
+    readFileSyncFn: readDefaultPrTemplate,
+    getRepoRootFn: () => '/tmp/repo',
+    getCurrentBranchFn: () => 'issue/upstream-1861-draft-pr-merge-sync-friction',
+    ensureGhCliFn: () => {},
+    resolveUpstreamFn: () => ({ owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' }),
+    ensureForkRemoteFn: () => ({
+      owner: 'svelderrainruiz',
+      repo: 'compare-vi-cli-action',
+      sameOwnerFork: false,
+      remoteName: 'origin'
+    }),
+    pushBranchFn: () => ({ status: 'already-published' }),
+    runGhPrCreateFn: (payload) => {
+      draftCalls.push(payload);
+      return {
+        strategy: 'gh-pr-create',
+        pullRequest: {
+          number: 1862,
+          url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1862',
+          isDraft: true
+        }
+      };
+    },
+    resolveStandingIssueNumberFn: () => ({ issueNumber: 1861, source: 'cli' }),
+    loadBranchClassContractFn: () => TEST_BRANCH_CONTRACT
+  });
+
+  assert.equal(draftCalls.length, 1);
+  assert.equal(draftCalls[0].draft, true);
 });
 
 test('parseRouterIssueNumber returns positive integer issue values', () => {

--- a/tools/priority/__tests__/remote-utils.test.mjs
+++ b/tools/priority/__tests__/remote-utils.test.mjs
@@ -308,6 +308,33 @@ test('buildGhPrCreateArgs preserves the standard gh create path for user forks',
     'develop',
     '--head',
     'fork-owner:issue/963-test',
+    '--title',
+    'Helper title',
+    '--body',
+    'Helper body'
+  ]);
+});
+
+test('buildGhPrCreateArgs supports explicit draft mode for user forks', () => {
+  const args = buildGhPrCreateArgs({
+    upstream: { owner: 'upstream-owner', repo: 'repo' },
+    origin: { owner: 'fork-owner', repo: 'repo' },
+    branch: 'issue/963-test',
+    base: 'develop',
+    title: 'Helper title',
+    body: 'Helper body',
+    draft: true
+  });
+
+  assert.deepEqual(args, [
+    'pr',
+    'create',
+    '--repo',
+    'upstream-owner/repo',
+    '--base',
+    'develop',
+    '--head',
+    'fork-owner:issue/963-test',
     '--draft',
     '--title',
     'Helper title',
@@ -427,10 +454,11 @@ test('graphql PR helpers expose the same-owner fork mutation contract', () => {
     body: 'Body'
   });
   assert.match(request.query, /createPullRequest/);
-  assert.match(request.query, /draft: true/);
+  assert.match(request.query, /draft: \$draft/);
   assert.equal(request.variables.repositoryId, 'R_upstream');
   assert.equal(request.variables.headRepositoryId, 'R_fork');
   assert.equal(request.variables.headRefName, 'issue/963-org-owned-fork-pr-helper');
+  assert.equal(request.variables.draft, true);
 });
 
 test('findExistingPullRequest matches the branch/base pair and same-owner cross-repo head', () => {
@@ -905,13 +933,57 @@ test('runGhPrCreate preserves the gh CLI path for user-owned forks', () => {
     'develop',
     '--head',
     'svelderrainruiz:issue/963-org-owned-fork-pr-helper',
-    '--draft',
     '--title',
     'Fix #963',
     '--body',
     'Body'
   ]);
   assert.equal(result.strategy, 'gh-pr-create');
+  assert.equal(result.pullRequest, null);
+});
+
+test('runGhPrCreate keeps explicit draft mode for user-owned forks', () => {
+  const calls = [];
+  const result = runGhPrCreate(
+    {
+      repoRoot: '/tmp/repo',
+      upstream: { owner: 'LabVIEW-Community-CI-CD', repo: 'compare-vi-cli-action' },
+      origin: { owner: 'svelderrainruiz', repo: 'compare-vi-cli-action', sameOwnerFork: false },
+      branch: 'issue/963-org-owned-fork-pr-helper',
+      base: 'develop',
+      title: 'Fix #963',
+      body: 'Body',
+      draft: true
+    },
+    {
+      spawnSyncFn: (command, args) => {
+        calls.push({ command, args });
+        return {
+          status: 0,
+          stdout: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/963\n',
+          stderr: ''
+        };
+      }
+    }
+  );
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].args, [
+    'pr',
+    'create',
+    '--repo',
+    'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    '--base',
+    'develop',
+    '--head',
+    'svelderrainruiz:issue/963-org-owned-fork-pr-helper',
+    '--draft',
+    '--title',
+    'Fix #963',
+    '--body',
+    'Body'
+  ]);
+  assert.equal(result.pullRequest?.isDraft, true);
 });
 
 test('runGhPrCreate surfaces gh CLI stdout and parses the created PR URL on success', () => {
@@ -942,7 +1014,8 @@ test('runGhPrCreate surfaces gh CLI stdout and parses the created PR URL on succ
   assert.equal(result.strategy, 'gh-pr-create');
   assert.deepEqual(result.pullRequest, {
     number: 963,
-    url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/963'
+    url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/963',
+    isDraft: false
   });
 });
 
@@ -1053,6 +1126,6 @@ test('runGhPrCreate redacts title and body from gh command errors', () => {
           findExistingPullRequestFn: () => null
         }
       ),
-    /gh pr create --repo LabVIEW-Community-CI-CD\/compare-vi-cli-action --base develop --head svelderrainruiz:issue\/963-org-owned-fork-pr-helper --draft --title <redacted:title> --body <redacted:body> failed: gh: create failed/i
+    /gh pr create --repo LabVIEW-Community-CI-CD\/compare-vi-cli-action --base develop --head svelderrainruiz:issue\/963-org-owned-fork-pr-helper --title <redacted:title> --body <redacted:body> failed: gh: create failed/i
   );
 });

--- a/tools/priority/create-pr.mjs
+++ b/tools/priority/create-pr.mjs
@@ -52,6 +52,7 @@ const USAGE_LINES = [
   '  --title <text>          Explicit pull request title.',
   '  --body <text>           Explicit pull request body.',
   '  --body-file <path>      Read the pull request body from a file.',
+  '  --draft                 Create the pull request as draft instead of ready-for-review.',
   `  --report-dir <path>     Directory for the machine-readable report (default: ${DEFAULT_REPORT_DIR}).`,
   '  --head-remote <name>    Fork remote to push/open from (default: AGENT_PRIORITY_ACTIVE_FORK_REMOTE or origin).',
   '  -h, --help              Show this message and exit.'
@@ -73,6 +74,7 @@ export function parseArgs(argv = process.argv) {
     title: null,
     body: null,
     bodyFile: null,
+    draft: null,
     reportDir: DEFAULT_REPORT_DIR,
     headRemote: null,
     help: false
@@ -96,6 +98,11 @@ export function parseArgs(argv = process.argv) {
 
     if (token === '-h' || token === '--help') {
       options.help = true;
+      continue;
+    }
+
+    if (token === '--draft') {
+      options.draft = true;
       continue;
     }
 
@@ -1318,7 +1325,8 @@ export function createPriorityPr({
     branch,
     base,
     title,
-    body
+    body,
+    draft: options.draft === true
   });
   const readyTransition = maybePromotePullRequestToReady({
     repoRoot,

--- a/tools/priority/lib/remote-utils.mjs
+++ b/tools/priority/lib/remote-utils.mjs
@@ -408,7 +408,7 @@ export function pushToRemote(repoRoot, remote, ref) {
   }
 }
 
-export function buildGhPrCreateArgs({ upstream, origin, headRepository, branch, base, title, body }) {
+export function buildGhPrCreateArgs({ upstream, origin, headRepository, branch, base, title, body, draft = false }) {
   const resolvedHeadRepository = headRepository ?? origin;
   const repoSlug = requireRepositorySlug(upstream, 'upstream');
   return [
@@ -420,7 +420,7 @@ export function buildGhPrCreateArgs({ upstream, origin, headRepository, branch, 
     base,
     '--head',
     `${resolvedHeadRepository.owner}:${branch}`,
-    '--draft',
+    ...(draft ? ['--draft'] : []),
     '--title',
     normalizePrText(title, { label: 'PR title' }),
     '--body',
@@ -482,7 +482,8 @@ export function buildCreatePullRequestMutation({
   headRefName,
   baseRefName,
   title,
-  body
+  body,
+  draft = true
 }) {
   return {
     query: `
@@ -491,6 +492,7 @@ export function buildCreatePullRequestMutation({
         $headRepositoryId: ID,
         $headRefName: String!,
         $baseRefName: String!,
+        $draft: Boolean!,
         $title: String!,
         $body: String!
       ) {
@@ -500,7 +502,7 @@ export function buildCreatePullRequestMutation({
             headRepositoryId: $headRepositoryId,
             headRefName: $headRefName,
             baseRefName: $baseRefName,
-            draft: true,
+            draft: $draft,
             title: $title,
             body: $body,
             maintainerCanModify: true
@@ -518,6 +520,7 @@ export function buildCreatePullRequestMutation({
       headRepositoryId,
       headRefName,
       baseRefName,
+      draft: draft === true,
       title,
       body
     }
@@ -744,7 +747,7 @@ export function findOpenAncestorPullRequest(
 }
 
 export function runGhPrCreate(
-  { repoRoot, upstream, origin, headRepository, branch, base, title, body },
+  { repoRoot, upstream, origin, headRepository, branch, base, title, body, draft = null },
   {
     spawnSyncFn = spawnSync,
     loadRepositoryGraphMetadataFn = loadRepositoryGraphMetadata,
@@ -758,6 +761,7 @@ export function runGhPrCreate(
 ) {
   const resolvedHeadRepository = headRepository ?? origin;
   const strategy = selectPullRequestCreateStrategy({ upstream, headRepository: resolvedHeadRepository });
+  const createAsDraft = draft === true || strategy === 'graphql-same-owner-fork';
 
   if (strategy === 'graphql-same-owner-fork') {
     const upstreamMetadata = loadRepositoryGraphMetadataFn(repoRoot, upstream, {
@@ -780,6 +784,7 @@ export function runGhPrCreate(
           headRepositoryId: originMetadata.id,
           headRefName,
           baseRefName: base,
+          draft: createAsDraft,
           title,
           body
         });
@@ -792,7 +797,10 @@ export function runGhPrCreate(
         writeStdoutFn(`${pullRequest.url}\n`);
         return {
           strategy,
-          pullRequest
+          pullRequest: {
+            ...pullRequest,
+            isDraft: createAsDraft
+          }
         };
       } catch (error) {
         if (isExistingPullRequestError(error)) {
@@ -850,7 +858,8 @@ export function runGhPrCreate(
     branch,
     base,
     title,
-    body
+    body,
+    draft: createAsDraft
   });
   const result = spawnSyncFn('gh', args, {
     cwd: repoRoot,
@@ -909,7 +918,8 @@ export function runGhPrCreate(
   const pullRequest = urlMatch?.[0]
     ? {
         number: Number.parseInt(urlMatch.groups.number, 10),
-        url: urlMatch[0]
+        url: urlMatch[0],
+        isDraft: createAsDraft
       }
     : null;
 


### PR DESCRIPTION
# Summary

Delivers issue #1861 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1861
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/upstream-1861-draft-pr-merge-sync-friction`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1861