### PR TITLE
feat: project TestStand process model into session receipts #1905

### DIFF
--- a/dist/tools/schemas/definitions.js
+++ b/dist/tools/schemas/definitions.js
@@ -316,6 +316,7 @@ const testStandExecutionCellSchema = z.object({
     cellClass: z.enum(['worker', 'coordinator', 'kernel-coordinator']).nullable().optional(),
     suiteClass: z.enum(['single-compare', 'dual-plane-parity']).nullable().optional(),
     planeBinding: z.string().min(1).nullable().optional(),
+    runtimeSurface: z.literal('windows-native-teststand').nullable().optional(),
     premiumSaganMode: z.boolean().optional(),
     operatorAuthorizationRef: z.string().min(1).nullable().optional(),
     workingRoot: z.string().min(1).nullable().optional(),
@@ -323,10 +324,18 @@ const testStandExecutionCellSchema = z.object({
     isolatedLaneGroupId: z.string().min(1).nullable().optional(),
     hostOsFingerprintSha256: hexSha256.nullable().optional(),
 });
+const testStandProcessModelSchema = z.object({
+    runtimeSurface: z.literal('windows-native-teststand'),
+    processModelClass: z.enum(['sequential-process-model', 'parallel-process-model']),
+    windowsOnly: z.literal(true),
+    rootHarnessInstanceId: z.string().min(1),
+    planeCount: z.number().int().min(1),
+});
 const testStandHarnessInstanceSchema = z.object({
     harnessKind: z.string().min(1),
     instanceId: z.string().min(1),
     role: z.enum(['single-plane', 'coordinator', 'plane-child']),
+    processModelClass: z.enum(['sequential-process-model', 'parallel-process-model']),
     planeBinding: z.string().min(1).nullable().optional(),
     parentInstanceId: z.string().min(1).nullable().optional(),
 });
@@ -345,6 +354,7 @@ const testStandPlaneSessionSchema = z.object({
     exitCode: z.number(),
     executionCell: testStandExecutionCellSchema.nullable().optional(),
     harnessInstance: testStandHarnessInstanceSchema.nullable().optional(),
+    processModel: testStandProcessModelSchema.optional(),
 });
 const testStandParitySummarySchema = z.object({
     status: z.enum(['match', 'mismatch', 'incomplete']),
@@ -370,6 +380,7 @@ const testStandCompareSessionSchema = z.object({
     error: z.union([z.string().min(1), z.null()]).optional(),
     executionCell: testStandExecutionCellSchema.nullable().optional(),
     harnessInstance: testStandHarnessInstanceSchema.nullable().optional(),
+    processModel: testStandProcessModelSchema.optional(),
     suiteClass: z.enum(['single-compare', 'dual-plane-parity']).optional(),
     primaryPlane: z.string().min(1).optional(),
     requestedSimultaneous: z.boolean().optional(),

--- a/docs/TESTSTAND_INTEGRATION_PLAN.md
+++ b/docs/TESTSTAND_INTEGRATION_PLAN.md
@@ -70,6 +70,8 @@ Parity sessions use `schema = teststand-compare-session/v2` and include:
 - `suiteClass = dual-plane-parity`
 - `primaryPlane = native-labview-2026-64`
 - `requestedSimultaneous = true`
+- `processModel.runtimeSurface = windows-native-teststand`
+- `processModel.processModelClass = parallel-process-model`
 - `planes.x64` / `planes.x32` single-plane session records
 - `parity.status`, `mismatchCount`, and field-level mismatch details
 
@@ -101,8 +103,16 @@ Session receipts project both:
 
 - `executionCell`
 - `harnessInstance`
+- `processModel`
 
 That keeps TestStand evidence attributable to one agent-owned memory/process boundary instead of an unscoped host run.
+
+The explicit process-model contract now makes 3 things machine-readable:
+
+- `executionCell.runtimeSurface = windows-native-teststand`
+- `harnessInstance.processModelClass = sequential-process-model|parallel-process-model`
+- `processModel.rootHarnessInstanceId` / `planeCount` so coordinator-owned parity runs stay attributable even when child
+  plane receipts are inspected independently
 
 When the owning agent also needs an isolated Docker lane for repeatable adjunct tooling, prefer
 `priority:lane:execution-cell:bundle` over separate lease calls. That bundle projects one effective billable rate,

--- a/docs/schema/generated/teststand-compare-session.schema.json
+++ b/docs/schema/generated/teststand-compare-session.schema.json
@@ -355,6 +355,17 @@
                     }
                   ]
                 },
+                "runtimeSurface": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "const": "windows-native-teststand"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "premiumSaganMode": {
                   "type": "boolean"
                 },
@@ -442,6 +453,13 @@
                     "plane-child"
                   ]
                 },
+                "processModelClass": {
+                  "type": "string",
+                  "enum": [
+                    "sequential-process-model",
+                    "parallel-process-model"
+                  ]
+                },
                 "planeBinding": {
                   "anyOf": [
                     {
@@ -468,7 +486,8 @@
               "required": [
                 "harnessKind",
                 "instanceId",
-                "role"
+                "role",
+                "processModelClass"
               ],
               "additionalProperties": false
             },
@@ -476,6 +495,42 @@
               "type": "null"
             }
           ]
+        },
+        "processModel": {
+          "type": "object",
+          "properties": {
+            "runtimeSurface": {
+              "type": "string",
+              "const": "windows-native-teststand"
+            },
+            "processModelClass": {
+              "type": "string",
+              "enum": [
+                "sequential-process-model",
+                "parallel-process-model"
+              ]
+            },
+            "windowsOnly": {
+              "type": "boolean",
+              "const": true
+            },
+            "rootHarnessInstanceId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "planeCount": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "runtimeSurface",
+            "processModelClass",
+            "windowsOnly",
+            "rootHarnessInstanceId",
+            "planeCount"
+          ],
+          "additionalProperties": false
         },
         "suiteClass": {
           "type": "string",
@@ -578,6 +633,9 @@
                       "type": "null"
                     }
                   ]
