### PR TITLE
[workflow-policy] fail early on immutable published-tag repair

### DIFF
--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -157,6 +157,10 @@ automation path:
   - the target `version`
   - `apply = true`
   - `repair_existing_tag = true`
+- if the target tag already backs an immutable published GitHub Release, do not
+  rerun `repair_existing_tag` against the same published tag
+  - use the protected-tag authority path or publish a new authoritative tag
+    identity instead
 - provision `RELEASE_TAG_SIGNING_PRIVATE_KEY` and optional
   `RELEASE_TAG_SIGNING_PUBLIC_KEY` for workflow-owned signing
 - optionally set `RELEASE_TAG_SIGNING_IDENTITY_NAME` and
@@ -165,6 +169,9 @@ automation path:
   identity from the resolved policy token account
 - inspect `tests/results/_agent/release/release-conductor-report.json`
   first
+- inspect `release.immutableRelease`
+  - if `repairBlocked = true`, repair-in-place is unavailable for that
+    published tag
 - require both:
   - `release.tagCreated = true`
   - `release.tagPushed = true`
@@ -188,6 +195,9 @@ matching remediation path:
 - `tag-not-annotated`, `tag-signature-unverified`
   - Use `node tools/npm/run-script.mjs priority:release:signing:readiness`
     first.
+  - If the target tag already backs an immutable published release, stop and
+    use the protected-tag authority path or publish a new authoritative tag
+    identity instead of rerunning repair on the same tag.
   - If signing readiness is `ready`, run the release conductor in repair mode
     for the target version so the authoritative tag is recreated as a signed
     annotated tag without changing the intended release commit.
@@ -199,10 +209,11 @@ matching remediation path:
     repaired tag itself carrying the newer workflow definition.
 - `workflow-signing-secret-missing`, `workflow-signing-secret-unverifiable`
 - `workflow-signing-admin-scope-missing`, `workflow-signing-key-missing`, `workflow-signing-authority-unverifiable`
-- `release-conductor-apply-disabled`, `release-conductor-apply-unverifiable`
+- `release-conductor-apply-disabled`, `release-conductor-apply-unverifiable`, `release-repair-immutable-blocked`
   - Use `node tools/npm/run-script.mjs priority:release:signing:readiness` to confirm the blocker, provision or repair
-    the workflow signing secrets, signing authority, or release-conductor enablement, and only then rerun authoritative
-    release publication.
+    the workflow signing secrets, signing authority, or release-conductor enablement. When the blocker is
+    `release-repair-immutable-blocked`, do not rerun `repair_existing_tag` on the same published tag; route through
+    the protected-tag authority path or publish a new authoritative tag identity instead.
 - `checksum-invalid-line`, `checksum-empty`, `checksum-entry-missing-file`, `checksum-missing-artifact`, `checksum-mismatch`
   - Regenerate `SHA256SUMS.txt` from fresh artifacts and ensure no post-pack mutation occurred.
 - `sbom-parse-failed`, `sbom-invalid`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -153,6 +153,10 @@ finds repair-eligible tag failures:
     - `version = <existing tag version>`
     - `apply = true`
     - `repair_existing_tag = true`
+  - if the target tag already backs an immutable published GitHub Release, do
+    not rerun `repair_existing_tag` against the same published tag
+    - use the protected-tag authority path or publish a new authoritative tag
+      identity instead
 
 Authoritative signed tag publication now belongs to the release conductor control
 plane:
@@ -178,6 +182,7 @@ plane:
   - signer identity used for tag creation/repair
   - whether the tag was created
   - whether the tag was pushed authoritatively
+  - immutable published-release observation for the target tag
   - whether repair mode was requested/performed for an existing tag
   - the authoritative remote tag object/commit used for repair
   - which workflow ref carried the replay dispatch
@@ -213,6 +218,7 @@ If the report emits an external blocker such as:
 - `workflow-signing-authority-unverifiable`
 - `release-conductor-apply-disabled`
 - `release-conductor-apply-unverifiable`
+- `release-repair-immutable-blocked`
 
 promotion remains blocked by external signing readiness. Repair the specific
 secret, authority, or apply-gating surface first, then refresh readiness

