### PR TITLE
feat: concentrate execution topology in governor handoff #1905

### DIFF
--- a/docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json
+++ b/docs/schemas/autonomous-governor-portfolio-summary-report-v1.schema.json
@@ -52,6 +52,7 @@
         "queueHandoffNextWakeCondition",
         "queueHandoffPrUrl",
         "queueAuthoritySource",
+        "executionTopology",
         "executionBundleStatus",
         "executionBundlePlaneBinding",
         "executionBundlePremiumSaganMode",
@@ -70,6 +71,7 @@
         "queueHandoffNextWakeCondition": { "type": ["string", "null"] },
         "queueHandoffPrUrl": { "type": ["string", "null"] },
         "queueAuthoritySource": { "type": ["string", "null"] },
+        "executionTopology": { "$ref": "#/$defs/executionTopology" },
         "executionBundleStatus": { "type": ["string", "null"] },
         "executionBundlePlaneBinding": { "type": ["string", "null"] },
         "executionBundlePremiumSaganMode": { "type": "boolean" },
@@ -260,6 +262,12 @@
         "queueHandoffNextWakeCondition",
         "queueHandoffPrUrl",
         "queueAuthoritySource",
+        "executionTopologyStatus",
+        "executionTopologyExecutionPlane",
+        "executionTopologyProviderId",
+        "executionTopologyWorkerSlotId",
+        "executionTopologyActiveLogicalLaneCount",
+        "executionTopologySeededLogicalLaneCount",
         "executionBundleStatus",
         "executionBundlePlaneBinding",
         "executionBundlePremiumSaganMode",
@@ -294,6 +302,12 @@
         "queueHandoffNextWakeCondition": { "type": ["string", "null"] },
         "queueHandoffPrUrl": { "type": ["string", "null"] },
         "queueAuthoritySource": { "type": ["string", "null"] },
+        "executionTopologyStatus": { "type": ["string", "null"] },
+        "executionTopologyExecutionPlane": { "type": ["string", "null"] },
+        "executionTopologyProviderId": { "type": ["string", "null"] },
+        "executionTopologyWorkerSlotId": { "type": ["string", "null"] },
+        "executionTopologyActiveLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "executionTopologySeededLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
         "executionBundleStatus": { "type": ["string", "null"] },
         "executionBundlePlaneBinding": { "type": ["string", "null"] },
         "executionBundlePremiumSaganMode": { "type": "boolean" },
@@ -313,6 +327,110 @@
           "type": "array",
           "items": { "type": "string" }
         }
+      }
+    }
+  },
+  "$defs": {
+    "executionBundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "planeBinding",
+        "premiumSaganMode",
+        "reciprocalLinkReady",
+        "effectiveBillableRateUsdPerHour",
+        "executionCellLeaseId",
+        "dockerLaneLeaseId",
+        "harnessInstanceId",
+        "cellId",
+        "laneId",
+        "isolatedLaneGroupId",
+        "fingerprintSha256"
+      ],
+      "properties": {
+        "status": { "type": ["string", "null"] },
+        "planeBinding": { "type": ["string", "null"] },
+        "premiumSaganMode": { "type": "boolean" },
+        "reciprocalLinkReady": { "type": "boolean" },
+        "effectiveBillableRateUsdPerHour": { "type": ["number", "null"], "minimum": 0 },
+        "executionCellLeaseId": { "type": ["string", "null"] },
+        "dockerLaneLeaseId": { "type": ["string", "null"] },
+        "harnessInstanceId": { "type": ["string", "null"] },
+        "cellId": { "type": ["string", "null"] },
+        "laneId": { "type": ["string", "null"] },
+        "isolatedLaneGroupId": { "type": ["string", "null"] },
+        "fingerprintSha256": { "type": ["string", "null"] }
+      }
+    },
+    "executionTopologyLogicalLaneActivation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["activeLaneCount", "seededLaneCount", "catalogCount"],
+      "properties": {
+        "activeLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "seededLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "catalogCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "executionTopologyProviderDispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "providerId",
+        "providerKind",
+        "executionPlane",
+        "assignmentMode",
+        "dispatchSurface",
+        "completionMode",
+        "workerSlotId",
+        "dispatchStatus",
+        "completionStatus",
+        "failureClass"
+      ],
+      "properties": {
+        "providerId": { "type": ["string", "null"] },
+        "providerKind": { "type": ["string", "null"] },
+        "executionPlane": { "type": ["string", "null"] },
+        "assignmentMode": { "type": ["string", "null"] },
+        "dispatchSurface": { "type": ["string", "null"] },
+        "completionMode": { "type": ["string", "null"] },
+        "workerSlotId": { "type": ["string", "null"] },
+        "dispatchStatus": { "type": ["string", "null"] },
+        "completionStatus": { "type": ["string", "null"] },
+        "failureClass": { "type": ["string", "null"] }
+      }
+    },
+    "executionTopology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "executionPlane",
+        "providerId",
+        "workerSlotId",
+        "activeLogicalLaneCount",
+        "seededLogicalLaneCount",
+        "catalogCount",
+        "premiumSaganMode",
+        "reciprocalLinkReady",
+        "logicalLaneActivation",
+        "providerDispatch",
+        "executionBundle"
+      ],
+      "properties": {
+        "status": { "type": ["string", "null"] },
+        "executionPlane": { "type": ["string", "null"] },
+        "providerId": { "type": ["string", "null"] },
+        "workerSlotId": { "type": ["string", "null"] },
+        "activeLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "seededLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "catalogCount": { "type": "integer", "minimum": 0 },
+        "premiumSaganMode": { "type": "boolean" },
+        "reciprocalLinkReady": { "type": "boolean" },
+        "logicalLaneActivation": { "$ref": "#/$defs/executionTopologyLogicalLaneActivation" },
+        "providerDispatch": { "$ref": "#/$defs/executionTopologyProviderDispatch" },
+        "executionBundle": { "$ref": "#/$defs/executionBundle" }
       }
     }
   }

