### PR TITLE
feat: require lv32 host-plane contract for cli compare (#1905)

### DIFF
--- a/.github/workflows/labview-cli-compare.yml
+++ b/.github/workflows/labview-cli-compare.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cli-compare:
-    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress, labview-2026, lv32]
     env:
       # Headless + safe UI behaviour
       LV_SUPPRESS_UI: '1'
@@ -30,23 +30,38 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Validate LabVIEW CLI presence
+      - name: Validate native LV32 host-plane readiness
+        id: host_plane
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $defaultCli = 'C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.exe'
-          $cli = $env:LABVIEW_CLI_PATH
-          if ([string]::IsNullOrWhiteSpace($cli)) { $cli = $defaultCli }
+          $reportPath = node tools/npm/run-script.mjs env:labview:2026:host-planes
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 12
+          if ($report.native.planes.x32.status -ne 'ready') {
+            Write-Host "::error::LabVIEW 2026 native x32 host plane is not ready. Observed status: $($report.native.planes.x32.status)"
+            exit 1
+          }
+          $cli = [string]$report.native.planes.x32.cliPath
+          if ([string]::IsNullOrWhiteSpace($cli)) {
+            Write-Host '::error::LabVIEW CLI path missing from the native x32 host-plane report.'
+            exit 1
+          }
           if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) {
             Write-Host "::error::LabVIEWCLI.exe not found. Checked: $cli"
-            Write-Host 'Install LabVIEW 2025 Q3 or later (includes LabVIEW CLI), or set LABVIEW_CLI_PATH.'
+            Write-Host 'Repair the canonical LabVIEW 2026 host plane before trusting this specialized LV32 lane.'
             exit 1
           }
           "cli=$cli" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "reportPath=$reportPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Run LabVIEW CLI Compare
         id: compare
         uses: ./
+        env:
+          LABVIEW_CLI_PATH: ${{ steps.host_plane.outputs.cli }}
         with:
           base: VI1.vi
           head: VI2.vi
@@ -64,6 +79,7 @@ jobs:
         if: always()
         shell: pwsh
         run: |
+          Write-Host "hostPlane = ${{ steps.host_plane.outputs.reportPath }}"
           Write-Host "diff      = ${{ steps.compare.outputs.diff }}"
           Write-Host "exitCode  = ${{ steps.compare.outputs.exitCode }}"
           Write-Host "cliPath   = ${{ steps.compare.outputs.cliPath }}"

--- a/docs/SELFHOSTED_CI_SETUP.md
+++ b/docs/SELFHOSTED_CI_SETUP.md
@@ -98,8 +98,18 @@ today's compare jobs is:
 
 - `tools/policy/runner-capability-routing.json`
 
-That matrix intentionally keeps most current compare jobs ingress-only until
-they truly consume `labview-2026`, `lv32`, `docker-lane`, or `teststand`.
+That matrix keeps most compare jobs ingress-only, but
+`.github/workflows/labview-cli-compare.yml` is now an explicit native 32-bit
+consumer:
+
+- `runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress, labview-2026, lv32]`
+- emit `node tools/npm/run-script.mjs env:labview:2026:host-planes`
+- require `native.planes.x32.status = ready` before trusting the lane
+- source `LABVIEW_CLI_PATH` from the generated host-plane receipt instead of a
+  hard-coded `Program Files (x86)` fallback
+
+Keep `labview-2026`, `lv32`, `docker-lane`, and `teststand` opt-in everywhere
+else until a job has the same explicit machine-readable need.
 
 ## Maintenance
 

--- a/tools/policy/runner-capability-routing.json
+++ b/tools/policy/runner-capability-routing.json
@@ -13,16 +13,7 @@
     "docker-lane",
     "teststand"
   ],
