### PR TITLE
[release]: derive workflow signing authority for #1877

### DIFF
--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -76,16 +76,41 @@ jobs:
         env:
           RELEASE_TAG_SIGNING_PRIVATE_KEY: ${{ secrets.RELEASE_TAG_SIGNING_PRIVATE_KEY }}
           RELEASE_TAG_SIGNING_PUBLIC_KEY: ${{ secrets.RELEASE_TAG_SIGNING_PUBLIC_KEY }}
+          RELEASE_TAG_SIGNING_IDENTITY_NAME: ${{ vars.RELEASE_TAG_SIGNING_IDENTITY_NAME || '' }}
+          RELEASE_TAG_SIGNING_IDENTITY_EMAIL: ${{ vars.RELEASE_TAG_SIGNING_IDENTITY_EMAIL || '' }}
         run: |
           set -euo pipefail
           if [[ -z "${RELEASE_TAG_SIGNING_PRIVATE_KEY:-}" ]]; then
             echo "No release tag signing key configured; skipping workflow-owned signing setup."
             exit 0
           fi
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::GH_TOKEN is unavailable after Resolve-PolicyToken; cannot derive workflow signing identity."
+            exit 1
+          fi
           signing_dir="$RUNNER_TEMP/release-tag-signing"
           mkdir -p "$signing_dir"
           private_key_path="$signing_dir/id_release_tag_signing"
           public_key_path="${private_key_path}.pub"
+          signing_login="$(gh api user --jq '.login')"
+          signing_id="$(gh api user --jq '.id')"
+          signing_name="${RELEASE_TAG_SIGNING_IDENTITY_NAME:-}"
+          signing_email="${RELEASE_TAG_SIGNING_IDENTITY_EMAIL:-}"
+
+          if [[ -z "$signing_name" ]]; then
+            signing_name="$(gh api user --jq '.name // .login')"
+          fi
+          if [[ -z "$signing_email" ]]; then
+            signing_email="$(gh api user --jq '.email // \"\"')"
+          fi
+          if [[ -z "$signing_email" ]]; then
+            signing_email="${signing_id}+${signing_login}@users.noreply.github.com"
+          fi
+
+          identity_source="policy-token-user"
+          if [[ -n "${RELEASE_TAG_SIGNING_IDENTITY_NAME:-}" || -n "${RELEASE_TAG_SIGNING_IDENTITY_EMAIL:-}" ]]; then
+            identity_source="repo-variable-override"
+          fi
 
           printf '%s\n' "$RELEASE_TAG_SIGNING_PRIVATE_KEY" > "$private_key_path"
           chmod 600 "$private_key_path"
@@ -99,12 +124,19 @@ jobs:
 
           git config gpg.format ssh
           git config user.signingkey "$public_key_path"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "$signing_name"
+          git config user.email "$signing_email"
           git config tag.gpgSign true
 
-          echo "RELEASE_TAG_SIGNING_BACKEND=ssh" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG_SIGNING_SOURCE=workflow-secret" >> "$GITHUB_ENV"
+          {
+            echo "RELEASE_TAG_SIGNING_BACKEND=ssh"
+            echo "RELEASE_TAG_SIGNING_SOURCE=workflow-secret"
+            echo "RELEASE_TAG_SIGNING_IDENTITY_NAME=$signing_name"
+            echo "RELEASE_TAG_SIGNING_IDENTITY_EMAIL=$signing_email"
+            echo "RELEASE_TAG_SIGNING_IDENTITY_LOGIN=$signing_login"
+            echo "RELEASE_TAG_SIGNING_IDENTITY_ID=$signing_id"
+            echo "RELEASE_TAG_SIGNING_IDENTITY_SOURCE=$identity_source"
+          } >> "$GITHUB_ENV"
 
       - name: Run release conductor
         shell: pwsh

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -159,6 +159,10 @@ automation path:
   - `repair_existing_tag = true`
 - provision `RELEASE_TAG_SIGNING_PRIVATE_KEY` and optional
   `RELEASE_TAG_SIGNING_PUBLIC_KEY` for workflow-owned signing
+- optionally set `RELEASE_TAG_SIGNING_IDENTITY_NAME` and
+  `RELEASE_TAG_SIGNING_IDENTITY_EMAIL` when the signing authority should use an
+  explicit Git identity override; otherwise the workflow derives the signer
+  identity from the resolved policy token account
 - inspect `tests/results/_agent/release/release-conductor-report.json`
   first
 - require both:

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -160,12 +160,19 @@ plane:
 - `.github/workflows/release-conductor.yml` may load
   `RELEASE_TAG_SIGNING_PRIVATE_KEY` and optional
   `RELEASE_TAG_SIGNING_PUBLIC_KEY`
