### PR TITLE
fix: filter non-summary hook receipts from handoff output

### DIFF
--- a/tests/AgentHandoff.Local.Tests.ps1
+++ b/tests/AgentHandoff.Local.Tests.ps1
@@ -4,7 +4,67 @@ $ErrorActionPreference = 'Stop'
 Describe 'Local Agent Handoff' -Tag 'Unit' {
   It 'prints AGENT_HANDOFF.txt' {
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
-    $handoffPath = Join-Path $repoRoot 'AGENT_HANDOFF.txt'
+    $workspaceRoot = Join-Path $TestDrive 'repo'
+    $toolsDir = Join-Path $workspaceRoot 'tools'
+    $script = Join-Path $toolsDir 'Print-AgentHandoff.ps1'
+    $entrypointPath = Join-Path $toolsDir 'Test-AgentHandoffEntryPoint.ps1'
+    $watcherManagerPath = Join-Path $toolsDir 'Dev-WatcherManager.ps1'
+    $issueDir = Join-Path $workspaceRoot 'tests' 'results' '_agent' 'issue'
+    $cachePath = Join-Path $workspaceRoot '.agent_priority_cache.json'
+    New-Item -ItemType Directory -Force -Path $toolsDir, $issueDir | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Print-AgentHandoff.ps1') -Destination $script -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Test-AgentHandoffEntryPoint.ps1') -Destination $entrypointPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Dev-WatcherManager.ps1') -Destination $watcherManagerPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'AGENT_HANDOFF.txt') -Destination (Join-Path $workspaceRoot 'AGENT_HANDOFF.txt') -Force
+
+    [pscustomobject][ordered]@{
+      schema = 'standing-priority/issue@v1'
+      number = 1909
+      title = 'Build Sagan context concentrator for durable subagent memory'
+      state = 'OPEN'
+      updatedAt = '2026-03-25T07:00:00Z'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1909'
+      labels = @('governor', 'standing-priority')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      bodyDigest = 'body-digest-1909'
+      digest = 'digest-1909'
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir '1909.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      schema = 'agent/priority-router@v1'
+      issue = [pscustomobject][ordered]@{
+        number = 1909
+        title = 'Build Sagan context concentrator for durable subagent memory'
+      }
+      updatedAt = '2026-03-25T07:00:00Z'
+      actions = @()
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir 'router.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      number = 1909
+      title = 'Build Sagan context concentrator for durable subagent memory'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1909'
+      cachedAtUtc = '2026-03-25T07:00:00Z'
+      repository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      state = 'OPEN'
+      labels = @('standing-priority', 'governor')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      lastSeenUpdatedAt = '2026-03-25T07:00:00Z'
+      issueDigest = 'digest-1909'
+      bodyDigest = 'body-digest-1909'
+      lastFetchSource = 'fixture'
+      lastFetchError = $null
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $cachePath -Encoding utf8
+
+    $fixture = [pscustomobject]@{
+      WorkspaceRoot = $workspaceRoot
+      ScriptPath = $script
+    }
+    $handoffPath = Join-Path $fixture.WorkspaceRoot 'AGENT_HANDOFF.txt'
     Test-Path -LiteralPath $handoffPath | Should -BeTrue
     $handoffLines = Get-Content -LiteralPath $handoffPath
     $handoffText = $handoffLines -join "`n"
@@ -13,11 +73,16 @@ Describe 'Local Agent Handoff' -Tag 'Unit' {
     $handoffText | Should -Match '## First Actions'
     $handoffText | Should -Match '## Live State Surfaces'
     $handoffText | Should -Not -Match '^## 20\d{2}-\d{2}-\d{2}'
-    $script = Join-Path $repoRoot 'tools' 'Print-AgentHandoff.ps1'
+    $script = $fixture.ScriptPath
     Test-Path -LiteralPath $script | Should -BeTrue
     $resultsRoot = Join-Path $TestDrive 'results'
     New-Item -ItemType Directory -Force -Path $resultsRoot | Out-Null
-    $null = & $script -ApplyToggles -ResultsRoot $resultsRoot
+    Push-Location $fixture.WorkspaceRoot
+    try {
+      $null = & $script -ApplyToggles -ResultsRoot $resultsRoot
+    } finally {
+      Pop-Location
+    }
     $env:LV_SUPPRESS_UI | Should -Be '1'
     $env:WATCH_RESULTS_DIR | Should -Match 'tests/results/_watch'
     Test-Path -LiteralPath (Join-Path $resultsRoot '_agent/handoff/entrypoint-status.json') | Should -BeTrue
@@ -47,5 +112,113 @@ Describe 'Local Agent Handoff' -Tag 'Unit' {
     $content | Should -Match 'executionTopologySuiteClass'
     $content | Should -Match 'execAuth\s*:'
     $content | Should -Match 'executionTopologyOperatorAuthorizationRef'
+  }
+
+  It 'ignores provider review receipts when summarizing hook results' {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $workspaceRoot = Join-Path $TestDrive 'repo'
+    $toolsDir = Join-Path $workspaceRoot 'tools'
+    $script = Join-Path $toolsDir 'Print-AgentHandoff.ps1'
+    $entrypointPath = Join-Path $toolsDir 'Test-AgentHandoffEntryPoint.ps1'
+    $watcherManagerPath = Join-Path $toolsDir 'Dev-WatcherManager.ps1'
+    $issueDir = Join-Path $workspaceRoot 'tests' 'results' '_agent' 'issue'
+    $cachePath = Join-Path $workspaceRoot '.agent_priority_cache.json'
+    New-Item -ItemType Directory -Force -Path $toolsDir, $issueDir | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Print-AgentHandoff.ps1') -Destination $script -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Test-AgentHandoffEntryPoint.ps1') -Destination $entrypointPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tools' 'Dev-WatcherManager.ps1') -Destination $watcherManagerPath -Force
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'AGENT_HANDOFF.txt') -Destination (Join-Path $workspaceRoot 'AGENT_HANDOFF.txt') -Force
+
+    [pscustomobject][ordered]@{
+      schema = 'standing-priority/issue@v1'
+      number = 1909
+      title = 'Build Sagan context concentrator for durable subagent memory'
+      state = 'OPEN'
+      updatedAt = '2026-03-25T07:00:00Z'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1909'
+      labels = @('governor', 'standing-priority')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      bodyDigest = 'body-digest-1909'
+      digest = 'digest-1909'
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir '1909.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      schema = 'agent/priority-router@v1'
+      issue = [pscustomobject][ordered]@{
+        number = 1909
+        title = 'Build Sagan context concentrator for durable subagent memory'
+      }
+      updatedAt = '2026-03-25T07:00:00Z'
+      actions = @()
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $issueDir 'router.json') -Encoding utf8
+
+    [pscustomobject][ordered]@{
+      number = 1909
+      title = 'Build Sagan context concentrator for durable subagent memory'
+      url = 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1909'
+      cachedAtUtc = '2026-03-25T07:00:00Z'
+      repository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+      state = 'OPEN'
+      labels = @('standing-priority', 'governor')
+      assignees = @()
+      milestone = $null
+      commentCount = 0
+      lastSeenUpdatedAt = '2026-03-25T07:00:00Z'
+      issueDigest = 'digest-1909'
+      bodyDigest = 'body-digest-1909'
+      lastFetchSource = 'fixture'
+      lastFetchError = $null
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $cachePath -Encoding utf8
+
+    $fixture = [pscustomobject]@{
+      WorkspaceRoot = $workspaceRoot
+    }
+    Test-Path -LiteralPath $script | Should -BeTrue
+
+    $resultsRoot = Join-Path $TestDrive 'results-with-hooks'
+    $hooksDir = Join-Path $resultsRoot '_hooks'
+    New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
+
+    @{
+      schema = 'hooks-summary/v1'
+      hook = 'pre-commit'
+      timestamp = '2026-03-25T05:31:42Z'
+      status = 'ok'
+      exitCode = 0
+      environment = @{
+        plane = 'windows-pwsh'
+        enforcement = 'warn'
+      }
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $hooksDir 'pre-commit.json') -Encoding utf8
+
+    @{
+      schema = 'priority/agent-review-policy@v1'
+      overall = @{
+        status = 'failed'
+      }
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $hooksDir 'pre-commit-agent-review-policy.json') -Encoding utf8
+
+    @{
+      schema = 'priority/copilot-cli-review@v1'
+      overall = @{
+        status = 'failed'
+      }
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $hooksDir 'pre-commit-copilot-cli-review.json') -Encoding utf8
+
+    Push-Location $fixture.WorkspaceRoot
+    try {
+      $null = & $script -ApplyToggles -ResultsRoot $resultsRoot
+    } finally {
+      Pop-Location
+    }
+
+    $hookSummaryPath = Join-Path $resultsRoot '_agent/handoff/hook-summary.json'
+    Test-Path -LiteralPath $hookSummaryPath | Should -BeTrue
+    $hookSummary = @(Get-Content -LiteralPath $hookSummaryPath -Raw | ConvertFrom-Json -ErrorAction Stop)
+    $hookSummary.Count | Should -Be 1
+    $hookSummary[0].hook | Should -Be 'pre-commit'
+    $hookSummary[0].status | Should -Be 'ok'
   }
 }

--- a/tools/Print-AgentHandoff.ps1
+++ b/tools/Print-AgentHandoff.ps1
@@ -34,6 +34,36 @@ function Format-BoolLabel {
   return 'unknown'
 }
 
+function Test-IsHookSummaryFileName {
+  param([string]$FileName)
+
+  if ([string]::IsNullOrWhiteSpace($FileName)) {
+    return $false
+  }
+
+  return $FileName -match '^(pre-commit|post-commit|pre-push)(\.(shell|pwsh))?\.json$'
+}
+
+function Get-OptionalPropertyValue {
+  param(
+    [AllowNull()]
+    [object]$Object,
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  if ($null -eq $Object) {
+    return $null
+  }
+
+  $property = $Object.PSObject.Properties[$Name]
+  if ($null -ne $property) {
+    return $property.Value
+  }
+
+  return $null
+}
+
 function New-WatcherEventsTelemetry {
   param($EventsStatus)
 
@@ -917,7 +947,9 @@ function Write-HookSummaries {
     return @()
   }
 
-  $files = Get-ChildItem -LiteralPath $hooksDir -Filter '*.json' -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending
+  $files = Get-ChildItem -LiteralPath $hooksDir -Filter '*.json' -ErrorAction SilentlyContinue |
+    Where-Object { Test-IsHookSummaryFileName -FileName $_.Name } |
+    Sort-Object LastWriteTime -Descending
   if (-not $files) {
     Write-Host '  (no hook summaries found)'
     return @()
@@ -937,11 +969,11 @@ function Write-HookSummaries {
       $latest[$hookName] = [ordered]@{
         hook = $hookName
         file = $file.FullName
-        status = $summary.status
-        exitCode = $summary.exitCode
-        timestamp = $summary.timestamp
-        plane = if ($summary.environment) { $summary.environment.plane } else { $null }
-        enforcement = if ($summary.environment) { $summary.environment.enforcement } else { $null }
+        status = Get-OptionalPropertyValue -Object $summary -Name 'status'
+        exitCode = Get-OptionalPropertyValue -Object $summary -Name 'exitCode'
+        timestamp = Get-OptionalPropertyValue -Object $summary -Name 'timestamp'
+        plane = if ($summary.environment) { Get-OptionalPropertyValue -Object $summary.environment -Name 'plane' } else { $null }
+        enforcement = if ($summary.environment) { Get-OptionalPropertyValue -Object $summary.environment -Name 'enforcement' } else { $null }
       }
     }
   }


### PR DESCRIPTION
# Summary

Delivers issue #1909 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1909
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/upstream-1909-handoff-hook-summary-filter`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1909