--- a/docs/schemas/autonomous-governor-summary-report-v1.schema.json
+++ b/docs/schemas/autonomous-governor-summary-report-v1.schema.json
@@ -138,6 +138,7 @@
         "outcome",
         "blockerClass",
         "nextWakeCondition",
+        "executionTopology",
         "executionBundle",
         "queueAuthorityRefresh",
         "prUrl",
@@ -162,38 +163,8 @@
         "outcome": { "type": ["string", "null"] },
         "blockerClass": { "type": ["string", "null"] },
         "nextWakeCondition": { "type": ["string", "null"] },
-        "executionBundle": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "status",
-            "planeBinding",
-            "premiumSaganMode",
-            "reciprocalLinkReady",
-            "effectiveBillableRateUsdPerHour",
-            "executionCellLeaseId",
-            "dockerLaneLeaseId",
-            "harnessInstanceId",
-            "cellId",
-            "laneId",
-            "isolatedLaneGroupId",
-            "fingerprintSha256"
-          ],
-          "properties": {
-            "status": { "type": ["string", "null"] },
-            "planeBinding": { "type": ["string", "null"] },
-            "premiumSaganMode": { "type": "boolean" },
-            "reciprocalLinkReady": { "type": "boolean" },
-            "effectiveBillableRateUsdPerHour": { "type": ["number", "null"], "minimum": 0 },
-            "executionCellLeaseId": { "type": ["string", "null"] },
-            "dockerLaneLeaseId": { "type": ["string", "null"] },
-            "harnessInstanceId": { "type": ["string", "null"] },
-            "cellId": { "type": ["string", "null"] },
-            "laneId": { "type": ["string", "null"] },
-            "isolatedLaneGroupId": { "type": ["string", "null"] },
-            "fingerprintSha256": { "type": ["string", "null"] }
-          }
-        },
+        "executionTopology": { "$ref": "#/$defs/executionTopology" },
+        "executionBundle": { "$ref": "#/$defs/executionBundle" },
         "queueAuthorityRefresh": { "$ref": "#/$defs/queueAuthorityRefresh" },
         "prUrl": { "type": ["string", "null"] },
         "issueNumber": { "type": ["integer", "null"], "minimum": 1 },
@@ -364,6 +335,12 @@
         "releasePublishedBundleState",
         "releasePublishedBundleReleaseTag",
         "releasePublishedBundleAuthoritativeConsumerPin",
+        "executionTopologyStatus",
+        "executionTopologyExecutionPlane",
+        "executionTopologyProviderId",
+        "executionTopologyWorkerSlotId",
+        "executionTopologyActiveLogicalLaneCount",
+        "executionTopologySeededLogicalLaneCount",
         "executionBundleStatus",
         "executionBundlePlaneBinding",
         "executionBundlePremiumSaganMode",
@@ -424,6 +401,12 @@
         "releasePublishedBundleState": { "type": ["string", "null"] },
         "releasePublishedBundleReleaseTag": { "type": ["string", "null"] },
         "releasePublishedBundleAuthoritativeConsumerPin": { "type": ["string", "null"] },
+        "executionTopologyStatus": { "type": ["string", "null"] },
+        "executionTopologyExecutionPlane": { "type": ["string", "null"] },
+        "executionTopologyProviderId": { "type": ["string", "null"] },
+        "executionTopologyWorkerSlotId": { "type": ["string", "null"] },
+        "executionTopologyActiveLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "executionTopologySeededLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
         "executionBundleStatus": { "type": ["string", "null"] },
         "executionBundlePlaneBinding": { "type": ["string", "null"] },
         "executionBundlePremiumSaganMode": { "type": "boolean" },
@@ -490,6 +473,108 @@
         "isInMergeQueue": { "type": ["boolean", "null"] },
         "autoMergeEnabled": { "type": ["boolean", "null"] },
         "mergedAt": { "type": ["string", "null"] }