+                },
+                "processModel": {
+                  "$ref": "#/definitions/teststand-compare-session/properties/processModel"
                 }
               },
               "required": [

--- a/fixtures/teststand-session/session-index.dual-plane-parity.json
+++ b/fixtures/teststand-session/session-index.dual-plane-parity.json
@@ -36,6 +36,7 @@
     "cellClass": "kernel-coordinator",
     "suiteClass": "dual-plane-parity",
     "planeBinding": "dual-plane-parity",
+    "runtimeSurface": "windows-native-teststand",
     "premiumSaganMode": false,
     "operatorAuthorizationRef": null,
     "workingRoot": "tests/results/teststand-session",
@@ -47,8 +48,16 @@
     "harnessKind": "teststand-compare-harness",
     "instanceId": "ts-harness-sagan-01",
     "role": "coordinator",
+    "processModelClass": "parallel-process-model",
     "planeBinding": "dual-plane-parity",
     "parentInstanceId": null
+  },
+  "processModel": {
+    "runtimeSurface": "windows-native-teststand",
+    "processModelClass": "parallel-process-model",
+    "windowsOnly": true,
+    "rootHarnessInstanceId": "ts-harness-sagan-01",
+    "planeCount": 2
   },
   "planes": {
     "x64": {
@@ -89,6 +98,7 @@
         "cellClass": "kernel-coordinator",
         "suiteClass": "dual-plane-parity",
         "planeBinding": "native-labview-2026-64",
+        "runtimeSurface": "windows-native-teststand",
         "premiumSaganMode": false,
         "operatorAuthorizationRef": null,
         "workingRoot": "tests/results/teststand-session/planes/x64",
@@ -100,8 +110,16 @@
         "harnessKind": "teststand-compare-harness",
         "instanceId": "ts-harness-sagan-01-x64",
         "role": "plane-child",
+        "processModelClass": "parallel-process-model",
         "planeBinding": "native-labview-2026-64",
         "parentInstanceId": "ts-harness-sagan-01"
+      },
+      "processModel": {
+        "runtimeSurface": "windows-native-teststand",
+        "processModelClass": "parallel-process-model",
+        "windowsOnly": true,
+        "rootHarnessInstanceId": "ts-harness-sagan-01",
+        "planeCount": 2
       }
     },
     "x32": {
@@ -142,6 +160,7 @@
         "cellClass": "kernel-coordinator",
         "suiteClass": "dual-plane-parity",
         "planeBinding": "native-labview-2026-32",
+        "runtimeSurface": "windows-native-teststand",
         "premiumSaganMode": false,
         "operatorAuthorizationRef": null,
         "workingRoot": "tests/results/teststand-session/planes/x32",
@@ -153,8 +172,16 @@
         "harnessKind": "teststand-compare-harness",
         "instanceId": "ts-harness-sagan-01-x32",
         "role": "plane-child",
+        "processModelClass": "parallel-process-model",
         "planeBinding": "native-labview-2026-32",
         "parentInstanceId": "ts-harness-sagan-01"
+      },
+      "processModel": {
+        "runtimeSurface": "windows-native-teststand",
+        "processModelClass": "parallel-process-model",
+        "windowsOnly": true,
+        "rootHarnessInstanceId": "ts-harness-sagan-01",
+        "planeCount": 2
       }
     }
   },

