### PR TITLE
fix(release): fail before unsigned tag push

### DIFF
--- a/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
+++ b/docs/DELIVERY_CONTROL_PLANE_PR_LANES.md
@@ -17,7 +17,7 @@ This scaffold tracks the six planned mergeable slices so agents can resume deter
 
 - Keep each lane mergeable and production-safe in isolation.
 - Rebase each next lane on merged upstream `develop` before opening its PR.
-- Preserve signed-tag policy; release conductor must remain proposal-only when signing material is unavailable.
+- Preserve signed-tag policy; release conductor must fail closed before tag creation when signing material is unavailable.
 
 ## Resume commands
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -476,8 +476,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
     Auto mode activates on release windows, open `release/*` PRs, or `release-burst` labels, and backs off for
     30 minutes whenever the throughput controller enters `stabilize`.
   For queue-aware release proposals, run `node tools/npm/run-script.mjs priority:release:conductor -- --dry-run`.
-  Apply mode requires `RELEASE_CONDUCTOR_ENABLED=1`; if signing material is unavailable, the conductor remains
-  proposal-only and emits evidence without mutating tags.
+  Apply mode requires `RELEASE_CONDUCTOR_ENABLED=1`; if signing material is unavailable, the conductor now fails closed
+  before tag creation and emits readiness evidence without mutating tags.
   Hosted `schedule` and `workflow_run` conductor lanes stay proposal-only when apply mode is disabled, and dry-runs
   record advisory-only queue-evidence / no-recent-success diagnostics instead of failing for missing queue artifacts or
   idle dwell windows.

--- a/docs/release/TAG_PREP_CHECKLIST.md
+++ b/docs/release/TAG_PREP_CHECKLIST.md
@@ -62,6 +62,14 @@ the archived release notes
 
 ## 6. Tag Creation
 
+- [ ] Verify signed-tag readiness before push:
+
+```pwsh
+node tools/npm/run-script.mjs priority:release:conductor -- --apply --channel rc --version 0.6.4-rc.1
+```
+
+- [ ] Confirm `tests/results/_agent/release/release-conductor-report.json` reports
+      `status: pass` before pushing the RC tag.
 - [ ] Create an annotated RC tag:
 
 ```pwsh

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -428,7 +428,7 @@ test('runReleaseConductor creates signed tag when apply is enabled and signing k
   assert.ok(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'));
 });
 
-test('runReleaseConductor stays proposal-only when signing material is unavailable', async () => {
+test('runReleaseConductor blocks apply when signing material is unavailable', async () => {
   const readJsonOptionalFn = async (filePath) => {
     const normalized = String(filePath);
     if (normalized.includes('queue-supervisor-report.json')) {
@@ -498,9 +498,11 @@ test('runReleaseConductor stays proposal-only when signing material is unavailab
     writeReportFn: async (reportPath) => reportPath
   });
 
-  assert.equal(exitCode, 0);
-  assert.equal(report.decision.status, 'pass');
+  assert.equal(exitCode, 1);
+  assert.equal(report.decision.status, 'fail');
   assert.equal(report.release.proposalOnly, true);
   assert.equal(report.release.tagCreated, false);
+  assert.equal(report.release.signingMaterial.available, false);
+  assert.ok(report.decision.blockers.some((entry) => entry.code === 'tag-signing-material-missing'));
   assert.equal(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'), false);
 });

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -579,6 +579,11 @@ export async function runReleaseConductor(options = {}) {
         code: 'missing-version-for-tag',
         message: 'Apply mode requires --version to propose/create a release tag.'
       });
+    } else if (!signingMaterial.available) {
+      blockers.push({
+        code: 'tag-signing-material-missing',
+        message: 'Apply mode requires signed-tag readiness before tag push. Configure user.signingkey (or equivalent signing material) and retry.'
+      });
     } else if (signingMaterial.available) {
       const tagResult = runCommandFn('git', ['tag', '-s', targetTag, '-m', `Release ${targetTag}`], {
         cwd: repoRoot,


### PR DESCRIPTION
## Summary
- fail release conductor apply mode closed when signed-tag readiness is missing
- emit 	ag-signing-material-missing instead of silently staying proposal-only
- document conductor readiness as a prerequisite before RC tag push

## Testing
- node --test tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
- node tools/npm/run-script.mjs docs:manifest:validate
- node tools/npm/run-script.mjs lint:md:changed
- git diff --check
