### PR TITLE
[governance]: fix priority:pr GraphQL draft typing for same-owner fork PR creation (#1874)

### DIFF
--- a/tools/priority/__tests__/remote-utils.test.mjs
+++ b/tools/priority/__tests__/remote-utils.test.mjs
@@ -13,6 +13,7 @@ import {
   loadRepositoryGraphMetadata,
   ensureOriginFork,
   pushBranch,
+  buildGraphqlArgs,
   buildGhPrCreateArgs,
   buildGhPrEditArgs,
   buildGhPrListArgs,
@@ -459,6 +460,36 @@ test('graphql PR helpers expose the same-owner fork mutation contract', () => {
   assert.equal(request.variables.headRepositoryId, 'R_fork');
   assert.equal(request.variables.headRefName, 'issue/963-org-owned-fork-pr-helper');
   assert.equal(request.variables.draft, true);
+});
+
+test('buildGraphqlArgs preserves string variables and sends booleans as typed GraphQL fields', () => {
+  const args = buildGraphqlArgs('mutation Test { noop }', {
+    repositoryId: 'R_upstream',
+    headRepositoryId: 'R_fork',
+    headRefName: 'issue/963-org-owned-fork-pr-helper',
+    baseRefName: 'develop',
+    draft: false,
+    retryCount: 2
+  });
+
+  assert.deepEqual(args, [
+    'api',
+    'graphql',
+    '-f',
+    'query=mutation Test { noop }',
+    '-f',
+    'repositoryId=R_upstream',
+    '-f',
+    'headRepositoryId=R_fork',
+    '-f',
+    'headRefName=issue/963-org-owned-fork-pr-helper',
+    '-f',
+    'baseRefName=develop',
+    '-F',
+    'draft=false',
+    '-F',
+    'retryCount=2'
+  ]);
 });
 
 test('findExistingPullRequest matches the branch/base pair and same-owner cross-repo head', () => {

--- a/tools/priority/lib/remote-utils.mjs
+++ b/tools/priority/lib/remote-utils.mjs
@@ -174,7 +174,13 @@ export function buildGraphqlArgs(query, variables = {}) {
     if (value == null) {
       continue;
     }
-    args.push('-f', `${key}=${String(value)}`);
+    const flag =
+      typeof value === 'boolean' ||
+      typeof value === 'number' ||
+      typeof value === 'bigint'
+        ? '-F'
+        : '-f';
+    args.push(flag, `${key}=${String(value)}`);
   }
   return args;
 }


### PR DESCRIPTION
## Summary
- fix same-owner fork GraphQL argument typing in the shared remote-utils helper
- send boolean and numeric GraphQL variables with typed fields instead of stringifying them
- lock the regression with focused remote-utils coverage

## Validation
- `node --test tools/priority/__tests__/remote-utils.test.mjs tools/priority/__tests__/create-pr.test.mjs`
- `git diff --check`