### PR TITLE
Publish vi-history capability contract for template distribution

### DIFF
--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -91,6 +91,37 @@ object is the supported downstream summary surface: requested/executed modes,
 coverage and outcome interpretation, report paths, and per-mode tallies without
 the raw backend comparison payloads.
 
+## Template distribution contract
+
+`comparevi-tools-release.json` now also exposes a first-class capability record
+at `consumerContract.capabilities.viHistory`.
+
+Use that capability record when a downstream distributor such as
+`LabviewGitHubCiTemplate` needs to stamp `vi-history` support into generated
+repositories without copying compare's internal control plane.
+
+The capability contract tells downstream distributors:
+
+- this repository is the upstream producer for `vi-history`
+- the distribution model is the immutable release bundle
+- the authoritative downstream pin lives at
+  `versionContract.authoritativeConsumerPin`
+- the template should resolve the capability's consumer surfaces from the
+  referenced contract paths inside the same `comparevi-tools-release.json`
+  payload:
+  - `consumerContract.historyFacade`
+  - `consumerContract.localRuntimeProfiles`
+  - `consumerContract.localOperatorSession`
+  - `consumerContract.diagnosticsCommentRenderer`
+  - `consumerContract.hostedNiLinuxRunner`
+
+That keeps the producer/distributor boundary clean:
+
+- `compare-vi-cli-action` publishes and versions the capability
+- `LabviewGitHubCiTemplate` distributes the capability
+- generated repositories consume the pinned release surface instead of
+  vendoring compare internals
+
 For hosted GitHub runner diagnostics, use the same extracted bundle root as
 `COMPAREVI_SCRIPTS_ROOT` and resolve the NI Linux runner from
 `tools/Run-NILinuxContainerCompare.ps1`. Keep its adjacent support scripts