+- the workflow may also honor optional repo variables:
+  - `RELEASE_TAG_SIGNING_IDENTITY_NAME`
+  - `RELEASE_TAG_SIGNING_IDENTITY_EMAIL`
+  - when unset, the workflow derives signer identity from the resolved policy
+    token account before recreating or publishing the signed tag
 - when signing material is present, release conductor must:
   - configure workflow-owned tag signing
+  - configure workflow-owned signer identity
   - create the signed annotated tag
   - push the tag to the authoritative remote for the target repository
 - `tests/results/_agent/release/release-conductor-report.json` must record:
   - signing backend/source
+  - signer identity used for tag creation/repair
   - whether the tag was created
   - whether the tag was pushed authoritatively
   - whether repair mode was requested/performed for an existing tag

--- a/docs/schemas/release-conductor-report-v1.schema.json
+++ b/docs/schemas/release-conductor-report-v1.schema.json
@@ -76,12 +76,25 @@
         "signingMaterial": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["available", "signingKey", "source", "backend"],
+          "required": ["available", "signingKey", "source", "backend", "identity"],
           "properties": {
             "available": { "type": "boolean" },
             "signingKey": { "type": ["string", "null"] },
             "source": { "type": "string" },
-            "backend": { "type": "string" }
+            "backend": { "type": "string" },
+            "identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["available", "name", "email", "source", "login", "accountId"],
+              "properties": {
+                "available": { "type": "boolean" },
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "source": { "type": "string" },
+                "login": { "type": ["string", "null"] },
+                "accountId": { "type": ["string", "null"] }
+              }
+            }
           }
         },
         "repair": {

--- a/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
@@ -17,12 +17,18 @@ test('release conductor workflow keeps workflow_run proposal-only when apply mod
   assert.match(workflow, /RELEASE_CONDUCTOR_ENABLED:\s+\$\{\{\s*vars\.RELEASE_CONDUCTOR_ENABLED \|\| '0'\s*\}\}/);
   assert.match(workflow, /name:\s+Configure release tag signing material/);
   assert.match(workflow, /if \[\[ -z "\$\{RELEASE_TAG_SIGNING_PRIVATE_KEY:-\}" \]\]; then/);
+  assert.match(workflow, /if \[\[ -z "\$\{GH_TOKEN:-\}" \]\]; then/);
+  assert.match(workflow, /RELEASE_TAG_SIGNING_IDENTITY_NAME:\s+\$\{\{\s*vars\.RELEASE_TAG_SIGNING_IDENTITY_NAME \|\| ''\s*\}\}/);
+  assert.match(workflow, /RELEASE_TAG_SIGNING_IDENTITY_EMAIL:\s+\$\{\{\s*vars\.RELEASE_TAG_SIGNING_IDENTITY_EMAIL \|\| ''\s*\}\}/);
+  assert.match(workflow, /signing_login="\$\(gh api user --jq '\.login'\)"/);
+  assert.match(workflow, /signing_id="\$\(gh api user --jq '\.id'\)"/);
   assert.match(workflow, /git config gpg\.format ssh/);
   assert.match(workflow, /git config user\.signingkey "\$public_key_path"/);
-  assert.match(workflow, /git config user\.name "github-actions\[bot\]"/);
-  assert.match(workflow, /git config user\.email "41898282\+github-actions\[bot\]@users\.noreply\.github\.com"/);
+  assert.match(workflow, /git config user\.name "\$signing_name"/);
+  assert.match(workflow, /git config user\.email "\$signing_email"/);
   assert.match(workflow, /RELEASE_TAG_SIGNING_BACKEND=ssh/);
   assert.match(workflow, /RELEASE_TAG_SIGNING_SOURCE=workflow-secret/);
+  assert.match(workflow, /RELEASE_TAG_SIGNING_IDENTITY_SOURCE=\$identity_source/);
   assert.match(
     workflow,
     /elseif \(\$eventName -eq 'workflow_run'\) \{\s+\$apply = \$conductorEnabled\s+if \(-not \$apply\) \{\s+Write-Host 'Release conductor apply mode disabled; workflow_run will remain proposal-only\.'\s+\}\s+\}/ms

--- a/tools/priority/__tests__/release-signing-readiness-schema.test.mjs
+++ b/tools/priority/__tests__/release-signing-readiness-schema.test.mjs
@@ -61,8 +61,13 @@ test('release signing readiness report matches schema', async () => {
       '      - name: Configure release tag signing material',
       '        run: |',
       '          echo RELEASE_TAG_SIGNING_PRIVATE_KEY',
+      '          echo RELEASE_TAG_SIGNING_IDENTITY_NAME',
+      '          echo RELEASE_TAG_SIGNING_IDENTITY_EMAIL',
+      "          signing_login=\"$(gh api user --jq '.login')\"",
       '          git config gpg.format ssh',
-      '          git config user.signingkey "$public_key_path"'
+      '          git config user.signingkey "$public_key_path"',
+      '          git config user.name "$signing_name"',
+      '          git config user.email "$signing_email"'
     ].join('\n')
   );
 

--- a/tools/priority/__tests__/release-signing-readiness.test.mjs
+++ b/tools/priority/__tests__/release-signing-readiness.test.mjs
@@ -92,8 +92,13 @@ function seedWorkflowContract(repoRoot) {
       '      - name: Configure release tag signing material',
       '        run: |',
       '          echo RELEASE_TAG_SIGNING_PRIVATE_KEY',
+      '          echo RELEASE_TAG_SIGNING_IDENTITY_NAME',
+      '          echo RELEASE_TAG_SIGNING_IDENTITY_EMAIL',
+      "          signing_login=\"$(gh api user --jq '.login')\"",
       '          git config gpg.format ssh',
-      '          git config user.signingkey "$public_key_path"'
+      '          git config user.signingkey "$public_key_path"',
+      '          git config user.name "$signing_name"',
+      '          git config user.email "$signing_email"'
     ].join('\n')
   );
 }

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -495,15 +495,34 @@ function detectSigningMaterial({ runCommandFn, repoRoot, environment = process.e
     cwd: repoRoot,
     allowFailure: true
   });
+  const nameResult = runCommandFn('git', ['config', '--get', 'user.name'], {
+    cwd: repoRoot,
+    allowFailure: true
+  });
+  const emailResult = runCommandFn('git', ['config', '--get', 'user.email'], {
+    cwd: repoRoot,
+    allowFailure: true
+  });
   const configuredFormat = asOptional(formatResult.stdout);
   const backend = asOptional(environment.RELEASE_TAG_SIGNING_BACKEND) ?? configuredFormat ?? 'openpgp';
   const source = signingKey ? asOptional(environment.RELEASE_TAG_SIGNING_SOURCE) ?? 'git-config' : 'missing';
+  const identityName = asOptional(nameResult.stdout);
+  const identityEmail = asOptional(emailResult.stdout);
+  const identityAvailable = Boolean(identityName && identityEmail);
 
   return {
     available: Boolean(signingKey),
     signingKey,
     source,
-    backend
+    backend,
+    identity: {
+      available: identityAvailable,
+      name: identityName,
+      email: identityEmail,
+      source: identityAvailable ? asOptional(environment.RELEASE_TAG_SIGNING_IDENTITY_SOURCE) ?? 'git-config' : 'missing',
+      login: asOptional(environment.RELEASE_TAG_SIGNING_IDENTITY_LOGIN),
+      accountId: asOptional(environment.RELEASE_TAG_SIGNING_IDENTITY_ID)
+    }
   };
 }
 

