### PR TITLE
fix: unblock release-conductor identity bootstrap for #1877

### DIFF
--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -101,7 +101,7 @@ jobs:
             signing_name="$(gh api user --jq '.name // .login')"
           fi
           if [[ -z "$signing_email" ]]; then
-            signing_email="$(gh api user --jq '.email // \"\"')"
+            signing_email="$(gh api user --jq '.email // ""')"
           fi
           if [[ -z "$signing_email" ]]; then
             signing_email="${signing_id}+${signing_login}@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- fix the release-conductor signing step jq expression for workflow-owned identity bootstrap
- unblock hosted repair/publication for `v0.6.4-rc.1`
- keep `#1877` on the same publication path instead of minting a new blocker class

## Validation
- `node --test tools/priority/__tests__/release-conductor-workflow-contract.test.mjs tools/priority/__tests__/release-signing-readiness.test.mjs tools/priority/__tests__/release-signing-readiness-schema.test.mjs tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs`
- `git diff --check`

## Failure Signature
- hosted run `23463044449` failed in `Configure release tag signing material`
- root cause: `gh api user --jq '.email // \"\"'` over-escaped the jq program and caused a parse failure