### PR TITLE
[governance]: project vi-history distributor dependency into governor portfolio (#1889)

### DIFF
--- a/docs/knowledgebase/Agent-Handoff-Surfaces.md
+++ b/docs/knowledgebase/Agent-Handoff-Surfaces.md
@@ -94,11 +94,13 @@ entrypoint and machine-generated live state.
   - merge-queue-owned PR waits, including the next wake condition and PR URL
   - template pivot readiness
   - current governor mode and next owner
-- latest wake lifecycle terminal state
-- funding-quality posture for the latest wake
-- release-signing readiness, including explicit external blockers when workflow
-  signing material is absent
-- cross-repo owner and next-owner decisions
+  - `vi-history` distributor dependency status between compare and the
+    canonical template
+  - latest wake lifecycle terminal state
+  - funding-quality posture for the latest wake
+  - release-signing readiness, including explicit external blockers when workflow
+    signing material is absent
+  - cross-repo owner and next-owner decisions
   - repo graph truth for producer lineage, canonical development, and consumer proving
   - wake conditions that should reopen compare or template work
   - supported downstream monitoring for canonical template and consumer forks

--- a/docs/knowledgebase/CrossRepo-VIHistory.md
+++ b/docs/knowledgebase/CrossRepo-VIHistory.md
@@ -122,6 +122,11 @@ That keeps the producer/distributor boundary clean:
 - generated repositories consume the pinned release surface instead of
   vendoring compare internals
 
+The autonomous governor portfolio also treats that producer/distributor link as
+an explicit dependency. Compare remains the current owner until the signed
+producer-native `CompareVI.Tools` release is ready, and only then does the
+portfolio hand off the next-owner route to `LabviewGitHubCiTemplate`.
+
 For hosted GitHub runner diagnostics, use the same extracted bundle root as
 `COMPAREVI_SCRIPTS_ROOT` and resolve the NI Linux runner from
 `tools/Run-NILinuxContainerCompare.ps1`. Keep its adjacent support scripts

--- a/docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json
+++ b/docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json
@@ -70,7 +70,7 @@
     "portfolio": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repositoryCount", "repositories", "unsupportedPaths"],
+      "required": ["repositoryCount", "repositories", "dependencies", "unsupportedPaths"],
       "properties": {
         "repositoryCount": {
           "type": "integer",
@@ -175,6 +175,39 @@
             }
           }
         },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "status",
