### PR TITLE
[governance]: refresh merge-queue authority during hosted waits

### DIFF
--- a/docs/schemas/autonomous-governor-summary-report-v1.schema.json
+++ b/docs/schemas/autonomous-governor-summary-report-v1.schema.json
@@ -192,7 +192,8 @@
           "enum": [
             "none",
             "delivery-runtime",
-            "merge-sync-summary"
+            "merge-sync-summary",
+            "queue-refresh-summary"
           ]
         },
         "nextWakeCondition": { "type": ["string", "null"] },

--- a/tools/priority/__tests__/autonomous-governor-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-summary.test.mjs
@@ -140,6 +140,66 @@ function createMergeSyncSummary(overrides = {}) {
   };
 }
 
+function createQueueRefreshReceipt(overrides = {}) {
+  return {
+    schema: 'priority/queue-refresh-receipt@v1',
+    operation: 'dequeue-update-requeue',
+    generatedAt: '2026-03-23T05:27:31.683Z',
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    pr: 1864,
+    dryRun: true,
+    baseRefName: 'develop',
+    headRefName: 'issue/upstream-1863-pr-create-merge-sync-handoff',
+    headRepositorySlug: 'svelderrainruiz/compare-vi-cli-action',
+    headRemote: 'origin',
+    queueManagedBase: true,
+    initial: {
+      state: 'OPEN',
+      mergeStateStatus: 'UNSTABLE',
+      isInMergeQueue: true,
+      autoMergeEnabled: false,
+      mergedAt: null,
+      headRefOid: '8ea4bbe3d9ea2ed1f268f52d3c32d7424d0ce76b',
+      currentBranch: 'issue/upstream-1869-merge-queue-refresh'
+    },
+    dequeue: {
+      attempted: true,
+      status: 'dry-run',
+      reason: 'dry-run',
+      helperCallsExecuted: [],
+      pullRequestId: 'PR_kwDOP5zZjs7Mks-1',
+      pollAttemptsUsed: 0,
+      finalIsInMergeQueue: true
+    },
+    refresh: {
+      attempted: true,
+      status: 'dry-run',
+      reason: 'dry-run',
+      helperCallsExecuted: [],
+      mode: 'rebase',
+      baseRemoteRef: 'upstream/develop',
+      forcePushTarget: 'origin:issue/upstream-1863-pr-create-merge-sync-handoff',
+      rebasedHeadSha: null
+    },
+    requeue: {
+      attempted: true,
+      status: 'dry-run',
+      reason: 'dry-run',
+      helperCallsExecuted: [],
+      mergeSummaryPath: 'tests/results/_agent/queue/merge-sync-1864.json',
+      promotionStatus: null,
+      materialized: null,
+      finalMode: null,
+      finalReason: null
+    },
+    summary: {
+      status: 'dry-run',
+      reason: 'dry-run'
+    },
+    ...overrides
+  };
+}
+
 test('parseArgs keeps governor summary defaults and accepts overrides', () => {
   const parsed = parseArgs([
     'node',
@@ -268,4 +328,49 @@ test('runAutonomousGovernorSummary prefers merge-sync queue evidence when it pro
   assert.equal(report.summary.queueHandoffStatus, 'merge-queue-progress');
   assert.equal(report.summary.queueHandoffNextWakeCondition, 'merge-queue-progress');
   assert.equal(report.summary.queueAuthoritySource, 'merge-sync-summary');
+});
+
+test('runAutonomousGovernorSummary prefers fresher queue-refresh evidence over older merge-sync state', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'governor-summary-queue-refresh-'));
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'issue', 'no-standing-priority.json'), createQueueEmpty());
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'continuity-summary.json'), createContinuitySummary());
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'monitoring-mode.json'), createMonitoringMode());
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'issue', 'wake-lifecycle.json'), createWakeLifecycle());
+  writeJson(
+    path.join(tmpDir, 'tests', 'results', '_agent', 'capital', 'wake-investment-accounting.json'),
+    createWakeInvestmentAccounting()
+  );
+  writeJson(
+    path.join(tmpDir, 'tests', 'results', '_agent', 'runtime', 'delivery-agent-state.json'),
+    createDeliveryRuntimeState()
+  );
+  writeJson(
+    path.join(tmpDir, 'tests', 'results', '_agent', 'issue', 'LabVIEW-Community-CI-CD-compare-vi-cli-action-pr-1864-queue-admission.json'),
+    createMergeSyncSummary({
+      promotion: {
+        status: 'already-auto-merge-enabled',
+        final: {
+          state: 'OPEN',
+          mergeStateStatus: 'BLOCKED',
+          isInMergeQueue: false,
+          autoMergeEnabled: true,
+          mergedAt: null
+        }
+      }
+    })
+  );
+  writeJson(
+    path.join(tmpDir, 'tests', 'results', '_agent', 'queue', 'queue-refresh-1864.json'),
+    createQueueRefreshReceipt()
+  );
+
+  const { report } = await runAutonomousGovernorSummary({ repoRoot: tmpDir });
+
+  assert.equal(report.compare.queueAuthority.status, 'merge-queue-progress');
+  assert.equal(report.compare.queueAuthority.source, 'queue-refresh-summary');
+  assert.equal(report.compare.queueAuthority.summaryPath, 'tests/results/_agent/queue/queue-refresh-1864.json');
+  assert.equal(report.compare.queueAuthority.mergeStateStatus, 'UNSTABLE');
+  assert.equal(report.compare.queueAuthority.isInMergeQueue, true);
+  assert.equal(report.summary.queueHandoffStatus, 'merge-queue-progress');
+  assert.equal(report.summary.queueAuthoritySource, 'queue-refresh-summary');
 });

