### PR TITLE
feat: formalize ingress runner capability matrix (#1905)

### DIFF
--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -31,6 +31,9 @@ Artifacts appear under `tests/results/` (JSON summary, results XML, dispatcher l
 - Runner online with labels `[self-hosted, Windows, X64, comparevi, capability-ingress]`.
 - VI fixtures available and accessible by runner service.
 - LVCompare not blocked by antivirus / pending updates.
+- Current compare self-hosted workflows stay ingress-only by policy. Reserve
+  `labview-2026`, `lv32`, `docker-lane`, and `teststand` for jobs that
+  explicitly lease those specialized planes through the governed host fabric.
 
 ## Troubleshooting
 

--- a/docs/SELFHOSTED_CI_SETUP.md
+++ b/docs/SELFHOSTED_CI_SETUP.md
@@ -93,7 +93,13 @@ Self-hosted compare workflows should target:
 
 Add capability labels only when a job truly needs them. `capability-ingress` is
 the stable ingress requirement; execution cells and Docker lanes remain the
-local isolation mechanism behind it.
+local isolation mechanism behind it. The checked-in routing source of truth for
+today's compare jobs is:
+
+- `tools/policy/runner-capability-routing.json`
+
+That matrix intentionally keeps most current compare jobs ingress-only until
+they truly consume `labview-2026`, `lv32`, `docker-lane`, or `teststand`.
 
 ## Maintenance
 

--- a/tools/policy/runner-capability-routing.json
+++ b/tools/policy/runner-capability-routing.json
@@ -1,0 +1,178 @@
+{
+  "version": 1,
+  "baseIngressLabels": [
+    "self-hosted",
+    "Windows",
+    "X64",
+    "comparevi",
+    "capability-ingress"
+  ],
+  "optionalCapabilityLabels": [
+    "labview-2026",
+    "lv32",
+    "docker-lane",
+    "teststand"
+  ],
+  "deferredCapabilityCandidates": [
+    {
+      "workflow": ".github/workflows/labview-cli-compare.yml",
+      "job": "cli-compare",
+      "candidateLabels": [
+        "lv32"
+      ],
+      "reason": "The job validates the Program Files (x86) LabVIEW CLI path today, but this slice keeps lv32 reserved for explicit native 32-bit plane consumers until that label contract is widened deliberately."
+    }
+  ],
+  "workflowJobRouting": [
+    {
+      "workflow": ".github/workflows/ci-orchestrated.yml",
+      "jobs": [
+        {
+          "id": "probe",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "pester-category",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "drift",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "windows-single",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/compare-artifacts.yml",
+      "jobs": [
+        {
+          "id": "publish",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/labview-cli-compare.yml",
+      "jobs": [
+        {
+          "id": "cli-compare",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/pester-reusable.yml",
+      "jobs": [
+        {
+          "id": "preflight",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "pester",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/runbook-validation.yml",
+      "jobs": [
+        {
+          "id": "runbook-check",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/smoke-on-label.yml",
+      "jobs": [
+        {
+          "id": "smoke",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/smoke.yml",
+      "jobs": [
+        {
+          "id": "preflight",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "compare",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/vi-compare-pr.yml",
+      "jobs": [
+        {
+          "id": "preflight",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "vi-compare",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/vi-compare-refs.yml",
+      "jobs": [
+        {
+          "id": "preflight",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "compare",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/vi-history-compare.yml",
+      "jobs": [
+        {
+          "id": "preflight",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        },
+        {
+          "id": "compare-history",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/vi-staging-smoke.yml",
+      "jobs": [
+        {
+          "id": "smoke",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    }
+  ]
+}

--- a/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
+++ b/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
@@ -4,37 +4,70 @@ import path from 'node:path';
 import test from 'node:test';
 
 const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..');
+const routingPolicy = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'tools/policy/runner-capability-routing.json'), 'utf8')
+);
 
-const selfHostedWorkflowPaths = [
-  '.github/workflows/ci-orchestrated.yml',
-  '.github/workflows/compare-artifacts.yml',
-  '.github/workflows/labview-cli-compare.yml',
-  '.github/workflows/pester-reusable.yml',
-  '.github/workflows/runbook-validation.yml',
-  '.github/workflows/smoke-on-label.yml',
-  '.github/workflows/smoke.yml',
-  '.github/workflows/vi-compare-pr.yml',
-  '.github/workflows/vi-compare-refs.yml',
-  '.github/workflows/vi-history-compare.yml',
-  '.github/workflows/vi-staging-smoke.yml'
-];
+const ingressRunOnPattern = /\bruns-on:\s*\[[^\]\r\n]*\bself-hosted\b[^\]\r\n]*\]/g;
+const expectedBaseRunsOn = `runs-on: [${routingPolicy.baseIngressLabels.join(', ')}]`;
 
 function readWorkflow(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
 
-test('self-hosted compare workflows require comparevi capability ingress labels', () => {
-  for (const workflowPath of selfHostedWorkflowPaths) {
-    const content = readWorkflow(workflowPath);
-    assert.match(
-      content,
-      /runs-on:\s*\[self-hosted,\s*Windows,\s*X64,\s*comparevi,\s*capability-ingress\]/,
-      `${workflowPath} must route through compare capability ingress`
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractJobBlock(workflowText, jobId) {
+  const pattern = new RegExp(
+    `\\n  ${escapeRegex(jobId)}:\\r?\\n([\\s\\S]*?)(?=\\n  [A-Za-z0-9_-]+:\\r?\\n|$)`
+  );
+  const match = workflowText.match(pattern);
+  assert.ok(match, `job ${jobId} must exist in workflow`);
+  return match[1];
+}
+
+test('self-hosted compare workflows stay ingress-only until they need specialized planes', () => {
+  for (const workflow of routingPolicy.workflowJobRouting) {
+    const content = readWorkflow(workflow.workflow);
+    const selfHostedCount = content.match(ingressRunOnPattern)?.length ?? 0;
+
+    assert.equal(
+      selfHostedCount,
+      workflow.jobs.length,
+      `${workflow.workflow} must keep policy coverage for every self-hosted compare job`
     );
-    assert.doesNotMatch(
-      content,
-      /runs-on:\s*\[self-hosted,\s*Windows,\s*X64\]/,
-      `${workflowPath} must not fall back to generic self-hosted Windows routing`
-    );
+
+    for (const job of workflow.jobs) {
+      assert.deepEqual(
+        job.requiredCapabilityLabels,
+        [],
+        `${workflow.workflow}#${job.id} should remain ingress-only in this slice`
+      );
+
+      const jobBlock = extractJobBlock(content, job.id);
+      assert.match(
+        jobBlock,
+        new RegExp(escapeRegex(expectedBaseRunsOn)),
+        `${workflow.workflow}#${job.id} must route through compare capability ingress`
+      );
+    }
   }
+});
+
+test('workflow updater probe job defaults to compare capability ingress labels', () => {
+  const updater = fs.readFileSync(
+    path.join(repoRoot, 'tools/workflows/_update_workflows_impl.py'),
+    'utf8'
+  );
+
+  assert.match(updater, /COMPARE_CAPABILITY_INGRESS_RUNS_ON\s*=\s*\[/);
+  assert.match(updater, /'comparevi'/);
+  assert.match(updater, /'capability-ingress'/);
+  assert.doesNotMatch(
+    updater,
+    /'runs-on': \['self-hosted', 'Windows', 'X64'\]/,
+    'workflow updater must not reintroduce generic self-hosted routing'
+  );
 });

--- a/tools/priority/__tests__/runner-capability-routing-policy.test.mjs
+++ b/tools/priority/__tests__/runner-capability-routing-policy.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..');
+const policyPath = path.join(repoRoot, 'tools/policy/runner-capability-routing.json');
+const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+
+test('runner capability routing policy defines a stable ingress base and reserved specialized labels', () => {
+  assert.equal(policy.version, 1);
+  assert.deepEqual(policy.baseIngressLabels, [
+    'self-hosted',
+    'Windows',
+    'X64',
+    'comparevi',
+    'capability-ingress'
+  ]);
+  assert.deepEqual(policy.optionalCapabilityLabels, [
+    'labview-2026',
+    'lv32',
+    'docker-lane',
+    'teststand'
+  ]);
+});
+
+test('runner capability routing policy covers all current self-hosted compare workflows in scope', () => {
+  const expectedWorkflows = [
+    '.github/workflows/ci-orchestrated.yml',
+    '.github/workflows/compare-artifacts.yml',
+    '.github/workflows/labview-cli-compare.yml',
+    '.github/workflows/pester-reusable.yml',
+    '.github/workflows/runbook-validation.yml',
+    '.github/workflows/smoke-on-label.yml',
+    '.github/workflows/smoke.yml',
+    '.github/workflows/vi-compare-pr.yml',
+    '.github/workflows/vi-compare-refs.yml',
+    '.github/workflows/vi-history-compare.yml',
+    '.github/workflows/vi-staging-smoke.yml'
+  ];
+
+  assert.deepEqual(
+    policy.workflowJobRouting.map((entry) => entry.workflow),
+    expectedWorkflows
+  );
+
+  for (const entry of policy.workflowJobRouting) {
+    assert.ok(fs.existsSync(path.join(repoRoot, entry.workflow)), `${entry.workflow} must exist`);
+    assert.ok(entry.jobs.length > 0, `${entry.workflow} must list at least one self-hosted job`);
+    for (const job of entry.jobs) {
+      assert.equal(job.routingClass, 'ingress-only');
+      assert.deepEqual(job.requiredCapabilityLabels, []);
+    }
+  }
+});
+
+test('runner capability routing policy records deferred specialization candidates explicitly', () => {
+  assert.deepEqual(policy.deferredCapabilityCandidates, [
+    {
+      workflow: '.github/workflows/labview-cli-compare.yml',
+      job: 'cli-compare',
+      candidateLabels: ['lv32'],
+      reason:
+        'The job validates the Program Files (x86) LabVIEW CLI path today, but this slice keeps lv32 reserved for explicit native 32-bit plane consumers until that label contract is widened deliberately.'
+    }
+  ]);
+});

--- a/tools/workflows/_update_workflows_impl.py
+++ b/tools/workflows/_update_workflows_impl.py
@@ -29,6 +29,14 @@ yaml = YAML(typ='rt')
 yaml.preserve_quotes = True
 yaml.width = 4096  # avoid folding
 
+COMPARE_CAPABILITY_INGRESS_RUNS_ON = [
+    'self-hosted',
+    'Windows',
+    'X64',
+    'comparevi',
+    'capability-ingress',
+]
+
 
 def load_yaml(path: Path):
     with path.open('r', encoding='utf-8') as fp:
@@ -624,7 +632,7 @@ def ensure_interactivity_probe_job(doc) -> bool:
     )
     job = {
         'if': desired_if,
-        'runs-on': ['self-hosted', 'Windows', 'X64'],
+        'runs-on': list(COMPARE_CAPABILITY_INGRESS_RUNS_ON),
         'timeout-minutes': 2,
         'needs': ['normalize', 'preflight'],
         'outputs': desired_outputs,


### PR DESCRIPTION
## Summary
- add a checked-in runner capability routing matrix for compare self-hosted workflows
- keep current compare jobs ingress-only until they truly consume specialized planes
- patch the workflow updater so generated self-hosted probe jobs keep the ingress labels by default

## Validation
- `node --test tools/priority/__tests__/capability-ingress-runner-routing.test.mjs tools/priority/__tests__/runner-capability-routing-policy.test.mjs tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`
