### PR TITLE
[release] add repair mode for existing unsigned tags (#1895)

### DIFF
--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: false
         type: boolean
+      repair_existing_tag:
+        description: 'Repair an existing authoritative tag as a signed annotated tag'
+        required: false
+        default: false
+        type: boolean
       channel:
         description: 'Release channel'
         required: false
@@ -138,6 +143,10 @@ jobs:
             $args += '--apply'
           } else {
             $args += '--dry-run'
+          }
+
+          if ('${{ inputs.repair_existing_tag }}' -eq 'true') {
+            $args += '--repair-existing-tag'
           }
 
           $channelInput = '${{ inputs.channel }}'

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -151,6 +151,12 @@ Before relying on a local workstation tag, prefer the release conductor
 automation path:
 
 - run `.github/workflows/release-conductor.yml` in apply mode
+- if the authoritative release tag already exists but the trust gate reports
+  `tag-not-annotated` or `tag-signature-unverified`, rerun
+  `.github/workflows/release-conductor.yml` with:
+  - the target `version`
+  - `apply = true`
+  - `repair_existing_tag = true`
 - provision `RELEASE_TAG_SIGNING_PRIVATE_KEY` and optional
   `RELEASE_TAG_SIGNING_PUBLIC_KEY` for workflow-owned signing
 - inspect `tests/results/_agent/release/release-conductor-report.json`
@@ -158,6 +164,9 @@ automation path:
 - require both:
   - `release.tagCreated = true`
   - `release.tagPushed = true`
+  - when repair mode is used:
+    - `release.repair.status = repaired`
+    - `release.repair.remoteTargetCommitOid` matches the authoritative commit
 
 When the release trust gate fails, inspect `tests/results/_agent/supply-chain/release-trust-gate.json` and follow the
 matching remediation path:
@@ -169,7 +178,13 @@ matching remediation path:
 - `tag-signature-cli-unavailable`
   - Restore GitHub CLI availability on runner and retry release.
 - `tag-not-annotated`, `tag-signature-unverified`
-  - Recreate release tag as a signed annotated tag and rerun release.
+  - Use `node tools/npm/run-script.mjs priority:release:signing:readiness`
+    first.
+  - If signing readiness is `ready`, run the release conductor in repair mode
+    for the target version so the authoritative tag is recreated as a signed
+    annotated tag without changing the intended release commit.
+  - Rerun release only after the repair report shows
+    `release.repair.status = repaired`.
 - `workflow-signing-secret-missing`, `workflow-signing-secret-unverifiable`
 - `workflow-signing-admin-scope-missing`, `workflow-signing-key-missing`, `workflow-signing-authority-unverifiable`
 - `release-conductor-apply-disabled`, `release-conductor-apply-unverifiable`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -154,6 +154,8 @@ plane:
   - signing backend/source
   - whether the tag was created
   - whether the tag was pushed authoritatively
+  - whether repair mode was requested/performed for an existing tag
+  - the authoritative remote tag object/commit used for repair
   - any push failure blocker
 
 ## Workflow signing readiness

--- a/docs/schemas/release-conductor-report-v1.schema.json
+++ b/docs/schemas/release-conductor-report-v1.schema.json
@@ -50,7 +50,8 @@
         "tagError",
         "tagPushError",
         "tagPushRemote",
-        "signingMaterial"
+        "signingMaterial",
+        "repair"
       ],
       "properties": {
         "stream": { "type": "string" },
@@ -81,6 +82,41 @@
             "signingKey": { "type": ["string", "null"] },
             "source": { "type": "string" },
             "backend": { "type": "string" }
+          }
+        },
+        "repair": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requested",
+            "status",
+            "remoteTagRef",
+            "remoteTagExists",
+            "remoteTagAnnotated",
+            "remoteTagObjectOid",
+            "remoteTargetCommitOid",
+            "localTagPresent",
+            "localTagDeleted",
+            "tagRecreated",
+            "pushLeaseExpectedOid",
+            "lookupError"
+          ],
+          "properties": {
+            "requested": { "type": "boolean" },
+            "status": {
+              "type": "string",
+              "enum": ["not-requested", "repair-available", "ready", "repaired", "blocked"]
+            },
+            "remoteTagRef": { "type": ["string", "null"] },
+            "remoteTagExists": { "type": "boolean" },
+            "remoteTagAnnotated": { "type": ["boolean", "null"] },
+            "remoteTagObjectOid": { "type": ["string", "null"] },
+            "remoteTargetCommitOid": { "type": ["string", "null"] },
+            "localTagPresent": { "type": "boolean" },
+            "localTagDeleted": { "type": "boolean" },
+            "tagRecreated": { "type": "boolean" },
+            "pushLeaseExpectedOid": { "type": ["string", "null"] },
+            "lookupError": { "type": ["string", "null"] }
           }
         }
       }

