### PR TITLE
fix(release): recover finalize metadata for merged release lanes (#1877)

### DIFF
--- a/tools/priority/__tests__/release-utils.test.mjs
+++ b/tools/priority/__tests__/release-utils.test.mjs
@@ -10,7 +10,8 @@ import {
   writeReleaseMetadata,
   summarizeStatusCheckRollup,
   getReleaseMetadataPath,
-  assertReleaseMetadataExists
+  assertReleaseMetadataExists,
+  ensureReleaseBranchMetadata
 } from '../lib/release-utils.mjs';
 
 test('normalizeVersionInput handles tagged and untagged semver', () => {
@@ -73,5 +74,57 @@ test('assertReleaseMetadataExists succeeds after writing release metadata', asyn
   assert.equal(
     artifactPath,
     path.join(repoDir, 'tests', 'results', '_agent', 'release', 'release-v1.0.0-branch.json')
+  );
+});
+
+test('ensureReleaseBranchMetadata recovers missing branch metadata when branch state is already authoritative', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-utils-recover-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+
+  const result = await ensureReleaseBranchMetadata(repoDir, {
+    tag: 'v1.2.3-rc.1',
+    semver: '1.2.3-rc.1',
+    branch: 'release/v1.2.3-rc.1',
+    branchExists: true,
+    baseCommit: 'abc123',
+    releaseCommit: 'def456',
+    pullRequest: {
+      number: 42,
+      url: 'https://example.test/pr/42',
+      mergeStateStatus: 'MERGED'
+    },
+    recoverySource: 'release-finalize'
+  });
+
+  assert.equal(result.recovered, true);
+  assert.equal(
+    result.artifactPath,
+    path.join(repoDir, 'tests', 'results', '_agent', 'release', 'release-v1.2.3-rc.1-branch.json')
+  );
+
+  const contents = JSON.parse(await readFile(result.artifactPath, 'utf8'));
+  assert.equal(contents.schema, 'release/branch@v1');
+  assert.equal(contents.branch, 'release/v1.2.3-rc.1');
+  assert.equal(contents.baseBranch, 'develop');
+  assert.equal(contents.releaseCommit, 'def456');
+  assert.equal(contents.recovered, true);
+  assert.equal(contents.recoverySource, 'release-finalize');
+  assert.equal(contents.pullRequest.number, 42);
+});
+
+test('ensureReleaseBranchMetadata preserves missing-artifact failure when branch state is not authoritative', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-utils-no-recover-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () =>
+      ensureReleaseBranchMetadata(repoDir, {
+        tag: 'v1.2.3',
+        semver: '1.2.3',
+        branch: 'release/v1.2.3',
+        branchExists: false,
+        pullRequest: null
+      }),
+    /Missing required artifact/i
   );
 });

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -22,7 +22,8 @@ import {
   normalizeVersionInput,
   writeReleaseMetadata,
   summarizeStatusChecks,
-  assertReleaseMetadataExists
+  assertReleaseMetadataExists,
+  ensureReleaseBranchMetadata
 } from './lib/release-utils.mjs';
 import {
   readSessionIndexHygiene,
@@ -306,9 +307,6 @@ async function main() {
   process.chdir(repoRoot);
   ensureCleanWorkingTree(run, 'Working tree not clean. Commit or stash changes before finalizing the release.');
   ensureGhCli();
-  await assertReleaseMetadataExists(repoRoot, tag, 'branch');
-  const standingPriorityParity = await collectStandingPriorityParityEvidence(repoRoot);
-  const hygiene = collectReleaseHygiene(repoRoot);
 
   const releaseBranch = `release/${tag}`;
   ensureBranchExists(releaseBranch);
@@ -316,9 +314,23 @@ async function main() {
 
   const upstream = resolveUpstream(repoRoot);
   ensureOriginFork(repoRoot, upstream);
-  const compareEvidence = await collectCompareEvidenceGate(repoRoot, upstream, releaseBranch);
-
   const prInfo = ensureReleasePrReady(repoRoot, releaseBranch, requiredReleaseChecks);
+  const releaseBranchCommit = run('git', ['rev-parse', releaseBranch], { cwd: repoRoot });
+  const releaseBaseCommit = run('git', ['merge-base', 'upstream/develop', releaseBranch], { cwd: repoRoot });
+  await ensureReleaseBranchMetadata(repoRoot, {
+    tag,
+    semver,
+    branch: releaseBranch,
+    branchExists: true,
+    baseCommit: releaseBaseCommit,
+    releaseCommit: releaseBranchCommit,
+    pullRequest: prInfo,
+    recoverySource: 'release-finalize'
+  });
+
+  const standingPriorityParity = await collectStandingPriorityParityEvidence(repoRoot);
+  const hygiene = collectReleaseHygiene(repoRoot);
+  const compareEvidence = await collectCompareEvidenceGate(repoRoot, upstream, releaseBranch);
 
   run('git', ['fetch', 'origin'], { cwd: repoRoot });
   run('git', ['fetch', 'upstream'], { cwd: repoRoot });

--- a/tools/priority/lib/release-utils.mjs
+++ b/tools/priority/lib/release-utils.mjs
@@ -41,6 +41,59 @@ export async function assertReleaseMetadataExists(repoRoot, tag, kind) {
   }
 }
 
+export async function ensureReleaseBranchMetadata(
+  repoRoot,
+  {
+    tag,
+    semver,
+    branch,
+    branchExists = false,
+    baseBranch = 'develop',
+    baseCommit = null,
+    releaseCommit = null,
+    pullRequest = null,
+    previousVersion = null,
+    surfaceVersions = null,
+    recoverySource = 'release-finalize'
+  }
+) {
+  try {
+    const artifactPath = await assertReleaseMetadataExists(repoRoot, tag, 'branch');
+    return {
+      artifactPath,
+      recovered: false
+    };
+  } catch (error) {
+    if (!branchExists || !pullRequest) {
+      throw error;
+    }
+
+    const payload = {
+      schema: 'release/branch@v1',
+      createdAt: new Date().toISOString(),
+      tag,
+      version: tag,
+      semver,
+      branch,
+      baseBranch,
+      baseCommit,
+      releaseCommit,
+      previousVersion,
+      surfaceVersions,
+      pullRequest,
+      recovered: true,
+      recoverySource
+    };
+
+    const artifactPath = await writeReleaseMetadata(repoRoot, tag, 'branch', payload);
+    return {
+      artifactPath,
+      recovered: true,
+      payload
+    };
+  }
+}
+
 export function summarizeStatusCheckRollup(rollup = []) {
   return (rollup || [])
     .filter(Boolean)


### PR DESCRIPTION
## Summary
- recover release branch metadata during `release:finalize` when the release PR is already merged and the branch artifact is missing in a fresh checkout
- keep the finalize gate honest by requiring authoritative branch state and PR evidence before reconstructing metadata
- add focused release-utils coverage for the recovery path

## Testing
- `node --test tools/priority/__tests__/release-utils.test.mjs`
- `node tools/npm/run-script.mjs release:finalize:dry -- 0.6.4-rc.1`
- `git diff --check`

Closes #1877