--- a/fixtures/teststand-session/session-index.json
+++ b/fixtures/teststand-session/session-index.json
@@ -64,6 +64,7 @@
     "cellClass": "worker",
     "suiteClass": "single-compare",
     "planeBinding": "native-labview-2025-64",
+    "runtimeSurface": "windows-native-teststand",
     "premiumSaganMode": false,
     "operatorAuthorizationRef": null,
     "workingRoot": "tests/results/teststand-session",
@@ -75,7 +76,15 @@
     "harnessKind": "teststand-compare-harness",
     "instanceId": "ts-harness-hooke-01",
     "role": "single-plane",
+    "processModelClass": "sequential-process-model",
     "planeBinding": "native-labview-2025-64",
     "parentInstanceId": null
+  },
+  "processModel": {
+    "runtimeSurface": "windows-native-teststand",
+    "processModelClass": "sequential-process-model",
+    "windowsOnly": true,
+    "rootHarnessInstanceId": "ts-harness-hooke-01",
+    "planeCount": 1
   }
 }

--- a/tests/TestStand-CompareHarness.Tests.ps1
+++ b/tests/TestStand-CompareHarness.Tests.ps1
@@ -130,10 +130,17 @@ exit 0
       $indexData.executionCell.agentId | Should -Be 'hooke'
       $indexData.executionCell.agentClass | Should -Be 'subagent'
       $indexData.executionCell.cellClass | Should -Be 'worker'
+      $indexData.executionCell.runtimeSurface | Should -Be 'windows-native-teststand'
       $indexData.executionCell.premiumSaganMode | Should -BeFalse
       $indexData.executionCell.operatorAuthorizationRef | Should -BeNullOrEmpty
       $indexData.harnessInstance.instanceId | Should -Be 'ts-harness-hooke-01'
       $indexData.harnessInstance.role | Should -Be 'single-plane'
+      $indexData.harnessInstance.processModelClass | Should -Be 'sequential-process-model'
+      $indexData.processModel.runtimeSurface | Should -Be 'windows-native-teststand'
+      $indexData.processModel.processModelClass | Should -Be 'sequential-process-model'
+      $indexData.processModel.windowsOnly | Should -BeTrue
+      $indexData.processModel.rootHarnessInstanceId | Should -Be 'ts-harness-hooke-01'
+      $indexData.processModel.planeCount | Should -Be 1
     }
     finally { Pop-Location }
   }
@@ -356,10 +363,17 @@ exit 0
       $indexData.executionCell.agentId | Should -Be 'sagan'
       $indexData.executionCell.agentClass | Should -Be 'sagan'
       $indexData.executionCell.cellClass | Should -Be 'kernel-coordinator'
+      $indexData.executionCell.runtimeSurface | Should -Be 'windows-native-teststand'
       $indexData.executionCell.premiumSaganMode | Should -BeFalse
       $indexData.executionCell.operatorAuthorizationRef | Should -BeNullOrEmpty
       $indexData.harnessInstance.instanceId | Should -Be 'ts-harness-sagan-01'
       $indexData.harnessInstance.role | Should -Be 'coordinator'
