### PR TITLE
fix: keep generic pester ingress off lv32 fallback (#1905)

### DIFF
--- a/.github/workflows/pester-reusable.yml
+++ b/.github/workflows/pester-reusable.yml
@@ -98,17 +98,17 @@ jobs:
         shell: pwsh
         run: |
           $defaultCli = 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompare.exe'
-          $x86Cli     = 'C:\Program Files (x86)\National Instruments\Shared\LabVIEW Compare\LVCompare.exe'
           $candidates = @()
           if ($env:LVCOMPARE_PATH) { $candidates += $env:LVCOMPARE_PATH }
-          $candidates += @($defaultCli, $x86Cli)
+          $candidates += $defaultCli
           $cli = $null
           foreach ($p in $candidates) {
             if ($p -and (Test-Path -LiteralPath $p)) { $cli = $p; break }
           }
           if (-not $cli) {
             $tried = ($candidates | Where-Object { $_ }) -join '; '
-            Write-Host ("::error::LVCompare.exe not found. Tried: {0}" -f $tried)
+            Write-Host ("::error::LVCompare.exe not found on the generic ingress surface. Tried: {0}" -f $tried)
+            Write-Host '::error::pester-reusable does not silently fall back to Program Files (x86); use LVCOMPARE_PATH or an explicit specialized LV32 workflow when that surface is required.'
             exit 1
           } else {
             Write-Host ("Resolved LVCompare path: {0}" -f $cli)

--- a/docs/SELFHOSTED_CI_SETUP.md
+++ b/docs/SELFHOSTED_CI_SETUP.md
@@ -111,6 +111,11 @@ consumer:
 Keep `labview-2026`, `lv32`, `docker-lane`, and `teststand` opt-in everywhere
 else until a job has the same explicit machine-readable need.
 
+`.github/workflows/pester-reusable.yml` stays on the generic ingress surface.
+It may use an explicit `LVCOMPARE_PATH` override, but it does not silently fall
+back to `C:\Program Files (x86)\National Instruments\Shared\LabVIEW Compare\LVCompare.exe`
+on the default ingress lane.
+
 ## Maintenance
 
 - Keep LabVIEW and Windows patched.

--- a/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
+++ b/tools/priority/__tests__/capability-ingress-runner-routing.test.mjs
@@ -82,6 +82,25 @@ test('labview-cli-compare consumes an explicit LV32 host-plane readiness receipt
   );
 });
 
+test('pester-reusable generic ingress preflight stays off implicit x86 LVCompare fallback', () => {
+  const workflow = readWorkflow('.github/workflows/pester-reusable.yml');
+  const jobBlock = extractJobBlock(workflow, 'preflight');
+
+  assert.match(jobBlock, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress\]/);
+  assert.match(jobBlock, /LVCOMPARE_PATH:\s*\$\{\{\s*vars\.LVCOMPARE_PATH \|\| ''\s*\}\}/);
+  assert.match(jobBlock, /C:\\Program Files\\National Instruments\\Shared\\LabVIEW Compare\\LVCompare\.exe/);
+  assert.doesNotMatch(
+    jobBlock,
+    /Program Files \(x86\)\\National Instruments\\Shared\\LabVIEW Compare\\LVCompare\.exe/,
+    'generic ingress preflight should not silently fall back to the specialized x86 compare path'
+  );
+  assert.match(
+    jobBlock,
+    /does not silently fall back to Program Files \(x86\); use LVCOMPARE_PATH or an explicit specialized LV32 workflow/,
+    'generic ingress preflight should explain how to use the specialized path explicitly when needed'
+  );
+});
+
 test('workflow updater probe job defaults to compare capability ingress labels', () => {
   const updater = fs.readFileSync(
     path.join(repoRoot, 'tools/workflows/_update_workflows_impl.py'),


### PR DESCRIPTION
## Summary
- keep generic `pester-reusable` ingress jobs off the implicit `Program Files (x86)` LVCompare fallback
- document that the reusable Pester lane stays ingress-only unless an explicit override or specialized LV32 workflow is chosen
- lock the contract in with a workflow test so the heuristic does not drift back in

## Validation
- `node --test tools/priority/__tests__/capability-ingress-runner-routing.test.mjs tools/priority/__tests__/runner-capability-routing-policy.test.mjs`
- `Invoke-Pester tests/Assert-RunnerLabelContract.Tests.ps1 -Output Detailed`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `git diff --check`
