### PR TITLE
[release]: distinguish signing authority blockers in readiness (#1893)

### DIFF
--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -58,7 +58,9 @@ Configuration path: `Settings -> Environments -> <environment> -> Required revie
    - confirm `tests/results/_agent/release/release-signing-readiness.json` reports:
      - `codePathState = ready`
      - `signingCapabilityState = configured`
-   - if `externalBlocker = workflow-signing-secret-missing|workflow-signing-secret-unverifiable`,
+     - `signingAuthorityState = ready`
+     - `releaseConductorApplyState = enabled`
+   - if `externalBlocker` reports any signing secret, signing authority, or apply-gating blocker,
      treat that as an explicit external blocker and stop before rerunning release publication flows
 7. Verify rollback drill health:
    - `node tools/npm/run-script.mjs priority:rollback:drill:health -- --repo <owner/repo>`
@@ -169,8 +171,11 @@ matching remediation path:
 - `tag-not-annotated`, `tag-signature-unverified`
   - Recreate release tag as a signed annotated tag and rerun release.
 - `workflow-signing-secret-missing`, `workflow-signing-secret-unverifiable`
+- `workflow-signing-admin-scope-missing`, `workflow-signing-key-missing`, `workflow-signing-authority-unverifiable`
+- `release-conductor-apply-disabled`, `release-conductor-apply-unverifiable`
   - Use `node tools/npm/run-script.mjs priority:release:signing:readiness` to confirm the blocker, provision or repair
-    the workflow signing secrets, and only then rerun authoritative release publication.
+    the workflow signing secrets, signing authority, or release-conductor enablement, and only then rerun authoritative
+    release publication.
 - `checksum-invalid-line`, `checksum-empty`, `checksum-entry-missing-file`, `checksum-missing-artifact`, `checksum-mismatch`
   - Regenerate `SHA256SUMS.txt` from fresh artifacts and ensure no post-pack mutation occurred.
 - `sbom-parse-failed`, `sbom-invalid`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -175,10 +175,19 @@ That report distinguishes:
 - `publicationState`
   - whether authoritative signed tag publication has already succeeded
 
-If the report emits `externalBlocker = workflow-signing-secret-missing` or
-`workflow-signing-secret-unverifiable`, promotion remains blocked by external
-signing readiness and release attempts must not be rerun just to rediscover the
-same missing capability.
+If the report emits an external blocker such as:
+
+- `workflow-signing-secret-missing`
+- `workflow-signing-secret-unverifiable`
+- `workflow-signing-admin-scope-missing`
+- `workflow-signing-key-missing`
+- `workflow-signing-authority-unverifiable`
+- `release-conductor-apply-disabled`
+- `release-conductor-apply-unverifiable`
+
+promotion remains blocked by external signing readiness. Repair the specific
+secret, authority, or apply-gating surface first, then refresh readiness
+instead of rerunning release publication just to rediscover the same blocker.
 
 ## Rollback drill health gate
 

--- a/docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json
+++ b/docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json
@@ -190,6 +190,8 @@
               "releaseSigningStatus",
               "releasePublicationState",
               "signingCapabilityState",
+              "signingAuthorityState",
+              "releaseConductorApplyState",
               "externalBlocker",
               "detail"
             ],
@@ -203,6 +205,8 @@
               "releaseSigningStatus": { "type": ["string", "null"] },
               "releasePublicationState": { "type": ["string", "null"] },
               "signingCapabilityState": { "type": ["string", "null"] },
+              "signingAuthorityState": { "type": ["string", "null"] },
+              "releaseConductorApplyState": { "type": ["string", "null"] },
               "externalBlocker": { "type": ["string", "null"] },
               "detail": { "type": "string" }
             }
@@ -244,6 +248,8 @@
         "viHistoryDistributorDependencyTargetRepository",
         "viHistoryDistributorDependencyExternalBlocker",
         "viHistoryDistributorDependencyPublicationState",
+        "viHistoryDistributorDependencySigningAuthorityState",
+        "viHistoryDistributorDependencyReleaseConductorApplyState",
         "portfolioWakeConditionCount",
         "triggeredWakeConditions"
       ],
@@ -268,6 +274,8 @@
         "viHistoryDistributorDependencyTargetRepository": { "type": ["string", "null"] },
         "viHistoryDistributorDependencyExternalBlocker": { "type": ["string", "null"] },
         "viHistoryDistributorDependencyPublicationState": { "type": ["string", "null"] },
+        "viHistoryDistributorDependencySigningAuthorityState": { "type": ["string", "null"] },
+        "viHistoryDistributorDependencyReleaseConductorApplyState": { "type": ["string", "null"] },
         "portfolioWakeConditionCount": { "type": "integer", "minimum": 0 },
         "triggeredWakeConditions": {
           "type": "array",

--- a/docs/schemas/autonomous-governor-summary-report-v1.schema.json
+++ b/docs/schemas/autonomous-governor-summary-report-v1.schema.json
@@ -174,6 +174,8 @@
         "status",
         "codePathState",
         "signingCapabilityState",
+        "signingAuthorityState",
+        "releaseConductorApplyState",
         "publicationState",
         "externalBlocker",
         "blockerCount"
@@ -190,6 +192,8 @@
         },
         "codePathState": { "type": ["string", "null"] },
         "signingCapabilityState": { "type": ["string", "null"] },
+        "signingAuthorityState": { "type": ["string", "null"] },
+        "releaseConductorApplyState": { "type": ["string", "null"] },
         "publicationState": { "type": ["string", "null"] },
         "externalBlocker": { "type": ["string", "null"] },
         "blockerCount": { "type": "integer", "minimum": 0 }
@@ -314,6 +318,8 @@
         "monitoringStatus",
         "futureAgentAction",
         "releaseSigningStatus",
+        "releaseSigningAuthorityState",
+        "releaseConductorApplyState",
         "releaseSigningExternalBlocker",
         "releasePublicationState",
         "queueHandoffStatus",
@@ -364,6 +370,8 @@
             "missing"
           ]
         },
+        "releaseSigningAuthorityState": { "type": ["string", "null"] },
+        "releaseConductorApplyState": { "type": ["string", "null"] },
         "releaseSigningExternalBlocker": { "type": ["string", "null"] },
         "releasePublicationState": { "type": ["string", "null"] },
         "queueHandoffStatus": {

--- a/docs/schemas/release-signing-readiness-report-v1.schema.json
+++ b/docs/schemas/release-signing-readiness-report-v1.schema.json
@@ -11,6 +11,8 @@
     "inputs",
     "workflowContract",
     "secretInventory",
+    "releaseConductorApply",
+    "signingAuthority",
     "publication",
     "summary",
     "blockers"
@@ -89,6 +91,68 @@
         "error": { "type": ["string", "null"] }
       }
     },
+    "releaseConductorApply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "variablePresent",
+        "enabled",
+        "configuredValue",
+        "listedVariableCount",
+        "listedVariableNames",
+        "source",
+        "error"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "disabled",
+            "unverifiable"
+          ]
+        },
+        "variablePresent": { "type": ["boolean", "null"] },
+        "enabled": { "type": ["boolean", "null"] },
+        "configuredValue": { "type": ["string", "null"] },
+        "listedVariableCount": { "type": ["integer", "null"], "minimum": 0 },
+        "listedVariableNames": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "source": { "type": "string", "minLength": 1 },
+        "error": { "type": ["string", "null"] }
+      }
+    },
+    "signingAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "requiredScope",
+        "scopeAvailable",
+        "listedKeyCount",
+        "source",
+        "error"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "ready",
+            "keys-missing",
+            "scope-missing",
+            "unverifiable"
+          ]
+        },
+        "requiredScope": { "type": "string", "minLength": 1 },
+        "scopeAvailable": { "type": ["boolean", "null"] },
+        "listedKeyCount": { "type": ["integer", "null"], "minimum": 0 },
+        "source": { "type": "string", "minLength": 1 },
+        "error": { "type": ["string", "null"] }
+      }
+    },
     "publication": {
       "type": "object",
       "additionalProperties": false,
@@ -120,6 +184,8 @@
         "status",
         "codePathState",
         "signingCapabilityState",
+        "signingAuthorityState",
+        "releaseConductorApplyState",
         "publicationState",
         "externalBlocker",
         "blockerCount"
@@ -147,6 +213,23 @@
             "unverifiable"
           ]
         },
+        "signingAuthorityState": {
+          "type": "string",
+          "enum": [
+            "ready",
+            "keys-missing",
+            "scope-missing",
+            "unverifiable"
+          ]
+        },
+        "releaseConductorApplyState": {
+          "type": "string",
+          "enum": [
+            "enabled",
+            "disabled",
+            "unverifiable"
+          ]
+        },
         "publicationState": {
           "type": "string",
           "enum": [
@@ -164,6 +247,11 @@
           "enum": [
             "workflow-signing-secret-missing",
             "workflow-signing-secret-unverifiable",
+            "workflow-signing-admin-scope-missing",
+            "workflow-signing-key-missing",
+            "workflow-signing-authority-unverifiable",
+            "release-conductor-apply-disabled",
+            "release-conductor-apply-unverifiable",
             null
           ]
         },
@@ -185,7 +273,12 @@
             "enum": [
               "workflow-signing-contract-missing",
               "workflow-signing-secret-missing",
-              "workflow-signing-secret-unverifiable"
+              "workflow-signing-secret-unverifiable",
+              "workflow-signing-admin-scope-missing",
+              "workflow-signing-key-missing",
+              "workflow-signing-authority-unverifiable",
+              "release-conductor-apply-disabled",
+              "release-conductor-apply-unverifiable"
             ]
           },
           "message": { "type": "string", "minLength": 1 }

--- a/tools/priority/__tests__/autonomous-governor-portfolio-summary-schema.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-portfolio-summary-schema.test.mjs
@@ -67,6 +67,16 @@ test('autonomous governor portfolio summary schema validates a generated report'
       queueState: { status: 'queue-empty', reason: 'queue-empty', openIssueCount: 0, ready: true },
       continuity: { status: 'maintained', turnBoundary: 'safe-idle', supervisionState: 'idle-monitoring', operatorPromptRequiredToResume: false },
       monitoringMode: { status: 'active', futureAgentAction: 'future-agent-may-pivot', wakeConditionCount: 0 },
+      releaseSigningReadiness: {
+        status: 'missing',
+        codePathState: null,
+        signingCapabilityState: null,
+        signingAuthorityState: null,
+        releaseConductorApplyState: null,
+        publicationState: null,
+        externalBlocker: null,
+        blockerCount: 0
+      },
       deliveryRuntime: {
         status: 'checks-pending',
         runtimeStatus: 'waiting-ci',
@@ -117,6 +127,11 @@ test('autonomous governor portfolio summary schema validates a generated report'
       wakeTerminalState: 'monitoring',
       monitoringStatus: 'active',
       futureAgentAction: 'future-agent-may-pivot',
+      releaseSigningStatus: 'missing',
+      releaseSigningAuthorityState: null,
+      releaseConductorApplyState: null,
+      releaseSigningExternalBlocker: null,
+      releasePublicationState: null,
       queueHandoffStatus: 'checks-pending',
       queueHandoffNextWakeCondition: 'checks-green',
       queueHandoffPrUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864',

--- a/tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs
@@ -47,6 +47,8 @@ function createCompareGovernorSummary(overrides = {}) {
         status: 'warn',
         codePathState: 'ready',
         signingCapabilityState: 'missing',
+        signingAuthorityState: 'scope-missing',
+        releaseConductorApplyState: 'disabled',
         publicationState: 'unobserved',
         externalBlocker: 'workflow-signing-secret-missing'
       }
@@ -93,6 +95,8 @@ function createCompareGovernorSummary(overrides = {}) {
       queueHandoffPrUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864',
       queueAuthoritySource: 'delivery-runtime',
       releaseSigningStatus: 'warn',
+      releaseSigningAuthorityState: 'scope-missing',
+      releaseConductorApplyState: 'disabled',
       releaseSigningExternalBlocker: 'workflow-signing-secret-missing',
       releasePublicationState: 'unobserved'
     },
@@ -322,6 +326,8 @@ test('runAutonomousGovernorPortfolioSummary keeps compare as owner during active
     'workflow-signing-secret-missing'
   );
   assert.equal(report.summary.viHistoryDistributorDependencyPublicationState, 'unobserved');
+  assert.equal(report.summary.viHistoryDistributorDependencySigningAuthorityState, 'scope-missing');
+  assert.equal(report.summary.viHistoryDistributorDependencyReleaseConductorApplyState, 'disabled');
   assert.equal(report.compare.queueHandoffPrUrl, 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864');
   assert.equal(report.compare.queueAuthoritySource, 'delivery-runtime');
   assert.equal(report.portfolio.repositoryCount, 4);
@@ -336,6 +342,8 @@ test('runAutonomousGovernorPortfolioSummary keeps compare as owner during active
       releaseSigningStatus: 'warn',
       releasePublicationState: 'unobserved',
       signingCapabilityState: 'missing',
+      signingAuthorityState: 'scope-missing',
+      releaseConductorApplyState: 'disabled',
       externalBlocker: 'workflow-signing-secret-missing',
       detail: 'awaiting-compare-release-signing-blocker-clear'
     }
@@ -365,6 +373,15 @@ test('runAutonomousGovernorPortfolioSummary routes ownership to canonical templa
         status: 'blocked',
         futureAgentAction: 'reopen-template-monitoring-work',
         wakeConditionCount: 1
+      },
+      releaseSigningReadiness: {
+        status: 'warn',
+        codePathState: 'ready',
+        signingCapabilityState: 'missing',
+        signingAuthorityState: 'scope-missing',
+        releaseConductorApplyState: 'disabled',
+        publicationState: 'unobserved',
+        externalBlocker: 'workflow-signing-secret-missing'
       }
     },
     wake: {
@@ -391,7 +408,16 @@ test('runAutonomousGovernorPortfolioSummary routes ownership to canonical templa
       continuityStatus: 'maintained',
       wakeTerminalState: 'monitoring',
       monitoringStatus: 'blocked',
-      futureAgentAction: 'reopen-template-monitoring-work'
+      futureAgentAction: 'reopen-template-monitoring-work',
+      releaseSigningStatus: 'warn',
+      releaseSigningAuthorityState: 'scope-missing',
+      releaseConductorApplyState: 'disabled',
+      releaseSigningExternalBlocker: 'workflow-signing-secret-missing',
+      releasePublicationState: 'unobserved',
+      queueHandoffStatus: 'none',
+      queueHandoffNextWakeCondition: null,
+      queueHandoffPrUrl: null,
+      queueAuthoritySource: 'none'
     }
   });
   const monitoringMode = createMonitoringMode({
@@ -477,6 +503,8 @@ test('runAutonomousGovernorPortfolioSummary keeps next owner on compare while vi
         status: 'warn',
         codePathState: 'ready',
         signingCapabilityState: 'missing',
+        signingAuthorityState: 'scope-missing',
+        releaseConductorApplyState: 'disabled',
         publicationState: 'unobserved',
         externalBlocker: 'workflow-signing-secret-missing'
       }
@@ -511,6 +539,8 @@ test('runAutonomousGovernorPortfolioSummary keeps next owner on compare while vi
       queueHandoffPrUrl: null,
       queueAuthoritySource: 'none',
       releaseSigningStatus: 'warn',
+      releaseSigningAuthorityState: 'scope-missing',
+      releaseConductorApplyState: 'disabled',
       releaseSigningExternalBlocker: 'workflow-signing-secret-missing',
       releasePublicationState: 'unobserved'
     }
@@ -563,7 +593,9 @@ test('runAutonomousGovernorPortfolioSummary flips next owner to template once vi
       releaseSigningReadiness: {
         status: 'pass',
         codePathState: 'ready',
-        signingCapabilityState: 'ready',
+        signingCapabilityState: 'configured',
+        signingAuthorityState: 'ready',
+        releaseConductorApplyState: 'enabled',
         publicationState: 'producer-native-ready',
         externalBlocker: null
       }
@@ -598,6 +630,8 @@ test('runAutonomousGovernorPortfolioSummary flips next owner to template once vi
       queueHandoffPrUrl: null,
       queueAuthoritySource: 'none',
       releaseSigningStatus: 'pass',
+      releaseSigningAuthorityState: 'ready',
+      releaseConductorApplyState: 'enabled',
       releaseSigningExternalBlocker: null,
       releasePublicationState: 'producer-native-ready'
     }

--- a/tools/priority/__tests__/autonomous-governor-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-summary.test.mjs
@@ -120,6 +120,24 @@ function createReleaseSigningReadiness(overrides = {}) {
       source: 'github-actions-secrets-api',
       error: null
     },
+    releaseConductorApply: {
+      status: 'disabled',
+      variablePresent: false,
+      enabled: false,
+      configuredValue: null,
+      listedVariableCount: 0,
+      listedVariableNames: [],
+      source: 'github-actions-variables-api',
+      error: null
+    },
+    signingAuthority: {
+      status: 'scope-missing',
+      requiredScope: 'admin:ssh_signing_key',
+      scopeAvailable: false,
+      listedKeyCount: null,
+      source: 'github-user-ssh-signing-keys-api',
+      error: 'This API operation needs the \"admin:ssh_signing_key\" scope.'
+    },
     publication: {
       status: 'tag-created-not-pushed',
       tagCreated: true,
@@ -130,14 +148,24 @@ function createReleaseSigningReadiness(overrides = {}) {
       status: 'warn',
       codePathState: 'ready',
       signingCapabilityState: 'missing',
+      signingAuthorityState: 'scope-missing',
+      releaseConductorApplyState: 'disabled',
       publicationState: 'tag-created-not-pushed',
       externalBlocker: 'workflow-signing-secret-missing',
-      blockerCount: 1
+      blockerCount: 3
     },
     blockers: [
       {
         code: 'workflow-signing-secret-missing',
         message: 'RELEASE_TAG_SIGNING_PRIVATE_KEY is not configured for the repository Actions secrets surface.'
+      },
+      {
+        code: 'release-conductor-apply-disabled',
+        message: 'RELEASE_CONDUCTOR_ENABLED is not set to 1 for the repository Actions variable surface.'
+      },
+      {
+        code: 'workflow-signing-admin-scope-missing',
+        message: 'admin:ssh_signing_key is not available to the current automation identity, so SSH signing-key authority cannot be verified or managed.'
       }
     ],
     ...overrides
@@ -338,9 +366,13 @@ test('runAutonomousGovernorSummary carries explicit release signing blocker stat
   assert.equal(report.compare.releaseSigningReadiness.status, 'warn');
   assert.equal(report.compare.releaseSigningReadiness.codePathState, 'ready');
   assert.equal(report.compare.releaseSigningReadiness.signingCapabilityState, 'missing');
+  assert.equal(report.compare.releaseSigningReadiness.signingAuthorityState, 'scope-missing');
+  assert.equal(report.compare.releaseSigningReadiness.releaseConductorApplyState, 'disabled');
   assert.equal(report.compare.releaseSigningReadiness.publicationState, 'tag-created-not-pushed');
   assert.equal(report.compare.releaseSigningReadiness.externalBlocker, 'workflow-signing-secret-missing');
   assert.equal(report.summary.releaseSigningStatus, 'warn');
+  assert.equal(report.summary.releaseSigningAuthorityState, 'scope-missing');
+  assert.equal(report.summary.releaseConductorApplyState, 'disabled');
   assert.equal(report.summary.releaseSigningExternalBlocker, 'workflow-signing-secret-missing');
   assert.equal(report.summary.releasePublicationState, 'tag-created-not-pushed');
 });

--- a/tools/priority/__tests__/release-signing-readiness-schema.test.mjs
+++ b/tools/priority/__tests__/release-signing-readiness-schema.test.mjs
@@ -75,9 +75,19 @@ test('release signing readiness report matches schema', async () => {
     },
     {
       now: new Date('2026-03-23T17:30:00Z'),
-      runGhJsonFn: () => ({
-        secrets: [{ name: 'RELEASE_TAG_SIGNING_PRIVATE_KEY' }]
-      })
+      runGhJsonFn: (args) => {
+        const endpoint = args[1] ?? '';
+        if (endpoint.includes('/actions/secrets')) {
+          return { secrets: [{ name: 'RELEASE_TAG_SIGNING_PRIVATE_KEY' }] };
+        }
+        if (endpoint.includes('/actions/variables')) {
+          return { variables: [{ name: 'RELEASE_CONDUCTOR_ENABLED', value: '1' }] };
+        }
+        if (endpoint.startsWith('user/ssh_signing_keys')) {
+          return [{ id: 1, title: 'compare-release-signing' }];
+        }
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
     }
   );
 

--- a/tools/priority/__tests__/release-signing-readiness.test.mjs
+++ b/tools/priority/__tests__/release-signing-readiness.test.mjs
@@ -75,9 +75,19 @@ test('runReleaseSigningReadiness reports explicit external blocker when workflow
     },
     {
       now: new Date('2026-03-23T17:20:00Z'),
-      runGhJsonFn: () => ({
-        secrets: [{ name: 'GH_TOKEN' }]
-      })
+      runGhJsonFn: (args) => {
+        const endpoint = args[1] ?? '';
+        if (endpoint.includes('/actions/secrets')) {
+          return { secrets: [{ name: 'GH_TOKEN' }] };
+        }
+        if (endpoint.includes('/actions/variables')) {
+          return { variables: [] };
+        }
+        if (endpoint.startsWith('user/ssh_signing_keys')) {
+          throw new Error('This API operation needs the "admin:ssh_signing_key" scope.');
+        }
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
     }
   );
 
@@ -85,10 +95,18 @@ test('runReleaseSigningReadiness reports explicit external blocker when workflow
   assert.equal(result.report.summary.status, 'warn');
   assert.equal(result.report.summary.codePathState, 'ready');
   assert.equal(result.report.summary.signingCapabilityState, 'missing');
+  assert.equal(result.report.summary.signingAuthorityState, 'scope-missing');
+  assert.equal(result.report.summary.releaseConductorApplyState, 'disabled');
   assert.equal(result.report.summary.publicationState, 'unobserved');
   assert.equal(result.report.summary.externalBlocker, 'workflow-signing-secret-missing');
   assert.equal(result.report.secretInventory.requiredSecretPresent, false);
-  assert.deepEqual(result.report.blockers.map((entry) => entry.code), ['workflow-signing-secret-missing']);
+  assert.equal(result.report.releaseConductorApply.status, 'disabled');
+  assert.equal(result.report.signingAuthority.status, 'scope-missing');
+  assert.deepEqual(result.report.blockers.map((entry) => entry.code), [
+    'workflow-signing-secret-missing',
+    'release-conductor-apply-disabled',
+    'workflow-signing-admin-scope-missing'
+  ]);
 });
 
 test('runReleaseSigningReadiness reports publication success when signing capability is configured', async () => {
@@ -109,9 +127,19 @@ test('runReleaseSigningReadiness reports publication success when signing capabi
     },
     {
       now: new Date('2026-03-23T17:21:00Z'),
-      runGhJsonFn: () => ({
-        secrets: [{ name: REQUIRED_SIGNING_SECRET }, { name: OPTIONAL_SIGNING_SECRET }]
-      })
+      runGhJsonFn: (args) => {
+        const endpoint = args[1] ?? '';
+        if (endpoint.includes('/actions/secrets')) {
+          return { secrets: [{ name: REQUIRED_SIGNING_SECRET }, { name: OPTIONAL_SIGNING_SECRET }] };
+        }
+        if (endpoint.includes('/actions/variables')) {
+          return { variables: [{ name: 'RELEASE_CONDUCTOR_ENABLED', value: '1' }] };
+        }
+        if (endpoint.startsWith('user/ssh_signing_keys')) {
+          return [{ id: 1, title: 'compare-release-signing' }];
+        }
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
     }
   );
 
@@ -119,9 +147,13 @@ test('runReleaseSigningReadiness reports publication success when signing capabi
   assert.equal(result.report.summary.status, 'pass');
   assert.equal(result.report.summary.codePathState, 'ready');
   assert.equal(result.report.summary.signingCapabilityState, 'configured');
+  assert.equal(result.report.summary.signingAuthorityState, 'ready');
+  assert.equal(result.report.summary.releaseConductorApplyState, 'enabled');
   assert.equal(result.report.summary.publicationState, 'authoritative-publication-successful');
   assert.equal(result.report.summary.externalBlocker, null);
   assert.equal(result.report.secretInventory.requiredSecretPresent, true);
+  assert.equal(result.report.releaseConductorApply.enabled, true);
+  assert.equal(result.report.signingAuthority.listedKeyCount, 1);
   assert.equal(result.report.publication.targetTag, 'v0.6.4-rc.1');
   assert.deepEqual(result.report.blockers, []);
 });

--- a/tools/priority/autonomous-governor-portfolio-summary.mjs
+++ b/tools/priority/autonomous-governor-portfolio-summary.mjs
@@ -153,6 +153,12 @@ function deriveViHistoryDistributorDependency(compareGovernorSummary, monitoring
     asOptional(compareGovernorSummary?.summary?.releasePublicationState) ||
     asOptional(releaseSigningReadiness?.publicationState);
   const signingCapabilityState = asOptional(releaseSigningReadiness?.signingCapabilityState);
+  const signingAuthorityState =
+    asOptional(compareGovernorSummary?.summary?.releaseSigningAuthorityState) ||
+    asOptional(releaseSigningReadiness?.signingAuthorityState);
+  const releaseConductorApplyState =
+    asOptional(compareGovernorSummary?.summary?.releaseConductorApplyState) ||
+    asOptional(releaseSigningReadiness?.releaseConductorApplyState);
   const externalBlocker =
     asOptional(compareGovernorSummary?.summary?.releaseSigningExternalBlocker) ||
     asOptional(releaseSigningReadiness?.externalBlocker);
@@ -179,6 +185,8 @@ function deriveViHistoryDistributorDependency(compareGovernorSummary, monitoring
     releaseSigningStatus,
     releasePublicationState,
     signingCapabilityState,
+    signingAuthorityState,
+    releaseConductorApplyState,
     externalBlocker,
     detail
   };
@@ -422,6 +430,8 @@ function buildReport({
       viHistoryDistributorDependencyTargetRepository: viHistoryDistributorDependency.dependentRepository,
       viHistoryDistributorDependencyExternalBlocker: viHistoryDistributorDependency.externalBlocker,
       viHistoryDistributorDependencyPublicationState: viHistoryDistributorDependency.releasePublicationState,
+      viHistoryDistributorDependencySigningAuthorityState: viHistoryDistributorDependency.signingAuthorityState,
+      viHistoryDistributorDependencyReleaseConductorApplyState: viHistoryDistributorDependency.releaseConductorApplyState,
       portfolioWakeConditionCount: triggeredWakeConditions.length,
       triggeredWakeConditions
     }

--- a/tools/priority/autonomous-governor-summary.mjs
+++ b/tools/priority/autonomous-governor-summary.mjs
@@ -344,6 +344,8 @@ function deriveReleaseSigningReadiness(releaseSigningReadinessReport) {
       status: 'missing',
       codePathState: null,
       signingCapabilityState: null,
+      signingAuthorityState: null,
+      releaseConductorApplyState: null,
       publicationState: null,
       externalBlocker: null,
       blockerCount: 0
@@ -354,6 +356,8 @@ function deriveReleaseSigningReadiness(releaseSigningReadinessReport) {
     status: asOptional(releaseSigningReadinessReport?.summary?.status) || 'missing',
     codePathState: asOptional(releaseSigningReadinessReport?.summary?.codePathState),
     signingCapabilityState: asOptional(releaseSigningReadinessReport?.summary?.signingCapabilityState),
+    signingAuthorityState: asOptional(releaseSigningReadinessReport?.summary?.signingAuthorityState),
+    releaseConductorApplyState: asOptional(releaseSigningReadinessReport?.summary?.releaseConductorApplyState),
     publicationState: asOptional(releaseSigningReadinessReport?.summary?.publicationState),
     externalBlocker: asOptional(releaseSigningReadinessReport?.summary?.externalBlocker),
     blockerCount: Number.isInteger(releaseSigningReadinessReport?.summary?.blockerCount)
@@ -710,6 +714,8 @@ function buildReport({
       monitoringStatus: asOptional(monitoringMode?.summary?.status),
       futureAgentAction: asOptional(monitoringMode?.summary?.futureAgentAction),
       releaseSigningStatus: releaseSigningReadiness.status,
+      releaseSigningAuthorityState: releaseSigningReadiness.signingAuthorityState,
+      releaseConductorApplyState: releaseSigningReadiness.releaseConductorApplyState,
       releaseSigningExternalBlocker: releaseSigningReadiness.externalBlocker,
       releasePublicationState: releaseSigningReadiness.publicationState,
       queueHandoffStatus: queueAuthority.status,

--- a/tools/priority/release-signing-readiness.mjs
+++ b/tools/priority/release-signing-readiness.mjs
@@ -23,6 +23,8 @@ export const DEFAULT_RELEASE_CONDUCTOR_REPORT_PATH = path.join(
 );
 export const REQUIRED_SIGNING_SECRET = 'RELEASE_TAG_SIGNING_PRIVATE_KEY';
 export const OPTIONAL_SIGNING_SECRET = 'RELEASE_TAG_SIGNING_PUBLIC_KEY';
+export const REQUIRED_SIGNING_SCOPE = 'admin:ssh_signing_key';
+export const RELEASE_CONDUCTOR_ENABLE_VARIABLE = 'RELEASE_CONDUCTOR_ENABLED';
 
 function asOptional(value) {
   if (value == null) {
@@ -184,6 +186,42 @@ function normalizeSecretInventory(payload) {
   };
 }
 
+function normalizeVariableInventory(payload) {
+  const variables = Array.isArray(payload?.variables) ? payload.variables : [];
+  const values = new Map(
+    variables
+      .map((entry) => [String(entry?.name ?? '').trim(), asOptional(entry?.value)])
+      .filter(([name]) => Boolean(name))
+  );
+  const configuredValue = values.get(RELEASE_CONDUCTOR_ENABLE_VARIABLE) ?? null;
+  const enabled = configuredValue === '1';
+  return {
+    status: enabled ? 'enabled' : 'disabled',
+    variablePresent: values.has(RELEASE_CONDUCTOR_ENABLE_VARIABLE),
+    enabled,
+    configuredValue,
+    listedVariableCount: variables.length,
+    listedVariableNames: Array.from(values.keys()).sort()
+  };
+}
+
+function normalizeSigningAuthority(payload) {
+  const keys = Array.isArray(payload) ? payload : Array.isArray(payload?.ssh_signing_keys) ? payload.ssh_signing_keys : [];
+  return {
+    status: keys.length > 0 ? 'ready' : 'keys-missing',
+    requiredScope: REQUIRED_SIGNING_SCOPE,
+    scopeAvailable: true,
+    listedKeyCount: keys.length
+  };
+}
+
+function hasMissingScopeError(message, scope) {
+  if (!message || !scope) {
+    return false;
+  }
+  return message.includes(scope) || message.includes(`"${scope}"`);
+}
+
 function derivePublicationState(conductorReport) {
   const release = conductorReport?.release ?? null;
   if (!release) {
@@ -219,9 +257,9 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
   const now = deps.now ?? new Date();
 
   const workflowContract = hasSigningWorkflowContract(repoRoot);
+  const [owner, repo] = repository.split('/');
   let secretInventory;
   try {
-    const [owner, repo] = repository.split('/');
     const payload = runGhJsonFn(['api', `repos/${owner}/${repo}/actions/secrets?per_page=100`], { cwd: repoRoot });
     secretInventory = {
       ...normalizeSecretInventory(payload),
@@ -237,6 +275,48 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
       listedSecretNames: [],
       source: 'github-actions-secrets-api',
       error: error?.message ?? String(error)
+    };
+  }
+
+  let releaseConductorApply;
+  try {
+    const payload = runGhJsonFn(['api', `repos/${owner}/${repo}/actions/variables?per_page=100`], { cwd: repoRoot });
+    releaseConductorApply = {
+      ...normalizeVariableInventory(payload),
+      source: 'github-actions-variables-api',
+      error: null
+    };
+  } catch (error) {
+    releaseConductorApply = {
+      status: 'unverifiable',
+      variablePresent: null,
+      enabled: null,
+      configuredValue: null,
+      listedVariableCount: null,
+      listedVariableNames: [],
+      source: 'github-actions-variables-api',
+      error: error?.message ?? String(error)
+    };
+  }
+
+  let signingAuthority;
+  try {
+    const payload = runGhJsonFn(['api', 'user/ssh_signing_keys?per_page=100'], { cwd: repoRoot });
+    signingAuthority = {
+      ...normalizeSigningAuthority(payload),
+      source: 'github-user-ssh-signing-keys-api',
+      error: null
+    };
+  } catch (error) {
+    const message = error?.message ?? String(error);
+    const scopeMissing = hasMissingScopeError(message, REQUIRED_SIGNING_SCOPE);
+    signingAuthority = {
+      status: scopeMissing ? 'scope-missing' : 'unverifiable',
+      requiredScope: REQUIRED_SIGNING_SCOPE,
+      scopeAvailable: scopeMissing ? false : null,
+      listedKeyCount: null,
+      source: 'github-user-ssh-signing-keys-api',
+      error: message
     };
   }
 
@@ -261,6 +341,43 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
       message: 'Unable to verify repository Actions secrets from the current automation identity.'
     });
   }
+  if (releaseConductorApply.status === 'disabled') {
+    blockers.push({
+      code: 'release-conductor-apply-disabled',
+      message: `${RELEASE_CONDUCTOR_ENABLE_VARIABLE} is not set to 1 for the repository Actions variable surface.`
+    });
+  } else if (releaseConductorApply.status === 'unverifiable') {
+    blockers.push({
+      code: 'release-conductor-apply-unverifiable',
+      message: 'Unable to verify release conductor apply gating from the current automation identity.'
+    });
+  }
+  if (signingAuthority.status === 'keys-missing') {
+    blockers.push({
+      code: 'workflow-signing-key-missing',
+      message: 'Authenticated identity can inspect SSH signing keys, but no SSH signing key is currently registered.'
+    });
+  } else if (signingAuthority.status === 'scope-missing') {
+    blockers.push({
+      code: 'workflow-signing-admin-scope-missing',
+      message: `${REQUIRED_SIGNING_SCOPE} is not available to the current automation identity, so SSH signing-key authority cannot be verified or managed.`
+    });
+  } else if (signingAuthority.status === 'unverifiable') {
+    blockers.push({
+      code: 'workflow-signing-authority-unverifiable',
+      message: 'Unable to verify SSH signing-key authority for the current automation identity.'
+    });
+  }
+
+  const externalBlockerPriority = [
+    'workflow-signing-secret-missing',
+    'workflow-signing-secret-unverifiable',
+    'workflow-signing-admin-scope-missing',
+    'workflow-signing-key-missing',
+    'workflow-signing-authority-unverifiable',
+    'release-conductor-apply-disabled',
+    'release-conductor-apply-unverifiable'
+  ];
 
   const summary = {
     status: blockers.length === 0 ? 'pass' : 'warn',
@@ -271,10 +388,10 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
         : secretInventory.status === 'missing'
           ? 'missing'
           : 'unverifiable',
+    signingAuthorityState: signingAuthority.status,
+    releaseConductorApplyState: releaseConductorApply.status,
     publicationState: publication.status,
-    externalBlocker:
-      blockers.find((entry) => entry.code === 'workflow-signing-secret-missing' || entry.code === 'workflow-signing-secret-unverifiable')
-        ?.code ?? null,
+    externalBlocker: externalBlockerPriority.find((code) => blockers.some((entry) => entry.code === code)) ?? null,
     blockerCount: blockers.length
   };
 
@@ -291,6 +408,8 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
       reasons: workflowContract.reasons
     },
     secretInventory,
+    releaseConductorApply,
+    signingAuthority,
     publication,
     summary,
     blockers


### PR DESCRIPTION
## Summary
- distinguish repository signing material, signing-authority scope, and release-conductor apply gating in release readiness
- carry the richer signing blocker state into governor and portfolio summaries
- update release docs so the external blocker contract matches the machine-readable receipts

## Testing
- `node --test tools/priority/__tests__/release-signing-readiness.test.mjs tools/priority/__tests__/release-signing-readiness-schema.test.mjs tools/priority/__tests__/autonomous-governor-summary.test.mjs tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs tools/priority/__tests__/autonomous-governor-portfolio-summary-schema.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`

Closes #1893