+              "ownerRepository",
+              "dependentRepository",
+              "requiredCapability",
+              "source",
+              "releaseSigningStatus",
+              "releasePublicationState",
+              "signingCapabilityState",
+              "externalBlocker",
+              "detail"
+            ],
+            "properties": {
+              "id": { "type": "string" },
+              "status": { "type": "string", "enum": ["ready", "blocked", "unknown"] },
+              "ownerRepository": { "type": ["string", "null"] },
+              "dependentRepository": { "type": ["string", "null"] },
+              "requiredCapability": { "type": "string" },
+              "source": { "type": "string" },
+              "releaseSigningStatus": { "type": ["string", "null"] },
+              "releasePublicationState": { "type": ["string", "null"] },
+              "signingCapabilityState": { "type": ["string", "null"] },
+              "externalBlocker": { "type": ["string", "null"] },
+              "detail": { "type": "string" }
+            }
+          }
+        },
         "unsupportedPaths": {
           "type": "array",
           "items": {
@@ -207,6 +240,10 @@
         "queueHandoffNextWakeCondition",
         "queueHandoffPrUrl",
         "queueAuthoritySource",
+        "viHistoryDistributorDependencyStatus",
+        "viHistoryDistributorDependencyTargetRepository",
+        "viHistoryDistributorDependencyExternalBlocker",
+        "viHistoryDistributorDependencyPublicationState",
         "portfolioWakeConditionCount",
         "triggeredWakeConditions"
       ],
@@ -227,6 +264,10 @@
         "queueHandoffNextWakeCondition": { "type": ["string", "null"] },
         "queueHandoffPrUrl": { "type": ["string", "null"] },
         "queueAuthoritySource": { "type": ["string", "null"] },
+        "viHistoryDistributorDependencyStatus": { "type": "string", "enum": ["ready", "blocked", "unknown"] },
+        "viHistoryDistributorDependencyTargetRepository": { "type": ["string", "null"] },
+        "viHistoryDistributorDependencyExternalBlocker": { "type": ["string", "null"] },
+        "viHistoryDistributorDependencyPublicationState": { "type": ["string", "null"] },
         "portfolioWakeConditionCount": { "type": "integer", "minimum": 0 },
         "triggeredWakeConditions": {
           "type": "array",

--- a/tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs
@@ -42,6 +42,13 @@ function createCompareGovernorSummary(overrides = {}) {
         status: 'blocked',
         futureAgentAction: 'stay-in-compare-monitoring',
         wakeConditionCount: 3
+      },
+      releaseSigningReadiness: {
+        status: 'warn',
+        codePathState: 'ready',
+        signingCapabilityState: 'missing',
+        publicationState: 'unobserved',
+        externalBlocker: 'workflow-signing-secret-missing'
       }
     },
     wake: {
@@ -84,7 +91,10 @@ function createCompareGovernorSummary(overrides = {}) {
       queueHandoffStatus: 'checks-pending',
       queueHandoffNextWakeCondition: 'checks-green',
       queueHandoffPrUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864',
-      queueAuthoritySource: 'delivery-runtime'
+      queueAuthoritySource: 'delivery-runtime',
+      releaseSigningStatus: 'warn',
+      releaseSigningExternalBlocker: 'workflow-signing-secret-missing',
+      releasePublicationState: 'unobserved'
     },
     ...overrides
   };
@@ -306,9 +316,30 @@ test('runAutonomousGovernorPortfolioSummary keeps compare as owner during active
   assert.equal(report.summary.queueHandoffStatus, 'checks-pending');
   assert.equal(report.summary.queueHandoffNextWakeCondition, 'checks-green');
   assert.equal(report.summary.queueAuthoritySource, 'delivery-runtime');
+  assert.equal(report.summary.viHistoryDistributorDependencyStatus, 'blocked');
+  assert.equal(
+    report.summary.viHistoryDistributorDependencyExternalBlocker,
+    'workflow-signing-secret-missing'
+  );
+  assert.equal(report.summary.viHistoryDistributorDependencyPublicationState, 'unobserved');
   assert.equal(report.compare.queueHandoffPrUrl, 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864');
   assert.equal(report.compare.queueAuthoritySource, 'delivery-runtime');
   assert.equal(report.portfolio.repositoryCount, 4);
+  assert.deepEqual(report.portfolio.dependencies, [
+    {
+      id: 'vi-history-producer-native-distributor',
+      status: 'blocked',
+      ownerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      dependentRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      requiredCapability: 'vi-history',
+      source: 'compare-release-signing-readiness',
+      releaseSigningStatus: 'warn',
+      releasePublicationState: 'unobserved',
+      signingCapabilityState: 'missing',
+      externalBlocker: 'workflow-signing-secret-missing',
+      detail: 'awaiting-compare-release-signing-blocker-clear'
+    }
+  ]);
   assert.deepEqual(report.portfolio.repositories.find((entry) => entry.id === 'compare').triggeredWakeConditions, [
     'compare-queue-not-empty',
     'compare-continuity-not-safe-idle',
@@ -424,4 +455,178 @@ test('runAutonomousGovernorPortfolioSummary routes ownership to canonical templa
     report.portfolio.repositories.find((entry) => entry.id === 'canonical-template').triggeredWakeConditions,
     ['template-canonical-open-issues']
   );
+});
+
+test('runAutonomousGovernorPortfolioSummary keeps next owner on compare while vi-history distributor dependency is blocked', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'governor-portfolio-vi-history-blocked-'));
+  const compareSummary = createCompareGovernorSummary({
+    compare: {
+      queueState: { status: 'queue-empty', reason: 'queue-empty', openIssueCount: 0, ready: true },
+      continuity: {
+        status: 'maintained',
+        turnBoundary: 'safe-idle',
+        supervisionState: 'idle-monitoring',
+        operatorPromptRequiredToResume: false
+      },
+      monitoringMode: {
+        status: 'active',
+        futureAgentAction: 'future-agent-may-pivot',
+        wakeConditionCount: 0
+      },
+      releaseSigningReadiness: {
+        status: 'warn',
+        codePathState: 'ready',
+        signingCapabilityState: 'missing',
+        publicationState: 'unobserved',
+        externalBlocker: 'workflow-signing-secret-missing'
+      }
+    },
+    wake: {
+      terminalState: 'monitoring',
+      currentStage: 'monitoring',
+      classification: null,
+      decision: null,
+      monitoringStatus: 'active',
+      authoritativeTier: null,
+      blockedLowerTierEvidence: false,
+      replayMatched: false,
+      replayAuthorityCompatible: null,
+      issueNumber: null,
+      issueUrl: null,
+      recommendedOwnerRepository: null
+    },
+    summary: {
+      governorMode: 'monitoring-active',
+      currentOwnerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      nextOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      nextAction: 'future-agent-may-pivot',
+      signalQuality: 'idle-monitoring',
+      queueState: 'queue-empty',
+      continuityStatus: 'maintained',
+      wakeTerminalState: 'monitoring',
+      monitoringStatus: 'active',
+      futureAgentAction: 'future-agent-may-pivot',
+      queueHandoffStatus: 'none',
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: 'none',
+      releaseSigningStatus: 'warn',
+      releaseSigningExternalBlocker: 'workflow-signing-secret-missing',
+      releasePublicationState: 'unobserved'
+    }
+  });
+  const monitoringMode = createMonitoringMode({
+    compare: {
+      queueState: { reportPath: 'tests/results/_agent/issue/no-standing-priority.json', ready: true, status: 'queue-empty', detail: 'queue-empty' },
+      continuity: { reportPath: 'tests/results/_agent/handoff/continuity-summary.json', ready: true, status: 'maintained', detail: 'safe-idle' },
+      pivotGate: { reportPath: 'tests/results/_agent/promotion/template-pivot-gate-report.json', ready: true, status: 'ready', detail: 'future-agent-may-pivot' },
+      readyForMonitoring: true
+    },
+    summary: {
+      status: 'active',
+      futureAgentAction: 'future-agent-may-pivot',
+      wakeConditionCount: 0,
+      triggeredWakeConditions: []
+    }
+  });
+
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'autonomous-governor-summary.json'), compareSummary);
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'monitoring-mode.json'), monitoringMode);
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'downstream-repo-graph-truth.json'), createRepoGraphTruth());
+
+  const { report } = await runAutonomousGovernorPortfolioSummary({ repoRoot: tmpDir });
+
+  assert.equal(report.summary.governorMode, 'monitoring-active');
+  assert.equal(report.summary.currentOwnerRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(report.summary.nextOwnerRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(report.summary.nextAction, 'complete-compare-vi-history-producer-release');
+  assert.equal(report.summary.ownerDecisionSource, 'compare-vi-history-distributor-dependency');
+  assert.equal(report.summary.viHistoryDistributorDependencyStatus, 'blocked');
+});
+
+test('runAutonomousGovernorPortfolioSummary flips next owner to template once vi-history distributor dependency is ready', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'governor-portfolio-vi-history-ready-'));
+  const compareSummary = createCompareGovernorSummary({
+    compare: {
+      queueState: { status: 'queue-empty', reason: 'queue-empty', openIssueCount: 0, ready: true },
+      continuity: {
+        status: 'maintained',
+        turnBoundary: 'safe-idle',
+        supervisionState: 'idle-monitoring',
+        operatorPromptRequiredToResume: false
+      },
+      monitoringMode: {
+        status: 'active',
+        futureAgentAction: 'future-agent-may-pivot',
+        wakeConditionCount: 0
+      },
+      releaseSigningReadiness: {
+        status: 'pass',
+        codePathState: 'ready',
+        signingCapabilityState: 'ready',
+        publicationState: 'producer-native-ready',
+        externalBlocker: null
+      }
+    },
+    wake: {
+      terminalState: 'monitoring',
+      currentStage: 'monitoring',
+      classification: null,
+      decision: null,
+      monitoringStatus: 'active',
+      authoritativeTier: null,
+      blockedLowerTierEvidence: false,
+      replayMatched: false,
+      replayAuthorityCompatible: null,
+      issueNumber: null,
+      issueUrl: null,
+      recommendedOwnerRepository: null
+    },
+    summary: {
+      governorMode: 'monitoring-active',
+      currentOwnerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+      nextOwnerRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      nextAction: 'future-agent-may-pivot',
+      signalQuality: 'idle-monitoring',
+      queueState: 'queue-empty',
+      continuityStatus: 'maintained',
+      wakeTerminalState: 'monitoring',
+      monitoringStatus: 'active',
+      futureAgentAction: 'future-agent-may-pivot',
+      queueHandoffStatus: 'none',
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: 'none',
+      releaseSigningStatus: 'pass',
+      releaseSigningExternalBlocker: null,
+      releasePublicationState: 'producer-native-ready'
+    }
+  });
+  const monitoringMode = createMonitoringMode({
+    compare: {
+      queueState: { reportPath: 'tests/results/_agent/issue/no-standing-priority.json', ready: true, status: 'queue-empty', detail: 'queue-empty' },
+      continuity: { reportPath: 'tests/results/_agent/handoff/continuity-summary.json', ready: true, status: 'maintained', detail: 'safe-idle' },
+      pivotGate: { reportPath: 'tests/results/_agent/promotion/template-pivot-gate-report.json', ready: true, status: 'ready', detail: 'future-agent-may-pivot' },
+      readyForMonitoring: true
+    },
+    summary: {
+      status: 'active',
+      futureAgentAction: 'future-agent-may-pivot',
+      wakeConditionCount: 0,
+      triggeredWakeConditions: []
+    }
+  });
+
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'autonomous-governor-summary.json'), compareSummary);
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'monitoring-mode.json'), monitoringMode);
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'downstream-repo-graph-truth.json'), createRepoGraphTruth());
+
+  const { report } = await runAutonomousGovernorPortfolioSummary({ repoRoot: tmpDir });
+
+  assert.equal(report.summary.governorMode, 'monitoring-active');
+  assert.equal(report.summary.currentOwnerRepository, 'LabVIEW-Community-CI-CD/compare-vi-cli-action');
+  assert.equal(report.summary.nextOwnerRepository, 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate');
+  assert.equal(report.summary.nextAction, 'future-agent-may-pivot');
+  assert.equal(report.summary.ownerDecisionSource, 'compare-monitoring-mode');
+  assert.equal(report.summary.viHistoryDistributorDependencyStatus, 'ready');
 });