-  "deferredCapabilityCandidates": [
-    {
-      "workflow": ".github/workflows/labview-cli-compare.yml",
-      "job": "cli-compare",
-      "candidateLabels": [
-        "lv32"
-      ],
-      "reason": "The job validates the Program Files (x86) LabVIEW CLI path today, but this slice keeps lv32 reserved for explicit native 32-bit plane consumers until that label contract is widened deliberately."
-    }
-  ],
+  "deferredCapabilityCandidates": [],
   "workflowJobRouting": [
     {
       "workflow": ".github/workflows/ci-orchestrated.yml",
@@ -64,8 +55,14 @@
       "jobs": [
         {
           "id": "cli-compare",
-          "routingClass": "ingress-only",
-          "requiredCapabilityLabels": []
+          "routingClass": "specialized-opt-in",
+          "requiredCapabilityLabels": [
+            "labview-2026",
+            "lv32"
+          ],
+          "requiredHealthReceipts": [
+            "labview-2026-host-plane-report"
+          ]
         }
       ]
     },

--- a/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
+++ b/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
@@ -9,7 +9,6 @@ const routingPolicy = JSON.parse(
 );
 
 const ingressRunOnPattern = /\bruns-on:\s*\[[^\]\r\n]*\bself-hosted\b[^\]\r\n]*\]/g;