+      }
+    },
+    "executionBundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "planeBinding",
+        "premiumSaganMode",
+        "reciprocalLinkReady",
+        "effectiveBillableRateUsdPerHour",
+        "executionCellLeaseId",
+        "dockerLaneLeaseId",
+        "harnessInstanceId",
+        "cellId",
+        "laneId",
+        "isolatedLaneGroupId",
+        "fingerprintSha256"
+      ],
+      "properties": {
+        "status": { "type": ["string", "null"] },
+        "planeBinding": { "type": ["string", "null"] },
+        "premiumSaganMode": { "type": "boolean" },
+        "reciprocalLinkReady": { "type": "boolean" },
+        "effectiveBillableRateUsdPerHour": { "type": ["number", "null"], "minimum": 0 },
+        "executionCellLeaseId": { "type": ["string", "null"] },
+        "dockerLaneLeaseId": { "type": ["string", "null"] },
+        "harnessInstanceId": { "type": ["string", "null"] },
+        "cellId": { "type": ["string", "null"] },
+        "laneId": { "type": ["string", "null"] },
+        "isolatedLaneGroupId": { "type": ["string", "null"] },
+        "fingerprintSha256": { "type": ["string", "null"] }
+      }
+    },
+    "executionTopologyLogicalLaneActivation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["activeLaneCount", "seededLaneCount", "catalogCount"],
+      "properties": {
+        "activeLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "seededLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "catalogCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "executionTopologyProviderDispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "providerId",
+        "providerKind",
+        "executionPlane",
+        "assignmentMode",
+        "dispatchSurface",
+        "completionMode",
+        "workerSlotId",
+        "dispatchStatus",
+        "completionStatus",
+        "failureClass"
+      ],
+      "properties": {
+        "providerId": { "type": ["string", "null"] },
+        "providerKind": { "type": ["string", "null"] },
+        "executionPlane": { "type": ["string", "null"] },
+        "assignmentMode": { "type": ["string", "null"] },
+        "dispatchSurface": { "type": ["string", "null"] },
+        "completionMode": { "type": ["string", "null"] },
+        "workerSlotId": { "type": ["string", "null"] },
+        "dispatchStatus": { "type": ["string", "null"] },
+        "completionStatus": { "type": ["string", "null"] },
+        "failureClass": { "type": ["string", "null"] }
+      }
+    },
+    "executionTopology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "executionPlane",
+        "providerId",
+        "workerSlotId",
+        "activeLogicalLaneCount",
+        "seededLogicalLaneCount",
+        "catalogCount",
+        "premiumSaganMode",
+        "reciprocalLinkReady",
+        "logicalLaneActivation",
+        "providerDispatch",
+        "executionBundle"
+      ],
+      "properties": {
+        "status": { "type": ["string", "null"] },
+        "executionPlane": { "type": ["string", "null"] },
+        "providerId": { "type": ["string", "null"] },
+        "workerSlotId": { "type": ["string", "null"] },
+        "activeLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "seededLogicalLaneCount": { "type": ["integer", "null"], "minimum": 0 },
+        "catalogCount": { "type": "integer", "minimum": 0 },
+        "premiumSaganMode": { "type": "boolean" },
+        "reciprocalLinkReady": { "type": "boolean" },
+        "logicalLaneActivation": { "$ref": "#/$defs/executionTopologyLogicalLaneActivation" },
+        "providerDispatch": { "$ref": "#/$defs/executionTopologyProviderDispatch" },
+        "executionBundle": { "$ref": "#/$defs/executionBundle" }
       }
     }
   }

--- a/tools/Print-AgentHandoff.ps1
+++ b/tools/Print-AgentHandoff.ps1
@@ -1569,6 +1569,14 @@ try {
         Write-Host ("  pr       : {0}" -f (Format-NullableValue $governor.summary.queueHandoffPrUrl))
       }
     }