--- a/tools/priority/__tests__/monitoring-work-injection-schema.test.mjs
+++ b/tools/priority/__tests__/monitoring-work-injection-schema.test.mjs
@@ -124,11 +124,30 @@ test('monitoring work injection report matches schema', async () => {
       monitoringStatus: 'active',
       futureAgentAction: 'future-agent-may-pivot',
       governorMode: 'compare-governance-work',
-      nextAction: 'continue-compare-governance-work'
+      nextAction: 'continue-compare-governance-work',
+      queueHandoffStatus: null,
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: null
     },
     portfolio: {
       repositoryCount: 4,
       repositories: [],
+      dependencies: [
+        {
+          id: 'vi-history-producer-native-distributor',
+          status: 'unknown',
+          ownerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          dependentRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+          requiredCapability: 'vi-history',
+          source: 'compare-release-signing-readiness',
+          releaseSigningStatus: null,
+          releasePublicationState: null,
+          signingCapabilityState: null,
+          externalBlocker: null,
+          detail: 'fixture'
+        }
+      ],
       unsupportedPaths: []
     },
     summary: {
@@ -141,6 +160,14 @@ test('monitoring work injection report matches schema', async () => {
       templateMonitoringStatus: 'pass',
       supportedProofStatus: 'pass',
       repoGraphStatus: 'pass',
+      queueHandoffStatus: null,
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: null,
+      viHistoryDistributorDependencyStatus: 'unknown',
+      viHistoryDistributorDependencyTargetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      viHistoryDistributorDependencyExternalBlocker: null,
+      viHistoryDistributorDependencyPublicationState: null,
       portfolioWakeConditionCount: 0,
       triggeredWakeConditions: []
     }

--- a/tools/priority/__tests__/monitoring-work-injection.test.mjs
+++ b/tools/priority/__tests__/monitoring-work-injection.test.mjs
@@ -64,7 +64,10 @@ function createGovernorPortfolioSummary({
   governorMode = 'compare-governance-work',
   nextAction = 'continue-compare-governance-work',
   ownerDecisionSource = 'compare-governor-summary',
-  status = 'active'
+  status = 'active',
+  viHistoryDistributorDependencyStatus = 'unknown',
+  viHistoryDistributorDependencyExternalBlocker = null,
+  viHistoryDistributorDependencyPublicationState = null
 } = {}) {
   return {
     schema: 'priority/autonomous-governor-portfolio-summary-report@v1',
@@ -81,11 +84,30 @@ function createGovernorPortfolioSummary({
       monitoringStatus: 'active',
       futureAgentAction: 'future-agent-may-pivot',
       governorMode,
-      nextAction
+      nextAction,
+      queueHandoffStatus: null,
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: null
     },
     portfolio: {
       repositoryCount: 4,
       repositories: [],
+      dependencies: [
+        {
+          id: 'vi-history-producer-native-distributor',
+          status: viHistoryDistributorDependencyStatus,
+          ownerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          dependentRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+          requiredCapability: 'vi-history',
+          source: 'compare-release-signing-readiness',
+          releaseSigningStatus: null,
+          releasePublicationState: viHistoryDistributorDependencyPublicationState,
+          signingCapabilityState: null,
+          externalBlocker: viHistoryDistributorDependencyExternalBlocker,
+          detail: 'fixture'
+        }
+      ],
       unsupportedPaths: []
     },
     summary: {
@@ -98,6 +120,14 @@ function createGovernorPortfolioSummary({
       templateMonitoringStatus: 'pass',
       supportedProofStatus: 'pass',
       repoGraphStatus: 'pass',
+      queueHandoffStatus: null,
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: null,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       portfolioWakeConditionCount: 0,
       triggeredWakeConditions: []
     }

--- a/tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs
@@ -8,7 +8,10 @@ function createGovernorPortfolioSummary({
   nextOwnerRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
   nextAction = 'continue-compare-governance-work',
   ownerDecisionSource = 'compare-governor-summary',
-  governorMode = 'compare-governance-work'
+  governorMode = 'compare-governance-work',
+  viHistoryDistributorDependencyStatus = 'unknown',
+  viHistoryDistributorDependencyExternalBlocker = null,
+  viHistoryDistributorDependencyPublicationState = null
 } = {}) {
   return {
     schema: 'priority/autonomous-governor-portfolio-summary-report@v1',
@@ -25,11 +28,30 @@ function createGovernorPortfolioSummary({
       monitoringStatus: 'active',
       futureAgentAction: 'future-agent-may-pivot',
       governorMode,
-      nextAction
+      nextAction,
+      queueHandoffStatus: null,
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: null
     },
     portfolio: {
       repositoryCount: 4,
       repositories: [],
+      dependencies: [
+        {
+          id: 'vi-history-producer-native-distributor',
+          status: viHistoryDistributorDependencyStatus,
+          ownerRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+          dependentRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+          requiredCapability: 'vi-history',
+          source: 'compare-release-signing-readiness',
+          releaseSigningStatus: null,
+          releasePublicationState: viHistoryDistributorDependencyPublicationState,
+          signingCapabilityState: null,
+          externalBlocker: viHistoryDistributorDependencyExternalBlocker,
+          detail: 'fixture'
+        }
+      ],
       unsupportedPaths: []
     },
     summary: {
@@ -42,6 +64,14 @@ function createGovernorPortfolioSummary({
       templateMonitoringStatus: 'pass',
       supportedProofStatus: 'pass',
       repoGraphStatus: 'pass',
+      queueHandoffStatus: null,
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: null,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       portfolioWakeConditionCount: 0,
       triggeredWakeConditions: []
     }

--- a/tools/priority/autonomous-governor-portfolio-summary.mjs
+++ b/tools/priority/autonomous-governor-portfolio-summary.mjs
@@ -140,6 +140,50 @@ function createWakeConditionsByRepository(triggeredWakeConditions) {
   };
 }
 
+function deriveViHistoryDistributorDependency(compareGovernorSummary, monitoringMode) {
+  const compareRepository =
+    asOptional(compareGovernorSummary?.summary?.currentOwnerRepository) ||
+    asOptional(monitoringMode?.policy?.compareRepository) ||
+    asOptional(compareGovernorSummary?.repository);
+  const dependentRepository = asOptional(monitoringMode?.policy?.pivotTargetRepository);
+  const releaseSigningReadiness = compareGovernorSummary?.compare?.releaseSigningReadiness;
+  const releaseSigningStatus =
+    asOptional(compareGovernorSummary?.summary?.releaseSigningStatus) || asOptional(releaseSigningReadiness?.status);
+  const releasePublicationState =
+    asOptional(compareGovernorSummary?.summary?.releasePublicationState) ||
+    asOptional(releaseSigningReadiness?.publicationState);
+  const signingCapabilityState = asOptional(releaseSigningReadiness?.signingCapabilityState);
+  const externalBlocker =
+    asOptional(compareGovernorSummary?.summary?.releaseSigningExternalBlocker) ||
+    asOptional(releaseSigningReadiness?.externalBlocker);
+
+  let status = 'unknown';
+  let detail = 'missing-release-signing-readiness';
+  if (releasePublicationState === 'producer-native-ready') {
+    status = 'ready';
+    detail = 'producer-native-release-ready';
+  } else if (releaseSigningStatus || releasePublicationState || signingCapabilityState || externalBlocker) {
+    status = 'blocked';
+    detail = externalBlocker
+      ? 'awaiting-compare-release-signing-blocker-clear'
+      : 'awaiting-producer-native-release-publication';
+  }
+
+  return {
+    id: 'vi-history-producer-native-distributor',
+    status,
+    ownerRepository: compareRepository,
+    dependentRepository,
+    requiredCapability: 'vi-history',
+    source: 'compare-release-signing-readiness',
+    releaseSigningStatus,
+    releasePublicationState,
+    signingCapabilityState,
+    externalBlocker,
+    detail
+  };
+}
+
 function derivePortfolioMode(compareGovernorSummary, monitoringMode) {
   const compareMode = asOptional(compareGovernorSummary?.summary?.governorMode);
   const futureAgentAction = asOptional(monitoringMode?.summary?.futureAgentAction);
@@ -151,7 +195,7 @@ function derivePortfolioMode(compareGovernorSummary, monitoringMode) {
   return compareMode || 'attention-required';
 }
 
-function deriveOwners(compareGovernorSummary, monitoringMode, portfolioMode) {
+function deriveOwners(compareGovernorSummary, monitoringMode, portfolioMode, viHistoryDistributorDependency) {
   const compareRepository =
     asOptional(compareGovernorSummary?.summary?.currentOwnerRepository) ||
     asOptional(monitoringMode?.policy?.compareRepository) ||
@@ -170,6 +214,22 @@ function deriveOwners(compareGovernorSummary, monitoringMode, portfolioMode) {
   }
 
   if (portfolioMode === 'monitoring-active') {
+    if (
+      futureAgentAction === 'future-agent-may-pivot' &&
+      viHistoryDistributorDependency?.status !== 'ready' &&
+      viHistoryDistributorDependency?.dependentRepository === pivotTargetRepository
+    ) {
+      return {
+        currentOwnerRepository: compareRepository,
+        nextOwnerRepository: compareRepository,
+        nextAction:
+          viHistoryDistributorDependency.status === 'unknown'
+            ? 'refresh-compare-vi-history-distributor-dependency'
+            : 'complete-compare-vi-history-producer-release',
+        ownerDecisionSource: 'compare-vi-history-distributor-dependency'
+      };
+    }
+
     return {
       currentOwnerRepository: compareRepository,
       nextOwnerRepository: futureAgentAction === 'future-agent-may-pivot' ? pivotTargetRepository : compareRepository,
@@ -295,7 +355,13 @@ function buildReport({
   now
 }) {
   const portfolioMode = derivePortfolioMode(compareGovernorSummary, monitoringMode);
-  const ownerDecision = deriveOwners(compareGovernorSummary, monitoringMode, portfolioMode);
+  const viHistoryDistributorDependency = deriveViHistoryDistributorDependency(compareGovernorSummary, monitoringMode);
+  const ownerDecision = deriveOwners(
+    compareGovernorSummary,
+    monitoringMode,
+    portfolioMode,
+    viHistoryDistributorDependency
+  );
   const repositoryEntries = deriveRepositoryEntries(repoGraphTruth, monitoringMode, compareGovernorSummary);
   const templateMonitoringStatus = deriveTemplateMonitoringStatus(repositoryEntries);
   const supportedProofStatus = deriveSupportedProofStatus(repositoryEntries);
@@ -329,6 +395,7 @@ function buildReport({
     portfolio: {
       repositoryCount: repositoryEntries.length,
       repositories: repositoryEntries,
+      dependencies: [viHistoryDistributorDependency],
       unsupportedPaths: Array.isArray(monitoringMode?.templateMonitoring?.unsupportedPaths)
         ? monitoringMode.templateMonitoring.unsupportedPaths.map((entry) => ({
             name: asOptional(entry?.name),
@@ -351,6 +418,10 @@ function buildReport({
       queueHandoffNextWakeCondition: asOptional(compareGovernorSummary?.summary?.queueHandoffNextWakeCondition),
       queueHandoffPrUrl: asOptional(compareGovernorSummary?.summary?.queueHandoffPrUrl),
       queueAuthoritySource: asOptional(compareGovernorSummary?.summary?.queueAuthoritySource),
+      viHistoryDistributorDependencyStatus: viHistoryDistributorDependency.status,
+      viHistoryDistributorDependencyTargetRepository: viHistoryDistributorDependency.dependentRepository,
+      viHistoryDistributorDependencyExternalBlocker: viHistoryDistributorDependency.externalBlocker,
+      viHistoryDistributorDependencyPublicationState: viHistoryDistributorDependency.releasePublicationState,
       portfolioWakeConditionCount: triggeredWakeConditions.length,
       triggeredWakeConditions
     }


### PR DESCRIPTION
## Summary
- project the `vi-history` distributor dependency into the autonomous governor portfolio
- keep compare as the routed next owner while the signed producer-native bundle is still blocked
- flip next-owner routing back to `LabviewGitHubCiTemplate` once compare publication reaches `producer-native-ready`

## Validation
- `node --test tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs tools/priority/__tests__/autonomous-governor-portfolio-summary-schema.test.mjs tools/priority/__tests__/monitoring-work-injection.test.mjs tools/priority/__tests__/monitoring-work-injection-schema.test.mjs tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs schema:validate -- --schema docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json --data tests/results/_agent/handoff/1889-proof/autonomous-governor-portfolio-summary.json`
- `git diff --check`

## Proof
- `tests/results/_agent/handoff/1889-proof/autonomous-governor-portfolio-summary.json`
  - `summary.currentOwnerRepository = LabVIEW-Community-CI-CD/compare-vi-cli-action`
  - `summary.nextOwnerRepository = LabVIEW-Community-CI-CD/compare-vi-cli-action`
  - `summary.nextAction = complete-compare-vi-history-producer-release`
  - `summary.viHistoryDistributorDependencyStatus = blocked`
  - `summary.viHistoryDistributorDependencyExternalBlocker = workflow-signing-secret-missing`