+      $indexData.harnessInstance.processModelClass | Should -Be 'parallel-process-model'
+      $indexData.processModel.runtimeSurface | Should -Be 'windows-native-teststand'
+      $indexData.processModel.processModelClass | Should -Be 'parallel-process-model'
+      $indexData.processModel.windowsOnly | Should -BeTrue
+      $indexData.processModel.rootHarnessInstanceId | Should -Be 'ts-harness-sagan-01'
+      $indexData.processModel.planeCount | Should -Be 2
       $indexData.parity.status | Should -Be 'match'
       $indexData.parity.mismatchCount | Should -Be 0
       $indexData.planes.x64.plane | Should -Be 'native-labview-2026-64'
@@ -380,14 +394,26 @@ exit 0
       $indexData.planes.x32.executionCell.cellId | Should -Be 'exec-cell-sagan-01'
       $indexData.planes.x64.executionCell.cellClass | Should -Be 'kernel-coordinator'
       $indexData.planes.x32.executionCell.cellClass | Should -Be 'kernel-coordinator'
+      $indexData.planes.x64.executionCell.runtimeSurface | Should -Be 'windows-native-teststand'
+      $indexData.planes.x32.executionCell.runtimeSurface | Should -Be 'windows-native-teststand'
       $indexData.planes.x64.executionCell.premiumSaganMode | Should -BeFalse
       $indexData.planes.x32.executionCell.premiumSaganMode | Should -BeFalse
       $indexData.planes.x64.harnessInstance.role | Should -Be 'plane-child'
       $indexData.planes.x32.harnessInstance.role | Should -Be 'plane-child'
+      $indexData.planes.x64.harnessInstance.processModelClass | Should -Be 'parallel-process-model'
+      $indexData.planes.x32.harnessInstance.processModelClass | Should -Be 'parallel-process-model'
       $indexData.planes.x64.harnessInstance.parentInstanceId | Should -Be 'ts-harness-sagan-01'
       $indexData.planes.x32.harnessInstance.parentInstanceId | Should -Be 'ts-harness-sagan-01'
       $indexData.planes.x64.harnessInstance.instanceId | Should -Be 'ts-harness-sagan-01-x64'
       $indexData.planes.x32.harnessInstance.instanceId | Should -Be 'ts-harness-sagan-01-x32'
+      $indexData.planes.x64.processModel.runtimeSurface | Should -Be 'windows-native-teststand'
+      $indexData.planes.x32.processModel.runtimeSurface | Should -Be 'windows-native-teststand'
+      $indexData.planes.x64.processModel.processModelClass | Should -Be 'parallel-process-model'
+      $indexData.planes.x32.processModel.processModelClass | Should -Be 'parallel-process-model'
+      $indexData.planes.x64.processModel.rootHarnessInstanceId | Should -Be 'ts-harness-sagan-01'
+      $indexData.planes.x32.processModel.rootHarnessInstanceId | Should -Be 'ts-harness-sagan-01'
+      $indexData.planes.x64.processModel.planeCount | Should -Be 2
+      $indexData.planes.x32.processModel.planeCount | Should -Be 2
       Test-Path -LiteralPath (Join-Path $outputRoot 'planes\x64\session-index.json') | Should -BeTrue
       Test-Path -LiteralPath (Join-Path $outputRoot 'planes\x32\session-index.json') | Should -BeTrue
       $x64Child = Get-Content -LiteralPath (Join-Path $outputRoot 'planes\x64\session-index.json') -Raw | ConvertFrom-Json -Depth 12
@@ -396,8 +422,14 @@ exit 0
       $x32Child.executionCell.cellId | Should -Be 'exec-cell-sagan-01'
       $x64Child.executionCell.cellClass | Should -Be 'kernel-coordinator'
       $x32Child.executionCell.cellClass | Should -Be 'kernel-coordinator'
+      $x64Child.executionCell.runtimeSurface | Should -Be 'windows-native-teststand'
+      $x32Child.executionCell.runtimeSurface | Should -Be 'windows-native-teststand'
       $x64Child.harnessInstance.instanceId | Should -Be 'ts-harness-sagan-01-x64'
       $x32Child.harnessInstance.instanceId | Should -Be 'ts-harness-sagan-01-x32'