--- a/docs/schemas/release-conductor-report-v1.schema.json
+++ b/docs/schemas/release-conductor-report-v1.schema.json
@@ -51,6 +51,7 @@
         "tagPushError",
         "tagPushRemote",
         "signingMaterial",
+        "immutableRelease",
         "repair",
         "publicationReplay"
       ],
@@ -94,6 +95,62 @@
                 "source": { "type": "string" },
                 "login": { "type": ["string", "null"] },
                 "accountId": { "type": ["string", "null"] }
+              }
+            }
+          }
+        },
+        "immutableRelease": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "tagRef",
+            "repairBlocked",
+            "repositorySetting",
+            "publishedRelease"
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "unobserved",
+                "published-release-immutable",
+                "published-release-mutable",
+                "release-not-found",
+                "unverifiable"
+              ]
+            },
+            "tagRef": { "type": ["string", "null"] },
+            "repairBlocked": { "type": "boolean" },
+            "repositorySetting": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status", "enabled", "enforcedByOwner", "error"],
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": ["unobserved", "enabled", "disabled", "unverifiable"]
+                },
+                "enabled": { "type": ["boolean", "null"] },
+                "enforcedByOwner": { "type": ["boolean", "null"] },
+                "error": { "type": ["string", "null"] }
+              }
+            },
+            "publishedRelease": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status", "exists", "immutable", "releaseId", "releaseUrl", "tagName", "error"],
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": ["unobserved", "release-not-found", "mutable", "immutable", "unverifiable"]
+                },
+                "exists": { "type": ["boolean", "null"] },
+                "immutable": { "type": ["boolean", "null"] },
+                "releaseId": { "type": ["integer", "null"] },
+                "releaseUrl": { "type": ["string", "null"] },
+                "tagName": { "type": ["string", "null"] },
+                "error": { "type": ["string", "null"] }
               }
             }
           }

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -960,6 +960,133 @@ test('runReleaseConductor repairs an existing authoritative tag when repair mode
   );
 });
 