-const expectedBaseRunsOn = `runs-on: [${routingPolicy.baseIngressLabels.join(', ')}]`;
 
 function readWorkflow(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
@@ -28,7 +27,11 @@ function extractJobBlock(workflowText, jobId) {
   return match[1];
 }
 
-test('self-hosted compare workflows stay ingress-only until they need specialized planes', () => {
+function expectedRunsOn(job) {
+  return `runs-on: [${routingPolicy.baseIngressLabels.concat(job.requiredCapabilityLabels ?? []).join(', ')}]`;
+}
+
+test('self-hosted compare workflows follow the checked-in routing policy', () => {
   for (const workflow of routingPolicy.workflowJobRouting) {
     const content = readWorkflow(workflow.workflow);
     const selfHostedCount = content.match(ingressRunOnPattern)?.length ?? 0;
@@ -40,20 +43,43 @@ test('self-hosted compare workflows stay ingress-only until they need specialize
     );
 
     for (const job of workflow.jobs) {
-      assert.deepEqual(
-        job.requiredCapabilityLabels,
-        [],
-        `${workflow.workflow}#${job.id} should remain ingress-only in this slice`
-      );
+      if ((job.requiredCapabilityLabels ?? []).length === 0) {
+        assert.equal(
+          job.routingClass,
+          'ingress-only',
+          `${workflow.workflow}#${job.id} should stay ingress-only when no specialized labels are required`
+        );
+      } else {
+        assert.equal(
+          job.routingClass,
+          'specialized-opt-in',
+          `${workflow.workflow}#${job.id} must declare a specialized opt-in routing class`
+        );
+      }
 
       const jobBlock = extractJobBlock(content, job.id);
       assert.match(
         jobBlock,
-        new RegExp(escapeRegex(expectedBaseRunsOn)),
-        `${workflow.workflow}#${job.id} must route through compare capability ingress`
+        new RegExp(escapeRegex(expectedRunsOn(job))),
+        `${workflow.workflow}#${job.id} must route through its declared compare capability contract`
       );
     }
   }
+});
+
+test('labview-cli-compare consumes an explicit LV32 host-plane readiness receipt', () => {
+  const workflow = readWorkflow('.github/workflows/labview-cli-compare.yml');
+  const jobBlock = extractJobBlock(workflow, 'cli-compare');
+
+  assert.match(jobBlock, /id:\s*host_plane/);
+  assert.match(jobBlock, /node tools\/npm\/run-script\.mjs env:labview:2026:host-planes/);
+  assert.match(jobBlock, /\$report\.native\.planes\.x32\.status -ne 'ready'/);
+  assert.match(jobBlock, /LABVIEW_CLI_PATH:\s*\$\{\{\s*steps\.host_plane\.outputs\.cli\s*\}\}/);
+  assert.doesNotMatch(
+    jobBlock,
+    /Program Files \(x86\)\\National Instruments\\Shared\\LabVIEW CLI\\LabVIEWCLI\.exe/,
+    'specialized LV32 workflow should derive its CLI path from the host-plane receipt instead of a hard-coded fallback'
+  );
 });
 
 test('workflow updater probe job defaults to compare capability ingress labels', () => {

--- a/tools/priority/__tests__/docker-labview-path-contract.test.mjs
+++ b/tools/priority/__tests__/docker-labview-path-contract.test.mjs
@@ -157,3 +157,19 @@ test('actionlint config no longer carries legacy Windows docker runner labels', 
   assert.doesNotMatch(config, /self-hosted-docker-windows/);
   assert.doesNotMatch(config, /hosted-docker-windows/);
 });
+
+test('labview-cli-compare routes through the explicit lv32 host plane contract', () => {
+  const workflow = readRepoFile('.github/workflows/labview-cli-compare.yml');
+
+  assert.match(
+    workflow,
+    /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress, labview-2026, lv32\]/
+  );
+  assert.match(workflow, /node tools\/npm\/run-script\.mjs env:labview:2026:host-planes/);
+  assert.match(workflow, /\$report\.native\.planes\.x32\.status -ne 'ready'/);
+  assert.match(workflow, /LABVIEW_CLI_PATH:\s*\$\{\{\s*steps\.host_plane\.outputs\.cli\s*\}\}/);
+  assert.doesNotMatch(
+    workflow,
+    /Program Files \(x86\)\\National Instruments\\Shared\\LabVIEW CLI\\LabVIEWCLI\.exe/
+  );
+});

--- a/tools/priority/__tests__/runner-capability-routing-policy.test.mjs
+++ b/tools/priority/__tests__/runner-capability-routing-policy.test.mjs
@@ -48,20 +48,18 @@ test('runner capability routing policy covers all current self-hosted compare wo
     assert.ok(fs.existsSync(path.join(repoRoot, entry.workflow)), `${entry.workflow} must exist`);
     assert.ok(entry.jobs.length > 0, `${entry.workflow} must list at least one self-hosted job`);
     for (const job of entry.jobs) {
-      assert.equal(job.routingClass, 'ingress-only');
-      assert.deepEqual(job.requiredCapabilityLabels, []);
+      if (entry.workflow === '.github/workflows/labview-cli-compare.yml' && job.id === 'cli-compare') {
+        assert.equal(job.routingClass, 'specialized-opt-in');
+        assert.deepEqual(job.requiredCapabilityLabels, ['labview-2026', 'lv32']);
+        assert.deepEqual(job.requiredHealthReceipts, ['labview-2026-host-plane-report']);
+      } else {
+        assert.equal(job.routingClass, 'ingress-only');
+        assert.deepEqual(job.requiredCapabilityLabels, []);
+      }
     }
   }
 });
 
-test('runner capability routing policy records deferred specialization candidates explicitly', () => {
-  assert.deepEqual(policy.deferredCapabilityCandidates, [
-    {
-      workflow: '.github/workflows/labview-cli-compare.yml',
-      job: 'cli-compare',
-      candidateLabels: ['lv32'],
-      reason:
-        'The job validates the Program Files (x86) LabVIEW CLI path today, but this slice keeps lv32 reserved for explicit native 32-bit plane consumers until that label contract is widened deliberately.'
-    }
-  ]);
+test('runner capability routing policy records no deferred specialization candidates after lv32 promotion', () => {
+  assert.deepEqual(policy.deferredCapabilityCandidates, []);
 });


### PR DESCRIPTION
## Summary
- promote `labview-cli-compare` from deferred ingress-only routing to an explicit `labview-2026 + lv32` consumer for #1905
- require the existing LabVIEW 2026 host-plane receipt before trusting the native x32 lane
- source `LABVIEW_CLI_PATH` from the generated host-plane receipt instead of a hard-coded `Program Files (x86)` fallback

## Validation
- `node --test tools/priority/__tests__/capability-ingress-runner-routing.test.mjs tools/priority/__tests__/runner-capability-routing-policy.test.mjs tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- `Invoke-Pester tests/Assert-RunnerLabelContract.Tests.ps1 -Output Detailed`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs env:labview:2026:host-planes`
- `pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 -Repository LabVIEW-Community-CI-CD/compare-vi-cli-action -RunnerName GHOST-comparevi-capability-ingress -RequiredLabel lv32 -Token (gh auth token)`
- `git diff --check`

## Notes
- this is the follow-on to #1946
- it converts the first deferred `lv32` candidate in `tools/policy/runner-capability-routing.json` into an explicit specialized consumer
