### PR TITLE
[runtime]: surface vi-history distributor dependency in queue-empty handoff (#1891)

### DIFF
--- a/tests/Import-HandoffState.Tests.ps1
+++ b/tests/Import-HandoffState.Tests.ps1
@@ -341,10 +341,29 @@ Describe 'Import-HandoffState' -Tag 'Unit' {
         futureAgentAction = 'stay-in-compare-monitoring'
         governorMode = 'compare-governance-work'
         nextAction = 'continue-compare-governance-work'
+        queueHandoffStatus = $null
+        queueHandoffNextWakeCondition = $null
+        queueHandoffPrUrl = $null
+        queueAuthoritySource = $null
       }
       portfolio = [ordered]@{
         repositoryCount = 4
         repositories = @()
+        dependencies = @(
+          [ordered]@{
+            id = 'vi-history-producer-native-distributor'
+            status = 'blocked'
+            ownerRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+            dependentRepository = 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'
+            requiredCapability = 'vi-history'
+            source = 'compare-release-signing-readiness'
+            releaseSigningStatus = 'warn'
+            releasePublicationState = 'unobserved'
+            signingCapabilityState = 'missing'
+            externalBlocker = 'workflow-signing-secret-missing'
+            detail = 'awaiting-compare-release-signing-blocker-clear'
+          }
+        )
         unsupportedPaths = @()
       }
       summary = [ordered]@{
@@ -357,6 +376,14 @@ Describe 'Import-HandoffState' -Tag 'Unit' {
         templateMonitoringStatus = 'pass'
         supportedProofStatus = 'pass'
         repoGraphStatus = 'pass'
+        queueHandoffStatus = $null
+        queueHandoffNextWakeCondition = $null
+        queueHandoffPrUrl = $null
+        queueAuthoritySource = $null
+        viHistoryDistributorDependencyStatus = 'blocked'
+        viHistoryDistributorDependencyTargetRepository = 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'
+        viHistoryDistributorDependencyExternalBlocker = 'workflow-signing-secret-missing'
+        viHistoryDistributorDependencyPublicationState = 'unobserved'
         portfolioWakeConditionCount = 3
         triggeredWakeConditions = @(
           'compare-queue-not-empty',
@@ -371,6 +398,9 @@ Describe 'Import-HandoffState' -Tag 'Unit' {
     $output | Should -Match '\[handoff\] Governor portfolio summary'
     $output | Should -Match 'mode\s+: compare-governance-work'
     $output | Should -Match 'proof\s+: pass'
+    $output | Should -Match 'vhist\s+: blocked'
+    $output | Should -Match 'vhistRepo: LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate'
+    $output | Should -Match 'vhistBlk : workflow-signing-secret-missing'
     $global:HandoffAutonomousGovernorPortfolioSummary.schema | Should -Be 'priority/autonomous-governor-portfolio-summary-report@v1'
 
     Remove-Variable -Name HandoffAutonomousGovernorPortfolioSummary -Scope Global -ErrorAction SilentlyContinue

--- a/tools/Print-AgentHandoff.ps1
+++ b/tools/Print-AgentHandoff.ps1
@@ -1606,6 +1606,15 @@ try {
     Write-Host ("  next     : {0}" -f (Format-NullableValue $portfolio.summary.nextAction))
     Write-Host ("  template : {0}" -f (Format-NullableValue $portfolio.summary.templateMonitoringStatus))
     Write-Host ("  proof    : {0}" -f (Format-NullableValue $portfolio.summary.supportedProofStatus))
+    if ($portfolio.summary.PSObject.Properties['viHistoryDistributorDependencyStatus']) {
+      Write-Host ("  vhist    : {0}" -f (Format-NullableValue $portfolio.summary.viHistoryDistributorDependencyStatus))
+      if ($portfolio.summary.PSObject.Properties['viHistoryDistributorDependencyTargetRepository'] -and $portfolio.summary.viHistoryDistributorDependencyTargetRepository) {
+        Write-Host ("  vhistRepo: {0}" -f (Format-NullableValue $portfolio.summary.viHistoryDistributorDependencyTargetRepository))
+      }
+      if ($portfolio.summary.PSObject.Properties['viHistoryDistributorDependencyExternalBlocker'] -and $portfolio.summary.viHistoryDistributorDependencyExternalBlocker) {
+        Write-Host ("  vhistBlk : {0}" -f (Format-NullableValue $portfolio.summary.viHistoryDistributorDependencyExternalBlocker))
+      }
+    }
     if ($portfolio.summary.nextOwnerRepository) {
       Write-Host ("  nextRepo : {0}" -f (Format-NullableValue $portfolio.summary.nextOwnerRepository))
     }
@@ -1627,6 +1636,15 @@ try {
         ('- Template monitoring: {0}' -f (Format-NullableValue $portfolio.summary.templateMonitoringStatus)),
         ('- Supported proof: {0}' -f (Format-NullableValue $portfolio.summary.supportedProofStatus))
       )
+      if ($portfolio.summary.PSObject.Properties['viHistoryDistributorDependencyStatus']) {
+        $portfolioLines += ('- VI-history dependency: {0}' -f (Format-NullableValue $portfolio.summary.viHistoryDistributorDependencyStatus))
+        if ($portfolio.summary.PSObject.Properties['viHistoryDistributorDependencyTargetRepository'] -and $portfolio.summary.viHistoryDistributorDependencyTargetRepository) {
+          $portfolioLines += ('- VI-history target: {0}' -f (Format-NullableValue $portfolio.summary.viHistoryDistributorDependencyTargetRepository))
+        }
+        if ($portfolio.summary.PSObject.Properties['viHistoryDistributorDependencyExternalBlocker'] -and $portfolio.summary.viHistoryDistributorDependencyExternalBlocker) {
+          $portfolioLines += ('- VI-history blocker: {0}' -f (Format-NullableValue $portfolio.summary.viHistoryDistributorDependencyExternalBlocker))
+        }
+      }
       if ($portfolio.summary.nextOwnerRepository) {
         $portfolioLines += ('- Next owner: {0}' -f (Format-NullableValue $portfolio.summary.nextOwnerRepository))
       }

--- a/tools/priority/Import-HandoffState.ps1
+++ b/tools/priority/Import-HandoffState.ps1
@@ -310,6 +310,15 @@ if ($governorPortfolioSummary) {
   Write-Host ("  next     : {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.nextAction))
   Write-Host ("  template : {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.templateMonitoringStatus))
   Write-Host ("  proof    : {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.supportedProofStatus))
+  if ($governorPortfolioSummary.summary.PSObject.Properties['viHistoryDistributorDependencyStatus']) {
+    Write-Host ("  vhist    : {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.viHistoryDistributorDependencyStatus))
+    if ($governorPortfolioSummary.summary.PSObject.Properties['viHistoryDistributorDependencyTargetRepository'] -and $governorPortfolioSummary.summary.viHistoryDistributorDependencyTargetRepository) {
+      Write-Host ("  vhistRepo: {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.viHistoryDistributorDependencyTargetRepository))
+    }
+    if ($governorPortfolioSummary.summary.PSObject.Properties['viHistoryDistributorDependencyExternalBlocker'] -and $governorPortfolioSummary.summary.viHistoryDistributorDependencyExternalBlocker) {
+      Write-Host ("  vhistBlk : {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.viHistoryDistributorDependencyExternalBlocker))
+    }
+  }
   if ($governorPortfolioSummary.summary.nextOwnerRepository) {
     Write-Host ("  nextRepo : {0}" -f (Format-NullableValue $governorPortfolioSummary.summary.nextOwnerRepository))
   }

--- a/tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs
@@ -197,6 +197,44 @@ test('planCompareviRuntimeStep keeps queue-empty compare ownership as idle with 
   );
 });
 
+test('planCompareviRuntimeStep explains blocked vi-history distributor dependency during queue-empty compare ownership', async () => {
+  const decision = await compareviRuntimeTest.planCompareviRuntimeStep({
+    repoRoot: '/tmp/repo',
+    env: { GITHUB_REPOSITORY: 'LabVIEW-Community-CI-CD/compare-vi-cli-action' },
+    options: {},
+    deps: {
+      loadDeliveryAgentPolicyFn: async () => ({ implementationRemote: 'origin' }),
+      runMonitoringWorkInjectionFn: async () => ({
+        issueNumber: null,
+        outputPath: '/tmp/repo/tests/results/_agent/issue/monitoring-work-injection.json',
+        ledgerPath: '/tmp/repo/tests/results/_agent/ops/ops-decision-ledger.json'
+      }),
+      classifyNoStandingPriorityConditionFn: async () => ({
+        status: 'classified',
+        reason: 'queue-empty',
+        openIssueCount: 0,
+        message: 'queue empty'
+      }),
+      resolveStandingPriorityForRepoFn: async () => ({ found: null }),
+      readGovernorPortfolioSummaryFn: async () =>
+        createGovernorPortfolioSummary({
+          nextAction: 'complete-compare-vi-history-producer-release',
+          ownerDecisionSource: 'compare-vi-history-distributor-dependency',
+          governorMode: 'monitoring-active',
+          viHistoryDistributorDependencyStatus: 'blocked',
+          viHistoryDistributorDependencyExternalBlocker: 'workflow-signing-secret-missing',
+          viHistoryDistributorDependencyPublicationState: 'unobserved'
+        })
+    }
+  });
+
+  assert.equal(decision.outcome, 'idle');
+  assert.match(decision.reason, /vi-history distributor dependency/i);
+  assert.match(decision.reason, /workflow-signing-secret-missing/i);
+  assert.equal(decision.artifacts.governorPortfolioHandoff.status, 'owner-match');
+  assert.equal(decision.artifacts.governorPortfolioHandoff.viHistoryDistributorDependencyStatus, 'blocked');
+});
+
 test('planCompareviRuntimeStep describes repo-context pivot preparation when compare remains current owner but template is next', async () => {
   const decision = await compareviRuntimeTest.planCompareviRuntimeStep({
     repoRoot: '/tmp/repo',

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -416,6 +416,10 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
       nextAction: null,
       ownerDecisionSource: null,
       governorMode: null,
+      viHistoryDistributorDependencyStatus: null,
+      viHistoryDistributorDependencyTargetRepository: null,
+      viHistoryDistributorDependencyExternalBlocker: null,
+      viHistoryDistributorDependencyPublicationState: null,
       reason: `Unable to read governor portfolio summary: ${error?.message || String(error)}`
     };
   }
@@ -429,6 +433,10 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
       nextAction: null,
       ownerDecisionSource: null,
       governorMode: null,
+      viHistoryDistributorDependencyStatus: null,
+      viHistoryDistributorDependencyTargetRepository: null,
+      viHistoryDistributorDependencyExternalBlocker: null,
+      viHistoryDistributorDependencyPublicationState: null,
       reason: 'Governor portfolio summary is unavailable for queue-empty handoff.'
     };
   }
@@ -442,6 +450,10 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
       nextAction: null,
       ownerDecisionSource: null,
       governorMode: null,
+      viHistoryDistributorDependencyStatus: null,
+      viHistoryDistributorDependencyTargetRepository: null,
+      viHistoryDistributorDependencyExternalBlocker: null,
+      viHistoryDistributorDependencyPublicationState: null,
       reason: 'Governor portfolio summary does not match the expected schema.'
     };
   }
@@ -451,6 +463,14 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
   const nextAction = normalizeText(payload?.summary?.nextAction) || null;
   const ownerDecisionSource = normalizeText(payload?.summary?.ownerDecisionSource) || null;
   const governorMode = normalizeText(payload?.summary?.governorMode) || null;
+  const viHistoryDistributorDependencyStatus =
+    normalizeText(payload?.summary?.viHistoryDistributorDependencyStatus) || null;
+  const viHistoryDistributorDependencyTargetRepository =
+    normalizeText(payload?.summary?.viHistoryDistributorDependencyTargetRepository) || null;
+  const viHistoryDistributorDependencyExternalBlocker =
+    normalizeText(payload?.summary?.viHistoryDistributorDependencyExternalBlocker) || null;
+  const viHistoryDistributorDependencyPublicationState =
+    normalizeText(payload?.summary?.viHistoryDistributorDependencyPublicationState) || null;
 
   if (!currentOwnerRepository || !nextOwnerRepository || !nextAction || !ownerDecisionSource || !governorMode) {
     return {
@@ -461,8 +481,32 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
       nextAction,
       ownerDecisionSource,
       governorMode,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository,
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       reason: 'Governor portfolio summary is missing required owner handoff fields.'
     };
+  }
+
+  let reason = null;
+  if (currentOwnerRepository === repository) {
+    if (viHistoryDistributorDependencyStatus === 'blocked' && viHistoryDistributorDependencyTargetRepository) {
+      reason =
+        `Governor portfolio keeps current ownership in ${currentOwnerRepository} while the vi-history distributor ` +
+        `dependency for ${viHistoryDistributorDependencyTargetRepository} remains blocked` +
+        (viHistoryDistributorDependencyExternalBlocker
+          ? ` (${viHistoryDistributorDependencyExternalBlocker}).`
+          : '.');
+    } else if (viHistoryDistributorDependencyStatus === 'unknown' && viHistoryDistributorDependencyTargetRepository) {
+      reason =
+        `Governor portfolio keeps current ownership in ${currentOwnerRepository} until the vi-history distributor ` +
+        `dependency for ${viHistoryDistributorDependencyTargetRepository} is refreshed.`;
+    } else {
+      reason = `Governor portfolio keeps current ownership in ${currentOwnerRepository}.`;
+    }
+  } else {
+    reason = `Governor portfolio assigns current ownership to ${currentOwnerRepository}.`;
   }
 
   return {
@@ -473,10 +517,11 @@ async function resolveGovernorPortfolioHandoff({ repoRoot, repository, deps = {}
     nextAction,
     ownerDecisionSource,
     governorMode,
-    reason:
-      currentOwnerRepository === repository
-        ? `Governor portfolio keeps current ownership in ${currentOwnerRepository}.`
-        : `Governor portfolio assigns current ownership to ${currentOwnerRepository}.`
+    viHistoryDistributorDependencyStatus,
+    viHistoryDistributorDependencyTargetRepository,
+    viHistoryDistributorDependencyExternalBlocker,
+    viHistoryDistributorDependencyPublicationState,
+    reason
   };
 }
 
@@ -508,8 +553,29 @@ async function resolveGovernorPortfolioPivotExecution({
   const nextAction = normalizeText(governorPortfolioHandoff?.nextAction) || null;
   const ownerDecisionSource = normalizeText(governorPortfolioHandoff?.ownerDecisionSource) || null;
   const governorMode = normalizeText(governorPortfolioHandoff?.governorMode) || null;
+  const viHistoryDistributorDependencyStatus =
+    normalizeText(governorPortfolioHandoff?.viHistoryDistributorDependencyStatus) || null;
+  const viHistoryDistributorDependencyTargetRepository =
+    normalizeText(governorPortfolioHandoff?.viHistoryDistributorDependencyTargetRepository) || null;
+  const viHistoryDistributorDependencyExternalBlocker =
+    normalizeText(governorPortfolioHandoff?.viHistoryDistributorDependencyExternalBlocker) || null;
+  const viHistoryDistributorDependencyPublicationState =
+    normalizeText(governorPortfolioHandoff?.viHistoryDistributorDependencyPublicationState) || null;
 
   if (!nextOwnerRepository || nextOwnerRepository.toLowerCase() === currentRepository.toLowerCase()) {
+    let reason = `Governor portfolio keeps repo-context ownership in ${currentRepository}.`;
+    if (viHistoryDistributorDependencyStatus === 'blocked' && viHistoryDistributorDependencyTargetRepository) {
+      reason =
+        `Governor portfolio keeps repo-context ownership in ${currentRepository} while the vi-history distributor ` +
+        `dependency for ${viHistoryDistributorDependencyTargetRepository} remains blocked` +
+        (viHistoryDistributorDependencyExternalBlocker
+          ? ` (${viHistoryDistributorDependencyExternalBlocker}).`
+          : '.');
+    } else if (viHistoryDistributorDependencyStatus === 'unknown' && viHistoryDistributorDependencyTargetRepository) {
+      reason =
+        `Governor portfolio keeps repo-context ownership in ${currentRepository} until the vi-history distributor ` +
+        `dependency for ${viHistoryDistributorDependencyTargetRepository} is refreshed.`;
+    }
     return {
       status: 'same-repository',
       registryPath: null,
@@ -519,12 +585,16 @@ async function resolveGovernorPortfolioPivotExecution({
       nextAction,
       ownerDecisionSource,
       governorMode,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository,
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       targetEntrypointPath: null,
       targetHeadSha: null,
       targetCheckoutState: null,
       targetReceipts: null,
       targetCurrentState: null,
-      reason: `Governor portfolio keeps repo-context ownership in ${currentRepository}.`
+      reason
     };
   }
 
@@ -538,6 +608,10 @@ async function resolveGovernorPortfolioPivotExecution({
       nextAction,
       ownerDecisionSource,
       governorMode,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository,
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       targetEntrypointPath: null,
       targetHeadSha: null,
       targetCheckoutState: null,
@@ -573,6 +647,10 @@ async function resolveGovernorPortfolioPivotExecution({
       nextAction,
       ownerDecisionSource,
       governorMode,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository,
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       targetEntrypointPath: null,
       targetHeadSha: null,
       targetCheckoutState: null,
@@ -592,6 +670,10 @@ async function resolveGovernorPortfolioPivotExecution({
       nextAction,
       ownerDecisionSource,
       governorMode,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository,
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       targetEntrypointPath: null,
       targetHeadSha: null,
       targetCheckoutState: null,
@@ -611,6 +693,10 @@ async function resolveGovernorPortfolioPivotExecution({
       nextAction,
       ownerDecisionSource,
       governorMode,
+      viHistoryDistributorDependencyStatus,
+      viHistoryDistributorDependencyTargetRepository,
+      viHistoryDistributorDependencyExternalBlocker,
+      viHistoryDistributorDependencyPublicationState,
       targetEntrypointPath: null,
       targetHeadSha: null,
       targetCheckoutState: null,
@@ -649,6 +735,10 @@ async function resolveGovernorPortfolioPivotExecution({
     nextAction,
     ownerDecisionSource,
     governorMode,
+    viHistoryDistributorDependencyStatus,
+    viHistoryDistributorDependencyTargetRepository,
+    viHistoryDistributorDependencyExternalBlocker,
+    viHistoryDistributorDependencyPublicationState,
     targetEntrypointPath: normalizeText(entrypoint.path) || null,
     targetHeadSha: normalizeText(entrypoint.headSha) || null,
     targetCheckoutState: normalizeText(entrypoint.checkoutState) || null,
@@ -1074,7 +1164,16 @@ async function planCompareviRuntimeStepFromLiveStanding({ repoRoot, targetReposi
 
       let reason = classification.message;
       if (governorPortfolioHandoff.status === 'owner-match') {
-        if (
+        if (normalizeText(governorPortfolioHandoff.viHistoryDistributorDependencyStatus) === 'blocked') {
+          const dependencyTarget =
+            normalizeText(governorPortfolioHandoff.viHistoryDistributorDependencyTargetRepository) ||
+            'the canonical template';
+          const dependencyBlocker = normalizeText(governorPortfolioHandoff.viHistoryDistributorDependencyExternalBlocker);
+          reason =
+            `standing queue is empty; governor portfolio keeps ownership in ${governorPortfolioHandoff.currentOwnerRepository} ` +
+            `while the vi-history distributor dependency for ${dependencyTarget} remains blocked` +
+            (dependencyBlocker ? ` (${dependencyBlocker}).` : '.');
+        } else if (
           normalizeText(governorPortfolioHandoff.nextOwnerRepository) &&
           normalizeText(governorPortfolioHandoff.nextOwnerRepository).toLowerCase() !== targetRepository.toLowerCase() &&
           ['future-agent-may-pivot', 'reopen-template-monitoring-work'].includes(


### PR DESCRIPTION
## Summary
- surface the `vi-history` distributor dependency directly in runtime queue-empty handoff metadata
- explain why compare keeps ownership while signed producer-native publication is still blocked
- show the same dependency status in handoff import/display surfaces for future agents

## Validation
- `node --test tools/priority/__tests__/runtime-supervisor-monitoring-work-injection.test.mjs`
- `Invoke-Pester tests/Import-HandoffState.Tests.ps1`
- `pwsh -NoLogo -NoProfile -File tools/Test-AgentHandoffEntryPoint.ps1 -Quiet`
- `git diff --check`