+    if ($governor.summary.PSObject.Properties['executionTopologyStatus'] -and $governor.summary.executionTopologyStatus) {
+      Write-Host ("  execTopo : {0}" -f (Format-NullableValue $governor.summary.executionTopologyStatus))
+      Write-Host ("  execProv : {0}" -f (Format-NullableValue $governor.summary.executionTopologyProviderId))
+      Write-Host ("  execSlot : {0}" -f (Format-NullableValue $governor.summary.executionTopologyWorkerSlotId))
+      Write-Host ("  execLanes: {0}/{1}" -f
+        (Format-NullableValue $governor.summary.executionTopologyActiveLogicalLaneCount),
+        (Format-NullableValue $governor.summary.executionTopologySeededLogicalLaneCount))
+    }
     if ($governor.summary.PSObject.Properties['executionBundleStatus'] -and $governor.summary.executionBundleStatus) {
       Write-Host ("  exec     : {0}" -f (Format-NullableValue $governor.summary.executionBundleStatus))
       Write-Host ("  execPlan : {0}" -f (Format-NullableValue $governor.summary.executionBundlePlaneBinding))
@@ -1615,6 +1623,14 @@ try {
         if ($governor.summary.PSObject.Properties['queueHandoffPrUrl'] -and $governor.summary.queueHandoffPrUrl) {
           $governorLines += ('- Queue PR: {0}' -f (Format-NullableValue $governor.summary.queueHandoffPrUrl))
         }
+      }
+      if ($governor.summary.PSObject.Properties['executionTopologyStatus'] -and $governor.summary.executionTopologyStatus) {
+        $governorLines += ('- Execution topology: {0}' -f (Format-NullableValue $governor.summary.executionTopologyStatus))
+        $governorLines += ('- Execution provider: {0}' -f (Format-NullableValue $governor.summary.executionTopologyProviderId))
+        $governorLines += ('- Execution worker slot: {0}' -f (Format-NullableValue $governor.summary.executionTopologyWorkerSlotId))
+        $governorLines += ('- Execution logical lanes active/seeded: {0}/{1}' -f
+          (Format-NullableValue $governor.summary.executionTopologyActiveLogicalLaneCount),
+          (Format-NullableValue $governor.summary.executionTopologySeededLogicalLaneCount))
       }
       if ($governor.summary.PSObject.Properties['executionBundleStatus'] -and $governor.summary.executionBundleStatus) {
         $governorLines += ('- Execution bundle: {0}' -f (Format-NullableValue $governor.summary.executionBundleStatus))
@@ -1667,6 +1683,14 @@ try {
         Write-Host ("  queueSrc : {0}" -f (Format-NullableValue $portfolio.summary.queueAuthoritySource))
       }
     }
+    if ($portfolio.summary.PSObject.Properties['executionTopologyStatus'] -and $portfolio.summary.executionTopologyStatus) {
+      Write-Host ("  execTopo : {0}" -f (Format-NullableValue $portfolio.summary.executionTopologyStatus))
+      Write-Host ("  execProv : {0}" -f (Format-NullableValue $portfolio.summary.executionTopologyProviderId))
+      Write-Host ("  execSlot : {0}" -f (Format-NullableValue $portfolio.summary.executionTopologyWorkerSlotId))
+      Write-Host ("  execLanes: {0}/{1}" -f
+        (Format-NullableValue $portfolio.summary.executionTopologyActiveLogicalLaneCount),
+        (Format-NullableValue $portfolio.summary.executionTopologySeededLogicalLaneCount))
+    }
     if ($portfolio.summary.PSObject.Properties['executionBundleStatus'] -and $portfolio.summary.executionBundleStatus) {
       Write-Host ("  exec     : {0}" -f (Format-NullableValue $portfolio.summary.executionBundleStatus))
       Write-Host ("  execPlan : {0}" -f (Format-NullableValue $portfolio.summary.executionBundlePlaneBinding))
@@ -1709,6 +1733,14 @@ try {
         if ($portfolio.summary.PSObject.Properties['queueAuthoritySource']) {
           $portfolioLines += ('- Queue source: {0}' -f (Format-NullableValue $portfolio.summary.queueAuthoritySource))
         }
+      }
+      if ($portfolio.summary.PSObject.Properties['executionTopologyStatus'] -and $portfolio.summary.executionTopologyStatus) {
+        $portfolioLines += ('- Execution topology: {0}' -f (Format-NullableValue $portfolio.summary.executionTopologyStatus))
+        $portfolioLines += ('- Execution provider: {0}' -f (Format-NullableValue $portfolio.summary.executionTopologyProviderId))
+        $portfolioLines += ('- Execution worker slot: {0}' -f (Format-NullableValue $portfolio.summary.executionTopologyWorkerSlotId))
+        $portfolioLines += ('- Execution logical lanes active/seeded: {0}/{1}' -f
+          (Format-NullableValue $portfolio.summary.executionTopologyActiveLogicalLaneCount),
+          (Format-NullableValue $portfolio.summary.executionTopologySeededLogicalLaneCount))
       }
       if ($portfolio.summary.PSObject.Properties['executionBundleStatus'] -and $portfolio.summary.executionBundleStatus) {
         $portfolioLines += ('- Execution bundle: {0}' -f (Format-NullableValue $portfolio.summary.executionBundleStatus))

--- a/tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs
@@ -54,6 +54,51 @@ function createCompareGovernorSummary(overrides = {}) {
         publishedBundleReleaseTag: 'v0.6.3-tools.14',
         publishedBundleAuthoritativeConsumerPin: null,
         externalBlocker: 'workflow-signing-secret-missing'
+      },
+      deliveryRuntime: {
+        executionTopology: {
+          status: 'bundle-committed',
+          executionPlane: 'hosted',
+          providerId: 'hosted-github-workflow',
+          workerSlotId: 'worker-slot-2',
+          activeLogicalLaneCount: 2,
+          seededLogicalLaneCount: 4,
+          catalogCount: 4,
+          premiumSaganMode: true,
+          reciprocalLinkReady: true,
+          logicalLaneActivation: {
+            activeLaneCount: 2,
+            seededLaneCount: 4,
+            catalogCount: 4
+          },
+          providerDispatch: {
+            providerId: 'hosted-github-workflow',
+            providerKind: 'hosted-github-workflow',
+            executionPlane: 'hosted',
+            assignmentMode: 'async-validation',
+            dispatchSurface: 'github-actions',
+            completionMode: 'async',
+            workerSlotId: 'worker-slot-2',
+            dispatchStatus: 'completed',
+            completionStatus: 'waiting',
+            failureClass: null
+          },
+          executionBundle: {
+            status: 'committed',
+            planeBinding: 'dual-plane-parity',
+            premiumSaganMode: true,
+            reciprocalLinkReady: true,
+            effectiveBillableRateUsdPerHour: 375,
+            executionCellLeaseId: 'exec-lease-123',
+            dockerLaneLeaseId: 'docker-lease-456',
+            harnessInstanceId: 'ts-harness-01',
+            cellId: 'cell-sagan-kernel',
+            laneId: 'docker-lane-01',
+            isolatedLaneGroupId:
+              'host-os-fingerprint:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            fingerprintSha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          }
+        }
       }
     },
     wake: {
@@ -97,6 +142,12 @@ function createCompareGovernorSummary(overrides = {}) {
       queueHandoffNextWakeCondition: 'checks-green',
       queueHandoffPrUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864',
       queueAuthoritySource: 'delivery-runtime',
+      executionTopologyStatus: 'bundle-committed',
+      executionTopologyExecutionPlane: 'hosted',
+      executionTopologyProviderId: 'hosted-github-workflow',
+      executionTopologyWorkerSlotId: 'worker-slot-2',
+      executionTopologyActiveLogicalLaneCount: 2,
+      executionTopologySeededLogicalLaneCount: 4,
       executionBundleStatus: 'committed',
       executionBundlePlaneBinding: 'dual-plane-parity',
       executionBundlePremiumSaganMode: true,
@@ -331,6 +382,12 @@ test('runAutonomousGovernorPortfolioSummary keeps compare as owner during active
   assert.equal(report.summary.queueHandoffStatus, 'checks-pending');
   assert.equal(report.summary.queueHandoffNextWakeCondition, 'checks-green');
   assert.equal(report.summary.queueAuthoritySource, 'delivery-runtime');
+  assert.equal(report.summary.executionTopologyStatus, 'bundle-committed');
+  assert.equal(report.summary.executionTopologyExecutionPlane, 'hosted');
+  assert.equal(report.summary.executionTopologyProviderId, 'hosted-github-workflow');
+  assert.equal(report.summary.executionTopologyWorkerSlotId, 'worker-slot-2');
+  assert.equal(report.summary.executionTopologyActiveLogicalLaneCount, 2);
+  assert.equal(report.summary.executionTopologySeededLogicalLaneCount, 4);
   assert.equal(report.summary.executionBundleStatus, 'committed');
   assert.equal(report.summary.executionBundlePlaneBinding, 'dual-plane-parity');
   assert.equal(report.summary.executionBundlePremiumSaganMode, true);
@@ -349,6 +406,15 @@ test('runAutonomousGovernorPortfolioSummary keeps compare as owner during active
   assert.equal(report.summary.viHistoryDistributorDependencyReleaseConductorApplyState, 'disabled');
   assert.equal(report.compare.queueHandoffPrUrl, 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864');
   assert.equal(report.compare.queueAuthoritySource, 'delivery-runtime');
+  assert.equal(report.compare.executionTopology.status, 'bundle-committed');
+  assert.equal(report.compare.executionTopology.executionPlane, 'hosted');
+  assert.equal(report.compare.executionTopology.providerId, 'hosted-github-workflow');
+  assert.equal(report.compare.executionTopology.workerSlotId, 'worker-slot-2');
+  assert.equal(report.compare.executionTopology.activeLogicalLaneCount, 2);
+  assert.equal(report.compare.executionTopology.seededLogicalLaneCount, 4);
+  assert.equal(report.compare.executionTopology.logicalLaneActivation.catalogCount, 4);
+  assert.equal(report.compare.executionTopology.providerDispatch.dispatchStatus, 'completed');
+  assert.equal(report.compare.executionTopology.executionBundle.status, 'committed');
   assert.equal(report.compare.executionBundleStatus, 'committed');
   assert.equal(report.compare.executionBundlePlaneBinding, 'dual-plane-parity');
   assert.equal(report.compare.executionBundlePremiumSaganMode, true);

--- a/tools/priority/__tests__/autonomous-governor-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-summary.test.mjs
@@ -180,6 +180,16 @@ function createDeliveryRuntimeState(overrides = {}) {
     schema: 'priority/delivery-agent-runtime-state@v1',
     status: 'waiting-ci',
     laneLifecycle: 'waiting-ci',
+    logicalLaneActivation: {
+      seededLaneCount: 4,
+      activeLaneCount: 2,
+      catalog: [
+        { id: 'logical-lane-01', activationState: 'active' },
+        { id: 'logical-lane-02', activationState: 'active' },
+        { id: 'logical-lane-03', activationState: 'seeded' },
+        { id: 'logical-lane-04', activationState: 'seeded' }
+      ]
+    },
     queueAuthorityRefresh: {
       attempted: false,
       status: null,
@@ -205,6 +215,18 @@ function createDeliveryRuntimeState(overrides = {}) {
       blockerClass: 'none',
       nextWakeCondition: 'checks-green',
       reason: 'Waiting for hosted checks to finish before merge queue advances.',
+      providerDispatch: {
+        providerId: 'hosted-github-workflow',
+        providerKind: 'hosted-github-workflow',
+        executionPlane: 'hosted',
+        assignmentMode: 'async-validation',
+        dispatchSurface: 'github-actions',
+        completionMode: 'async',
+        workerSlotId: 'worker-slot-2',
+        dispatchStatus: 'completed',
+        completionStatus: 'waiting',
+        failureClass: null
+      },
       concurrentLaneStatus: {
         executionBundle: {
           status: 'committed',
@@ -424,6 +446,16 @@ test('runAutonomousGovernorSummary carries queue-owned delivery runtime state in
   assert.equal(report.compare.deliveryRuntime.laneLifecycle, 'waiting-ci');
   assert.equal(report.compare.deliveryRuntime.nextWakeCondition, 'checks-green');
   assert.equal(report.compare.deliveryRuntime.prUrl, 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1864');
+  assert.equal(report.compare.deliveryRuntime.executionTopology.status, 'bundle-committed');
+  assert.equal(report.compare.deliveryRuntime.executionTopology.executionPlane, 'hosted');
+  assert.equal(report.compare.deliveryRuntime.executionTopology.providerId, 'hosted-github-workflow');
+  assert.equal(report.compare.deliveryRuntime.executionTopology.workerSlotId, 'worker-slot-2');
+  assert.equal(report.compare.deliveryRuntime.executionTopology.activeLogicalLaneCount, 2);
+  assert.equal(report.compare.deliveryRuntime.executionTopology.seededLogicalLaneCount, 4);
+  assert.equal(report.compare.deliveryRuntime.executionTopology.catalogCount, 4);
+  assert.equal(report.compare.deliveryRuntime.executionTopology.logicalLaneActivation.activeLaneCount, 2);
+  assert.equal(report.compare.deliveryRuntime.executionTopology.providerDispatch.dispatchStatus, 'completed');
+  assert.equal(report.compare.deliveryRuntime.executionTopology.executionBundle.status, 'committed');
   assert.equal(report.compare.deliveryRuntime.executionBundle.status, 'committed');
   assert.equal(report.compare.deliveryRuntime.executionBundle.planeBinding, 'dual-plane-parity');
   assert.equal(report.compare.deliveryRuntime.executionBundle.premiumSaganMode, true);
@@ -431,6 +463,12 @@ test('runAutonomousGovernorSummary carries queue-owned delivery runtime state in
   assert.equal(report.compare.deliveryRuntime.executionBundle.effectiveBillableRateUsdPerHour, 375);
   assert.equal(report.compare.deliveryRuntime.queueAuthorityRefresh.attempted, false);
   assert.equal(report.compare.deliveryRuntime.queueAuthorityRefresh.summaryPath, null);
+  assert.equal(report.summary.executionTopologyStatus, 'bundle-committed');
+  assert.equal(report.summary.executionTopologyExecutionPlane, 'hosted');
+  assert.equal(report.summary.executionTopologyProviderId, 'hosted-github-workflow');
+  assert.equal(report.summary.executionTopologyWorkerSlotId, 'worker-slot-2');
+  assert.equal(report.summary.executionTopologyActiveLogicalLaneCount, 2);
+  assert.equal(report.summary.executionTopologySeededLogicalLaneCount, 4);
   assert.equal(report.summary.executionBundleStatus, 'committed');
   assert.equal(report.summary.executionBundlePlaneBinding, 'dual-plane-parity');
   assert.equal(report.summary.executionBundlePremiumSaganMode, true);

--- a/tools/priority/autonomous-governor-portfolio-summary.mjs
+++ b/tools/priority/autonomous-governor-portfolio-summary.mjs
@@ -224,6 +224,113 @@ function derivePortfolioMode(compareGovernorSummary, monitoringMode) {
   return compareMode || 'attention-required';
 }
 
+function deriveExecutionTopology(compareGovernorSummary) {
+  const executionTopology = compareGovernorSummary?.compare?.deliveryRuntime?.executionTopology;
+  if (executionTopology && typeof executionTopology === 'object' && !Array.isArray(executionTopology)) {
+    return {
+      status: asOptional(executionTopology.status),
+      executionPlane: asOptional(executionTopology.executionPlane),
+      providerId: asOptional(executionTopology.providerId),
+      workerSlotId: asOptional(executionTopology.workerSlotId),
+      activeLogicalLaneCount: Number.isInteger(executionTopology.activeLogicalLaneCount)
+        ? executionTopology.activeLogicalLaneCount
+        : null,
+      seededLogicalLaneCount: Number.isInteger(executionTopology.seededLogicalLaneCount)
+        ? executionTopology.seededLogicalLaneCount
+        : null,
+      catalogCount: Number.isInteger(executionTopology.catalogCount) ? executionTopology.catalogCount : 0,
+      premiumSaganMode: executionTopology.premiumSaganMode === true,
+      reciprocalLinkReady: executionTopology.reciprocalLinkReady === true,
+      logicalLaneActivation: {
+        activeLaneCount: Number.isInteger(executionTopology?.logicalLaneActivation?.activeLaneCount)
+          ? executionTopology.logicalLaneActivation.activeLaneCount
+          : null,
+        seededLaneCount: Number.isInteger(executionTopology?.logicalLaneActivation?.seededLaneCount)
+          ? executionTopology.logicalLaneActivation.seededLaneCount
+          : null,
+        catalogCount: Number.isInteger(executionTopology?.logicalLaneActivation?.catalogCount)
+          ? executionTopology.logicalLaneActivation.catalogCount
+          : 0
+      },
+      providerDispatch: {
+        providerId: asOptional(executionTopology?.providerDispatch?.providerId),
+        providerKind: asOptional(executionTopology?.providerDispatch?.providerKind),
+        executionPlane: asOptional(executionTopology?.providerDispatch?.executionPlane),
+        assignmentMode: asOptional(executionTopology?.providerDispatch?.assignmentMode),
+        dispatchSurface: asOptional(executionTopology?.providerDispatch?.dispatchSurface),
+        completionMode: asOptional(executionTopology?.providerDispatch?.completionMode),
+        workerSlotId: asOptional(executionTopology?.providerDispatch?.workerSlotId),
+        dispatchStatus: asOptional(executionTopology?.providerDispatch?.dispatchStatus),
+        completionStatus: asOptional(executionTopology?.providerDispatch?.completionStatus),
+        failureClass: asOptional(executionTopology?.providerDispatch?.failureClass)
+      },
+      executionBundle: {
+        status: asOptional(executionTopology?.executionBundle?.status),
+        planeBinding: asOptional(executionTopology?.executionBundle?.planeBinding),
+        premiumSaganMode: executionTopology?.executionBundle?.premiumSaganMode === true,
+        reciprocalLinkReady: executionTopology?.executionBundle?.reciprocalLinkReady === true,
+        effectiveBillableRateUsdPerHour: Number.isFinite(executionTopology?.executionBundle?.effectiveBillableRateUsdPerHour)
+          ? executionTopology.executionBundle.effectiveBillableRateUsdPerHour
+          : null,
+        executionCellLeaseId: asOptional(executionTopology?.executionBundle?.executionCellLeaseId),
+        dockerLaneLeaseId: asOptional(executionTopology?.executionBundle?.dockerLaneLeaseId),
+        harnessInstanceId: asOptional(executionTopology?.executionBundle?.harnessInstanceId),
+        cellId: asOptional(executionTopology?.executionBundle?.cellId),
+        laneId: asOptional(executionTopology?.executionBundle?.laneId),
+        isolatedLaneGroupId: asOptional(executionTopology?.executionBundle?.isolatedLaneGroupId),
+        fingerprintSha256: asOptional(executionTopology?.executionBundle?.fingerprintSha256)
+      }
+    };
+  }
+
+  return {
+    status: asOptional(compareGovernorSummary?.summary?.executionBundleStatus),
+    executionPlane: asOptional(compareGovernorSummary?.summary?.executionBundlePlaneBinding),
+    providerId: null,
+    workerSlotId: null,
+    activeLogicalLaneCount: null,
+    seededLogicalLaneCount: null,
+    catalogCount: 0,
+    premiumSaganMode: compareGovernorSummary?.summary?.executionBundlePremiumSaganMode === true,
+    reciprocalLinkReady: compareGovernorSummary?.summary?.executionBundleReciprocalLinkReady === true,
+    logicalLaneActivation: {
+      activeLaneCount: null,
+      seededLaneCount: null,
+      catalogCount: 0
+    },
+    providerDispatch: {
+      providerId: null,
+      providerKind: null,
+      executionPlane: null,
+      assignmentMode: null,
+      dispatchSurface: null,
+      completionMode: null,
+      workerSlotId: null,
+      dispatchStatus: null,
+      completionStatus: null,
+      failureClass: null
+    },
+    executionBundle: {
+      status: asOptional(compareGovernorSummary?.summary?.executionBundleStatus),
+      planeBinding: asOptional(compareGovernorSummary?.summary?.executionBundlePlaneBinding),
+      premiumSaganMode: compareGovernorSummary?.summary?.executionBundlePremiumSaganMode === true,
+      reciprocalLinkReady: compareGovernorSummary?.summary?.executionBundleReciprocalLinkReady === true,
+      effectiveBillableRateUsdPerHour: Number.isFinite(
+        compareGovernorSummary?.summary?.executionBundleEffectiveBillableRateUsdPerHour
+      )
+        ? compareGovernorSummary.summary.executionBundleEffectiveBillableRateUsdPerHour
+        : null,
+      executionCellLeaseId: null,
+      dockerLaneLeaseId: null,
+      harnessInstanceId: null,
+      cellId: null,
+      laneId: null,
+      isolatedLaneGroupId: null,
+      fingerprintSha256: null
+    }
+  };
+}
+
 function deriveOwners(compareGovernorSummary, monitoringMode, portfolioMode, viHistoryDistributorDependency) {
   const compareRepository =
     asOptional(compareGovernorSummary?.summary?.currentOwnerRepository) ||
@@ -397,6 +504,7 @@ function buildReport({
   const triggeredWakeConditions = Array.isArray(monitoringMode?.summary?.triggeredWakeConditions)
     ? monitoringMode.summary.triggeredWakeConditions
     : [];
+  const executionTopology = deriveExecutionTopology(compareGovernorSummary);
 
   return {
     schema: 'priority/autonomous-governor-portfolio-summary-report@v1',
@@ -420,6 +528,7 @@ function buildReport({
       queueHandoffNextWakeCondition: asOptional(compareGovernorSummary?.summary?.queueHandoffNextWakeCondition),
       queueHandoffPrUrl: asOptional(compareGovernorSummary?.summary?.queueHandoffPrUrl),
       queueAuthoritySource: asOptional(compareGovernorSummary?.summary?.queueAuthoritySource),
+      executionTopology,
       executionBundleStatus: asOptional(compareGovernorSummary?.summary?.executionBundleStatus),
       executionBundlePlaneBinding: asOptional(compareGovernorSummary?.summary?.executionBundlePlaneBinding),
       executionBundlePremiumSaganMode: compareGovernorSummary?.summary?.executionBundlePremiumSaganMode === true,
@@ -457,6 +566,12 @@ function buildReport({
       queueHandoffNextWakeCondition: asOptional(compareGovernorSummary?.summary?.queueHandoffNextWakeCondition),
       queueHandoffPrUrl: asOptional(compareGovernorSummary?.summary?.queueHandoffPrUrl),
       queueAuthoritySource: asOptional(compareGovernorSummary?.summary?.queueAuthoritySource),
+      executionTopologyStatus: executionTopology.status,
+      executionTopologyExecutionPlane: executionTopology.executionPlane,
+      executionTopologyProviderId: executionTopology.providerId,
+      executionTopologyWorkerSlotId: executionTopology.workerSlotId,
+      executionTopologyActiveLogicalLaneCount: executionTopology.activeLogicalLaneCount,
+      executionTopologySeededLogicalLaneCount: executionTopology.seededLogicalLaneCount,
       executionBundleStatus: asOptional(compareGovernorSummary?.summary?.executionBundleStatus),
       executionBundlePlaneBinding: asOptional(compareGovernorSummary?.summary?.executionBundlePlaneBinding),
       executionBundlePremiumSaganMode: compareGovernorSummary?.summary?.executionBundlePremiumSaganMode === true,

--- a/tools/priority/autonomous-governor-summary.mjs
+++ b/tools/priority/autonomous-governor-summary.mjs
@@ -186,6 +186,94 @@ function parseBoolean(value) {
   return value === true;
 }
 
+function deriveExecutionTopologyStatus({ activeLogicalLaneCount, seededLogicalLaneCount, providerDispatch, executionBundle }) {
+  const bundleStatus = asOptional(executionBundle?.status);
+  if (bundleStatus) {
+    return `bundle-${bundleStatus}`;
+  }
+
+  const completionStatus = asOptional(providerDispatch?.completionStatus);
+  if (completionStatus) {
+    return `provider-${completionStatus}`;
+  }
+
+  const dispatchStatus = asOptional(providerDispatch?.dispatchStatus);
+  if (dispatchStatus) {
+    return `provider-${dispatchStatus}`;
+  }
+
+  if ((activeLogicalLaneCount ?? 0) > 0 || (seededLogicalLaneCount ?? 0) > 0) {
+    return 'logical-lanes-tracked';
+  }
+
+  return 'none';
+}
+
+function deriveExecutionTopology({ deliveryRuntimeState, activeLane, executionBundle }) {
+  const logicalLaneActivation = normalizeOptionalObject(deliveryRuntimeState?.logicalLaneActivation);
+  const logicalLaneCatalog = Array.isArray(logicalLaneActivation?.catalog) ? logicalLaneActivation.catalog : [];
+  const providerDispatch =
+    normalizeOptionalObject(activeLane?.providerDispatch) ??
+    normalizeOptionalObject(deliveryRuntimeState?.artifacts?.providerDispatch);
+  const activeLogicalLaneCount = Number.isInteger(logicalLaneActivation?.activeLaneCount)
+    ? logicalLaneActivation.activeLaneCount
+    : null;
+  const seededLogicalLaneCount = Number.isInteger(logicalLaneActivation?.seededLaneCount)
+    ? logicalLaneActivation.seededLaneCount
+    : null;
+  const executionPlane = asOptional(providerDispatch?.executionPlane) || asOptional(executionBundle?.planeBinding);
+
+  return {
+    status: deriveExecutionTopologyStatus({
+      activeLogicalLaneCount,
+      seededLogicalLaneCount,
+      providerDispatch,
+      executionBundle
+    }),
+    executionPlane,
+    providerId: asOptional(providerDispatch?.providerId),
+    workerSlotId: asOptional(providerDispatch?.workerSlotId),
+    activeLogicalLaneCount,
+    seededLogicalLaneCount,
+    catalogCount: logicalLaneCatalog.length,
+    premiumSaganMode: parseBoolean(executionBundle?.premiumSaganMode),
+    reciprocalLinkReady: parseBoolean(executionBundle?.reciprocalLinkReady),
+    logicalLaneActivation: {
+      activeLaneCount: activeLogicalLaneCount,
+      seededLaneCount: seededLogicalLaneCount,
+      catalogCount: logicalLaneCatalog.length
+    },
+    providerDispatch: {
+      providerId: asOptional(providerDispatch?.providerId),
+      providerKind: asOptional(providerDispatch?.providerKind),
+      executionPlane,
+      assignmentMode: asOptional(providerDispatch?.assignmentMode),
+      dispatchSurface: asOptional(providerDispatch?.dispatchSurface),
+      completionMode: asOptional(providerDispatch?.completionMode),
+      workerSlotId: asOptional(providerDispatch?.workerSlotId),
+      dispatchStatus: asOptional(providerDispatch?.dispatchStatus),
+      completionStatus: asOptional(providerDispatch?.completionStatus),
+      failureClass: asOptional(providerDispatch?.failureClass)
+    },
+    executionBundle: {
+      status: asOptional(executionBundle?.status),
+      planeBinding: asOptional(executionBundle?.planeBinding),
+      premiumSaganMode: parseBoolean(executionBundle?.premiumSaganMode),
+      reciprocalLinkReady: parseBoolean(executionBundle?.reciprocalLinkReady),
+      effectiveBillableRateUsdPerHour: Number.isFinite(executionBundle?.effectiveBillableRateUsdPerHour)
+        ? executionBundle.effectiveBillableRateUsdPerHour
+        : null,
+      executionCellLeaseId: asOptional(executionBundle?.executionCellLeaseId),
+      dockerLaneLeaseId: asOptional(executionBundle?.dockerLaneLeaseId),
+      harnessInstanceId: asOptional(executionBundle?.harnessInstanceId),
+      cellId: asOptional(executionBundle?.cellId),
+      laneId: asOptional(executionBundle?.laneId),
+      isolatedLaneGroupId: asOptional(executionBundle?.isolatedLaneGroupId),
+      fingerprintSha256: asOptional(executionBundle?.fingerprintSha256)
+    }
+  };
+}
+
 export function parseArgs(argv = process.argv) {
   const args = argv.slice(2);
   const options = {
@@ -385,6 +473,7 @@ function deriveDeliveryRuntime(deliveryRuntimeState) {
     normalizeOptionalObject(deliveryRuntimeState?.queueAuthorityRefresh);
   const concurrentLaneStatus = normalizeOptionalObject(activeLane?.concurrentLaneStatus);
   const executionBundle = normalizeOptionalObject(concurrentLaneStatus?.executionBundle);
+  const executionTopology = deriveExecutionTopology({ deliveryRuntimeState, activeLane, executionBundle });
 
   let status = 'none';
   if (prUrl) {
@@ -407,6 +496,7 @@ function deriveDeliveryRuntime(deliveryRuntimeState) {
     outcome,
     blockerClass,
     nextWakeCondition: asOptional(activeLane?.nextWakeCondition),
+    executionTopology,
     executionBundle: {
       status: asOptional(executionBundle?.status),
       planeBinding: asOptional(executionBundle?.planeBinding),
@@ -747,6 +837,12 @@ function buildReport({
       releasePublishedBundleState: releaseSigningReadiness.publishedBundleState,
       releasePublishedBundleReleaseTag: releaseSigningReadiness.publishedBundleReleaseTag,
       releasePublishedBundleAuthoritativeConsumerPin: releaseSigningReadiness.publishedBundleAuthoritativeConsumerPin,
+      executionTopologyStatus: deliveryRuntime.executionTopology.status,
+      executionTopologyExecutionPlane: deliveryRuntime.executionTopology.executionPlane,
+      executionTopologyProviderId: deliveryRuntime.executionTopology.providerId,
+      executionTopologyWorkerSlotId: deliveryRuntime.executionTopology.workerSlotId,
+      executionTopologyActiveLogicalLaneCount: deliveryRuntime.executionTopology.activeLogicalLaneCount,
+      executionTopologySeededLogicalLaneCount: deliveryRuntime.executionTopology.seededLogicalLaneCount,
       executionBundleStatus: deliveryRuntime.executionBundle.status,
       executionBundlePlaneBinding: deliveryRuntime.executionBundle.planeBinding,
       executionBundlePremiumSaganMode: deliveryRuntime.executionBundle.premiumSaganMode,


### PR DESCRIPTION
Concentrates logical lane activation, provider dispatch, and execution bundle state into one governor-level execution topology object, then projects it through governor summary, portfolio summary, and handoff output.

Validation:
- node --test tools/priority/__tests__/autonomous-governor-summary.test.mjs tools/priority/__tests__/autonomous-governor-summary-schema.test.mjs
- node --test tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs tools/priority/__tests__/autonomous-governor-portfolio-summary-schema.test.mjs
- pwsh -NoLogo -NoProfile -File tools/Test-AgentHandoffEntryPoint.ps1 -Quiet
- Invoke-Pester tests/Import-HandoffState.Tests.ps1 -Output Detailed
- node tools/npm/run-script.mjs docs:manifest:validate
- git diff --check