--- a/tools/priority/release-signing-readiness.mjs
+++ b/tools/priority/release-signing-readiness.mjs
@@ -177,8 +177,13 @@ function hasSigningWorkflowContract(repoRoot) {
   const requiredSnippets = [
     'Configure release tag signing material',
     'RELEASE_TAG_SIGNING_PRIVATE_KEY',
+    'RELEASE_TAG_SIGNING_IDENTITY_NAME',
+    'RELEASE_TAG_SIGNING_IDENTITY_EMAIL',
+    "gh api user --jq '.login'",
     'git config gpg.format ssh',
-    'git config user.signingkey "$public_key_path"'
+    'git config user.signingkey "$public_key_path"',
+    'git config user.name "$signing_name"',
+    'git config user.email "$signing_email"'
   ];
   const missing = requiredSnippets.filter((snippet) => !workflow.includes(snippet));
   return {


### PR DESCRIPTION
## Summary
- derive workflow-owned release tag identity from the resolved policy token account by default
- support optional repo-variable overrides for release tag identity while keeping the SSH signing path unchanged
- record signer identity in the release conductor receipt and tighten readiness/workflow contract coverage

## Testing
- `node --test tools/priority/__tests__/release-conductor-workflow-contract.test.mjs tools/priority/__tests__/release-signing-readiness.test.mjs tools/priority/__tests__/release-signing-readiness-schema.test.mjs tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs priority:release:signing:readiness`
- `git diff --check`

Closes #1877
