### PR TITLE
fix: replay release publication after repaired tags for #1877

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   certification-matrix:

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -171,6 +171,8 @@ automation path:
   - when repair mode is used:
     - `release.repair.status = repaired`
     - `release.repair.remoteTargetCommitOid` matches the authoritative commit
+    - `release.publicationReplay.status = dispatched`
+    - the replayed `Release on tag` run succeeds for the repaired tag ref
 
 When the release trust gate fails, inspect `tests/results/_agent/supply-chain/release-trust-gate.json` and follow the
 matching remediation path:
@@ -188,7 +190,8 @@ matching remediation path:
     for the target version so the authoritative tag is recreated as a signed
     annotated tag without changing the intended release commit.
   - Rerun release only after the repair report shows
-    `release.repair.status = repaired`.
+    `release.repair.status = repaired` and
+    `release.publicationReplay.status = dispatched`.
 - `workflow-signing-secret-missing`, `workflow-signing-secret-unverifiable`
 - `workflow-signing-admin-scope-missing`, `workflow-signing-key-missing`, `workflow-signing-authority-unverifiable`
 - `release-conductor-apply-disabled`, `release-conductor-apply-unverifiable`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -170,6 +170,8 @@ plane:
   - configure workflow-owned signer identity
   - create the signed annotated tag
   - push the tag to the authoritative remote for the target repository
+  - when repairing an existing tag, dispatch `.github/workflows/release.yml`
+    on the repaired tag ref so publication replays deterministically
 - `tests/results/_agent/release/release-conductor-report.json` must record:
   - signing backend/source
   - signer identity used for tag creation/repair
@@ -177,6 +179,7 @@ plane:
   - whether the tag was pushed authoritatively
   - whether repair mode was requested/performed for an existing tag
   - the authoritative remote tag object/commit used for repair
+  - whether repaired-tag publication replay was dispatched
   - any push failure blocker
 
 ## Workflow signing readiness

--- a/docs/schemas/release-conductor-report-v1.schema.json
+++ b/docs/schemas/release-conductor-report-v1.schema.json
@@ -51,7 +51,8 @@
         "tagPushError",
         "tagPushRemote",
         "signingMaterial",