+test('runReleaseConductor blocks repair mode when the published release is immutable', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] !== 'api') {
+      throw new Error(`unexpected gh args: ${args.join(' ')}`);
+    }
+    const endpoint = String(args[1] ?? '');
+    if (endpoint.includes('/actions/workflows/')) {
+      return makeWorkflowRunsResponse(endpoint);
+    }
+    if (endpoint === 'repos/owner/repo/immutable-releases') {
+      return { enabled: true, enforced_by_owner: false };
+    }
+    if (endpoint === 'repos/owner/repo/releases/tags/v0.8.0-rc.1') {
+      return {
+        id: 42,
+        tag_name: 'v0.8.0-rc.1',
+        immutable: true,
+        html_url: 'https://github.com/owner/repo/releases/tag/v0.8.0-rc.1'
+      };
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      if (args[2] === 'user.signingkey') {
+        return { status: 0, stdout: '/tmp/release-signing.pub', stderr: '' };
+      }
+      if (args[2] === 'gpg.format') {
+        return { status: 0, stdout: 'ssh', stderr: '' };
+      }
+      if (args[2] === 'remote.upstream.url') {
+        return { status: 0, stdout: 'https://github.com/owner/repo.git', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'missing config' };
+    }
+    if (command === 'git' && args[0] === 'ls-remote') {
+      return {
+        status: 0,
+        stdout: [
+          '1111111111111111111111111111111111111111\trefs/tags/v0.8.0-rc.1',
+          '2222222222222222222222222222222222222222\trefs/tags/v0.8.0-rc.1^{}'
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return { status: 1, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: true,
+      dryRun: false,
+      repairExistingTag: true,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'rc',
+      version: '0.8.0-rc.1',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(report.release.repair.status, 'blocked');
+  assert.equal(report.release.immutableRelease.status, 'published-release-immutable');
+  assert.equal(report.release.immutableRelease.publishedRelease.immutable, true);
+  assert.ok(report.decision.blockers.some((entry) => entry.code === 'repair-target-release-immutable'));
+  assert.equal(
+    commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag' && entry.args.includes('-f')),
+    false
+  );
+  assert.equal(
+    commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'push'),
+    false
+  );
+  assert.equal(
+    commandCalls.some((entry) => entry.command === 'gh' && entry.args[0] === 'workflow' && entry.args[1] === 'run'),
+    false
+  );
+});
+
 test('runReleaseConductor fails apply when repaired tag publication replay dispatch fails', async () => {
   const readJsonOptionalFn = async (filePath) => {
     const normalized = String(filePath);

--- a/tools/priority/__tests__/release-signing-readiness.test.mjs
+++ b/tools/priority/__tests__/release-signing-readiness.test.mjs
@@ -257,3 +257,65 @@ test('runReleaseSigningReadiness reports publication success when signing capabi
   assert.equal(result.report.publishedBundleObserver.status, 'producer-native-ready');
   assert.deepEqual(result.report.blockers, []);
 });
+
+test('runReleaseSigningReadiness reports immutable published-tag repair as an external blocker', async () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'release-signing-readiness-immutable-'));
+  seedWorkflowContract(repoRoot);
+  writeJson(path.join(repoRoot, DEFAULT_RELEASE_CONDUCTOR_REPORT_PATH), {
+    release: {
+      targetTag: 'v0.6.4-rc.2',
+      immutableRelease: {
+        status: 'published-release-immutable',
+        tagRef: 'v0.6.4-rc.2',
+        repairBlocked: true,
+        repositorySetting: {
+          status: 'enabled',
+          enabled: true,
+          enforcedByOwner: false,
+          error: null
+        },
+        publishedRelease: {
+          status: 'immutable',
+          exists: true,
+          immutable: true,
+          releaseId: 123,
+          releaseUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/releases/tag/v0.6.4-rc.2',
+          tagName: 'v0.6.4-rc.2',
+          error: null
+        }
+      }
+    },
+    decision: {
+      blockers: [{ code: 'repair-target-release-immutable' }]
+    }
+  });
+  writeJson(path.join(repoRoot, DEFAULT_RELEASE_PUBLISHED_BUNDLE_OBSERVER_PATH), createPublishedBundleObserver());
+
+  const result = await runReleaseSigningReadiness(
+    {
+      repoRoot,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    {
+      now: new Date('2026-03-23T17:22:00Z'),
+      runGhJsonFn: (args) => {
+        const endpoint = args[1] ?? '';
+        if (endpoint.includes('/actions/secrets')) {
+          return { secrets: [{ name: REQUIRED_SIGNING_SECRET }, { name: OPTIONAL_SIGNING_SECRET }] };
+        }
+        if (endpoint.includes('/actions/variables')) {
+          return { variables: [{ name: 'RELEASE_CONDUCTOR_ENABLED', value: '1' }] };
+        }
+        if (endpoint.startsWith('user/ssh_signing_keys')) {
+          return [{ id: 1, title: 'compare-release-signing' }];
+        }
+        throw new Error(`Unexpected endpoint: ${endpoint}`);
+      }
+    }
+  );
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.report.summary.status, 'warn');
+  assert.equal(result.report.summary.externalBlocker, 'release-repair-immutable-blocked');
+  assert.ok(result.report.blockers.some((entry) => entry.code === 'release-repair-immutable-blocked'));
+});

--- a/tools/priority/__tests__/release-trust-remediation.test.mjs
+++ b/tools/priority/__tests__/release-trust-remediation.test.mjs
@@ -22,6 +22,7 @@ test('buildReleaseTrustRemediationMarkdown emits repair guidance for unsigned or
   assert.match(markdown, /repair-eligible tag failures/);
   assert.match(markdown, /`version = 0\.6\.4-rc\.1`/);
   assert.match(markdown, /`repair_existing_tag = true`/);
+  assert.match(markdown, /immutable published GitHub Release/);
   assert.match(markdown, /Preserve tag identity and asset names/);
 });
 
@@ -71,4 +72,6 @@ test('runReleaseTrustRemediation writes markdown artifact and appends to workflo
   const summary = await readFile(summaryPath, 'utf8');
   assert.match(output, /`repair_existing_tag = true`/);
   assert.match(summary, /`repair_existing_tag = true`/);
+  assert.match(output, /protected-tag authority path/);
+  assert.match(summary, /protected-tag authority path/);
 });

