### PR TITLE
feat: project TestStand process model into loop status #1905

### DIFF
--- a/docs/schemas/loop-final-status-v1.schema.json
+++ b/docs/schemas/loop-final-status-v1.schema.json
@@ -17,7 +17,28 @@
     "histogram": {"type": ["array","null"], "items": {"type": "object"}},
     "diffSummaryEmitted": {"type": "boolean"},
     "basePath": {"type": "string"},
-    "headPath": {"type": "string"}
+    "headPath": {"type": "string"},
+    "harness": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "output": {"type": "string"},
+        "suiteClass": {"type": "string"},
+        "runtimeSurface": {"const": "windows-native-teststand"},
+        "processModelClass": {
+          "type": "string",
+          "enum": ["sequential-process-model", "parallel-process-model"]
+        },
+        "windowsOnly": {"type": "boolean"},
+        "requestedSimultaneous": {"type": "boolean"},
+        "executionCellLeasePath": {"type": "string"},
+        "executionCellId": {"type": "string"},
+        "executionCellLeaseId": {"type": "string"},
+        "harnessInstanceId": {"type": "string"}
+      },
+      "required": ["path", "output", "suiteClass", "runtimeSurface", "processModelClass", "windowsOnly", "requestedSimultaneous"],
+      "additionalProperties": true
+    }
   },
   "additionalProperties": true
 }