--- a/docs/schemas/comparevi-tools-release-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-tools-release-manifest-v1.schema.json
@@ -169,11 +169,111 @@
     "consumerContract": {
       "type": "object",
       "required": [
+        "capabilities",
         "historyFacade",
         "localRuntimeProfiles",
         "localOperatorSession"
       ],
       "properties": {
+        "capabilities": {
+          "type": "object",
+          "required": [
+            "viHistory"
+          ],
+          "properties": {
+            "viHistory": {
+              "type": "object",
+              "required": [
+                "schema",
+                "capabilityId",
+                "displayName",
+                "distributionRole",
+                "distributionModel",
+                "bundleMetadataPath",
+                "bundleImportPath",
+                "releaseAssetPattern",
+                "authoritativeConsumerPinFieldPath",
+                "authoritativeConsumerPinKindFieldPath",
+                "contractPaths",
+                "notes"
+              ],
+              "properties": {
+                "schema": {
+                  "const": "comparevi-tools/vi-history-capability@v1"
+                },
+                "capabilityId": {
+                  "const": "vi-history"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "distributionRole": {
+                  "type": "string",
+                  "enum": [
+                    "upstream-producer"
+                  ]
+                },
+                "distributionModel": {
+                  "type": "string",
+                  "enum": [
+                    "release-bundle"
+                  ]
+                },
+                "bundleMetadataPath": {
+                  "type": "string"
+                },
+                "bundleImportPath": {
+                  "type": "string"
+                },
+                "releaseAssetPattern": {
+                  "type": "string"
+                },
+                "authoritativeConsumerPinFieldPath": {
+                  "type": "string"
+                },
+                "authoritativeConsumerPinKindFieldPath": {
+                  "type": "string"
+                },
+                "contractPaths": {
+                  "type": "object",
+                  "required": [
+                    "historyFacade",
+                    "localRuntimeProfiles",
+                    "localOperatorSession",
+                    "diagnosticsCommentRenderer",
+                    "hostedNiLinuxRunner"
+                  ],
+                  "properties": {
+                    "historyFacade": {
+                      "type": "string"
+                    },
+                    "localRuntimeProfiles": {
+                      "type": "string"
+                    },
+                    "localOperatorSession": {
+                      "type": "string"
+                    },
+                    "diagnosticsCommentRenderer": {
+                      "type": "string"
+                    },
+                    "hostedNiLinuxRunner": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "notes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
         "historyFacade": {
           "type": "object",
           "required": [

--- a/docs/schemas/comparevi-tools-vi-history-capability-v1.schema.json
+++ b/docs/schemas/comparevi-tools-vi-history-capability-v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/comparevi-tools-vi-history-capability-v1.schema.json",
+  "title": "CompareVI.Tools VI History Capability v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "capabilityId",
+    "displayName",
+    "distributionRole",
+    "distributionModel",
+    "bundleMetadataPath",
+    "bundleImportPath",
+    "releaseAssetPattern",
+    "authoritativeConsumerPinFieldPath",
+    "authoritativeConsumerPinKindFieldPath",
+    "contractPaths",
+    "notes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-tools/vi-history-capability@v1"
+    },
+    "capabilityId": {
+      "const": "vi-history"
+    },
+    "displayName": {
+      "type": "string"
+    },
+    "distributionRole": {
+      "type": "string",
+      "enum": [
+        "upstream-producer"
+      ]
+    },
+    "distributionModel": {
+      "type": "string",
+      "enum": [
+        "release-bundle"
+      ]
+    },
+    "bundleMetadataPath": {
+      "type": "string"
+    },
+    "bundleImportPath": {
+      "type": "string"
+    },
+    "releaseAssetPattern": {
+      "type": "string"
+    },
+    "authoritativeConsumerPinFieldPath": {
+      "type": "string"
+    },
+    "authoritativeConsumerPinKindFieldPath": {
+      "type": "string"
+    },
+    "contractPaths": {
+      "type": "object",
+      "required": [
+        "historyFacade",
+        "localRuntimeProfiles",
+        "localOperatorSession",
+        "diagnosticsCommentRenderer",
+        "hostedNiLinuxRunner"
+      ],
+      "properties": {
+        "historyFacade": {
+          "type": "string"
+        },
+        "localRuntimeProfiles": {
+          "type": "string"
+        },
+        "localOperatorSession": {
+          "type": "string"
+        },
+        "diagnosticsCommentRenderer": {
+          "type": "string"
+        },
+        "hostedNiLinuxRunner": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/CompareVITools.Artifact.Tests.ps1
+++ b/tests/CompareVITools.Artifact.Tests.ps1
@@ -96,6 +96,23 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $metadata.source.sha | Should -Be '0123456789abcdef0123456789abcdef01234567'
     $metadata.source.releaseTag | Should -Be 'v9.9.9'
     @($metadata.compatibility.supportedPaths) | Should -Contain 'cross-repo-vi-history-via-hosted-ni-linux-runner'
+    $metadata.consumerContract.capabilities.viHistory.schema | Should -Be 'comparevi-tools/vi-history-capability@v1'
+    $metadata.consumerContract.capabilities.viHistory.capabilityId | Should -Be 'vi-history'
+    $metadata.consumerContract.capabilities.viHistory.displayName | Should -Be 'VI History'
+    $metadata.consumerContract.capabilities.viHistory.distributionRole | Should -Be 'upstream-producer'
+    $metadata.consumerContract.capabilities.viHistory.distributionModel | Should -Be 'release-bundle'
+    $metadata.consumerContract.capabilities.viHistory.bundleMetadataPath | Should -Be 'comparevi-tools-release.json'
+    $metadata.consumerContract.capabilities.viHistory.bundleImportPath | Should -Be 'tools/CompareVI.Tools/CompareVI.Tools.psd1'
+    $metadata.consumerContract.capabilities.viHistory.releaseAssetPattern | Should -Be 'CompareVI.Tools-v<release-version>.zip'
+    $metadata.consumerContract.capabilities.viHistory.authoritativeConsumerPinFieldPath | Should -Be 'versionContract.authoritativeConsumerPin'
+    $metadata.consumerContract.capabilities.viHistory.authoritativeConsumerPinKindFieldPath | Should -Be 'versionContract.authoritativeConsumerPinKind'
+    $metadata.consumerContract.capabilities.viHistory.contractPaths.historyFacade | Should -Be 'consumerContract.historyFacade'
+    $metadata.consumerContract.capabilities.viHistory.contractPaths.localRuntimeProfiles | Should -Be 'consumerContract.localRuntimeProfiles'
+    $metadata.consumerContract.capabilities.viHistory.contractPaths.localOperatorSession | Should -Be 'consumerContract.localOperatorSession'
+    $metadata.consumerContract.capabilities.viHistory.contractPaths.diagnosticsCommentRenderer | Should -Be 'consumerContract.diagnosticsCommentRenderer'
+    $metadata.consumerContract.capabilities.viHistory.contractPaths.hostedNiLinuxRunner | Should -Be 'consumerContract.hostedNiLinuxRunner'
+    ((@($metadata.consumerContract.capabilities.viHistory.notes) -join [Environment]::NewLine)) | Should -Match 'LabviewGitHubCiTemplate'
+    ((@($metadata.consumerContract.capabilities.viHistory.notes) -join [Environment]::NewLine)) | Should -Match 'authoritativeConsumerPin'
     $metadata.consumerContract.historyFacade.schema | Should -Be 'comparevi-tools/history-facade@v1'
     $metadata.consumerContract.historyFacade.exportedFunction | Should -Be 'Invoke-CompareVIHistoryFacade'
     $metadata.consumerContract.historyFacade.resultsRelativePath | Should -Be 'history-summary.json'
@@ -200,6 +217,8 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $archiveMetadata = Get-Content -LiteralPath $archiveMetadataPath -Raw | ConvertFrom-Json
     $archiveMetadata.bundle.metadataPath | Should -Be 'comparevi-tools-release.json'
     $archiveMetadata.bundle.files.Count | Should -BeGreaterThan 5
+    $archiveMetadata.consumerContract.capabilities.viHistory.schema | Should -Be 'comparevi-tools/vi-history-capability@v1'
+    $archiveMetadata.consumerContract.capabilities.viHistory.contractPaths.historyFacade | Should -Be 'consumerContract.historyFacade'
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Build-VIHistoryDevImage.ps1'
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Invoke-VIHistoryLocalOperatorSession.ps1'
     @($archiveMetadata.bundle.files.path) | Should -Contain 'tools/Invoke-VIHistoryLocalRefinement.ps1'
@@ -218,9 +237,10 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $metadataPath = Join-Path $TestDrive 'comparevi-tools-artifact-tools-iteration.json'
     $tempModulePath = Join-Path $TestDrive 'CompareVI.Tools.ToolsIteration.psd1'
     $tempModuleContents = Get-Content -LiteralPath $modulePath -Raw
-    $tempModuleContents = $tempModuleContents.Replace(
-      "ProjectUri = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'",
-      "ProjectUri = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action'`r`n      Prerelease = 'tools.14'"
+    $tempModuleContents = [regex]::Replace(
+      $tempModuleContents,
+      "Prerelease\s*=\s*'[^']+'",
+      "Prerelease = 'tools.14'"
     )
     Set-Content -LiteralPath $tempModulePath -Value $tempModuleContents -Encoding utf8
     $relativeModulePath = [System.IO.Path]::GetRelativePath($repoRoot, $tempModulePath)
@@ -230,28 +250,28 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
       -OutputRoot $outDir `
       -MetadataReportPath $metadataPath `
       -Repository 'owner/repo' `
-      -SourceRef 'refs/tags/v0.6.3-tools.14' `
+      -SourceRef "refs/tags/v$moduleVersion-tools.14" `
       -SourceSha '0123456789abcdef0123456789abcdef01234567' `
-      -ReleaseTag 'v0.6.3-tools.14'
+      -ReleaseTag "v$moduleVersion-tools.14"
 
     Test-Path -LiteralPath $metadataPath | Should -BeTrue
     & $schemaScript -JsonPath $metadataPath -SchemaPath $schemaPath
     $LASTEXITCODE | Should -Be 0
 
     $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
-    $metadata.module.version | Should -Be '0.6.3'
-    $metadata.module.releaseVersion | Should -Be '0.6.3-tools.14'
-    $metadata.versionContract.baseSemver | Should -Be '0.6.3'
-    $metadata.versionContract.releaseVersion | Should -Be '0.6.3-tools.14'
-    $metadata.versionContract.stableFamilyTag | Should -Be 'v0.6.3'
+    $metadata.module.version | Should -Be $moduleVersion
+    $metadata.module.releaseVersion | Should -Be "$moduleVersion-tools.14"
+    $metadata.versionContract.baseSemver | Should -Be $moduleVersion
+    $metadata.versionContract.releaseVersion | Should -Be "$moduleVersion-tools.14"
+    $metadata.versionContract.stableFamilyTag | Should -Be "v$moduleVersion"
     $metadata.versionContract.stableFamilyTagMutable | Should -BeTrue
     $metadata.versionContract.toolsIteration | Should -Be 14
-    $metadata.versionContract.authoritativeConsumerPin | Should -Be 'v0.6.3-tools.14'
+    $metadata.versionContract.authoritativeConsumerPin | Should -Be "v$moduleVersion-tools.14"
     $metadata.versionContract.authoritativeConsumerPinKind | Should -Be 'release-tag'
     ((@($metadata.versionContract.notes) -join [Environment]::NewLine)) | Should -Match 'stableFamilyTag'
   }
 
-  It 'emits an empty prerelease GitHub output for stable CompareVI.Tools bundles' {
+  It 'emits the module prerelease GitHub output deterministically' {
     $outDir = Join-Path $TestDrive 'artifacts-github-output'
     $metadataPath = Join-Path $TestDrive 'comparevi-tools-artifact-github-output.json'
     $githubOutputPath = Join-Path $TestDrive 'github-output.txt'
@@ -280,7 +300,7 @@ Describe 'CompareVI.Tools artifact publishing' -Tag 'REQ:DOTNET_CLI_RELEASE_ASSE
     $outputLines = Get-Content -LiteralPath $githubOutputPath
     $outputLines | Should -Contain "comparevi_tools_module_version=$moduleVersion"
     $outputLines | Should -Contain "comparevi_tools_release_version=$moduleReleaseVersion"
-    $outputLines | Should -Contain 'comparevi_tools_module_prerelease='
+    $outputLines | Should -Contain "comparevi_tools_module_prerelease=$modulePrerelease"
     @($outputLines | Where-Object { $_ -like 'comparevi_tools_module_prerelease=*' }).Count | Should -Be 1
   }
 

--- a/tests/CrossRepoVIHistoryDocs.Tests.ps1
+++ b/tests/CrossRepoVIHistoryDocs.Tests.ps1
@@ -17,6 +17,9 @@ Describe 'Cross-repo VI history docs' -Tag 'CompareVI' {
   It 'documents the canonical downstream demo consumer for the local-first loop' {
     $script:crossRepoDoc | Should -Match 'LabVIEW-Community-CI-CD/labview-icon-editor-demo'
     $script:crossRepoDoc | Should -Match 'comparevi-history'
+    $script:crossRepoDoc | Should -Match 'consumerContract\.capabilities\.viHistory'
+    $script:crossRepoDoc | Should -Match 'LabviewGitHubCiTemplate'
+    $script:crossRepoDoc | Should -Match 'versionContract\.authoritativeConsumerPin'
     $script:crossRepoDoc | Should -Match 'local-review'
     $script:crossRepoDoc | Should -Match 'local-proof'
     $script:crossRepoDoc | Should -Match 'priority:vi-history:budget'

--- a/tools/Publish-CompareVIToolsArtifact.ps1
+++ b/tools/Publish-CompareVIToolsArtifact.ps1
@@ -147,7 +147,12 @@ function Get-CompareVIToolsVersionContract {
 }
 
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
-$moduleManifestResolved = (Resolve-Path -LiteralPath (Join-Path $repoRoot $ModuleManifestPath)).Path
+$moduleManifestCandidate = if ([System.IO.Path]::IsPathRooted($ModuleManifestPath)) {
+  $ModuleManifestPath
+} else {
+  Join-Path $repoRoot $ModuleManifestPath
+}
+$moduleManifestResolved = (Resolve-Path -LiteralPath $moduleManifestCandidate).Path
 $moduleRoot = Split-Path -Parent $moduleManifestResolved
 $toolsRoot = Split-Path -Parent $moduleRoot
 
@@ -332,6 +337,32 @@ try {
   }
 
   $consumerContractMetadata = [ordered]@{
+    capabilities = [ordered]@{
+      viHistory = [ordered]@{
+        schema = 'comparevi-tools/vi-history-capability@v1'
+        capabilityId = 'vi-history'
+        displayName = 'VI History'
+        distributionRole = 'upstream-producer'
+        distributionModel = 'release-bundle'
+        bundleMetadataPath = 'comparevi-tools-release.json'
+        bundleImportPath = 'tools/CompareVI.Tools/CompareVI.Tools.psd1'
+        releaseAssetPattern = 'CompareVI.Tools-v<release-version>.zip'
+        authoritativeConsumerPinFieldPath = 'versionContract.authoritativeConsumerPin'
+        authoritativeConsumerPinKindFieldPath = 'versionContract.authoritativeConsumerPinKind'
+        contractPaths = [ordered]@{
+          historyFacade = 'consumerContract.historyFacade'
+          localRuntimeProfiles = 'consumerContract.localRuntimeProfiles'
+          localOperatorSession = 'consumerContract.localOperatorSession'
+          diagnosticsCommentRenderer = 'consumerContract.diagnosticsCommentRenderer'
+          hostedNiLinuxRunner = 'consumerContract.hostedNiLinuxRunner'
+        }
+        notes = @(
+          'Use this capability record when a downstream distributor such as LabviewGitHubCiTemplate needs to stamp vi-history support into generated repositories without copying compare internals.',
+          'Resolve the immutable downstream pin from versionContract.authoritativeConsumerPin and then read the referenced consumer contract paths from the same comparevi-tools-release.json payload.',
+          'The capability contract declares compare-vi-cli-action as the upstream producer; downstream repositories should distribute or consume the capability, not vendor the full backend control plane.'
+        )
+      }
+    }
     historyFacade = [ordered]@{
       schema = 'comparevi-tools/history-facade@v1'
       schemaUrl = 'https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/comparevi-tools-history-facade-v1.schema.json'


### PR DESCRIPTION
# Summary

Publishes a first-class `vi-history` capability contract from the `CompareVI.Tools` release manifest so `LabviewGitHubCiTemplate` can distribute the capability by pin instead of copying compare internals.

## Changes

- add `comparevi-tools/vi-history-capability@v1`
- advertise `consumerContract.capabilities.viHistory` in `comparevi-tools-release.json`
- document the producer/distributor boundary in `CrossRepo-VIHistory.md`
- update CompareVI.Tools artifact and docs tests for the new capability surface and current prerelease behavior

## Validation

- `Invoke-Pester tests/CompareVITools.Artifact.Tests.ps1`
- `Invoke-Pester tests/CrossRepoVIHistoryDocs.Tests.ps1`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `git diff --check`

Paired downstream distributor issue:
- `LabviewGitHubCiTemplate#16`

Closes #1875