--- a/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
+++ b/tools/priority/__tests__/supply-chain-trust-gate.test.mjs
@@ -354,7 +354,8 @@ test('verifyReleaseTagSignature fails for unsigned tag', async () => {
       (failure) =>
         failure.code === 'tag-signature-unverified' &&
         String(failure.hint).includes('priority:release:signing:readiness') &&
-        String(failure.hint).includes('repair_existing_tag = true')
+        String(failure.hint).includes('repair_existing_tag = true') &&
+        String(failure.hint).includes('immutable published GitHub Release')
     )
   );
   assert.equal(result.status.verified, false);
@@ -393,7 +394,8 @@ test('verifyReleaseTagSignature fails for lightweight tag', async () => {
       (failure) =>
         failure.code === 'tag-not-annotated' &&
         String(failure.hint).includes('priority:release:signing:readiness') &&
-        String(failure.hint).includes('repair_existing_tag = true')
+        String(failure.hint).includes('repair_existing_tag = true') &&
+        String(failure.hint).includes('immutable published GitHub Release')
     )
   );
   assert.equal(result.status.annotated, false);

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -201,6 +201,11 @@ function runGhJson(args, { cwd } = {}) {
   return raw ? JSON.parse(raw) : null;
 }
 
+function isGitHubNotFoundError(message) {
+  const normalized = asOptional(message);
+  return Boolean(normalized && (/\b404\b/.test(normalized) || /not found/i.test(normalized)));
+}
+
 async function readJsonOptional(filePath) {
   const resolved = path.resolve(filePath);
   if (!existsSync(resolved)) {
@@ -648,6 +653,123 @@ function resolveTagPushRemote({ repoRoot, repository, runCommandFn }) {
   };
 }
 
+function inspectImmutableReleaseState({ repository, tagRef, runGhJsonFn, cwd }) {
+  const normalizedTagRef = asOptional(tagRef);
+  const immutableRelease = {
+    status: 'unobserved',
+    tagRef: normalizedTagRef,
+    repairBlocked: false,
+    repositorySetting: {
+      status: 'unobserved',
+      enabled: null,
+      enforcedByOwner: null,
+      error: null
+    },
+    publishedRelease: {
+      status: 'unobserved',
+      exists: null,
+      immutable: null,
+      releaseId: null,
+      releaseUrl: null,
+      tagName: null,
+      error: null
+    }
+  };
+  if (!normalizedTagRef) {
+    return immutableRelease;
+  }
+
+  try {
+    const payload = runGhJsonFn(['api', `repos/${repository}/immutable-releases`], { cwd }) ?? {};
+    if (typeof payload?.enabled === 'boolean' || typeof payload?.enforced_by_owner === 'boolean') {
+      immutableRelease.repositorySetting = {
+        status: payload.enabled === true ? 'enabled' : 'disabled',
+        enabled: payload.enabled === true,
+        enforcedByOwner: payload.enforced_by_owner === true,
+        error: null
+      };
+    } else {
+      immutableRelease.repositorySetting = {
+        status: 'unverifiable',
+        enabled: null,
+        enforcedByOwner: null,
+        error: 'immutable release settings response shape was not recognized'
+      };
+    }
+  } catch (error) {
+    immutableRelease.repositorySetting = {
+      status: 'unverifiable',
+      enabled: null,
+      enforcedByOwner: null,
+      error: error?.message ?? String(error)
+    };
+  }
+
+  try {
+    const payload = runGhJsonFn(['api', `repos/${repository}/releases/tags/${normalizedTagRef}`], { cwd }) ?? {};
+    const looksLikeRelease =
+      typeof payload?.immutable === 'boolean' ||
+      Number.isInteger(payload?.id) ||
+      Boolean(asOptional(payload?.tag_name)) ||
+      Boolean(asOptional(payload?.html_url));
+    if (!looksLikeRelease) {
+      immutableRelease.publishedRelease = {
+        status: 'unverifiable',
+        exists: null,
+        immutable: null,
+        releaseId: null,
+        releaseUrl: null,
+        tagName: null,
+        error: 'release lookup response shape was not recognized'
+      };
+    } else {
+      immutableRelease.publishedRelease = {
+        status: payload.immutable === true ? 'immutable' : 'mutable',
+        exists: true,
+        immutable: payload.immutable === true,
+        releaseId: Number.isInteger(payload?.id) ? payload.id : null,
+        releaseUrl: asOptional(payload?.html_url) ?? asOptional(payload?.url),
+        tagName: asOptional(payload?.tag_name) ?? normalizedTagRef,
+        error: null
+      };
+    }
+  } catch (error) {
+    const message = error?.message ?? String(error);
+    immutableRelease.publishedRelease = {
+      status: isGitHubNotFoundError(message) ? 'release-not-found' : 'unverifiable',
+      exists: isGitHubNotFoundError(message) ? false : null,
+      immutable: null,
+      releaseId: null,
+      releaseUrl: null,
+      tagName: normalizedTagRef,
+      error: message
+    };
+  }
+
+  if (immutableRelease.publishedRelease.status === 'immutable') {
+    immutableRelease.status = 'published-release-immutable';
+    immutableRelease.repairBlocked = true;
+  } else if (immutableRelease.publishedRelease.status === 'mutable') {
+    immutableRelease.status = 'published-release-mutable';
+  } else if (immutableRelease.publishedRelease.status === 'release-not-found') {
+    immutableRelease.status = 'release-not-found';
+  } else if (
+    immutableRelease.repositorySetting.status === 'unverifiable' ||
+    immutableRelease.publishedRelease.status === 'unverifiable'
+  ) {
+    immutableRelease.status = 'unverifiable';
+  }
+
+  return immutableRelease;
+}
+
+function buildImmutableRepairBlockedMessage({ targetTag, immutableRelease }) {
+  const normalizedTag = asOptional(targetTag) ?? 'the current release tag';
+  const releaseUrl = asOptional(immutableRelease?.publishedRelease?.releaseUrl);
+  const releaseLocation = releaseUrl ? ` (${releaseUrl})` : '';
+  return `Authoritative tag ${normalizedTag} already backs an immutable published GitHub Release${releaseLocation}. Do not rerun release conductor with --repair-existing-tag against the same published tag; publish a new authoritative tag or use the protected-tag authority path.`;
+}
+
 async function writeReport(filePath, payload) {
   const resolved = path.resolve(filePath);
   await mkdir(path.dirname(resolved), { recursive: true });
@@ -786,13 +908,36 @@ export async function runReleaseConductor(options = {}) {
     remoteTag,
     localTag
   });
+  const immutableRelease =
+    targetTag && (repair.requested || repair.remoteTagExists)
+      ? inspectImmutableReleaseState({
+          repository,
+          tagRef: targetTag,
+          runGhJsonFn,
+          cwd: repoRoot
+        })
+      : inspectImmutableReleaseState({
+          repository,
+          tagRef: null,
+          runGhJsonFn,
+          cwd: repoRoot
+        });
+  const repairBlockedByImmutableRelease = Boolean(repair.remoteTagExists && immutableRelease.repairBlocked);
 
   if (repair.remoteTagExists && !repair.requested) {
-    repair.status = 'repair-available';
-    pushUniqueDecisionEntry(advisories, {
-      code: 'existing-tag-repair-available',
-      message: `Authoritative tag ${targetTag} already exists; rerun release conductor with --repair-existing-tag to recreate it as a signed annotated tag.`
-    });
+    repair.status = repairBlockedByImmutableRelease ? 'blocked' : 'repair-available';
+    pushUniqueDecisionEntry(
+      advisories,
+      repairBlockedByImmutableRelease
+        ? {
+            code: 'existing-tag-repair-blocked-by-immutable-release',
+            message: buildImmutableRepairBlockedMessage({ targetTag, immutableRelease })
+          }
+        : {
+            code: 'existing-tag-repair-available',
+            message: `Authoritative tag ${targetTag} already exists; rerun release conductor with --repair-existing-tag to recreate it as a signed annotated tag.`
+          }
+    );
   }
   if (repair.requested && !targetTag) {
     repair.status = 'blocked';
@@ -803,6 +948,8 @@ export async function runReleaseConductor(options = {}) {
   } else if (repair.requested && !repair.remoteTagExists) {
     repair.status = 'blocked';
   } else if (repair.requested && (!repair.remoteTargetCommitOid || !repair.pushLeaseExpectedOid)) {
+    repair.status = 'blocked';
+  } else if (repair.requested && repairBlockedByImmutableRelease) {
     repair.status = 'blocked';
   } else if (repair.requested && repair.remoteTagExists) {
     repair.status = applyRequested ? 'blocked' : 'ready';
@@ -828,6 +975,11 @@ export async function runReleaseConductor(options = {}) {
       blockers.push({
         code: 'repair-target-tag-missing',
         message: `Repair mode requires existing authoritative tag ${targetTag}, but no authoritative tag ref was found on ${tagPushRemote.remoteName}.`
+      });
+    } else if (repairBlockedByImmutableRelease) {
+      blockers.push({
+        code: 'repair-target-release-immutable',
+        message: buildImmutableRepairBlockedMessage({ targetTag, immutableRelease })
       });
     } else if (!repair.remoteTargetCommitOid || !repair.pushLeaseExpectedOid) {
       blockers.push({
@@ -945,10 +1097,17 @@ export async function runReleaseConductor(options = {}) {
           }
         }
     } else if (repair.remoteTagExists) {
-      blockers.push({
-        code: 'existing-tag-requires-repair-mode',
-        message: `Authoritative tag ${targetTag} already exists. Rerun release conductor with --repair-existing-tag to recreate it as a signed annotated tag at ${repair.remoteTargetCommitOid}.`
-      });
+      blockers.push(
+        repairBlockedByImmutableRelease
+          ? {
+              code: 'existing-tag-repair-blocked-by-immutable-release',
+              message: buildImmutableRepairBlockedMessage({ targetTag, immutableRelease })
+            }
+          : {
+              code: 'existing-tag-requires-repair-mode',
+              message: `Authoritative tag ${targetTag} already exists. Rerun release conductor with --repair-existing-tag to recreate it as a signed annotated tag at ${repair.remoteTargetCommitOid}.`
+            }
+      );
     } else if (signingMaterial.available) {
       const tagResult = runCommandFn('git', ['tag', '-s', targetTag, '-m', `Release ${targetTag}`], {
         cwd: repoRoot,
@@ -1011,6 +1170,7 @@ export async function runReleaseConductor(options = {}) {
       tagPushError,
       tagPushRemote,
       signingMaterial,
+      immutableRelease,
       repair,
       publicationReplay
     },

--- a/tools/priority/release-signing-readiness.mjs
+++ b/tools/priority/release-signing-readiness.mjs
@@ -325,6 +325,27 @@ function createPublishedBundleBlocker(publishedBundleObserver) {
   }
 }
 
+function createImmutableRepairBlocker(conductorReport) {
+  const blockerCodes = new Set(
+    (Array.isArray(conductorReport?.decision?.blockers) ? conductorReport.decision.blockers : [])
+      .map((entry) => String(entry?.code ?? '').trim())
+      .filter(Boolean)
+  );
+  const immutableBlocked =
+    conductorReport?.release?.immutableRelease?.repairBlocked === true ||
+    blockerCodes.has('repair-target-release-immutable') ||
+    blockerCodes.has('existing-tag-repair-blocked-by-immutable-release');
+  if (!immutableBlocked) {
+    return null;
+  }
+
+  const targetTag = asOptional(conductorReport?.release?.targetTag) ?? 'the current release tag';
+  return {
+    code: 'release-repair-immutable-blocked',
+    message: `Release conductor observed ${targetTag} as an immutable published GitHub Release, so in-place repair_existing_tag replay is blocked until a protected-tag authority path or new authoritative tag is used.`
+  };
+}
+
 export async function runReleaseSigningReadiness(options = {}, deps = {}) {
   const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
   const environment = deps.environment ?? process.env;
@@ -470,6 +491,10 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
   if (publishedBundleBlocker) {
     blockers.push(publishedBundleBlocker);
   }
+  const immutableRepairBlocker = createImmutableRepairBlocker(conductorReport);
+  if (immutableRepairBlocker) {
+    blockers.push(immutableRepairBlocker);
+  }
 
   const externalBlockerPriority = [
     'workflow-signing-secret-missing',
@@ -478,7 +503,8 @@ export async function runReleaseSigningReadiness(options = {}, deps = {}) {
     'workflow-signing-key-missing',
     'workflow-signing-authority-unverifiable',
     'release-conductor-apply-disabled',
-    'release-conductor-apply-unverifiable'
+    'release-conductor-apply-unverifiable',
+    'release-repair-immutable-blocked'
   ];
 
   const summary = {

--- a/tools/priority/release-trust-remediation.mjs
+++ b/tools/priority/release-trust-remediation.mjs
@@ -93,6 +93,8 @@ export function buildReleaseTrustRemediationMarkdown({ trustReport, tagRef }) {
   lines.push(`- Release trust gate reported repair-eligible tag failures for \`${normalizedTag ?? 'unknown-tag'}\`.`);
   lines.push(`- Failure codes: ${relevantFailures.map((failure) => `\`${failure.code}\``).join(', ')}`);
   lines.push('- Preserve tag identity and asset names. Do not rename the release tag to bypass trust verification.');
+  lines.push('- If the target tag already backs an immutable published GitHub Release, stop before rerunning repair mode on the same tag.');
+  lines.push('- In that case, use the protected-tag authority path or publish a new authoritative tag identity before replay.');
   lines.push('- Rerun `.github/workflows/release-conductor.yml` with:');
   lines.push(`  - \`version = ${normalizedVersion ?? 'X.Y.Z'}\``);
   lines.push('  - `apply = true`');

--- a/tools/priority/supply-chain-trust-gate.mjs
+++ b/tools/priority/supply-chain-trust-gate.mjs
@@ -33,9 +33,9 @@ const FAILURE_HINTS = {
   'tag-object-lookup-failed': 'Unable to resolve annotated tag object via GitHub API. Confirm tag object availability.',
   'tag-signature-parse-failed': 'Tag signature payload could not be parsed. Re-run and inspect gh api output.',
   'tag-not-annotated':
-    'Release tag is lightweight/non-annotated. Run priority:release:signing:readiness first; if readiness is ready, rerun .github/workflows/release-conductor.yml with repair_existing_tag = true to recreate the same release tag as a signed annotated tag.',
+    'Release tag is lightweight/non-annotated. Run priority:release:signing:readiness first; if the target tag already backs an immutable published GitHub Release, do not rerun repair_existing_tag on the same tag. Use the protected-tag authority path or publish a new authoritative tag. Otherwise, rerun .github/workflows/release-conductor.yml with repair_existing_tag = true to recreate the same release tag as a signed annotated tag.',
   'tag-signature-unverified':
-    'Release tag signature is not verified. Run priority:release:signing:readiness first; if readiness is ready, rerun .github/workflows/release-conductor.yml with repair_existing_tag = true to repair the same release tag before rerunning release.',
+    'Release tag signature is not verified. Run priority:release:signing:readiness first; if the target tag already backs an immutable published GitHub Release, do not rerun repair_existing_tag on the same tag. Use the protected-tag authority path or publish a new authoritative tag. Otherwise, rerun .github/workflows/release-conductor.yml with repair_existing_tag = true to repair the same release tag before rerunning release.',
   'attestation-cli-unavailable': 'GitHub CLI is unavailable. Install/enable gh on runner before trust gate.',
   'attestation-output-parse-failed': 'Attestation verification output was not valid JSON. Re-run verification and inspect gh logs.',
   'attestation-unverified': 'Artifact attestation verification failed. Confirm attest-build-provenance step and signer workflow.',


### PR DESCRIPTION
## Summary
- add immutable published-release observation to `release-conductor` and fail early when `repair_existing_tag` targets a published immutable release
- surface the same blocker in signing readiness, trust remediation, and supply-chain trust hints
- update the release runbooks/contracts so checked-in guidance stops recommending impossible in-place repair on an immutable published tag

## Validation
- `node --test tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs`
- `node --test tools/priority/__tests__/release-signing-readiness.test.mjs tools/priority/__tests__/release-signing-readiness-schema.test.mjs`
- `node --test tools/priority/__tests__/release-trust-remediation.test.mjs tools/priority/__tests__/supply-chain-trust-gate.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs hooks:pre-commit`
- `git diff --check`

## Links
- standing incident: #1943
- workflow/policy follow-up: #1951