--- a/scripts/Run-AutonomousIntegrationLoop.ps1
+++ b/scripts/Run-AutonomousIntegrationLoop.ps1
@@ -371,6 +371,10 @@ if ($UseTestStandHarness) {
     output = $resolvedOutputRoot
     warmup = $warmupMode
     suiteClass = $TestStandSuiteClass
+    runtimeSurface = 'windows-native-teststand'
+    processModelClass = if ($TestStandSuiteClass -eq 'dual-plane-parity') { 'parallel-process-model' } else { 'sequential-process-model' }
+    windowsOnly = $true
+    requestedSimultaneous = ($TestStandSuiteClass -eq 'dual-plane-parity')
     renderReport = $renderReport
     closeLabVIEW = $closeLabVIEW
     closeLVCompare = $closeLVCompare
@@ -553,6 +557,9 @@ if ($UseTestStandHarness -and $harnessPlan) {
   $planPayload.harnessOutput = $harnessPlan.output
   $planPayload.harnessWarmup = $harnessPlan.warmup
   $planPayload.harnessRenderReport = $harnessPlan.renderReport
+  $planPayload.harnessRuntimeSurface = $harnessPlan.runtimeSurface
+  $planPayload.harnessProcessModelClass = $harnessPlan.processModelClass
+  $planPayload.harnessRequestedSimultaneous = $harnessPlan.requestedSimultaneous
 }
 Write-JsonEvent 'plan' $planPayload
 
@@ -569,6 +576,8 @@ if ($DryRun) {
   if ($UseTestStandHarness -and $harnessPlan) {
     $dryRunPayload.harnessPath = $harnessPlan.path
     $dryRunPayload.harnessOutput = $harnessPlan.output
+    $dryRunPayload.harnessRuntimeSurface = $harnessPlan.runtimeSurface
+    $dryRunPayload.harnessProcessModelClass = $harnessPlan.processModelClass
   }
   Write-JsonEvent 'dryRun' $dryRunPayload
   Set-LoopExit 0
@@ -599,6 +608,21 @@ if ($FinalStatusJsonPath) {
       diffSummaryEmitted = [bool]$result.DiffSummary
       basePath = $result.BasePath
       headPath = $result.HeadPath
+    }
+    if ($UseTestStandHarness -and $harnessPlan) {
+      $obj.harness = [ordered]@{
+        path = $harnessPlan.path
+        output = $harnessPlan.output
+        suiteClass = $harnessPlan.suiteClass
+        runtimeSurface = $harnessPlan.runtimeSurface
+        processModelClass = $harnessPlan.processModelClass
+        windowsOnly = $harnessPlan.windowsOnly
+        requestedSimultaneous = $harnessPlan.requestedSimultaneous
+        executionCellLeasePath = $harnessPlan.executionCellLeasePath
+        executionCellId = $harnessPlan.executionCellId
+        executionCellLeaseId = $harnessPlan.executionCellLeaseId
+        harnessInstanceId = $harnessPlan.harnessInstanceId
+      }
     }
     $json = $obj | ConvertTo-Json -Depth 5
     $finalDir = Split-Path -Parent $FinalStatusJsonPath

--- a/tests/Run-AutonomousIntegrationLoop.Tests.ps1
+++ b/tests/Run-AutonomousIntegrationLoop.Tests.ps1
@@ -174,6 +174,19 @@ exit `$LASTEXITCODE
       $entries | ForEach-Object { [int]$_.timeout } | Sort-Object -Unique | Should -Be @(45)
       $entries | ForEach-Object { $_.replaceFlags } | Sort-Object -Unique | Should -Be @($true)
       $entries | ForEach-Object { $_.flags } | ForEach-Object { $_ } | Sort-Object -Unique | Should -Be @('-bar','-foo','1')
+
+      $finalStatus = Get-Content -LiteralPath (Join-Path $outDir 'final.json') -Raw | ConvertFrom-Json
+      $finalStatus.harness.path | Should -Be $harnessStub
+      $finalStatus.harness.output | Should -Be $outputRoot
+      $finalStatus.harness.suiteClass | Should -Be 'dual-plane-parity'
+      $finalStatus.harness.runtimeSurface | Should -Be 'windows-native-teststand'
+      $finalStatus.harness.processModelClass | Should -Be 'parallel-process-model'
+      $finalStatus.harness.windowsOnly | Should -BeTrue
+      $finalStatus.harness.requestedSimultaneous | Should -BeTrue
+      $finalStatus.harness.executionCellLeasePath | Should -Be 'E:\comparevi-lanes\cells\hooke-01\execution-cell.json'
+      $finalStatus.harness.executionCellId | Should -Be 'exec-cell-hooke-loop-01'
+      $finalStatus.harness.executionCellLeaseId | Should -Be 'lease-hooke-loop-01'
+      $finalStatus.harness.harnessInstanceId | Should -Be 'ts-loop-hooke-01'
     }
     finally {
       Remove-Item Env:HARNESS_LOG -ErrorAction SilentlyContinue

--- a/tests/Run-DX.Tests.ps1
+++ b/tests/Run-DX.Tests.ps1
@@ -86,6 +86,14 @@ $session = [ordered]@{
     harnessKind = 'teststand-compare-harness'
     instanceId = $HarnessInstanceId
     role = 'single-plane'
+    processModelClass = 'sequential-process-model'
+  }
+  processModel = @{
+    runtimeSurface = 'windows-native-teststand'
+    processModelClass = 'sequential-process-model'
+    windowsOnly = $true
+    rootHarnessInstanceId = $HarnessInstanceId
+    planeCount = 1
   }
 }
 $session | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutputRoot 'session-index.json') -Encoding utf8
@@ -145,6 +153,8 @@ exit 0
       $session.executionCell.cellId | Should -Be 'exec-cell-hooke-01'
       $session.executionCell.leaseId | Should -Be 'lease-hooke-01'
       $session.harnessInstance.instanceId | Should -Be 'harness-hooke-01'
+      $session.processModel.runtimeSurface | Should -Be 'windows-native-teststand'
+      $session.processModel.processModelClass | Should -Be 'sequential-process-model'
     }
     finally { Pop-Location }
   }
@@ -225,6 +235,14 @@ $session = [ordered]@{
     harnessKind = 'teststand-compare-harness'
     instanceId = $HarnessInstanceId
     role = 'single-plane'
+    processModelClass = 'sequential-process-model'
+  }
+  processModel = @{
+    runtimeSurface = 'windows-native-teststand'
+    processModelClass = 'sequential-process-model'
+    windowsOnly = $true
+    rootHarnessInstanceId = $HarnessInstanceId
+    planeCount = 1
   }
 }
 $session | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutputRoot 'session-index.json') -Encoding utf8
@@ -297,6 +315,7 @@ exit 0
     $content | Should -Match 'requestedSimultaneous\s*=\s*\$session\.requestedSimultaneous'
     $content | Should -Match 'executionCell\s*=\s*\$session\.executionCell'
     $content | Should -Match 'harnessInstance\s*=\s*\$session\.harnessInstance'
+    $content | Should -Match 'processModel\s*=\s*\$session\.processModel'
     $content | Should -Match 'parity\s*=\s*\$session\.parity'
     $content | Should -Match 'planes\s*=\s*\$session\.planes'
   }

--- a/tests/TestHelpers.Schema.ps1
+++ b/tests/TestHelpers.Schema.ps1
@@ -26,7 +26,7 @@ if (-not (Get-Variable -Name JsonShapeSpecs -Scope Script -ErrorAction SilentlyC
 
 $script:JsonShapeSpecs['FinalStatus'] = [pscustomobject]@{
   Required = @('schema','timestamp','iterations','diffs','errors','succeeded')
-  Optional = @('averageSeconds','totalSeconds','percentiles','histogram','diffSummaryEmitted','basePath','headPath')
+  Optional = @('averageSeconds','totalSeconds','percentiles','histogram','diffSummaryEmitted','basePath','headPath','harness')
   Types    = @{
     schema            = { param($v) $v -is [string] -and $v -eq 'loop-final-status-v1' }
   timestamp         = { param($v) ($v -is [string] -or $v -is [datetime]) }
@@ -41,6 +41,7 @@ $script:JsonShapeSpecs['FinalStatus'] = [pscustomobject]@{
     diffSummaryEmitted= { param($v) -not $v -or $v -is [bool] }
     basePath          = { param($v) -not $v -or $v -is [string] }
     headPath          = { param($v) -not $v -or $v -is [string] }
+    harness           = { param($v) -not $v -or ($v -is [hashtable] -or $v -is [pscustomobject]) }
   }
 }
 

--- a/tools/Run-DX.ps1
+++ b/tools/Run-DX.ps1
@@ -228,6 +228,7 @@ $harness = Join-Path $repoRoot 'tools/TestStand-CompareHarness.ps1'
         error    = $session.error
         executionCell = $session.executionCell
         harnessInstance = $session.harnessInstance
+        processModel = $session.processModel
         compare  = $session.compare
         content  = $session.content
         parity   = $session.parity


### PR DESCRIPTION
Stacked follow-on for #1905.

Summary:
- project TestStand process-model metadata into Run-DX status forwarding
- add a harness block to loop final-status output for Windows-only runtime/process-model identity
- formalize that harness block in the loop final-status schema

Validation:
- Invoke-Pester tests/Run-DX.Tests.ps1 -Output Detailed
- node tools/npm/run-script.mjs docs:manifest:validate
- git diff --check

Known gap:
- full tests/Run-AutonomousIntegrationLoop.Tests.ps1 currently times out on this host, so the loop side is covered by focused contract assertions rather than a complete Pester pass in this slice