### PR TITLE
feat: harden capability ingress routing (#1905)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,10 @@
 self-hosted-runner:
   labels:
+    - comparevi
+    - capability-ingress
+    - labview-2026
+    - lv32
+    - docker-lane
+    - teststand
     - self-hosted-docker-linux
     - hosted-docker-linux

--- a/.github/workflows/ci-orchestrated.yml
+++ b/.github/workflows/ci-orchestrated.yml
@@ -277,7 +277,7 @@ jobs:
   probe:
     # Quick interactivity probe on self-hosted Windows to decide single vs fallback
     if: ${{ inputs.strategy == 'single' || vars.ORCH_STRATEGY == 'single' }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 2
     needs: [normalize, preflight]
     env:
@@ -318,7 +318,7 @@ jobs:
 
   pester-category:
     if: ${{ inputs.strategy == 'matrix' || vars.ORCH_STRATEGY == 'matrix' || (inputs.strategy == '' && vars.ORCH_STRATEGY == '') || (inputs.strategy == 'single' && needs.probe.outputs.ok == 'false') }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 3
     needs: [normalize, preflight, probe]
     strategy:
@@ -623,7 +623,7 @@ jobs:
 
   drift:
     if: ${{ inputs.strategy == 'matrix' || vars.ORCH_STRATEGY == 'matrix' || (inputs.strategy == '' && vars.ORCH_STRATEGY == '') }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 3
     needs: [pester-category]
     env:
@@ -1010,7 +1010,7 @@ jobs:
       run: pwsh -File tools/Write-RerunHint.ps1 -Workflow 'ci-orchestrated.yml' -IncludeIntegration '${{ inputs.include_integration || 'true' }}' -SampleId '${{ inputs.sample_id || '' }}'
   windows-single:
     if: ${{ (inputs.strategy == 'single' || vars.ORCH_STRATEGY == 'single') && needs.probe.outputs.ok == 'true' }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 10
     needs: [normalize, preflight, probe]
     env:

--- a/.github/workflows/compare-artifacts.yml
+++ b/.github/workflows/compare-artifacts.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 45
     env:
       UNBLOCK_GUARD: '1'
@@ -165,4 +165,3 @@ jobs:
         snapshot-path: tests/results/runner-unblock-snapshot.json
         cleanup: "${{ env.UNBLOCK_GUARD == '1' }}"
         process-names: conhost,pwsh,LabVIEW,LVCompare
-

--- a/.github/workflows/labview-cli-compare.yml
+++ b/.github/workflows/labview-cli-compare.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cli-compare:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     env:
       # Headless + safe UI behaviour
       LV_SUPPRESS_UI: '1'
@@ -68,4 +68,3 @@ jobs:
           Write-Host "exitCode  = ${{ steps.compare.outputs.exitCode }}"
           Write-Host "cliPath   = ${{ steps.compare.outputs.cliPath }}"
           Write-Host "command   = ${{ steps.compare.outputs.command }}"
-

--- a/.github/workflows/pester-reusable.yml
+++ b/.github/workflows/pester-reusable.yml
@@ -71,7 +71,7 @@ jobs:
   preflight:
     name: Preflight (self-hosted)
     if: ${{ inputs.skip_run != 'true' }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 3
     env:
       CLEAN_LV_BEFORE: ${{ vars.CLEAN_LV_BEFORE || 'true' }}
@@ -132,7 +132,7 @@ jobs:
   pester:
     name: Pester (self-hosted)
     if: ${{ inputs.skip_run != 'true' }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     # No job-level timeout; rely on probes/guards for determinism
     needs: [normalize, preflight]
     env:

--- a/.github/workflows/runbook-validation.yml
+++ b/.github/workflows/runbook-validation.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   runbook-check:
     if: ${{ github.event.repository.fork != true && !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 3
     steps:
       - name: Checkout

--- a/.github/workflows/smoke-on-label.yml
+++ b/.github/workflows/smoke-on-label.yml
@@ -54,7 +54,7 @@ jobs:
   smoke:
     needs: pre-init
     if: github.event_name == 'workflow_dispatch' && needs.pre-init.outputs.docs_only != 'true'
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     env:
       UNBLOCK_GUARD: '1'
       WATCH_CONSOLE: '1'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   preflight:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
@@ -62,7 +62,7 @@ jobs:
           Write-Host 'Preflight OK: LVCompare present; LabVIEW not running.'
 
   compare:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     needs: preflight
     timeout-minutes: 3
     env:
@@ -232,4 +232,3 @@ jobs:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sample_id || github.ref }}
   cancel-in-progress: true
-

--- a/.github/workflows/vi-compare-pr.yml
+++ b/.github/workflows/vi-compare-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   preflight:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 10
     if: github.event_name == 'workflow_dispatch'
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   vi-compare:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     needs: preflight
     timeout-minutes: 45
     env:
@@ -222,4 +222,3 @@ jobs:
           $headers = @{ Authorization = "Bearer $env:XCLI_PAT"; Accept = 'application/vnd.github+json'; 'User-Agent' = 'xcli-bot' }
           $uri = "https://api.github.com/repos/$env:GH_REPO/issues/$env:PR_NUMBER/comments"
           Invoke-RestMethod -Method POST -Uri $uri -Headers $headers -ContentType 'application/json' -Body $payload
-

--- a/.github/workflows/vi-compare-refs.yml
+++ b/.github/workflows/vi-compare-refs.yml
@@ -61,7 +61,7 @@ concurrency:
 
 jobs:
   preflight:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     permissions:
       contents: read
     timeout-minutes: 5
@@ -79,7 +79,7 @@ jobs:
           Write-Host 'Preflight OK: LVCompare present; LabVIEW not running.'
 
   compare:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     needs: preflight
     permissions:
       contents: read
@@ -544,4 +544,3 @@ jobs:
           snapshot-path: tests/results/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
           process-names: 'conhost,pwsh,LabVIEW,LVCompare'
-

--- a/.github/workflows/vi-history-compare.yml
+++ b/.github/workflows/vi-history-compare.yml
@@ -61,7 +61,7 @@ concurrency:
 
 jobs:
   preflight:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -77,7 +77,7 @@ jobs:
           Write-Host 'Preflight OK: LVCompare present; LabVIEW not running.'
 
   compare-history:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     needs: preflight
     timeout-minutes: 60
     env:
@@ -149,4 +149,3 @@ jobs:
           snapshot-path: tests/results/runner-unblock-snapshot.json
           cleanup: ${{ env.UNBLOCK_GUARD == '1' }}
           process-names: 'conhost,pwsh,LabVIEW,LVCompare'
-

--- a/.github/workflows/vi-staging-smoke.yml
+++ b/.github/workflows/vi-staging-smoke.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   smoke:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -51,4 +51,3 @@ jobs:
           name: vi-staging-smoke
           path: tests/results/_agent/smoke/vi-stage/
           if-no-files-found: ignore
-

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -28,7 +28,7 @@ Artifacts appear under `tests/results/` (JSON summary, results XML, dispatcher l
 
 ## Checklist before running
 
-- Runner online with labels `[self-hosted, Windows, X64]`.
+- Runner online with labels `[self-hosted, Windows, X64, comparevi, capability-ingress]`.
 - VI fixtures available and accessible by runner service.
 - LVCompare not blocked by antivirus / pending updates.
 
@@ -45,4 +45,3 @@ Artifacts appear under `tests/results/` (JSON summary, results XML, dispatcher l
 - [`docs/SELFHOSTED_CI_SETUP.md`](./SELFHOSTED_CI_SETUP.md)
 - [`docs/E2E_TESTING_GUIDE.md`](./E2E_TESTING_GUIDE.md)
 - [`docs/TROUBLESHOOTING.md`](./TROUBLESHOOTING.md)
-

--- a/docs/SELFHOSTED_CI_SETUP.md
+++ b/docs/SELFHOSTED_CI_SETUP.md
@@ -1,18 +1,35 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Self-Hosted CI Setup
 
-Minimal steps to provision a Windows runner suitable for LVCompare workflows.
+Provision this machine as the canonical compare capability host, not as a
+generic shared workstation runner. GitHub Actions should land work on the host
+through a small ingress label surface, then the governed execution-cell and
+Docker-lane helpers decide how the work runs locally.
 
 ## Installations
 
 1. GitHub Actions runner (service mode).
-2. LabVIEW 2025 Q3 with LVCompare CLI feature.
+2. LabVIEW 2026 64-bit and 32-bit native paths when the host will serve dual-plane parity.
 3. PowerShell 7 (`pwsh`).
-4. Git + Node.js (optional for local tooling).
+4. Git + Node.js.
+5. Docker engine reachable through the governed host policy used by the Docker-lane handshake.
 
 ## Runner configuration
 
-- Labels: `self-hosted`, `Windows`, `X64`.
+- Canonical install root: `C:\actions-runner\comparevi-capability-ingress`
+- Canonical runner role: compare capability ingress host
+- Canonical service model: delayed-auto-start Windows service
+- Required labels:
+  - `self-hosted`
+  - `Windows`
+  - `X64`
+  - `comparevi`
+  - `capability-ingress`
+- Optional capability labels:
+  - `labview-2026`
+  - `lv32`
+  - `docker-lane`
+  - `teststand`
 - Prefer a small number of coarse GitHub runner labels over one runner registration per background agent.
 - Isolated Docker lanes should be leased locally through the Docker-lane handshake helper instead of by creating a
   permanent GitHub Actions runner service for each agent.
@@ -31,8 +48,17 @@ Test-Path 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompar
 [Environment]::GetEnvironmentVariable('LV_BASE_VI', 'Machine')
 [Environment]::GetEnvironmentVariable('LV_HEAD_VI', 'Machine')
 node tools/npm/run-script.mjs env:labview:2026:host-planes
+pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 `
+  -Repository LabVIEW-Community-CI-CD/compare-vi-cli-action `
+  -RunnerName GHOST-comparevi-capability-ingress `
+  -RequiredLabel capability-ingress `
+  -Token (gh auth token)
 node tools/npm/run-script.mjs priority:lane:docker:handshake -- --action request --lane-id docker-agent-check-01 --agent-id operator --agent-class other --capability docker-lane
 ```
+
+Inside a GitHub Actions job, the same helper automatically switches to
+run-jobs validation through `GITHUB_RUN_ID`, `RUNNER_NAME`, and
+`GITHUB_TOKEN`.
 
 Dispatch `Pester (self-hosted, real CLI)` manually to confirm environment validation and tests pass.
 
@@ -60,6 +86,14 @@ is a supported native-plane consumer:
 That harness does not define a separate runner class. It consumes one of the
 native LabVIEW planes and should be attributed to the same host OS fingerprint
 and isolated lane group.
+
+Self-hosted compare workflows should target:
+
+- `runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]`
+
+Add capability labels only when a job truly needs them. `capability-ingress` is
+the stable ingress requirement; execution cells and Docker lanes remain the
+local isolation mechanism behind it.
 
 ## Maintenance
 

--- a/tests/Assert-RunnerLabelContract.Tests.ps1
+++ b/tests/Assert-RunnerLabelContract.Tests.ps1
@@ -1,0 +1,173 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Assert-RunnerLabelContract.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Assert-RunnerLabelContract.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'passes when required label is present in run-jobs payload' {
+    $work = Join-Path $TestDrive 'success'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      jobs = @(
+        [ordered]@{
+          runner_name = 'host-a'
+          runner_id = 42
+          status = 'in_progress'
+          started_at = '2026-03-02T00:00:00Z'
+          labels = @('self-hosted', 'windows', 'comparevi', 'capability-ingress')
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+    $githubOutputPath = Join-Path $work 'github-output.txt'
+    $stepSummaryPath = Join-Path $work 'step-summary.md'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '100' `
+        -RunnerName 'host-a' `
+        -RequiredLabel 'capability-ingress' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath `
+        -GitHubOutputPath $githubOutputPath `
+        -StepSummaryPath $stepSummaryPath
+    } | Should -Not -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.schema | Should -Be 'runner-label-contract@v1'
+    $json.validationMode | Should -Be 'run-job'
+    $json.status | Should -Be 'success'
+    $json.failureClass | Should -Be 'none'
+    $json.hasRequiredLabel | Should -BeTrue
+    $json.runnerId | Should -Be '42'
+    @($json.labels) | Should -Contain 'capability-ingress'
+
+    $ghOutput = Get-Content -LiteralPath $githubOutputPath -Raw
+    $ghOutput | Should -Match 'has_required_label=true'
+    $ghOutput | Should -Match 'runner_label_contract_status=success'
+    $ghOutput | Should -Match 'runner_id=42'
+
+    $summary = Get-Content -LiteralPath $stepSummaryPath -Raw
+    $summary | Should -Match '### Runner Label Contract'
+    $summary | Should -Match 'status: `success`'
+  }
+
+  It 'fails with missing-label class when required label is absent' {
+    $work = Join-Path $TestDrive 'missing-label'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      jobs = @(
+        [ordered]@{
+          runner_name = 'host-b'
+          runner_id = 77
+          status = 'completed'
+          started_at = '2026-03-02T00:01:00Z'
+          labels = @('self-hosted', 'windows')
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '101' `
+        -RunnerName 'host-b' `
+        -RequiredLabel 'capability-ingress' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'missing-label'
+    $json.failureMessage | Should -Match 'missing required label'
+    $json.hasRequiredLabel | Should -BeFalse
+  }
+
+  It 'classifies 403 payload failures as api-permission' {
+    $work = Join-Path $TestDrive 'api-permission'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      status = 403
+      message = 'Resource not accessible by integration'
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '102' `
+        -RunnerName 'host-c' `
+        -RequiredLabel 'capability-ingress' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'api-permission'
+    $json.failureMessage | Should -Match 'Resource not accessible'
+  }
+
+  It 'passes when required label is present in repository runner inventory payload' {
+    $work = Join-Path $TestDrive 'inventory-success'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $runnerInventoryPath = Join-Path $work 'runners.json'
+    $payload = [ordered]@{
+      runners = @(
+        [ordered]@{
+          id = 25
+          name = 'GHOST-comparevi-capability-ingress'
+          status = 'online'
+          labels = @(
+            [ordered]@{ name = 'self-hosted' },
+            [ordered]@{ name = 'windows' },
+            [ordered]@{ name = 'comparevi' },
+            [ordered]@{ name = 'capability-ingress' }
+          )
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $runnerInventoryPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunnerName 'GHOST-comparevi-capability-ingress' `
+        -RequiredLabel 'capability-ingress' `
+        -RunnerInventoryPath $runnerInventoryPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Not -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.validationMode | Should -Be 'repository-runner'
+    $json.status | Should -Be 'success'
+    $json.runnerId | Should -Be '25'
+    @($json.labels) | Should -Contain 'capability-ingress'
+  }
+}

--- a/tools/Assert-RunnerLabelContract.ps1
+++ b/tools/Assert-RunnerLabelContract.ps1
@@ -1,0 +1,377 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Validates that the current Actions job runner includes a required label.
+
+.DESCRIPTION
+  Resolves runner metadata from the GitHub Actions run-jobs API or the
+  repository runner inventory API and fails with deterministic remediation text
+  when the required label is missing.
+
+  This script supports test/offline execution through -JobsPayloadPath or
+  -RunnerInventoryPath.
+#>
+[CmdletBinding()]
+param(
+  [string]$Repository = $env:GITHUB_REPOSITORY,
+  [string]$RunId = $env:GITHUB_RUN_ID,
+  [string]$RunnerName = $env:RUNNER_NAME,
+  [string]$RequiredLabel = 'capability-ingress',
+  [string]$Token = $env:GITHUB_TOKEN,
+  [string]$OutputJsonPath = 'results/fixture-drift/runner-label-contract.json',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY,
+  [string]$JobsPayloadPath = '',
+  [string]$RunnerInventoryPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [AllowNull()][AllowEmptyString()][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  $dest = Resolve-AbsolutePath -Path $Path
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Add-Content -LiteralPath $dest -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function New-ApiException {
+  param(
+    [Parameter(Mandatory)][string]$Message,
+    [AllowNull()][int]$StatusCode
+  )
+
+  $exception = [System.Exception]::new($Message)
+  if ($null -ne $StatusCode -and $StatusCode -gt 0) {
+    $exception.Data['HttpStatusCode'] = [int]$StatusCode
+  }
+  return $exception
+}
+
+function Get-StatusCodeFromError {
+  param([Parameter(Mandatory)][System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+  $statusCode = 0
+  try {
+    $ex = $ErrorRecord.Exception
+    if ($ex -and $ex.Data -and $ex.Data.Contains('HttpStatusCode')) {
+      return [int]$ex.Data['HttpStatusCode']
+    }
+    if ($ex -and $ex.PSObject.Properties['Response'] -and $ex.Response) {
+      if ($ex.Response.PSObject.Properties['StatusCode'] -and $ex.Response.StatusCode) {
+        return [int]$ex.Response.StatusCode
+      }
+    }
+  } catch {}
+
+  $message = [string]$ErrorRecord.Exception.Message
+  if ($message -match '"status"\s*:\s*"?(\d{3})"?' -or $message -match 'HTTP\s*(\d{3})') {
+    [void][int]::TryParse($Matches[1], [ref]$statusCode)
+  }
+  return $statusCode
+}
+
+function Convert-JobLabelsToArray {
+  param([AllowNull()]$Labels)
+
+  $values = New-Object System.Collections.Generic.List[string]
+  foreach ($entry in @($Labels)) {
+    if ($entry -is [string]) {
+      $candidate = [string]$entry
+    } elseif ($entry -and $entry.PSObject.Properties['name']) {
+      $candidate = [string]$entry.name
+    } else {
+      $candidate = ''
+    }
+    if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+      $values.Add($candidate) | Out-Null
+    }
+  }
+  return @($values.ToArray() | Sort-Object -Unique)
+}
+
+function Get-RunJobs {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [Parameter(Mandatory)][string]$RunId,
+    [string]$Token,
+    [string]$JobsPayloadPath
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($JobsPayloadPath)) {
+    $payloadResolved = Resolve-AbsolutePath -Path $JobsPayloadPath
+    if (-not (Test-Path -LiteralPath $payloadResolved -PathType Leaf)) {
+      throw (New-ApiException -Message ("Jobs payload file not found: {0}" -f $payloadResolved) -StatusCode 0)
+    }
+    $payload = Get-Content -LiteralPath $payloadResolved -Raw | ConvertFrom-Json -Depth 30
+    if ($payload -is [System.Array]) {
+      return @($payload)
+    }
+    if ($payload.PSObject.Properties['jobs'] -and $payload.jobs) {
+      return @($payload.jobs)
+    }
+    if ($payload.PSObject.Properties['status'] -and $payload.PSObject.Properties['message']) {
+      $status = 0
+      [void][int]::TryParse([string]$payload.status, [ref]$status)
+      throw (New-ApiException -Message ([string]$payload.message) -StatusCode $status)
+    }
+    throw (New-ApiException -Message ("Unsupported jobs payload format: {0}" -f $payloadResolved) -StatusCode 0)
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw (New-ApiException -Message 'GITHUB_TOKEN is required to validate runner labels. Set permissions.actions=read.' -StatusCode 401)
+  }
+
+  $headers = @{
+    Authorization = "Bearer $Token"
+    Accept = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+  }
+
+  $jobs = New-Object System.Collections.Generic.List[object]
+  $page = 1
+  $perPage = 100
+  do {
+    $uri = "https://api.github.com/repos/$Repository/actions/runs/$RunId/jobs?per_page=$perPage&page=$page"
+    try {
+      $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop
+    } catch {
+      $status = Get-StatusCodeFromError -ErrorRecord $_
+      $message = [string]$_.Exception.Message
+      throw (New-ApiException -Message $message -StatusCode $status)
+    }
+
+    $candidates = @($response.jobs)
+    foreach ($job in $candidates) {
+      $jobs.Add($job) | Out-Null
+    }
+    $page++
+  } while ($candidates.Count -eq $perPage)
+
+  return @($jobs.ToArray())
+}
+
+function Get-RepositoryRunners {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [string]$Token,
+    [string]$RunnerInventoryPath
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($RunnerInventoryPath)) {
+    $payloadResolved = Resolve-AbsolutePath -Path $RunnerInventoryPath
+    if (-not (Test-Path -LiteralPath $payloadResolved -PathType Leaf)) {
+      throw (New-ApiException -Message ("Runner inventory file not found: {0}" -f $payloadResolved) -StatusCode 0)
+    }
+    $payload = Get-Content -LiteralPath $payloadResolved -Raw | ConvertFrom-Json -Depth 30
+    if ($payload -is [System.Array]) {
+      return @($payload)
+    }
+    if ($payload.PSObject.Properties['runners'] -and $payload.runners) {
+      return @($payload.runners)
+    }
+    if ($payload.PSObject.Properties['status'] -and $payload.PSObject.Properties['message']) {
+      $status = 0
+      [void][int]::TryParse([string]$payload.status, [ref]$status)
+      throw (New-ApiException -Message ([string]$payload.message) -StatusCode $status)
+    }
+    throw (New-ApiException -Message ("Unsupported runner inventory payload format: {0}" -f $payloadResolved) -StatusCode 0)
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw (New-ApiException -Message 'GITHUB_TOKEN is required to validate repository runner labels. Set permissions.actions=read.' -StatusCode 401)
+  }
+
+  $headers = @{
+    Authorization = "Bearer $Token"
+    Accept = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+  }
+
+  $runners = New-Object System.Collections.Generic.List[object]
+  $page = 1
+  $perPage = 100
+  do {
+    $uri = "https://api.github.com/repos/$Repository/actions/runners?per_page=$perPage&page=$page"
+    try {
+      $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop
+    } catch {
+      $status = Get-StatusCodeFromError -ErrorRecord $_
+      $message = [string]$_.Exception.Message
+      throw (New-ApiException -Message $message -StatusCode $status)
+    }
+
+    $candidates = @($response.runners)
+    foreach ($runner in $candidates) {
+      $runners.Add($runner) | Out-Null
+    }
+    $page++
+  } while ($candidates.Count -eq $perPage)
+
+  return @($runners.ToArray())
+}
+
+$outputJsonResolved = Resolve-AbsolutePath -Path $OutputJsonPath
+$outputParent = Split-Path -Parent $outputJsonResolved
+if ($outputParent -and -not (Test-Path -LiteralPath $outputParent -PathType Container)) {
+  New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
+}
+
+$summary = [ordered]@{
+  schema = 'runner-label-contract@v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  repository = $Repository
+  runId = $RunId
+  validationMode = ''
+  runnerName = $RunnerName
+  runnerId = ''
+  requiredLabel = $RequiredLabel
+  labels = @()
+  hasRequiredLabel = $false
+  status = 'failure'
+  failureClass = 'preflight'
+  failureMessage = ''
+  jobsPayloadPath = if ([string]::IsNullOrWhiteSpace($JobsPayloadPath)) { '' } else { Resolve-AbsolutePath -Path $JobsPayloadPath }
+  runnerInventoryPath = if ([string]::IsNullOrWhiteSpace($RunnerInventoryPath)) { '' } else { Resolve-AbsolutePath -Path $RunnerInventoryPath }
+}
+
+$caught = $null
+try {
+  if ([string]::IsNullOrWhiteSpace($Repository)) { throw 'Repository is required.' }
+  if ([string]::IsNullOrWhiteSpace($RunnerName)) { throw 'RunnerName is required.' }
+  if ([string]::IsNullOrWhiteSpace($RequiredLabel)) { throw 'RequiredLabel is required.' }
+
+  $useRunJobsMode = (-not [string]::IsNullOrWhiteSpace($RunId)) -or (-not [string]::IsNullOrWhiteSpace($JobsPayloadPath))
+  if ($useRunJobsMode) {
+    if ([string]::IsNullOrWhiteSpace($RunId)) { throw 'RunId is required when validating via run-jobs metadata.' }
+    $summary.validationMode = 'run-job'
+
+    $jobs = Get-RunJobs -Repository $Repository -RunId $RunId -Token $Token -JobsPayloadPath $JobsPayloadPath
+    if (-not $jobs -or $jobs.Count -eq 0) {
+      throw (New-ApiException -Message ("No jobs returned for run {0} in {1}." -f $RunId, $Repository) -StatusCode 0)
+    }
+
+    $currentJob = $jobs |
+      Where-Object { $_.runner_name -eq $RunnerName -and $_.status -eq 'in_progress' } |
+      Select-Object -First 1
+    if (-not $currentJob) {
+      $currentJob = $jobs |
+        Where-Object { $_.runner_name -eq $RunnerName } |
+        Sort-Object started_at -Descending |
+        Select-Object -First 1
+    }
+    if (-not $currentJob) {
+      throw (New-ApiException -Message ("Unable to resolve current job metadata for runner '{0}' in run {1}. Remediation: verify Actions run-jobs API visibility and rerun fixture-drift." -f $RunnerName, $RunId) -StatusCode 0)
+    }
+
+    $labels = Convert-JobLabelsToArray -Labels $currentJob.labels
+    $hasRequiredLabel = $labels -contains $RequiredLabel
+    $summary.runnerId = [string]$currentJob.runner_id
+    $summary.labels = @($labels)
+    $summary.hasRequiredLabel = [bool]$hasRequiredLabel
+  } else {
+    $summary.validationMode = 'repository-runner'
+
+    $runners = Get-RepositoryRunners -Repository $Repository -Token $Token -RunnerInventoryPath $RunnerInventoryPath
+    if (-not $runners -or $runners.Count -eq 0) {
+      throw (New-ApiException -Message ("No repository runners returned for {0}." -f $Repository) -StatusCode 0)
+    }
+
+    $currentRunner = $runners |
+      Where-Object { $_.name -eq $RunnerName } |
+      Select-Object -First 1
+    if (-not $currentRunner) {
+      throw (New-ApiException -Message ("Unable to resolve repository runner '{0}' in {1}. Remediation: verify the runner is registered and online." -f $RunnerName, $Repository) -StatusCode 0)
+    }
+
+    $labels = Convert-JobLabelsToArray -Labels $currentRunner.labels
+    $hasRequiredLabel = $labels -contains $RequiredLabel
+    $summary.runnerId = [string]$currentRunner.id
+    $summary.labels = @($labels)
+    $summary.hasRequiredLabel = [bool]$hasRequiredLabel
+  }
+
+  if (-not $hasRequiredLabel) {
+    $summary.status = 'failure'
+    $summary.failureClass = 'missing-label'
+    $summary.failureMessage = ("Runner '{0}' (id={1}) is missing required label '{2}'. Remediation: add the label in Repository Settings > Actions > Runners, then re-run fixture-drift." -f $RunnerName, [string]$summary.runnerId, $RequiredLabel)
+  } else {
+    $summary.status = 'success'
+    $summary.failureClass = 'none'
+    $summary.failureMessage = ''
+  }
+} catch {
+  $caught = $_
+  $statusCode = Get-StatusCodeFromError -ErrorRecord $_
+  $summary.status = 'failure'
+  if ($statusCode -eq 403) {
+    $summary.failureClass = 'api-permission'
+  } elseif ($statusCode -eq 401) {
+    $summary.failureClass = 'auth'
+  } elseif ($statusCode -eq 404) {
+    $summary.failureClass = 'api-not-found'
+  } elseif ([string]::IsNullOrWhiteSpace([string]$summary.failureClass) -or [string]$summary.failureClass -eq 'preflight') {
+    $summary.failureClass = 'api-error'
+  }
+  if ([string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+    $summary.failureMessage = [string]$_.Exception.Message
+  }
+} finally {
+  ($summary | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $outputJsonResolved -Encoding utf8
+
+  $labelsCsv = if ($summary.labels -and @($summary.labels).Count -gt 0) { [string]::Join(',', @($summary.labels)) } else { '' }
+  Write-GitHubOutput -Key 'has_required_label' -Value ([string]$summary.hasRequiredLabel).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'labels' -Value $labelsCsv -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_id' -Value ([string]$summary.runnerId) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_status' -Value ([string]$summary.status) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_summary_path' -Value $outputJsonResolved -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_failure_class' -Value ([string]$summary.failureClass) -Path $GitHubOutputPath
+
+  if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+    $summaryLines = @(
+      '### Runner Label Contract',
+      '',
+      ('- validation mode: `{0}`' -f [string]$summary.validationMode),
+      ('- status: `{0}`' -f [string]$summary.status),
+      ('- required label: `{0}`' -f [string]$summary.requiredLabel),
+      ('- runner: `{0}` (id=`{1}`)' -f [string]$summary.runnerName, [string]$summary.runnerId),
+      ('- labels: `{0}`' -f $labelsCsv),
+      ('- summary json: `{0}`' -f $outputJsonResolved)
+    )
+    if ($summary.status -ne 'success') {
+      $summaryLines += ('- failure class: `{0}`' -f [string]$summary.failureClass)
+      if (-not [string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+        $summaryLines += ('- failure: {0}' -f [string]$summary.failureMessage)
+      }
+    }
+    $stepSummaryResolved = Resolve-AbsolutePath -Path $StepSummaryPath
+    $stepSummaryParent = Split-Path -Parent $stepSummaryResolved
+    if ($stepSummaryParent -and -not (Test-Path -LiteralPath $stepSummaryParent -PathType Container)) {
+      New-Item -ItemType Directory -Path $stepSummaryParent -Force | Out-Null
+    }
+    $summaryLines -join "`n" | Out-File -FilePath $stepSummaryResolved -Append -Encoding utf8
+  }
+}
+
+if ([string]$summary.status -ne 'success') {
+  throw ("Runner label contract failed ({0}): {1}" -f [string]$summary.failureClass, [string]$summary.failureMessage)
+}
+
+Write-Output $outputJsonResolved

--- a/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
+++ b/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..');
+
+const selfHostedWorkflowPaths = [
+  '.github/workflows/ci-orchestrated.yml',
+  '.github/workflows/compare-artifacts.yml',
+  '.github/workflows/labview-cli-compare.yml',
+  '.github/workflows/pester-reusable.yml',
+  '.github/workflows/runbook-validation.yml',
+  '.github/workflows/smoke-on-label.yml',
+  '.github/workflows/smoke.yml',
+  '.github/workflows/vi-compare-pr.yml',
+  '.github/workflows/vi-compare-refs.yml',
+  '.github/workflows/vi-history-compare.yml',
+  '.github/workflows/vi-staging-smoke.yml'
+];
+
+function readWorkflow(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('self-hosted compare workflows require comparevi capability ingress labels', () => {
+  for (const workflowPath of selfHostedWorkflowPaths) {
+    const content = readWorkflow(workflowPath);
+    assert.match(
+      content,
+      /runs-on:\s*\[self-hosted,\s*Windows,\s*X64,\s*comparevi,\s*capability-ingress\]/,
+      `${workflowPath} must route through compare capability ingress`
+    );
+    assert.doesNotMatch(
+      content,
+      /runs-on:\s*\[self-hosted,\s*Windows,\s*X64\]/,
+      `${workflowPath} must not fall back to generic self-hosted Windows routing`
+    );
+  }
+});

--- a/tools/priority/__tests__/docker-labview-path-contract.test.mjs
+++ b/tools/priority/__tests__/docker-labview-path-contract.test.mjs
@@ -146,6 +146,12 @@ test('docker desktop fast-loop only accepts lane-specific LabVIEW path contracts
 test('actionlint config no longer carries legacy Windows docker runner labels', () => {
   const config = readRepoFile('.github/actionlint.yaml');
 
+  assert.match(config, /comparevi/);
+  assert.match(config, /capability-ingress/);
+  assert.match(config, /labview-2026/);
+  assert.match(config, /lv32/);
+  assert.match(config, /docker-lane/);
+  assert.match(config, /teststand/);
   assert.match(config, /self-hosted-docker-linux/);
   assert.match(config, /hosted-docker-linux/);
   assert.doesNotMatch(config, /self-hosted-docker-windows/);


### PR DESCRIPTION
## Summary
- harden compare self-hosted workflow routing onto the canonical ingress taxonomy
- teach the runner label contract helper to validate either in-job run metadata or live repository runner inventory
- align actionlint and docs with the registered compare ingress runner labels

## Validation
- `Invoke-Pester tests/Assert-RunnerLabelContract.Tests.ps1 -Output Detailed`
- `node --test tools/priority/__tests__/capability-ingress-runner-routing.test.mjs tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 -Repository LabVIEW-Community-CI-CD/compare-vi-cli-action -RunnerName GHOST-comparevi-capability-ingress -RequiredLabel capability-ingress -Token (gh auth token)`
- `tools/PrePush-Checks.ps1` actionlint segment passes; full pre-push still reports pre-existing PSScriptAnalyzer debt from unchanged stacked PowerShell files