--- a/tools/priority/__tests__/delivery-agent-pr-sync.test.mjs
+++ b/tools/priority/__tests__/delivery-agent-pr-sync.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 
 import {
   classifyPullRequestWork,
@@ -86,6 +86,7 @@ test('runDeliveryTurnBroker updates a behind PR branch before waiting on review'
         schema: 'priority/delivery-agent-policy@v1',
         backlogAuthority: 'issues',
         implementationRemote: 'origin',
+        copilotReviewStrategy: 'off',
         autoSlice: true,
         autoMerge: true,
         maxActiveCodingLanes: 1,
@@ -114,6 +115,136 @@ test('runDeliveryTurnBroker updates a behind PR branch before waiting on review'
   assert.equal(brokerResult.outcome, 'branch-updated');
   assert.equal(brokerResult.details.actionType, 'sync-pr-branch');
   assert.equal(brokerResult.details.nextWakeCondition, 'checks-green');
+});
+
+test('runDeliveryTurnBroker refreshes queue authority during waiting-ci watch turns', async (t) => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'delivery-agent-watch-pr-queue-refresh-'));
+  t.after(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  const readyValidationDir = path.join(repoRoot, 'tests', 'results', '_agent', 'runtime', 'ready-validation-clearance');
+  await mkdir(readyValidationDir, { recursive: true });
+  await writeFile(
+    path.join(
+      readyValidationDir,
+      'LabVIEW-Community-CI-CD-compare-vi-cli-action-pr-1868.json'
+    ),
+    `${JSON.stringify(
+      {
+        schema: 'priority/ready-validation-clearance@v1',
+        generatedAt: '2026-03-23T05:20:00.000Z',
+        repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+        pullRequestNumber: 1868,
+        pullRequestUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1868',
+        readyHeadSha: '178a20cfcb43c89b55c2ddb291a039f97fd2ae1e',
+        currentHeadSha: '178a20cfcb43c89b55c2ddb291a039f97fd2ae1e',
+        status: 'current',
+        reason: 'PR remains in ready-validation on the same cleared head.'
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const commandLog = [];
+  const brokerResult = await runDeliveryTurnBroker({
+    repoRoot,
+    taskPacket: {
+      repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      status: 'waiting-ci',
+      objective: {
+        summary: 'Advance issue #1867'
+      },
+      evidence: {
+        delivery: {
+          laneLifecycle: 'waiting-ci',
+          pullRequest: {
+            number: 1868,
+            url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1868',
+            isDraft: false,
+            headRefOid: '178a20cfcb43c89b55c2ddb291a039f97fd2ae1e',
+            mergeStateStatus: 'BLOCKED',
+            copilotReviewSignal: {
+              actionableCommentCount: 0,
+              actionableThreadCount: 0,
+              hasCurrentHeadReview: true
+            },
+            copilotReviewWorkflow: {
+              status: 'COMPLETED',
+              conclusion: 'SUCCESS'
+            },
+            checks: {
+              blockerClass: 'ci'
+            }
+          }
+        }
+      }
+    },
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({
+        schema: 'priority/delivery-agent-policy@v1',
+        backlogAuthority: 'issues',
+        implementationRemote: 'origin',
+        autoSlice: true,
+        autoMerge: true,
+        maxActiveCodingLanes: 1,
+        allowPolicyMutations: false,
+        allowReleaseAdmin: false,
+        stopWhenNoOpenEpics: true,
+        codingTurnCommand: []
+      }),
+      runCommandFn: async (command, args, options) => {
+        commandLog.push({ command, args, cwd: options?.cwd || '' });
+        if (command === 'node' && args[0] === 'tools/priority/queue-refresh-pr.mjs') {
+          const summaryPath = args[args.indexOf('--summary-path') + 1];
+          await mkdir(path.dirname(summaryPath), { recursive: true });
+          await writeFile(
+            summaryPath,
+            `${JSON.stringify(
+              {
+                schema: 'priority/queue-refresh-receipt@v1',
+                initial: {
+                  state: 'OPEN',
+                  mergeStateStatus: 'UNSTABLE',
+                  isInMergeQueue: true,
+                  autoMergeEnabled: false,
+                  mergedAt: null
+                },
+                summary: {
+                  status: 'dry-run',
+                  reason: 'dry-run'
+                },
+                requeue: {
+                  promotionStatus: null
+                }
+              },
+              null,
+              2
+            )}\n`,
+            'utf8'
+          );
+          return {
+            status: 0,
+            stdout: '',
+            stderr: ''
+          };
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+      }
+    }
+  });
+
+  assert.equal(brokerResult.outcome, 'waiting-ci');
+  assert.equal(brokerResult.details.actionType, 'watch-pr');
+  assert.equal(brokerResult.details.nextWakeCondition, 'merge-queue-progress');
+  assert.ok(
+    brokerResult.details.helperCallsExecuted.some((entry) =>
+      entry.includes('tools/priority/queue-refresh-pr.mjs')
+    )
+  );
+  assert.equal(commandLog.length, 1);
 });
 
 test('runDeliveryTurnBroker falls back to local git sync when gh pr update-branch fails', async (t) => {

--- a/tools/priority/autonomous-governor-summary.mjs
+++ b/tools/priority/autonomous-governor-summary.mjs
@@ -122,8 +122,27 @@ function resolveMergeSyncSummaryCandidatePaths(repoRoot, repository, prNumber) {
   return Array.from(new Set([...directCandidates, ...discovered]));
 }
 
+function resolveQueueRefreshReceiptCandidatePaths(repoRoot, prNumber) {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return [];
+  }
+  return [path.join(repoRoot, 'tests', 'results', '_agent', 'queue', `queue-refresh-${prNumber}.json`)];
+}
+
 function resolveLatestMergeSyncSummaryPath(repoRoot, repository, prNumber) {
   const candidates = resolveMergeSyncSummaryCandidatePaths(repoRoot, repository, prNumber)
+    .filter((candidate) => fs.existsSync(candidate))
+    .map((candidate) => ({
+      path: candidate,
+      mtimeMs: fs.statSync(candidate).mtimeMs
+    }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  return candidates[0]?.path || null;
+}
+
+function resolveLatestQueueRefreshReceiptPath(repoRoot, prNumber) {
+  const candidates = resolveQueueRefreshReceiptCandidatePaths(repoRoot, prNumber)
     .filter((candidate) => fs.existsSync(candidate))
     .map((candidate) => ({
       path: candidate,
@@ -341,6 +360,11 @@ function deriveDeliveryRuntime(deliveryRuntimeState) {
 
 function deriveQueueAuthority({ repoRoot, repository, deliveryRuntime, readOptionalJsonFn }) {
   const prNumber = parsePullRequestNumber(deliveryRuntime.prUrl);
+  const queueRefreshReceiptPath = resolveLatestQueueRefreshReceiptPath(repoRoot, prNumber);
+  const queueRefreshReceipt = queueRefreshReceiptPath ? readOptionalJsonFn(queueRefreshReceiptPath) : null;
+  if (queueRefreshReceipt?.schema && queueRefreshReceipt.schema !== 'priority/queue-refresh-receipt@v1') {
+    throw new Error(`Expected priority/queue-refresh-receipt@v1 at ${queueRefreshReceiptPath}.`);
+  }
   const mergeSyncSummaryPath = resolveLatestMergeSyncSummaryPath(repoRoot, repository, prNumber);
   const mergeSyncSummary = mergeSyncSummaryPath ? readOptionalJsonFn(mergeSyncSummaryPath) : null;
   if (mergeSyncSummary?.schema && mergeSyncSummary.schema !== 'priority/sync-merge@v1') {
@@ -354,27 +378,68 @@ function deriveQueueAuthority({ repoRoot, repository, deliveryRuntime, readOptio
   let mergeStateStatus = null;
   let isInMergeQueue = false;
   let autoMergeEnabled = false;
+  let summaryPath = null;
 
-  if (mergeSyncSummary) {
-    promotionStatus = asOptional(mergeSyncSummary?.promotion?.status);
-    mergeStateStatus =
-      asOptional(mergeSyncSummary?.promotion?.final?.mergeStateStatus) ||
-      asOptional(mergeSyncSummary?.prState?.mergeStateStatus);
-    isInMergeQueue = mergeSyncSummary?.promotion?.final?.isInMergeQueue === true;
-    autoMergeEnabled = mergeSyncSummary?.promotion?.final?.autoMergeEnabled === true;
+  if (queueRefreshReceipt) {
+    promotionStatus = asOptional(queueRefreshReceipt?.requeue?.promotionStatus);
+    mergeStateStatus = asOptional(queueRefreshReceipt?.initial?.mergeStateStatus);
+    isInMergeQueue = queueRefreshReceipt?.initial?.isInMergeQueue === true;
+    autoMergeEnabled = queueRefreshReceipt?.initial?.autoMergeEnabled === true;
+    summaryPath = queueRefreshReceiptPath;
 
-    if (['merged', 'already-merged'].includes(promotionStatus) || normalizeUpper(mergeSyncSummary?.promotion?.final?.state) === 'MERGED') {
+    if (asOptional(queueRefreshReceipt?.initial?.mergedAt)) {
       status = 'queue-settled';
       nextWakeCondition = 'queue-settled';
-      source = 'merge-sync-summary';
-    } else if (isInMergeQueue || ['queued', 'already-queued'].includes(promotionStatus)) {
+      source = 'queue-refresh-summary';
+    } else if (isInMergeQueue) {
       status = 'merge-queue-progress';
       nextWakeCondition = 'merge-queue-progress';
-      source = 'merge-sync-summary';
-    } else if (autoMergeEnabled || ['auto-merge-enabled', 'already-auto-merge-enabled'].includes(promotionStatus)) {
+      source = 'queue-refresh-summary';
+    } else if (autoMergeEnabled) {
       status = 'checks-pending';
       nextWakeCondition = 'checks-green';
-      source = 'merge-sync-summary';
+      source = 'queue-refresh-summary';
+    } else if (asOptional(queueRefreshReceipt?.summary?.reason) === 'not-in-merge-queue') {
+      status = 'checks-pending';
+      nextWakeCondition = 'checks-green';
+      source = 'queue-refresh-summary';
+    }
+  }
+
+  if (mergeSyncSummary) {
+    const mergeSyncPromotionStatus = asOptional(mergeSyncSummary?.promotion?.status);
+    const mergeSyncMergeStateStatus =
+      asOptional(mergeSyncSummary?.promotion?.final?.mergeStateStatus) ||
+      asOptional(mergeSyncSummary?.prState?.mergeStateStatus);
+    const mergeSyncIsInQueue = mergeSyncSummary?.promotion?.final?.isInMergeQueue === true;
+    const mergeSyncAutoMergeEnabled = mergeSyncSummary?.promotion?.final?.autoMergeEnabled === true;
+
+    if (source !== 'queue-refresh-summary') {
+      promotionStatus = mergeSyncPromotionStatus;
+      mergeStateStatus = mergeSyncMergeStateStatus;
+      isInMergeQueue = mergeSyncIsInQueue;
+      autoMergeEnabled = mergeSyncAutoMergeEnabled;
+      summaryPath = mergeSyncSummaryPath;
+
+      if (
+        ['merged', 'already-merged'].includes(mergeSyncPromotionStatus) ||
+        normalizeUpper(mergeSyncSummary?.promotion?.final?.state) === 'MERGED'
+      ) {
+        status = 'queue-settled';
+        nextWakeCondition = 'queue-settled';
+        source = 'merge-sync-summary';
+      } else if (mergeSyncIsInQueue || ['queued', 'already-queued'].includes(mergeSyncPromotionStatus)) {
+        status = 'merge-queue-progress';
+        nextWakeCondition = 'merge-queue-progress';
+        source = 'merge-sync-summary';
+      } else if (
+        mergeSyncAutoMergeEnabled ||
+        ['auto-merge-enabled', 'already-auto-merge-enabled'].includes(mergeSyncPromotionStatus)
+      ) {
+        status = 'checks-pending';
+        nextWakeCondition = 'checks-green';
+        source = 'merge-sync-summary';
+      }
     }
   }
 
@@ -382,7 +447,7 @@ function deriveQueueAuthority({ repoRoot, repository, deliveryRuntime, readOptio
     status,
     source,
     nextWakeCondition,
-    summaryPath: mergeSyncSummaryPath ? toRelative(repoRoot, mergeSyncSummaryPath) : null,
+    summaryPath: summaryPath ? toRelative(repoRoot, summaryPath) : null,
     promotionStatus,
     mergeStateStatus,
     isInMergeQueue,

--- a/tools/priority/delivery-agent.mjs
+++ b/tools/priority/delivery-agent.mjs
@@ -4761,6 +4761,69 @@ async function mergePullRequest({ taskPacket, repoRoot, deps = {} }) {
   };
 }
 
+async function refreshQueueAuthorityDuringHostedWait({ taskPacket, repoRoot, deps = {} }) {
+  if (typeof deps.refreshQueueAuthorityDuringHostedWaitFn === 'function') {
+    return deps.refreshQueueAuthorityDuringHostedWaitFn({ taskPacket, repoRoot });
+  }
+  const pullRequest = taskPacket?.evidence?.delivery?.pullRequest ?? null;
+  const repository = normalizeText(taskPacket?.repository);
+  const prNumber = coercePositiveInteger(pullRequest?.number) ?? extractPullRequestNumberFromUrl(pullRequest?.url);
+  if (!repository || !prNumber) {
+    return null;
+  }
+
+  const queueRefreshSummaryPath = path.join(repoRoot, 'tests', 'results', '_agent', 'queue', `queue-refresh-${prNumber}.json`);
+  const mergeSummaryPath = path.join(repoRoot, 'tests', 'results', '_agent', 'queue', `merge-sync-${prNumber}.json`);
+  const helperArgs = [
+    'tools/priority/queue-refresh-pr.mjs',
+    '--pr',
+    String(prNumber),
+    '--repo',
+    repository,
+    '--dry-run',
+    '--summary-path',
+    queueRefreshSummaryPath,
+    '--merge-summary-path',
+    mergeSummaryPath
+  ];
+  const helperCall = `node ${helperArgs.join(' ')}`;
+  const result = await runCommand('node', helperArgs, { cwd: repoRoot, env: process.env }, deps);
+  if (result.status !== 0) {
+    const message =
+      normalizeText(result.stderr) || normalizeText(result.stdout) || `queue-refresh failed (${result.status})`;
+    return {
+      status: 'failed',
+      reason: message,
+      helperCall,
+      summaryPath: queueRefreshSummaryPath,
+      mergeSummaryPath,
+      nextWakeCondition: null
+    };
+  }
+
+  const receipt = await readJsonIfPresent(queueRefreshSummaryPath);
+  const isInMergeQueue = receipt?.initial?.isInMergeQueue === true;
+  const mergedAt = normalizeText(receipt?.initial?.mergedAt);
+  const autoMergeEnabled = receipt?.initial?.autoMergeEnabled === true;
+  let nextWakeCondition = 'checks-green';
+  if (mergedAt) {
+    nextWakeCondition = 'queue-settled';
+  } else if (isInMergeQueue) {
+    nextWakeCondition = 'merge-queue-progress';
+  } else if (autoMergeEnabled) {
+    nextWakeCondition = 'checks-green';
+  }
+
+  return {
+    status: 'completed',
+    reason: normalizeText(receipt?.summary?.reason) || 'queue-refresh-dry-run',
+    helperCall,
+    summaryPath: queueRefreshSummaryPath,
+    mergeSummaryPath,
+    nextWakeCondition
+  };
+}
+
 async function updatePullRequestBranch({ taskPacket, repoRoot, executionRoot = repoRoot, deps = {} }) {
   if (typeof deps.updatePullRequestBranchFn === 'function') {
     return deps.updatePullRequestBranchFn({ taskPacket, repoRoot, executionRoot });
@@ -5311,6 +5374,19 @@ export async function runDeliveryTurnBroker({
     if (draftOnlyResult) {
       return withWorkerProviderDispatch(draftOnlyResult, enrichedPacket);
     }
+    const queueAuthorityRefresh =
+      planned.laneLifecycle === 'waiting-ci'
+        ? await refreshQueueAuthorityDuringHostedWait({
+            taskPacket: enrichedPacket,
+            repoRoot,
+            deps
+          })
+        : null;
+    const helperCallsExecuted = [queueAuthorityRefresh?.helperCall].filter(Boolean);
+    const nextWakeCondition =
+      planned.laneLifecycle === 'waiting-review'
+        ? normalizeText(planned.pullRequest?.nextWakeCondition) || 'review-disposition-updated'
+        : normalizeText(queueAuthorityRefresh?.nextWakeCondition) || 'checks-green';
     return withWorkerProviderDispatch({
       status: 'completed',
       outcome: planned.laneLifecycle,
@@ -5324,10 +5400,7 @@ export async function runDeliveryTurnBroker({
         laneLifecycle: planned.laneLifecycle,
         blockerClass: planned.laneLifecycle === 'waiting-review' ? 'review' : 'ci',
         retryable: true,
-        nextWakeCondition:
-          planned.laneLifecycle === 'waiting-review'
-            ? normalizeText(planned.pullRequest?.nextWakeCondition) || 'review-disposition-updated'
-            : 'checks-green',
+        nextWakeCondition,
         pollIntervalSecondsHint:
           coercePositiveInteger(planned.pullRequest?.pollIntervalSecondsHint) ?? null,
         reviewPhase: planned.pullRequest?.isDraft === true ? 'draft-review' : 'ready-validation',
@@ -5335,7 +5408,7 @@ export async function runDeliveryTurnBroker({
           planned.laneLifecycle === 'waiting-review'
             ? planned.pullRequest?.copilotReviewWorkflow ?? null
             : null,
-        helperCallsExecuted: [],
+        helperCallsExecuted,
         filesTouched: []
       }
     }, enrichedPacket);


### PR DESCRIPTION
# Summary

Delivers issue #1869 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1869
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/upstream-1869-merge-queue-refresh`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1869