--- a/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
@@ -12,6 +12,8 @@ test('release conductor workflow keeps workflow_run proposal-only when apply mod
   const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release-conductor.yml');
   const workflow = await readFile(workflowPath, 'utf8');
 
+  assert.match(workflow, /repair_existing_tag:/);
+  assert.match(workflow, /description:\s+'Repair an existing authoritative tag as a signed annotated tag'/);
   assert.match(workflow, /RELEASE_CONDUCTOR_ENABLED:\s+\$\{\{\s*vars\.RELEASE_CONDUCTOR_ENABLED \|\| '0'\s*\}\}/);
   assert.match(workflow, /name:\s+Configure release tag signing material/);
   assert.match(workflow, /if \[\[ -z "\$\{RELEASE_TAG_SIGNING_PRIVATE_KEY:-\}" \]\]; then/);
@@ -25,4 +27,5 @@ test('release conductor workflow keeps workflow_run proposal-only when apply mod
   );
   assert.match(workflow, /RELEASE_TAG_SIGNING_BACKEND:\s+\$\{\{\s*env\.RELEASE_TAG_SIGNING_BACKEND \|\| ''\s*\}\}/);
   assert.match(workflow, /RELEASE_TAG_SIGNING_SOURCE:\s+\$\{\{\s*env\.RELEASE_TAG_SIGNING_SOURCE \|\| ''\s*\}\}/);
+  assert.match(workflow, /if \('\$\{\{\s*inputs\.repair_existing_tag\s*\}\}' -eq 'true'\) \{\s+\$args \+= '--repair-existing-tag'\s+\}/ms);
 });

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -40,6 +40,7 @@ test('parseArgs applies defaults and supports burst-style apply flags', () => {
   const defaults = parseArgs(['node', 'release-conductor.mjs']);
   assert.equal(defaults.apply, false);
   assert.equal(defaults.dryRun, true);
+  assert.equal(defaults.repairExistingTag, false);
   assert.equal(defaults.channel, 'stable');
   assert.equal(defaults.dwellMinutes, 60);
 
@@ -47,6 +48,7 @@ test('parseArgs applies defaults and supports burst-style apply flags', () => {
     'node',
     'release-conductor.mjs',
     '--apply',
+    '--repair-existing-tag',
     '--repo',
     'owner/repo',
     '--channel',
@@ -60,6 +62,7 @@ test('parseArgs applies defaults and supports burst-style apply flags', () => {
   ]);
   assert.equal(parsed.apply, true);
   assert.equal(parsed.dryRun, false);
+  assert.equal(parsed.repairExistingTag, true);
   assert.equal(parsed.repo, 'owner/repo');
   assert.equal(parsed.channel, 'rc');
   assert.equal(parsed.version, '0.8.0-rc.1');
@@ -118,6 +121,18 @@ test('gate evaluators classify pass/fail deterministically', () => {
   });
   assert.equal(quarantineFail.status, 'fail');
   assert.equal(quarantineFail.staleCount, 1);
+
+  const quarantineUnavailable = evaluateQuarantineGate({
+    now,
+    staleHours: 12,
+    queueReportEnvelope: {
+      exists: false,
+      error: null,
+      payload: null
+    }
+  });
+  assert.equal(quarantineUnavailable.status, 'fail');
+  assert.equal(quarantineUnavailable.staleHours, 12);
 });
 
 test('runReleaseConductor blocks apply when release conductor flag is disabled', async () => {
@@ -442,6 +457,337 @@ test('runReleaseConductor creates and publishes a signed tag when apply is enabl
   assert.equal(report.release.signingMaterial.backend, 'ssh');
   assert.ok(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'));
   assert.ok(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'push'));
+});
+
+test('runReleaseConductor blocks apply when authoritative tag already exists and repair mode is not requested', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      if (args[2] === 'user.signingkey') {
+        return { status: 0, stdout: '/tmp/release-signing.pub', stderr: '' };
+      }
+      if (args[2] === 'gpg.format') {
+        return { status: 0, stdout: 'ssh', stderr: '' };
+      }
+      if (args[2] === 'remote.upstream.url') {
+        return { status: 0, stdout: 'https://github.com/owner/repo.git', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'missing config' };
+    }
+    if (command === 'git' && args[0] === 'ls-remote') {
+      return {
+        status: 0,
+        stdout: [
+          '1111111111111111111111111111111111111111\trefs/tags/v0.8.0-rc.1',
+          '2222222222222222222222222222222222222222\trefs/tags/v0.8.0-rc.1^{}'
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return { status: 1, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      repairExistingTag: false,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'rc',
+      version: '0.8.0-rc.1',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(report.release.repair.status, 'repair-available');
+  assert.equal(report.release.repair.remoteTagExists, true);
+  assert.equal(report.release.repair.remoteTargetCommitOid, '2222222222222222222222222222222222222222');
+  assert.ok(report.decision.blockers.some((entry) => entry.code === 'existing-tag-requires-repair-mode'));
+  assert.equal(commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag'), false);
+});
+
+test('runReleaseConductor reports a repair plan in dry-run for an existing authoritative tag', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const runCommandFn = (command, args) => {
+    if (command === 'git' && args[0] === 'config') {
+      if (args[2] === 'remote.upstream.url') {
+        return { status: 0, stdout: 'https://github.com/owner/repo.git', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'missing config' };
+    }
+    if (command === 'git' && args[0] === 'ls-remote') {
+      return {
+        status: 0,
+        stdout: [
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v0.8.0-rc.1',
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/v0.8.0-rc.1^{}'
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return { status: 0, stdout: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: false,
+      dryRun: true,
+      repairExistingTag: true,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'rc',
+      version: '0.8.0-rc.1',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '0'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.repair.requested, true);
+  assert.equal(report.release.repair.status, 'ready');
+  assert.equal(report.release.repair.remoteTagExists, true);
+  assert.equal(report.release.repair.remoteTagAnnotated, true);
+  assert.equal(report.release.repair.remoteTagObjectOid, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  assert.equal(report.release.repair.remoteTargetCommitOid, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+  assert.equal(report.release.repair.localTagPresent, true);
+  assert.equal(report.release.proposalOnly, true);
+});
+
+test('runReleaseConductor repairs an existing authoritative tag when repair mode is enabled', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      if (args[2] === 'user.signingkey') {
+        return { status: 0, stdout: '/tmp/release-signing.pub', stderr: '' };
+      }
+      if (args[2] === 'gpg.format') {
+        return { status: 0, stdout: 'ssh', stderr: '' };
+      }
+      if (args[2] === 'remote.upstream.url') {
+        return { status: 0, stdout: 'https://github.com/owner/repo.git', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'missing config' };
+    }
+    if (command === 'git' && args[0] === 'ls-remote') {
+      return {
+        status: 0,
+        stdout: [
+          '1111111111111111111111111111111111111111\trefs/tags/v0.8.0-rc.1',
+          '2222222222222222222222222222222222222222\trefs/tags/v0.8.0-rc.1^{}'
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return { status: 0, stdout: '1111111111111111111111111111111111111111\n', stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'tag' && args[1] === '-d') {
+      return { status: 0, stdout: `Deleted tag '${args[2]}'`, stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'tag') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'push') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      repairExistingTag: true,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'rc',
+      version: '0.8.0-rc.1',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.proposalOnly, false);
+  assert.equal(report.release.tagCreated, true);
+  assert.equal(report.release.tagPushed, true);
+  assert.equal(report.release.repair.status, 'repaired');
+  assert.equal(report.release.repair.localTagDeleted, true);
+  assert.equal(report.release.repair.tagRecreated, true);
+  assert.equal(
+    commandCalls.some(
+      (entry) =>
+        entry.command === 'git' &&
+        entry.args[0] === 'push' &&
+        entry.args[1] === '--force-with-lease=refs/tags/v0.8.0-rc.1:1111111111111111111111111111111111111111'
+    ),
+    true
+  );
+  assert.equal(
+    commandCalls.some(
+      (entry) =>
+        entry.command === 'git' &&
+        entry.args[0] === 'tag' &&
+        entry.args[1] === '-s' &&
+        entry.args[2] === '-f' &&
+        entry.args[3] === 'v0.8.0-rc.1' &&
+        entry.args[4] === '2222222222222222222222222222222222222222'
+    ),
+    true
+  );
 });
 
 test('runReleaseConductor fails apply when signed tag push remote is unavailable', async () => {

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -24,6 +24,7 @@ function printUsage() {
   console.log('');
   console.log('Options:');
   console.log('  --apply                     Apply release mutation (default is --dry-run).');
+  console.log('  --repair-existing-tag       Repair an existing authoritative tag by recreating it as a signed annotated tag.');
   console.log(`  --report <path>             Write report JSON (default: ${DEFAULT_REPORT_PATH}).`);
   console.log(`  --queue-report <path>       Queue supervisor report path (default: ${DEFAULT_QUEUE_REPORT_PATH}).`);
   console.log(`  --policy-snapshot <path>    Policy snapshot path (default: ${DEFAULT_POLICY_SNAPSHOT_PATH}).`);
@@ -96,6 +97,7 @@ export function parseArgs(argv = process.argv) {
   const options = {
     apply: false,
     dryRun: true,
+    repairExistingTag: false,
     reportPath: DEFAULT_REPORT_PATH,
     queueReportPath: DEFAULT_QUEUE_REPORT_PATH,
     policySnapshotPath: DEFAULT_POLICY_SNAPSHOT_PATH,
@@ -117,6 +119,10 @@ export function parseArgs(argv = process.argv) {
     if (token === '--apply') {
       options.apply = true;
       options.dryRun = false;
+      continue;
+    }
+    if (token === '--repair-existing-tag') {
+      options.repairExistingTag = true;
       continue;
     }
     if (token === '--dry-run') {
@@ -350,6 +356,7 @@ export function evaluateQuarantineGate({
     return {
       status: 'fail',
       reasons: ['queue-report-unavailable'],
+      staleHours,
       staleCount: null,
       activeCount: null,
       staleEntries: []
@@ -469,6 +476,95 @@ function resolveTargetTag(version) {
   const normalized = asOptional(version);
   if (!normalized) return null;
   return normalized.startsWith('v') ? normalized : `v${normalized}`;
+}
+
+function inspectLocalTag({ repoRoot, tagRef, runCommandFn }) {
+  if (!tagRef) {
+    return {
+      present: false,
+      objectOid: null
+    };
+  }
+
+  const result = runCommandFn('git', ['rev-parse', '--verify', '--quiet', `refs/tags/${tagRef}`], {
+    cwd: repoRoot,
+    allowFailure: true
+  });
+  return {
+    present: result.status === 0,
+    objectOid: asOptional(result.stdout)
+  };
+}
+
+function inspectRemoteTag({ repoRoot, remoteName, tagRef, runCommandFn }) {
+  if (!remoteName || !tagRef) {
+    return {
+      exists: false,
+      refName: tagRef ? `refs/tags/${tagRef}` : null,
+      objectOid: null,
+      targetCommitOid: null,
+      annotated: null,
+      lookupError: null
+    };
+  }
+
+  const refName = `refs/tags/${tagRef}`;
+  const result = runCommandFn('git', ['ls-remote', '--tags', remoteName, refName, `${refName}^{}`], {
+    cwd: repoRoot,
+    allowFailure: true
+  });
+  if (result.status !== 0) {
+    return {
+      exists: false,
+      refName,
+      objectOid: null,
+      targetCommitOid: null,
+      annotated: null,
+      lookupError: asOptional(result.stderr) ?? asOptional(result.stdout) ?? `git ls-remote failed (${result.status})`
+    };
+  }
+
+  let objectOid = null;
+  let peeledOid = null;
+  for (const rawLine of String(result.stdout ?? '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    const [oid, resolvedRef] = line.split(/\s+/, 2);
+    if (resolvedRef === refName) {
+      objectOid = oid;
+    } else if (resolvedRef === `${refName}^{}`) {
+      peeledOid = oid;
+    }
+  }
+
+  const exists = Boolean(objectOid);
+  return {
+    exists,
+    refName,
+    objectOid,
+    targetCommitOid: peeledOid ?? objectOid,
+    annotated: exists ? Boolean(peeledOid) : null,
+    lookupError: null
+  };
+}
+
+function createRepairState({ requested, remoteTag = null, localTag = null }) {
+  return {
+    requested: Boolean(requested),
+    status: 'not-requested',
+    remoteTagRef: remoteTag?.refName ?? null,
+    remoteTagExists: Boolean(remoteTag?.exists),
+    remoteTagAnnotated: remoteTag?.annotated ?? null,
+    remoteTagObjectOid: remoteTag?.objectOid ?? null,
+    remoteTargetCommitOid: remoteTag?.targetCommitOid ?? null,
+    localTagPresent: Boolean(localTag?.present),
+    localTagDeleted: false,
+    tagRecreated: false,
+    pushLeaseExpectedOid: remoteTag?.objectOid ?? null,
+    lookupError: remoteTag?.lookupError ?? null
+  };
 }
 
 function resolveTagPushRemote({ repoRoot, repository, runCommandFn }) {
@@ -607,6 +703,72 @@ export async function runReleaseConductor(options = {}) {
   let tagPushError = null;
   let proposalOnly = true;
   const tagPushRemote = resolveTagPushRemote({ repoRoot, repository, runCommandFn });
+  const remoteTag = inspectRemoteTag({
+    repoRoot,
+    remoteName: asOptional(tagPushRemote.remoteName),
+    tagRef: targetTag,
+    runCommandFn
+  });
+  const localTag = inspectLocalTag({
+    repoRoot,
+    tagRef: targetTag,
+    runCommandFn
+  });
+  const repair = createRepairState({
+    requested: args.repairExistingTag,
+    remoteTag,
+    localTag
+  });
+
+  if (repair.remoteTagExists && !repair.requested) {
+    repair.status = 'repair-available';
+    pushUniqueDecisionEntry(advisories, {
+      code: 'existing-tag-repair-available',
+      message: `Authoritative tag ${targetTag} already exists; rerun release conductor with --repair-existing-tag to recreate it as a signed annotated tag.`
+    });
+  }
+  if (repair.requested && !targetTag) {
+    repair.status = 'blocked';
+  } else if (repair.requested && remoteTag.lookupError) {
+    repair.status = 'blocked';
+  } else if (repair.requested && !asOptional(tagPushRemote.remoteName)) {
+    repair.status = 'blocked';
+  } else if (repair.requested && !repair.remoteTagExists) {
+    repair.status = 'blocked';
+  } else if (repair.requested && (!repair.remoteTargetCommitOid || !repair.pushLeaseExpectedOid)) {
+    repair.status = 'blocked';
+  } else if (repair.requested && repair.remoteTagExists) {
+    repair.status = applyRequested ? 'blocked' : 'ready';
+  }
+
+  if (repair.requested) {
+    if (!targetTag) {
+      blockers.push({
+        code: 'missing-version-for-tag',
+        message: 'Repair mode requires --version to identify the authoritative release tag.'
+      });
+    } else if (!asOptional(tagPushRemote.remoteName)) {
+      blockers.push({
+        code: 'tag-push-remote-missing',
+        message: `Repair mode could not resolve an authoritative push remote matching ${repository}.`
+      });
+    } else if (remoteTag.lookupError) {
+      blockers.push({
+        code: 'repair-remote-tag-lookup-failed',
+        message: `Unable to inspect authoritative tag ${targetTag}: ${remoteTag.lookupError}`
+      });
+    } else if (!repair.remoteTagExists) {
+      blockers.push({
+        code: 'repair-target-tag-missing',
+        message: `Repair mode requires existing authoritative tag ${targetTag}, but no authoritative tag ref was found on ${tagPushRemote.remoteName}.`
+      });
+    } else if (!repair.remoteTargetCommitOid || !repair.pushLeaseExpectedOid) {
+      blockers.push({
+        code: 'repair-target-unresolved',
+        message: `Repair mode could not resolve the authoritative object/commit for ${targetTag}.`
+      });
+    }
+  }
 
   if (blockers.length === 0 && applyRequested && conductorEnabled) {
     if (!targetTag) {
@@ -618,6 +780,77 @@ export async function runReleaseConductor(options = {}) {
       blockers.push({
         code: 'tag-signing-material-missing',
         message: 'Apply mode requires signed-tag readiness before tag push. Configure user.signingkey (or equivalent signing material) and retry.'
+      });
+    } else if (args.repairExistingTag) {
+        if (repair.localTagPresent) {
+          const deleteResult = runCommandFn('git', ['tag', '-d', targetTag], {
+            cwd: repoRoot,
+            allowFailure: true
+          });
+          if (deleteResult.status !== 0) {
+            tagError = asOptional(deleteResult.stderr) ?? asOptional(deleteResult.stdout) ?? 'local tag delete failed';
+            blockers.push({
+              code: 'repair-local-tag-delete-failed',
+              message: `Unable to remove existing local tag ${targetTag} before repair: ${tagError}`
+            });
+          } else {
+            repair.localTagDeleted = true;
+          }
+        }
+
+        if (blockers.length === 0) {
+          const tagResult = runCommandFn(
+            'git',
+            ['tag', '-s', '-f', targetTag, repair.remoteTargetCommitOid, '-m', `Release ${targetTag}`],
+            {
+              cwd: repoRoot,
+              allowFailure: true
+            }
+          );
+          if (tagResult.status === 0) {
+            tagCreated = true;
+            repair.tagRecreated = true;
+            const pushRemoteName = asOptional(tagPushRemote.remoteName);
+            if (!pushRemoteName) {
+              tagPushError = 'Unable to resolve an authoritative git remote for repair publication.';
+              blockers.push({
+                code: 'tag-push-remote-missing',
+                message: `Signed repair tag ${targetTag} was created locally but no authoritative push remote matched ${repository}.`
+              });
+            } else {
+              const leaseArg = `--force-with-lease=refs/tags/${targetTag}:${repair.pushLeaseExpectedOid}`;
+              const pushResult = runCommandFn(
+                'git',
+                ['push', leaseArg, pushRemoteName, `refs/tags/${targetTag}:refs/tags/${targetTag}`],
+                {
+                  cwd: repoRoot,
+                  allowFailure: true
+                }
+              );
+              if (pushResult.status === 0) {
+                tagPushed = true;
+                proposalOnly = false;
+                repair.status = 'repaired';
+              } else {
+                tagPushError = asOptional(pushResult.stderr) ?? asOptional(pushResult.stdout) ?? 'repair tag push failed';
+                blockers.push({
+                  code: 'repair-tag-push-failed',
+                  message: `Signed repair publication failed for ${targetTag}: ${tagPushError}`
+                });
+              }
+            }
+          } else {
+            tagError = asOptional(tagResult.stderr) ?? asOptional(tagResult.stdout) ?? 'repair tag creation failed';
+            blockers.push({
+              code: 'repair-tag-recreate-failed',
+              message: `Signed repair tag creation failed for ${targetTag}: ${tagError}`
+            });
+          }
+        }
+    } else if (repair.remoteTagExists) {
+      blockers.push({
+        code: 'existing-tag-requires-repair-mode',
+        message: `Authoritative tag ${targetTag} already exists. Rerun release conductor with --repair-existing-tag to recreate it as a signed annotated tag at ${repair.remoteTargetCommitOid}.`
       });
     } else if (signingMaterial.available) {
       const tagResult = runCommandFn('git', ['tag', '-s', targetTag, '-m', `Release ${targetTag}`], {
@@ -680,7 +913,8 @@ export async function runReleaseConductor(options = {}) {
       tagError,
       tagPushError,
       tagPushRemote,
-      signingMaterial
+      signingMaterial,
+      repair
     },
     inputs: {
       reportPath: args.reportPath,


### PR DESCRIPTION
## Summary
- add explicit release-conductor repair mode for existing authoritative unsigned tags
- surface repair state in the release-conductor report contract and workflow dispatch input
- document the repair path for release publication without changing tag identity

## Validation
- node --test tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
- node tools/npm/run-script.mjs docs:manifest:validate
- node dist/tools/schemas/validate-json.js --schema docs/schemas/release-conductor-report-v1.schema.json --data E:/comparevi-lanes/1895-release-tag-repair-mode/tests/results/_agent/release/1895-release-conductor-repair-plan.json
- git diff --check

## Live proof
- tests/results/_agent/release/1895-release-conductor-repair-plan.json
  - release.repair.status = ready
  - remoteTagObjectOid = 1865c64d1fb53051e96405a068d828928868cbc3
  - remoteTargetCommitOid = 689ebb6c88aa6ca630dd233de67c3e0c6c14f46e

Issue: #1895