-        "repair"
+        "repair",
+        "publicationReplay"
       ],
       "properties": {
         "stream": { "type": "string" },
@@ -130,6 +131,22 @@
             "tagRecreated": { "type": "boolean" },
             "pushLeaseExpectedOid": { "type": ["string", "null"] },
             "lookupError": { "type": ["string", "null"] }
+          }
+        },
+        "publicationReplay": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["requested", "workflow", "ref", "dispatched", "status", "error"],
+          "properties": {
+            "requested": { "type": "boolean" },
+            "workflow": { "type": "string" },
+            "ref": { "type": ["string", "null"] },
+            "dispatched": { "type": "boolean" },
+            "status": {
+              "type": "string",
+              "enum": ["not-requested", "blocked", "dispatched", "dispatch-failed"]
+            },
+            "error": { "type": ["string", "null"] }
           }
         }
       }

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -917,6 +917,9 @@ test('runReleaseConductor repairs an existing authoritative tag when repair mode
   assert.equal(report.release.repair.status, 'repaired');
   assert.equal(report.release.repair.localTagDeleted, true);
   assert.equal(report.release.repair.tagRecreated, true);
+  assert.equal(report.release.publicationReplay.requested, true);
+  assert.equal(report.release.publicationReplay.status, 'dispatched');
+  assert.equal(report.release.publicationReplay.dispatched, true);
   assert.equal(
     commandCalls.some(
       (entry) =>
@@ -938,6 +941,131 @@ test('runReleaseConductor repairs an existing authoritative tag when repair mode
     ),
     true
   );
+  assert.equal(
+    commandCalls.some(
+      (entry) =>
+        entry.command === 'gh' &&
+        entry.args[0] === 'workflow' &&
+        entry.args[1] === 'run' &&
+        entry.args[2] === 'release.yml' &&
+        entry.args[3] === '--ref' &&
+        entry.args[4] === 'v0.8.0-rc.1'
+    ),
+    true
+  );
+});
+
+test('runReleaseConductor fails apply when repaired tag publication replay dispatch fails', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const runCommandFn = (command, args) => {
+    if (command === 'git' && args[0] === 'config') {
+      if (args[2] === 'user.signingkey') {
+        return { status: 0, stdout: '/tmp/release-signing.pub', stderr: '' };
+      }
+      if (args[2] === 'gpg.format') {
+        return { status: 0, stdout: 'ssh', stderr: '' };
+      }
+      if (args[2] === 'remote.upstream.url') {
+        return { status: 0, stdout: 'https://github.com/owner/repo.git', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'missing config' };
+    }
+    if (command === 'git' && args[0] === 'ls-remote') {
+      return {
+        status: 0,
+        stdout: [
+          '1111111111111111111111111111111111111111\trefs/tags/v0.8.0-rc.1',
+          '2222222222222222222222222222222222222222\trefs/tags/v0.8.0-rc.1^{}'
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return { status: 0, stdout: '1111111111111111111111111111111111111111\n', stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'tag' && args[1] === '-d') {
+      return { status: 0, stdout: `Deleted tag '${args[2]}'`, stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'tag') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'push') {
+      return { status: 0, stdout: '', stderr: '' };
+    }
+    if (command === 'gh' && args[0] === 'workflow' && args[1] === 'run') {
+      return { status: 1, stdout: '', stderr: 'dispatch denied' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      repairExistingTag: true,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'rc',
+      version: '0.8.0-rc.1',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(report.decision.status, 'fail');
+  assert.equal(report.release.repair.status, 'repaired');
+  assert.equal(report.release.publicationReplay.requested, true);
+  assert.equal(report.release.publicationReplay.status, 'dispatch-failed');
+  assert.equal(report.release.publicationReplay.dispatched, false);
+  assert.equal(report.release.publicationReplay.error, 'dispatch denied');
+  assert.ok(report.decision.blockers.some((entry) => entry.code === 'release-replay-dispatch-failed'));
 });
 
 test('runReleaseConductor fails apply when signed tag push remote is unavailable', async () => {

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -88,6 +88,15 @@ test('release workflow explicitly dispatches publish-tools-image with actions wr
   assert.match(dispatchStep.with.script, /const releaseChannel = releaseVersion\.includes\('-rc\.'\) \? 'rc' : 'stable';/);
 });
 
+test('release workflow remains tag-triggered and also supports workflow_dispatch replay for repaired tags', () => {
+  const workflowPath = path.join(workflowsRoot, 'release.yml');
+  const workflowRaw = readFileSync(workflowPath, 'utf8');
+  const workflow = yaml.load(workflowRaw);
+
+  assert.deepEqual(workflow?.on?.push?.tags, ['v*']);
+  assert.ok(Object.prototype.hasOwnProperty.call(workflow?.on ?? {}, 'workflow_dispatch'));
+});
+
 test('release workflow resolves downloaded artifacts through the shared helper before validation', () => {
   const workflowPath = path.join(workflowsRoot, 'release.yml');
   const workflowRaw = readFileSync(workflowPath, 'utf8');

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -13,6 +13,7 @@ export const DEFAULT_QUEUE_REPORT_PATH = path.join('tests', 'results', '_agent',
 export const DEFAULT_POLICY_SNAPSHOT_PATH = path.join('tests', 'results', '_agent', 'policy', 'policy-state-snapshot.json');
 export const DEFAULT_DWELL_MINUTES = 60;
 export const DEFAULT_QUARANTINE_STALE_HOURS = 24;
+export const RELEASE_PUBLICATION_WORKFLOW = 'release.yml';
 
 const REQUIRED_DWELL_WORKFLOWS = Object.freeze([
   { name: 'Validate', file: 'validate.yml' },
@@ -756,6 +757,14 @@ export async function runReleaseConductor(options = {}) {
   let tagError = null;
   let tagPushError = null;
   let proposalOnly = true;
+  const publicationReplay = {
+    requested: Boolean(args.repairExistingTag && applyRequested),
+    workflow: RELEASE_PUBLICATION_WORKFLOW,
+    ref: targetTag,
+    dispatched: false,
+    status: args.repairExistingTag && applyRequested ? 'blocked' : 'not-requested',
+    error: null
+  };
   const tagPushRemote = resolveTagPushRemote({ repoRoot, repository, runCommandFn });
   const remoteTag = inspectRemoteTag({
     repoRoot,
@@ -885,6 +894,28 @@ export async function runReleaseConductor(options = {}) {
                 tagPushed = true;
                 proposalOnly = false;
                 repair.status = 'repaired';
+                const dispatchResult = runCommandFn(
+                  'gh',
+                  ['workflow', 'run', RELEASE_PUBLICATION_WORKFLOW, '--ref', targetTag],
+                  {
+                    cwd: repoRoot,
+                    allowFailure: true
+                  }
+                );
+                if (dispatchResult.status === 0) {
+                  publicationReplay.dispatched = true;
+                  publicationReplay.status = 'dispatched';
+                } else {
+                  publicationReplay.status = 'dispatch-failed';
+                  publicationReplay.error =
+                    asOptional(dispatchResult.stderr) ??
+                    asOptional(dispatchResult.stdout) ??
+                    'release workflow dispatch failed';
+                  blockers.push({
+                    code: 'release-replay-dispatch-failed',
+                    message: `Release publication replay dispatch failed for ${targetTag}: ${publicationReplay.error}`
+                  });
+                }
               } else {
                 tagPushError = asOptional(pushResult.stderr) ?? asOptional(pushResult.stdout) ?? 'repair tag push failed';
                 blockers.push({
@@ -968,7 +999,8 @@ export async function runReleaseConductor(options = {}) {
       tagPushError,
       tagPushRemote,
       signingMaterial,
-      repair
+      repair,
+      publicationReplay
     },
     inputs: {
       reportPath: args.reportPath,


### PR DESCRIPTION
## Summary
- make `release.yml` dispatchable on tag refs for repaired-tag publication replay
- have `release-conductor` dispatch `release.yml` after a successful existing-tag repair
- record repaired-tag publication replay in the conductor report and docs

## Validation
- `node --test tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `git diff --check`

## Production Trigger
- conductor run `23464225561` succeeded with `repair.status = repaired`
- GitHub still did not create a new `Release on tag` run for `v0.6.4-rc.1`
- there is still no immutable release for `v0.6.4-rc.1`
- this patch closes that loop by replaying publication explicitly after repaired-tag push