+      $x64Child.harnessInstance.processModelClass | Should -Be 'parallel-process-model'
+      $x32Child.harnessInstance.processModelClass | Should -Be 'parallel-process-model'
+      $x64Child.processModel.rootHarnessInstanceId | Should -Be 'ts-harness-sagan-01'
+      $x32Child.processModel.rootHarnessInstanceId | Should -Be 'ts-harness-sagan-01'
     }
     finally { Pop-Location }
   }

--- a/tools/TestStand-CompareHarness.ps1
+++ b/tools/TestStand-CompareHarness.ps1
@@ -229,6 +229,11 @@ function Resolve-TestStandExecutionCellContext {
   $resolvedArtifactRoot = Get-FirstNonEmptyText @($leaseCommitArtifactRoot, $leaseRequestArtifactRoot, $OutputRoot)
   $resolvedHarnessKind = Get-FirstNonEmptyText @($leaseRequestHarnessKind, 'teststand-compare-harness')
   $resolvedRole = Get-FirstNonEmptyText @($Role, $(if (-not [string]::IsNullOrWhiteSpace($ParentHarnessInstanceId)) { 'plane-child' } elseif ($resolvedSuiteClass -eq 'dual-plane-parity' -and [string]::IsNullOrWhiteSpace($PlaneName)) { 'coordinator' } else { 'single-plane' }))
+  $resolvedProcessModelClass = if ($resolvedSuiteClass -eq 'dual-plane-parity') {
+    'parallel-process-model'
+  } else {
+    'sequential-process-model'
+  }
 
   $planeSuffix = if ($PlaneName -match '2026-64$') {
     'x64'
@@ -255,6 +260,7 @@ function Resolve-TestStandExecutionCellContext {
       cellClass = Get-FirstNonEmptyText @($leaseRequestCellClass)
       suiteClass = $resolvedSuiteClass
       planeBinding = $resolvedPlaneBinding
+      runtimeSurface = 'windows-native-teststand'
       premiumSaganMode = if ($null -eq $leaseGrantPremiumSaganMode) { $false } else { [bool]$leaseGrantPremiumSaganMode }
       operatorAuthorizationRef = Get-FirstNonEmptyText @($leaseRequestOperatorAuthorizationRef)
       workingRoot = $resolvedWorkingRoot
@@ -268,13 +274,23 @@ function Resolve-TestStandExecutionCellContext {
     harnessKind = $resolvedHarnessKind
     instanceId = $resolvedHarnessInstanceId
     role = $resolvedRole
+    processModelClass = $resolvedProcessModelClass
     planeBinding = $resolvedPlaneBinding
     parentInstanceId = Get-FirstNonEmptyText @($ParentHarnessInstanceId)
+  }
+
+  $processModel = [ordered]@{
+    runtimeSurface = 'windows-native-teststand'
+    processModelClass = $resolvedProcessModelClass
+    windowsOnly = $true
+    rootHarnessInstanceId = Get-FirstNonEmptyText @($ParentHarnessInstanceId, $resolvedHarnessInstanceId)
+    planeCount = if ($resolvedSuiteClass -eq 'dual-plane-parity') { 2 } else { 1 }
   }
 
   return [pscustomobject]@{
     executionCell = $executionCell
     harnessInstance = $harnessInstance
+    processModel = $processModel
   }
 }
 
@@ -473,6 +489,7 @@ function Invoke-TestStandSinglePlaneSession {
     exitCode = if ($cap) { [int]$cap.exitCode } else { 1 }
     executionCell = $cellLeaseContext.executionCell
     harnessInstance = $cellLeaseContext.harnessInstance
+    processModel = $cellLeaseContext.processModel
   }
 
   return [pscustomobject]$planeRecord
@@ -493,6 +510,7 @@ function Write-TestStandV1SessionIndex {
     error   = $PlaneSession.error
     executionCell = $PlaneSession.executionCell
     harnessInstance = $PlaneSession.harnessInstance
+    processModel = $PlaneSession.processModel
   }
 
   $indexPath = Join-Path $OutputRoot 'session-index.json'
@@ -780,6 +798,7 @@ function Invoke-DualPlaneParitySuite {
     exitCode = if ($null -ne $x64Index.outcome) { [int]$x64Index.outcome.exitCode } else { if ($x64Process.ExitCode -is [int]) { [int]$x64Process.ExitCode } else { 1 } }
     executionCell = $x64Index.executionCell
     harnessInstance = $x64Index.harnessInstance
+    processModel = $x64Index.processModel
   }
   $x32Session = [pscustomobject][ordered]@{
     plane = 'native-labview-2026-32'
@@ -793,6 +812,7 @@ function Invoke-DualPlaneParitySuite {
     exitCode = if ($null -ne $x32Index.outcome) { [int]$x32Index.outcome.exitCode } else { if ($x32Process.ExitCode -is [int]) { [int]$x32Process.ExitCode } else { 1 } }
     executionCell = $x32Index.executionCell
     harnessInstance = $x32Index.harnessInstance
+    processModel = $x32Index.processModel
   }
 
   $parity = New-DualPlaneParitySummary -X64Session $x64Session -X32Session $x32Session
@@ -815,6 +835,7 @@ function Invoke-DualPlaneParitySuite {
     error = $topError
     executionCell = $dualPlaneContext.executionCell
     harnessInstance = $dualPlaneContext.harnessInstance
+    processModel = $dualPlaneContext.processModel
     planes = [ordered]@{
       x64 = $x64Session
       x32 = $x32Session

--- a/tools/schemas/definitions.ts
+++ b/tools/schemas/definitions.ts
@@ -345,6 +345,7 @@ const testStandExecutionCellSchema = z.object({
   cellClass: z.enum(['worker', 'coordinator', 'kernel-coordinator']).nullable().optional(),
   suiteClass: z.enum(['single-compare', 'dual-plane-parity']).nullable().optional(),
   planeBinding: z.string().min(1).nullable().optional(),
+  runtimeSurface: z.literal('windows-native-teststand').nullable().optional(),
   premiumSaganMode: z.boolean().optional(),
   operatorAuthorizationRef: z.string().min(1).nullable().optional(),
   workingRoot: z.string().min(1).nullable().optional(),
@@ -353,10 +354,19 @@ const testStandExecutionCellSchema = z.object({
   hostOsFingerprintSha256: hexSha256.nullable().optional(),
 });
 
+const testStandProcessModelSchema = z.object({
+  runtimeSurface: z.literal('windows-native-teststand'),
+  processModelClass: z.enum(['sequential-process-model', 'parallel-process-model']),
+  windowsOnly: z.literal(true),
+  rootHarnessInstanceId: z.string().min(1),
+  planeCount: z.number().int().min(1),
+});
+
 const testStandHarnessInstanceSchema = z.object({
   harnessKind: z.string().min(1),
   instanceId: z.string().min(1),
   role: z.enum(['single-plane', 'coordinator', 'plane-child']),
+  processModelClass: z.enum(['sequential-process-model', 'parallel-process-model']),
   planeBinding: z.string().min(1).nullable().optional(),
   parentInstanceId: z.string().min(1).nullable().optional(),
 });
@@ -376,6 +386,7 @@ const testStandPlaneSessionSchema = z.object({
   exitCode: z.number(),
   executionCell: testStandExecutionCellSchema.nullable().optional(),
   harnessInstance: testStandHarnessInstanceSchema.nullable().optional(),
+  processModel: testStandProcessModelSchema.optional(),
 });
 
 const testStandParitySummarySchema = z.object({
@@ -405,6 +416,7 @@ const testStandCompareSessionSchema = z.object({
   error: z.union([z.string().min(1), z.null()]).optional(),
   executionCell: testStandExecutionCellSchema.nullable().optional(),
   harnessInstance: testStandHarnessInstanceSchema.nullable().optional(),
+  processModel: testStandProcessModelSchema.optional(),
   suiteClass: z.enum(['single-compare', 'dual-plane-parity']).optional(),
   primaryPlane: z.string().min(1).optional(),
   requestedSimultaneous: z.boolean().optional(),


### PR DESCRIPTION
Stacked follow-on for #1905.

Summary:
- project Windows-native TestStand runtime identity into execution-cell receipts
- project process-model metadata into harness instances and session receipts
- make dual-plane parity and single-plane sessions explicitly machine-readable without changing the parity behavior

Validation:
- node tools/npm/run-script.mjs session:teststand:validate
- Invoke-Pester tests/TestStand-CompareHarness.Tests.ps1 -Output Detailed
- node tools/npm/run-script.mjs docs:manifest:validate
- git diff --check