### PR TITLE
fix: guard empty downstream scorecard args in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -894,28 +894,34 @@ jobs:
         run: |
           set -euo pipefail
           channel="stable"
+          downstream_promotion_path="${{ steps.downstream_proving_artifacts.outputs.downstream_proving_scorecard_path }}"
           if printf '%s' "${RELEASE_TAG}" | grep -q -- '-rc\.'; then
             channel="rc"
           fi
           signed_tag_args=()
+          scorecard_args=(
+            --repo "${{ github.repository }}"
+            --stream comparevi-cli
+            --channel "${channel}"
+            --version "${{ needs.release.outputs.cli_version }}"
+            --tag-ref "${RELEASE_TAG}"
+            --ledger tests/results/promotion-contract/release-ledger.json
+            --slo tests/results/_agent/slo/release-slo-metrics.json
+            --rollback tests/results/_agent/release/rollback-drill-health.json
+            --trust tests/results/_agent/supply-chain/release-trust-gate.json
+            --downstream-proving-selection tests/results/_agent/release/downstream-proving-selection.json
+            --require-downstream-proving
+            --output tests/results/_agent/release/release-scorecard.json
+          )
+          if [ -n "${downstream_promotion_path}" ]; then
+            scorecard_args+=(--downstream-promotion "${downstream_promotion_path}")
+          fi
           if ! printf '%s' "${RELEASE_TAG}" | grep -Eq -- '-tools\.[0-9]+$'; then
             signed_tag_args+=(--require-signed-tag)
           fi
           node tools/priority/release-scorecard.mjs \
-            --repo "${{ github.repository }}" \
-            --stream comparevi-cli \
-            --channel "${channel}" \
-            --version "${{ needs.release.outputs.cli_version }}" \
-            --tag-ref "${RELEASE_TAG}" \
-            --ledger tests/results/promotion-contract/release-ledger.json \
-            --slo tests/results/_agent/slo/release-slo-metrics.json \
-            --rollback tests/results/_agent/release/rollback-drill-health.json \
-            --trust tests/results/_agent/supply-chain/release-trust-gate.json \
-            --downstream-proving-selection tests/results/_agent/release/downstream-proving-selection.json \
-            --downstream-promotion "${{ steps.downstream_proving_artifacts.outputs.downstream_proving_scorecard_path }}" \
-            --require-downstream-proving \
             "${signed_tag_args[@]}" \
-            --output tests/results/_agent/release/release-scorecard.json
+            "${scorecard_args[@]}"
 
       - name: Validate release scorecard schema
         if: always()

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -153,12 +153,16 @@ test('release workflow resolves downloaded artifacts through the shared helper b
   assert.match(workflowRaw, /docs\/schemas\/downstream-proving-selection-v1\.schema\.json/);
   assert.match(workflowRaw, /--downstream-proving-selection tests\/results\/_agent\/release\/downstream-proving-selection\.json/);
   assert.match(workflowRaw, /steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path/);
+  assert.match(workflowRaw, /downstream_promotion_path="\$\{\{\s*steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path\s*\}\}"/);
+  assert.match(workflowRaw, /if \[ -n "\$\{downstream_promotion_path\}" \]; then/);
+  assert.match(workflowRaw, /scorecard_args\+=\(--downstream-promotion "\$\{downstream_promotion_path\}"\)/);
   assert.match(workflowRaw, /tools\/release-review\/Evaluate-ReleaseReviewPolicy\.ps1/);
   assert.match(workflowRaw, /tests\/results\/release-contract\/review-comment\.md/);
   assert.match(workflowRaw, /--candidate-workflow release\.yml/);
-  assert.match(workflowRaw, /--downstream-promotion "\$\{\{\s*steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path\s*\}\}"/);
   assert.match(workflowRaw, /--require-downstream-proving/);
+  assert.doesNotMatch(workflowRaw, /--downstream-promotion "\$\{\{\s*steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path\s*\}\}"/);
   assert.match(workflowRaw, /signed_tag_args=\(\)/);
+  assert.match(workflowRaw, /scorecard_args=\(/);
   assert.match(workflowRaw, /signed_tag_args\+=\(--require-signed-tag\)/);
   assert.equal(releaseContractJob?.permissions?.actions, 'read');
   assert.equal(releaseContractJob?.if, "${{ always() && needs.release.result == 'success' }}");


### PR DESCRIPTION
# Summary

Delivers issue #1943 into `develop` using the standard automation PR helper.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: #1943
- Issue URL: (not supplied)
- Files, tools, workflows, or policies touched: Helper-driven PR creation path for `issue/upstream-1943-release-scorecard-downstream-arg`.
- Cross-repo or external-consumer impact: None expected at PR creation time.
- Required checks, merge-queue behavior, or approval flows affected: Standard `develop` branch protections and required checks apply.

## Validation Evidence

- Commands run:
  - None yet; this body was generated during PR creation.
- Key artifacts, logs, or workflow runs:
  - None yet.
- Risk-based checks not run:
  - Validation is deferred until implementation commits land on the branch.

## Risks and Follow-ups

- Residual risks: This body should be refreshed if the branch scope changes materially before merge.
- Follow-up issues or deferred work: None at PR creation time.
- Deployment, approval, or rollback notes: Standard PR review and required-check flow.

## Reviewer Focus

- Please verify: issue linkage, branch/base selection, and metadata routing are correct.
- Areas where the reasoning is subtle: None at PR creation time.
- Manual spot checks requested: None.

Closes #1943