### PR TITLE
[release] route unsigned-tag trust failures to repair mode (#1896)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,12 +245,25 @@ jobs:
             -JsonPath tests/results/_agent/supply-chain/release-trust-gate.json `
             -SchemaPath docs/schemas/supply-chain-trust-gate-v1.schema.json
 
+      - name: Append release trust remediation guidance
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          node tools/priority/release-trust-remediation.mjs \
+            --trust-report tests/results/_agent/supply-chain/release-trust-gate.json \
+            --tag-ref "${{ github.ref_name }}" \
+            --output tests/results/_agent/release/release-trust-remediation.md \
+            --summary "$GITHUB_STEP_SUMMARY"
+
       - name: Upload supply-chain trust artifact
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: release-supply-chain-trust-${{ github.run_id }}
-          path: tests/results/_agent/supply-chain/release-trust-gate.json
+          path: |
+            tests/results/_agent/supply-chain/release-trust-gate.json
+            tests/results/_agent/release/release-trust-remediation.md
           if-no-files-found: error
 
       - name: Enforce rollback drill health gate

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -140,6 +140,20 @@ Release tags must pass the supply-chain trust gate before GitHub Release publica
 
 If the trust gate fails, release publication is blocked (fail-closed) and the report artifact must be used for remediation.
 
+Release publication also emits trust remediation guidance when the trust gate
+finds repair-eligible tag failures:
+
+- Markdown artifact:
+  `tests/results/_agent/release/release-trust-remediation.md`
+- Required behavior:
+  - preserve the existing release tag identity
+  - route `tag-not-annotated` and `tag-signature-unverified` to release
+    conductor repair mode
+  - instruct repair using:
+    - `version = <existing tag version>`
+    - `apply = true`
+    - `repair_existing_tag = true`
+
 Authoritative signed tag publication now belongs to the release conductor control
 plane:
 

--- a/tools/priority/__tests__/release-trust-remediation.test.mjs
+++ b/tools/priority/__tests__/release-trust-remediation.test.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { buildReleaseTrustRemediationMarkdown, runReleaseTrustRemediation } from '../release-trust-remediation.mjs';
+
+test('buildReleaseTrustRemediationMarkdown emits repair guidance for unsigned or lightweight tags', () => {
+  const markdown = buildReleaseTrustRemediationMarkdown({
+    tagRef: 'v0.6.4-rc.1',
+    trustReport: {
+      failures: [{ code: 'tag-signature-unverified' }],
+      tagSignature: {
+        refName: 'v0.6.4-rc.1'
+      }
+    }
+  });
+
+  assert.match(markdown, /repair-eligible tag failures/);
+  assert.match(markdown, /`version = 0\.6\.4-rc\.1`/);
+  assert.match(markdown, /`repair_existing_tag = true`/);
+  assert.match(markdown, /Preserve tag identity and asset names/);
+});
+
+test('buildReleaseTrustRemediationMarkdown reports not-needed when no repair failures exist', () => {
+  const markdown = buildReleaseTrustRemediationMarkdown({
+    tagRef: 'v0.6.4-rc.1',
+    trustReport: {
+      failures: [{ code: 'checksum-mismatch' }]
+    }
+  });
+
+  assert.match(markdown, /No repair-mode remediation is required/);
+  assert.doesNotMatch(markdown, /repair_existing_tag/);
+});
+
+test('runReleaseTrustRemediation writes markdown artifact and appends to workflow summary', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'release-trust-remediation-'));
+  const trustPath = path.join(tempRoot, 'release-trust-gate.json');
+  const outputPath = path.join(tempRoot, 'release-trust-remediation.md');
+  const summaryPath = path.join(tempRoot, 'step-summary.md');
+
+  await writeFile(
+    trustPath,
+    JSON.stringify(
+      {
+        failures: [{ code: 'tag-not-annotated' }],
+        tagSignature: {
+          refName: 'v0.6.4-rc.1'
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  const result = await runReleaseTrustRemediation({
+    args: {
+      trustReportPath: trustPath,
+      outputPath,
+      summaryPath,
+      tagRef: 'v0.6.4-rc.1'
+    }
+  });
+
+  assert.equal(result.wroteSummary, true);
+  const output = await readFile(outputPath, 'utf8');
+  const summary = await readFile(summaryPath, 'utf8');
+  assert.match(output, /`repair_existing_tag = true`/);
+  assert.match(summary, /`repair_existing_tag = true`/);
+});

--- a/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
+++ b/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
@@ -349,6 +349,14 @@ test('verifyReleaseTagSignature fails for unsigned tag', async () => {
   });
 
   assert.ok(result.failures.some((failure) => failure.code === 'tag-signature-unverified'));
+  assert.ok(
+    result.failures.some(
+      (failure) =>
+        failure.code === 'tag-signature-unverified' &&
+        String(failure.hint).includes('priority:release:signing:readiness') &&
+        String(failure.hint).includes('repair_existing_tag = true')
+    )
+  );
   assert.equal(result.status.verified, false);
   assert.equal(result.status.reason, 'unsigned');
 });
@@ -380,6 +388,14 @@ test('verifyReleaseTagSignature fails for lightweight tag', async () => {
   });
 
   assert.ok(result.failures.some((failure) => failure.code === 'tag-not-annotated'));
+  assert.ok(
+    result.failures.some(
+      (failure) =>
+        failure.code === 'tag-not-annotated' &&
+        String(failure.hint).includes('priority:release:signing:readiness') &&
+        String(failure.hint).includes('repair_existing_tag = true')
+    )
+  );
   assert.equal(result.status.annotated, false);
   assert.equal(result.status.reason, 'not-annotated');
 });

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -155,6 +155,19 @@ test('release workflow resolves downloaded artifacts through the shared helper b
   assert.doesNotMatch(workflowRaw, /steps\.contract_artifacts\.outputs\.linux_tarball_path/);
 });
 
+test('release workflow appends repair-mode guidance for unsigned or lightweight tags', () => {
+  const workflowPath = path.join(workflowsRoot, 'release.yml');
+  const workflowRaw = readFileSync(workflowPath, 'utf8');
+
+  assert.match(workflowRaw, /name: Append release trust remediation guidance/);
+  assert.match(workflowRaw, /node tools\/priority\/release-trust-remediation\.mjs/);
+  assert.match(workflowRaw, /--trust-report tests\/results\/_agent\/supply-chain\/release-trust-gate\.json/);
+  assert.match(workflowRaw, /--tag-ref "\$\{\{\s*github\.ref_name\s*\}\}"/);
+  assert.match(workflowRaw, /--output tests\/results\/_agent\/release\/release-trust-remediation\.md/);
+  assert.match(workflowRaw, /--summary "\$GITHUB_STEP_SUMMARY"/);
+  assert.match(workflowRaw, /tests\/results\/_agent\/release\/release-trust-remediation\.md/);
+});
+
 test('monthly release workflow marks itself as the SLO remediation candidate', () => {
   const workflowPath = path.join(workflowsRoot, 'monthly-stability-release.yml');
   const workflowRaw = readFileSync(workflowPath, 'utf8');

--- a/tools/priority/release-trust-remediation.mjs
+++ b/tools/priority/release-trust-remediation.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_TRUST_REPORT_PATH = path.join('tests', 'results', '_agent', 'supply-chain', 'release-trust-gate.json');
+export const DEFAULT_OUTPUT_PATH = path.join('tests', 'results', '_agent', 'release', 'release-trust-remediation.md');
+const REPAIR_FAILURE_CODES = new Set(['tag-not-annotated', 'tag-signature-unverified']);
+
+function normalizeOptional(value) {
+  if (value == null) return null;
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function normalizeVersionFromTag(tagRef) {
+  const normalized = normalizeOptional(tagRef);
+  if (!normalized) {
+    return null;
+  }
+  return normalized.startsWith('v') ? normalized.slice(1) : normalized;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    trustReportPath: DEFAULT_TRUST_REPORT_PATH,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    summaryPath: null,
+    tagRef: null
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--trust-report' || token === '--output' || token === '--summary' || token === '--tag-ref') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      if (token === '--trust-report') options.trustReportPath = next;
+      if (token === '--output') options.outputPath = next;
+      if (token === '--summary') options.summaryPath = next;
+      if (token === '--tag-ref') options.tagRef = next;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      return { ...options, help: true };
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(path.resolve(filePath), 'utf8'));
+}
+
+async function writeText(filePath, contents) {
+  const resolved = path.resolve(filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, contents, 'utf8');
+  return resolved;
+}
+
+async function appendText(filePath, contents) {
+  const resolved = path.resolve(filePath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await appendFile(resolved, contents, 'utf8');
+  return resolved;
+}
+
+export function buildReleaseTrustRemediationMarkdown({ trustReport, tagRef }) {
+  const failures = Array.isArray(trustReport?.failures)
+    ? trustReport.failures
+    : Array.isArray(trustReport?.summary?.failures)
+      ? trustReport.summary.failures
+      : [];
+  const relevantFailures = failures.filter((failure) => REPAIR_FAILURE_CODES.has(String(failure?.code ?? '').trim()));
+  const normalizedTag = normalizeOptional(tagRef) ?? normalizeOptional(trustReport?.tagSignature?.refName);
+  const normalizedVersion = normalizeVersionFromTag(normalizedTag);
+
+  const lines = ['## Release Trust Remediation', ''];
+  if (relevantFailures.length === 0) {
+    lines.push('- No repair-mode remediation is required for the current trust-gate result.');
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  lines.push(`- Release trust gate reported repair-eligible tag failures for \`${normalizedTag ?? 'unknown-tag'}\`.`);
+  lines.push(`- Failure codes: ${relevantFailures.map((failure) => `\`${failure.code}\``).join(', ')}`);
+  lines.push('- Preserve tag identity and asset names. Do not rename the release tag to bypass trust verification.');
+  lines.push('- Rerun `.github/workflows/release-conductor.yml` with:');
+  lines.push(`  - \`version = ${normalizedVersion ?? 'X.Y.Z'}\``);
+  lines.push('  - `apply = true`');
+  lines.push('  - `repair_existing_tag = true`');
+  lines.push('- Continue release publication only after `tests/results/_agent/release/release-conductor-report.json` shows:');
+  lines.push('  - `release.repair.status = repaired`');
+  lines.push('  - `release.tagPushed = true`');
+  lines.push('');
+  return lines.join('\n');
+}
+
+export async function runReleaseTrustRemediation(options = {}) {
+  const args = options.args ?? parseArgs();
+  if (args.help) {
+    return { markdown: '', outputPath: null, summaryPath: null, wroteSummary: false };
+  }
+
+  const trustReport = await readJson(args.trustReportPath);
+  const markdown = buildReleaseTrustRemediationMarkdown({
+    trustReport,
+    tagRef: args.tagRef
+  });
+  const outputPath = await writeText(args.outputPath, `${markdown}\n`);
+
+  let summaryPath = null;
+  let wroteSummary = false;
+  if (args.summaryPath) {
+    summaryPath = await appendText(args.summaryPath, `\n${markdown}\n`);
+    wroteSummary = true;
+  }
+
+  return {
+    markdown,
+    outputPath,
+    summaryPath,
+    wroteSummary
+  };
+}
+
+async function main(argv = process.argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('Usage: node tools/priority/release-trust-remediation.mjs [options]');
+    console.log('');
+    console.log(`  --trust-report <path>  Trust-gate report path (default: ${DEFAULT_TRUST_REPORT_PATH}).`);
+    console.log(`  --output <path>        Markdown output path (default: ${DEFAULT_OUTPUT_PATH}).`);
+    console.log('  --summary <path>       Optional workflow step summary path to overwrite.');
+    console.log('  --tag-ref <value>      Optional release tag name override.');
+    return 0;
+  }
+
+  const result = await runReleaseTrustRemediation({ args });
+  console.log(`[release-trust-remediation] wrote ${result.outputPath}`);
+  if (result.wroteSummary) {
+    console.log(`[release-trust-remediation] summary ${result.summaryPath}`);
+  }
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  main(process.argv)
+    .then((exitCode) => {
+      if (exitCode !== 0) {
+        process.exitCode = exitCode;
+      }
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}

--- a/tools/priority/supply-chain-trust-gate.mjs
+++ b/tools/priority/supply-chain-trust-gate.mjs
@@ -32,8 +32,10 @@ const FAILURE_HINTS = {
   'tag-ref-lookup-failed': 'Unable to resolve release tag via GitHub API. Confirm tag exists and token has repo read access.',
   'tag-object-lookup-failed': 'Unable to resolve annotated tag object via GitHub API. Confirm tag object availability.',
   'tag-signature-parse-failed': 'Tag signature payload could not be parsed. Re-run and inspect gh api output.',
-  'tag-not-annotated': 'Release tag is lightweight/non-annotated. Create a signed annotated tag for release.',
-  'tag-signature-unverified': 'Release tag signature is not verified. Sign the tag and re-run the release.',
+  'tag-not-annotated':
+    'Release tag is lightweight/non-annotated. Run priority:release:signing:readiness first; if readiness is ready, rerun .github/workflows/release-conductor.yml with repair_existing_tag = true to recreate the same release tag as a signed annotated tag.',
+  'tag-signature-unverified':
+    'Release tag signature is not verified. Run priority:release:signing:readiness first; if readiness is ready, rerun .github/workflows/release-conductor.yml with repair_existing_tag = true to repair the same release tag before rerunning release.',
   'attestation-cli-unavailable': 'GitHub CLI is unavailable. Install/enable gh on runner before trust gate.',
   'attestation-output-parse-failed': 'Attestation verification output was not valid JSON. Re-run verification and inspect gh logs.',
   'attestation-unverified': 'Artifact attestation verification failed. Confirm attest-build-provenance step and signer workflow.',


### PR DESCRIPTION
## Summary
- append release-workflow repair guidance for unsigned or lightweight tags
- emit a trust-remediation markdown artifact alongside the trust-gate report
- point trust-gate hint text at readiness plus `repair_existing_tag = true`

## Validation
- node --test tools/priority/__tests__/release-trust-remediation.test.mjs tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs tools/priority/__tests__/supply-chain-trust-gate.test.mjs
- node tools/npm/run-script.mjs docs:manifest:validate
- git diff --check

Issue: #1896