### PR TITLE
[workflow-policy] add protected-tag-safe immutable release replay

### DIFF
--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -9,7 +9,7 @@ on:
         default: false
         type: boolean
       repair_existing_tag:
-        description: 'Repair an existing authoritative tag as a signed annotated tag'
+        description: 'Repair an existing authoritative tag or dispatch protected-tag-safe replay for immutable published tags'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,14 @@ on:
         description: 'Authoritative release tag to publish or replay.'
         required: true
         type: string
+      publication_mode:
+        description: 'Release publication behavior for workflow_dispatch replay.'
+        required: false
+        default: publish
+        type: choice
+        options:
+          - publish
+          - verify-existing-release
 
 jobs:
   certification-matrix:
@@ -21,6 +29,7 @@ jobs:
     outputs:
       target_tag: ${{ steps.release_target.outputs.tag }}
       channel: ${{ steps.channel.outputs.channel }}
+      publication_mode: ${{ steps.publication_mode.outputs.mode }}
     steps:
       - name: Resolve release target tag
         id: release_target
@@ -56,6 +65,25 @@ jobs:
             channel="rc"
           fi
           echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve publication mode
+        id: publication_mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          mode='publish'
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            mode='${{ inputs.publication_mode }}'
+          fi
+          case "$mode" in
+            publish|verify-existing-release)
+              ;;
+            *)
+              echo "Unsupported publication mode: $mode" >&2
+              exit 1
+              ;;
+          esac
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
 
       - name: Generate certification matrix
         shell: bash
@@ -100,6 +128,7 @@ jobs:
       target_tag: ${{ needs.certification-matrix.outputs.target_tag }}
     env:
       RELEASE_TAG: ${{ needs.certification-matrix.outputs.target_tag }}
+      RELEASE_PUBLICATION_MODE: ${{ needs.certification-matrix.outputs.publication_mode }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -365,8 +394,19 @@ jobs:
             '- `comparevi-history` is versioned and released separately; backend contract changes require an explicit facade ref bump/release in that repo.'
           ) | Out-File -FilePath RELEASE_NOTES.md -Encoding utf8 -Append
 
+      - name: Record protected-tag-safe replay mode
+        if: env.RELEASE_PUBLICATION_MODE == 'verify-existing-release'
+        shell: pwsh
+        run: |
+          @(
+            '## Protected-Tag-Safe Replay'
+            ''
+            ('- Verified `{0}` from workflow ref `develop` without mutating the existing GitHub Release.' -f $env:RELEASE_TAG)
+            '- GitHub Release mutation and Publish Tools Image dispatch are intentionally skipped in this mode.'
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
       - name: Create GitHub Release with assets (CHANGELOG)
-        if: steps.notes.outputs.fallback == 'false'
+        if: env.RELEASE_PUBLICATION_MODE == 'publish' && steps.notes.outputs.fallback == 'false'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
@@ -379,7 +419,7 @@ jobs:
             artifacts/cli/provenance.json
 
       - name: Create GitHub Release with assets (auto notes)
-        if: steps.notes.outputs.fallback == 'true'
+        if: env.RELEASE_PUBLICATION_MODE == 'publish' && steps.notes.outputs.fallback == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
@@ -392,6 +432,7 @@ jobs:
             artifacts/cli/provenance.json
 
       - name: Dispatch Publish Tools Image workflow
+        if: env.RELEASE_PUBLICATION_MODE == 'publish'
         uses: actions/github-script@v8
         with:
           script: |

--- a/docs/RELEASE_OPERATIONS_RUNBOOK.md
+++ b/docs/RELEASE_OPERATIONS_RUNBOOK.md
@@ -158,9 +158,13 @@ automation path:
   - `apply = true`
   - `repair_existing_tag = true`
 - if the target tag already backs an immutable published GitHub Release, do not
-  rerun `repair_existing_tag` against the same published tag
-  - use the protected-tag authority path or publish a new authoritative tag
-    identity instead
+  attempt in-place tag mutation against the same published tag
+  - rerun `.github/workflows/release-conductor.yml` with
+    `repair_existing_tag = true`
+  - require the resulting report to show:
+    - `release.repair.status = equivalent-replay-dispatched`
+    - `release.publicationReplay.status = dispatched`
+    - `release.publicationReplay.modeInputValue = verify-existing-release`
 - provision `RELEASE_TAG_SIGNING_PRIVATE_KEY` and optional
   `RELEASE_TAG_SIGNING_PUBLIC_KEY` for workflow-owned signing
 - optionally set `RELEASE_TAG_SIGNING_IDENTITY_NAME` and
@@ -173,15 +177,24 @@ automation path:
   - if `repairBlocked = true`, repair-in-place is unavailable for that
     published tag
 - require both:
-  - `release.tagCreated = true`
-  - `release.tagPushed = true`
-  - when repair mode is used:
+  - either:
+    - `release.tagCreated = true`
+    - `release.tagPushed = true`
+  - or:
+    - `release.repair.status = equivalent-replay-dispatched`
+    - `release.publicationReplay.status = dispatched`
+    - `release.publicationReplay.modeInputValue = verify-existing-release`
+  - when repair mode recreates a mutable authoritative tag:
     - `release.repair.status = repaired`
     - `release.repair.remoteTargetCommitOid` matches the authoritative commit
     - `release.publicationReplay.status = dispatched`
     - `release.publicationReplay.ref = develop`
     - `release.publicationReplay.tagInputValue` matches the authoritative tag
     - the replayed `Release on tag` run succeeds for the repaired tag
+  - when the published release is immutable:
+    - the replayed `Release on tag` run succeeds for the same authoritative tag
+    - `release.yml` runs with
+      `workflow_dispatch.inputs.publication_mode=verify-existing-release`
 
 When the release trust gate fails, inspect `tests/results/_agent/supply-chain/release-trust-gate.json` and follow the
 matching remediation path:
@@ -196,24 +209,28 @@ matching remediation path:
   - Use `node tools/npm/run-script.mjs priority:release:signing:readiness`
     first.
   - If the target tag already backs an immutable published release, stop and
-    use the protected-tag authority path or publish a new authoritative tag
-    identity instead of rerunning repair on the same tag.
+    rerun release conductor with `repair_existing_tag = true` so it dispatches
+    protected-tag-safe replay instead of mutating the published tag.
   - If signing readiness is `ready`, run the release conductor in repair mode
     for the target version so the authoritative tag is recreated as a signed
     annotated tag without changing the intended release commit.
-  - Rerun release only after the repair report shows
-    `release.repair.status = repaired` and
-    `release.publicationReplay.status = dispatched`.
-  - Repaired-tag replay now dispatches `release.yml` from `develop` with
-    `workflow_dispatch.inputs.release_tag=<target tag>`; do not rely on the
-    repaired tag itself carrying the newer workflow definition.
+  - Rerun release only after the repair report shows either:
+    - `release.repair.status = repaired` and
+      `release.publicationReplay.status = dispatched`
+    - or `release.repair.status = equivalent-replay-dispatched` and
+      `release.publicationReplay.modeInputValue = verify-existing-release`
+  - Replay dispatch now uses `release.yml` from `develop` with
+    `workflow_dispatch.inputs.release_tag=<target tag>`.
+    For immutable published tags it also sets
+    `workflow_dispatch.inputs.publication_mode=verify-existing-release`; do not
+    rely on the published tag itself carrying the newer workflow definition.
 - `workflow-signing-secret-missing`, `workflow-signing-secret-unverifiable`
 - `workflow-signing-admin-scope-missing`, `workflow-signing-key-missing`, `workflow-signing-authority-unverifiable`
 - `release-conductor-apply-disabled`, `release-conductor-apply-unverifiable`, `release-repair-immutable-blocked`
   - Use `node tools/npm/run-script.mjs priority:release:signing:readiness` to confirm the blocker, provision or repair
     the workflow signing secrets, signing authority, or release-conductor enablement. When the blocker is
-    `release-repair-immutable-blocked`, do not rerun `repair_existing_tag` on the same published tag; route through
-    the protected-tag authority path or publish a new authoritative tag identity instead.
+    `release-repair-immutable-blocked`, rerun `repair_existing_tag` only through the protected-tag-safe replay path;
+    do not attempt in-place tag mutation on the same published release tag.
 - `checksum-invalid-line`, `checksum-empty`, `checksum-entry-missing-file`, `checksum-missing-artifact`, `checksum-mismatch`
   - Regenerate `SHA256SUMS.txt` from fresh artifacts and ensure no post-pack mutation occurred.
 - `sbom-parse-failed`, `sbom-invalid`

--- a/docs/RELEASE_PROMOTION_CONTRACT.md
+++ b/docs/RELEASE_PROMOTION_CONTRACT.md
@@ -154,9 +154,12 @@ finds repair-eligible tag failures:
     - `apply = true`
     - `repair_existing_tag = true`
   - if the target tag already backs an immutable published GitHub Release, do
-    not rerun `repair_existing_tag` against the same published tag
-    - use the protected-tag authority path or publish a new authoritative tag
-      identity instead
+    not attempt in-place tag mutation against the same published tag
+    - rerun release conductor with `repair_existing_tag = true` so it dispatches
+      protected-tag-safe `release.yml` replay from `develop`
+    - the replay must use:
+      - `workflow_dispatch.inputs.release_tag=<target tag>`
+      - `workflow_dispatch.inputs.publication_mode=verify-existing-release`
 
 Authoritative signed tag publication now belongs to the release conductor control
 plane:
@@ -169,14 +172,18 @@ plane:
   - `RELEASE_TAG_SIGNING_IDENTITY_EMAIL`
   - when unset, the workflow derives signer identity from the resolved policy
     token account before recreating or publishing the signed tag
-- when signing material is present, release conductor must:
-  - configure workflow-owned tag signing
-  - configure workflow-owned signer identity
-  - create the signed annotated tag
-  - push the tag to the authoritative remote for the target repository
-  - when repairing an existing tag, dispatch `.github/workflows/release.yml`
-    from `develop` with `workflow_dispatch.inputs.release_tag=<target tag>` so
-    publication replays deterministically against the repaired authoritative tag
+  - when signing material is present, release conductor must:
+    - configure workflow-owned tag signing
+    - configure workflow-owned signer identity
+    - create the signed annotated tag
+    - push the tag to the authoritative remote for the target repository
+    - when repairing an existing tag, dispatch `.github/workflows/release.yml`
+      from `develop` with `workflow_dispatch.inputs.release_tag=<target tag>` so
+      publication replays deterministically against the repaired authoritative tag
+    - when the target tag already backs an immutable published release, dispatch
+      `.github/workflows/release.yml` from `develop` with
+      `workflow_dispatch.inputs.publication_mode=verify-existing-release`
+      instead of mutating the published GitHub Release
 - `tests/results/_agent/release/release-conductor-report.json` must record:
   - signing backend/source
   - signer identity used for tag creation/repair
@@ -187,6 +194,7 @@ plane:
   - the authoritative remote tag object/commit used for repair
   - which workflow ref carried the replay dispatch
   - which explicit tag input was used for repaired-tag publication replay
+  - which explicit publication mode input was used for the replay dispatch
   - whether repaired-tag publication replay was dispatched
   - any push failure blocker
 
@@ -223,6 +231,9 @@ If the report emits an external blocker such as:
 promotion remains blocked by external signing readiness. Repair the specific
 secret, authority, or apply-gating surface first, then refresh readiness
 instead of rerunning release publication just to rediscover the same blocker.
+When the blocker is `release-repair-immutable-blocked`, rerun release conductor
+only through the protected-tag-safe replay path; do not attempt in-place tag
+mutation on the same immutable published release.
 
 ## Published CompareVI.Tools bundle observer
 

--- a/docs/schemas/release-conductor-report-v1.schema.json
+++ b/docs/schemas/release-conductor-report-v1.schema.json
@@ -176,7 +176,15 @@
             "requested": { "type": "boolean" },
             "status": {
               "type": "string",
-              "enum": ["not-requested", "repair-available", "ready", "repaired", "blocked"]
+              "enum": [
+                "not-requested",
+                "repair-available",
+                "ready",
+                "ready-equivalent-replay",
+                "repaired",
+                "equivalent-replay-dispatched",
+                "blocked"
+              ]
             },
             "remoteTagRef": { "type": ["string", "null"] },
             "remoteTagExists": { "type": "boolean" },
@@ -193,13 +201,29 @@
         "publicationReplay": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["requested", "workflow", "ref", "tagInputName", "tagInputValue", "dispatched", "status", "error"],
+          "required": [
+            "requested",
+            "workflow",
+            "ref",
+            "tagInputName",
+            "tagInputValue",
+            "modeInputName",
+            "modeInputValue",
+            "dispatched",
+            "status",
+            "error"
+          ],
           "properties": {
             "requested": { "type": "boolean" },
             "workflow": { "type": "string" },
             "ref": { "type": ["string", "null"] },
             "tagInputName": { "type": ["string", "null"] },
             "tagInputValue": { "type": ["string", "null"] },
+            "modeInputName": { "type": ["string", "null"] },
+            "modeInputValue": {
+              "type": ["string", "null"],
+              "enum": ["publish", "verify-existing-release", null]
+            },
             "dispatched": { "type": "boolean" },
             "status": {
               "type": "string",

--- a/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
@@ -13,7 +13,7 @@ test('release conductor workflow keeps workflow_run proposal-only when apply mod
   const workflow = await readFile(workflowPath, 'utf8');
 
   assert.match(workflow, /repair_existing_tag:/);
-  assert.match(workflow, /description:\s+'Repair an existing authoritative tag as a signed annotated tag'/);
+  assert.match(workflow, /description:\s+'Repair an existing authoritative tag or dispatch protected-tag-safe replay for immutable published tags'/);
   assert.match(workflow, /RELEASE_CONDUCTOR_ENABLED:\s+\$\{\{\s*vars\.RELEASE_CONDUCTOR_ENABLED \|\| '0'\s*\}\}/);
   assert.match(workflow, /name:\s+Configure release tag signing material/);
   assert.match(workflow, /if \[\[ -z "\$\{RELEASE_TAG_SIGNING_PRIVATE_KEY:-\}" \]\]; then/);

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -923,6 +923,8 @@ test('runReleaseConductor repairs an existing authoritative tag when repair mode
   assert.equal(report.release.publicationReplay.ref, 'develop');
   assert.equal(report.release.publicationReplay.tagInputName, 'release_tag');
   assert.equal(report.release.publicationReplay.tagInputValue, 'v0.8.0-rc.1');
+  assert.equal(report.release.publicationReplay.modeInputName, 'publication_mode');
+  assert.equal(report.release.publicationReplay.modeInputValue, 'publish');
   assert.equal(
     commandCalls.some(
       (entry) =>
@@ -954,13 +956,15 @@ test('runReleaseConductor repairs an existing authoritative tag when repair mode
         entry.args[3] === '--ref' &&
         entry.args[4] === 'develop' &&
         entry.args[5] === '-f' &&
-        entry.args[6] === 'release_tag=v0.8.0-rc.1'
+        entry.args[6] === 'release_tag=v0.8.0-rc.1' &&
+        entry.args[7] === '-f' &&
+        entry.args[8] === 'publication_mode=publish'
     ),
     true
   );
 });
 
-test('runReleaseConductor blocks repair mode when the published release is immutable', async () => {
+test('runReleaseConductor dispatches protected-tag-safe replay when the published release is immutable', async () => {
   const readJsonOptionalFn = async (filePath) => {
     const normalized = String(filePath);
     if (normalized.includes('queue-supervisor-report.json')) {
@@ -1068,11 +1072,22 @@ test('runReleaseConductor blocks repair mode when the published release is immut
     writeReportFn: async (reportPath) => reportPath
   });
 
-  assert.equal(exitCode, 1);
-  assert.equal(report.release.repair.status, 'blocked');
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.proposalOnly, false);
+  assert.equal(report.release.tagCreated, false);
+  assert.equal(report.release.tagPushed, false);
+  assert.equal(report.release.repair.status, 'equivalent-replay-dispatched');
   assert.equal(report.release.immutableRelease.status, 'published-release-immutable');
   assert.equal(report.release.immutableRelease.publishedRelease.immutable, true);
-  assert.ok(report.decision.blockers.some((entry) => entry.code === 'repair-target-release-immutable'));
+  assert.equal(report.release.publicationReplay.requested, true);
+  assert.equal(report.release.publicationReplay.status, 'dispatched');
+  assert.equal(report.release.publicationReplay.dispatched, true);
+  assert.equal(report.release.publicationReplay.tagInputName, 'release_tag');
+  assert.equal(report.release.publicationReplay.tagInputValue, 'v0.8.0-rc.1');
+  assert.equal(report.release.publicationReplay.modeInputName, 'publication_mode');
+  assert.equal(report.release.publicationReplay.modeInputValue, 'verify-existing-release');
+  assert.deepEqual(report.decision.blockers, []);
   assert.equal(
     commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'tag' && entry.args.includes('-f')),
     false
@@ -1081,6 +1096,132 @@ test('runReleaseConductor blocks repair mode when the published release is immut
     commandCalls.some((entry) => entry.command === 'git' && entry.args[0] === 'push'),
     false
   );
+  assert.equal(
+    commandCalls.some(
+      (entry) =>
+        entry.command === 'gh' &&
+        entry.args[0] === 'workflow' &&
+        entry.args[1] === 'run' &&
+        entry.args[2] === 'release.yml' &&
+        entry.args[3] === '--ref' &&
+        entry.args[4] === 'develop' &&
+        entry.args[5] === '-f' &&
+        entry.args[6] === 'release_tag=v0.8.0-rc.1' &&
+        entry.args[7] === '-f' &&
+        entry.args[8] === 'publication_mode=verify-existing-release'
+    ),
+    true
+  );
+});
+
+test('runReleaseConductor reports equivalent replay availability in dry-run for immutable published releases', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] !== 'api') {
+      throw new Error(`unexpected gh args: ${args.join(' ')}`);
+    }
+    const endpoint = String(args[1] ?? '');
+    if (endpoint.includes('/actions/workflows/')) {
+      return makeWorkflowRunsResponse(endpoint);
+    }
+    if (endpoint === 'repos/owner/repo/immutable-releases') {
+      return { enabled: true, enforced_by_owner: false };
+    }
+    if (endpoint === 'repos/owner/repo/releases/tags/v0.8.0-rc.1') {
+      return {
+        id: 42,
+        tag_name: 'v0.8.0-rc.1',
+        immutable: true,
+        html_url: 'https://github.com/owner/repo/releases/tag/v0.8.0-rc.1'
+      };
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const commandCalls = [];
+  const runCommandFn = (command, args) => {
+    commandCalls.push({ command, args });
+    if (command === 'git' && args[0] === 'config') {
+      if (args[2] === 'remote.upstream.url') {
+        return { status: 0, stdout: 'https://github.com/owner/repo.git', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'missing config' };
+    }
+    if (command === 'git' && args[0] === 'ls-remote') {
+      return {
+        status: 0,
+        stdout: [
+          '1111111111111111111111111111111111111111\trefs/tags/v0.8.0-rc.1',
+          '2222222222222222222222222222222222222222\trefs/tags/v0.8.0-rc.1^{}'
+        ].join('\n'),
+        stderr: ''
+      };
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return { status: 1, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: false,
+      dryRun: true,
+      repairExistingTag: true,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'rc',
+      version: '0.8.0-rc.1',
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '0'
+    },
+    runGhJsonFn,
+    runCommandFn,
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.repair.status, 'ready-equivalent-replay');
+  assert.equal(report.release.immutableRelease.status, 'published-release-immutable');
+  assert.equal(report.release.publicationReplay.requested, false);
+  assert.equal(report.release.publicationReplay.status, 'not-requested');
   assert.equal(
     commandCalls.some((entry) => entry.command === 'gh' && entry.args[0] === 'workflow' && entry.args[1] === 'run'),
     false
@@ -1199,6 +1340,8 @@ test('runReleaseConductor fails apply when repaired tag publication replay dispa
   assert.equal(report.release.publicationReplay.ref, 'develop');
   assert.equal(report.release.publicationReplay.tagInputName, 'release_tag');
   assert.equal(report.release.publicationReplay.tagInputValue, 'v0.8.0-rc.1');
+  assert.equal(report.release.publicationReplay.modeInputName, 'publication_mode');
+  assert.equal(report.release.publicationReplay.modeInputValue, 'publish');
   assert.equal(report.release.publicationReplay.error, 'dispatch denied');
   assert.ok(report.decision.blockers.some((entry) => entry.code === 'release-replay-dispatch-failed'));
 });

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -78,6 +78,7 @@ test('release workflow explicitly dispatches publish-tools-image with actions wr
 
   assert.equal(releaseJob?.permissions?.actions, 'write');
   assert.ok(dispatchStep, 'release workflow should dispatch publish-tools-image explicitly');
+  assert.equal(dispatchStep.if, "env.RELEASE_PUBLICATION_MODE == 'publish'");
   assert.equal(dispatchStep.uses, 'actions/github-script@v8');
   assert.match(dispatchStep.with.script, /workflow_id:\s*'publish-tools-image\.yml'/);
   assert.match(dispatchStep.with.script, /ref:\s*'develop'/);
@@ -97,12 +98,23 @@ test('release workflow remains tag-triggered and also supports workflow_dispatch
   assert.ok(Object.prototype.hasOwnProperty.call(workflow?.on ?? {}, 'workflow_dispatch'));
   assert.equal(workflow?.on?.workflow_dispatch?.inputs?.release_tag?.required, true);
   assert.equal(workflow?.on?.workflow_dispatch?.inputs?.release_tag?.type, 'string');
+  assert.equal(workflow?.on?.workflow_dispatch?.inputs?.publication_mode?.default, 'publish');
+  assert.equal(workflow?.on?.workflow_dispatch?.inputs?.publication_mode?.type, 'choice');
+  assert.deepEqual(workflow?.on?.workflow_dispatch?.inputs?.publication_mode?.options, ['publish', 'verify-existing-release']);
   assert.match(workflowRaw, /name: Resolve release target tag/);
   assert.match(workflowRaw, /tag='\$\{\{\s*inputs\.release_tag\s*\}\}'/);
+  assert.match(workflowRaw, /name: Resolve publication mode/);
+  assert.match(workflowRaw, /mode='\$\{\{\s*inputs\.publication_mode\s*\}\}'/);
   assert.match(workflowRaw, /target_tag:\s*\$\{\{\s*steps\.release_target\.outputs\.tag\s*\}\}/);
+  assert.match(workflowRaw, /publication_mode:\s*\$\{\{\s*steps\.publication_mode\.outputs\.mode\s*\}\}/);
   assert.match(workflowRaw, /ref:\s*\$\{\{\s*steps\.release_target\.outputs\.tag\s*\}\}/);
   assert.match(workflowRaw, /RELEASE_TAG:\s*\$\{\{\s*needs\.certification-matrix\.outputs\.target_tag\s*\}\}/);
+  assert.match(workflowRaw, /RELEASE_PUBLICATION_MODE:\s*\$\{\{\s*needs\.certification-matrix\.outputs\.publication_mode\s*\}\}/);
   assert.match(workflowRaw, /tag_name:\s*\$\{\{\s*env\.RELEASE_TAG\s*\}\}/);
+  assert.match(workflowRaw, /if:\s*env\.RELEASE_PUBLICATION_MODE == 'publish' && steps\.notes\.outputs\.fallback == 'false'/);
+  assert.match(workflowRaw, /if:\s*env\.RELEASE_PUBLICATION_MODE == 'publish' && steps\.notes\.outputs\.fallback == 'true'/);
+  assert.match(workflowRaw, /name: Record protected-tag-safe replay mode/);
+  assert.match(workflowRaw, /if:\s*env\.RELEASE_PUBLICATION_MODE == 'verify-existing-release'/);
 });
 
 test('release workflow resolves downloaded artifacts through the shared helper before validation', () => {

--- a/tools/priority/release-conductor.mjs
+++ b/tools/priority/release-conductor.mjs
@@ -16,6 +16,9 @@ export const DEFAULT_QUARANTINE_STALE_HOURS = 24;
 export const RELEASE_PUBLICATION_WORKFLOW = 'release.yml';
 export const RELEASE_PUBLICATION_WORKFLOW_REF = 'develop';
 export const RELEASE_PUBLICATION_TAG_INPUT = 'release_tag';
+export const RELEASE_PUBLICATION_MODE_INPUT = 'publication_mode';
+export const RELEASE_PUBLICATION_MODE_PUBLISH = 'publish';
+export const RELEASE_PUBLICATION_MODE_VERIFY_EXISTING_RELEASE = 'verify-existing-release';
 
 const REQUIRED_DWELL_WORKFLOWS = Object.freeze([
   { name: 'Validate', file: 'validate.yml' },
@@ -27,7 +30,7 @@ function printUsage() {
   console.log('');
   console.log('Options:');
   console.log('  --apply                     Apply release mutation (default is --dry-run).');
-  console.log('  --repair-existing-tag       Repair an existing authoritative tag by recreating it as a signed annotated tag.');
+  console.log('  --repair-existing-tag       Repair an existing authoritative tag or dispatch protected-tag-safe replay for immutable published tags.');
   console.log(`  --report <path>             Write report JSON (default: ${DEFAULT_REPORT_PATH}).`);
   console.log(`  --queue-report <path>       Queue supervisor report path (default: ${DEFAULT_QUEUE_REPORT_PATH}).`);
   console.log(`  --policy-snapshot <path>    Policy snapshot path (default: ${DEFAULT_POLICY_SNAPSHOT_PATH}).`);
@@ -763,11 +766,11 @@ function inspectImmutableReleaseState({ repository, tagRef, runGhJsonFn, cwd }) 
   return immutableRelease;
 }
 
-function buildImmutableRepairBlockedMessage({ targetTag, immutableRelease }) {
+function buildImmutableRepairReplayMessage({ targetTag, immutableRelease }) {
   const normalizedTag = asOptional(targetTag) ?? 'the current release tag';
   const releaseUrl = asOptional(immutableRelease?.publishedRelease?.releaseUrl);
   const releaseLocation = releaseUrl ? ` (${releaseUrl})` : '';
-  return `Authoritative tag ${normalizedTag} already backs an immutable published GitHub Release${releaseLocation}. Do not rerun release conductor with --repair-existing-tag against the same published tag; publish a new authoritative tag or use the protected-tag authority path.`;
+  return `Authoritative tag ${normalizedTag} already backs an immutable published GitHub Release${releaseLocation}. Rerun release conductor with --repair-existing-tag to dispatch protected-tag-safe release replay from develop without mutating the published release.`;
 }
 
 async function writeReport(filePath, payload) {
@@ -887,6 +890,8 @@ export async function runReleaseConductor(options = {}) {
     ref: RELEASE_PUBLICATION_WORKFLOW_REF,
     tagInputName: RELEASE_PUBLICATION_TAG_INPUT,
     tagInputValue: targetTag,
+    modeInputName: RELEASE_PUBLICATION_MODE_INPUT,
+    modeInputValue: null,
     dispatched: false,
     status: args.repairExistingTag && applyRequested ? 'blocked' : 'not-requested',
     error: null
@@ -925,13 +930,13 @@ export async function runReleaseConductor(options = {}) {
   const repairBlockedByImmutableRelease = Boolean(repair.remoteTagExists && immutableRelease.repairBlocked);
 
   if (repair.remoteTagExists && !repair.requested) {
-    repair.status = repairBlockedByImmutableRelease ? 'blocked' : 'repair-available';
+    repair.status = repairBlockedByImmutableRelease ? 'ready-equivalent-replay' : 'repair-available';
     pushUniqueDecisionEntry(
       advisories,
       repairBlockedByImmutableRelease
         ? {
             code: 'existing-tag-repair-blocked-by-immutable-release',
-            message: buildImmutableRepairBlockedMessage({ targetTag, immutableRelease })
+            message: buildImmutableRepairReplayMessage({ targetTag, immutableRelease })
           }
         : {
             code: 'existing-tag-repair-available',
@@ -950,7 +955,7 @@ export async function runReleaseConductor(options = {}) {
   } else if (repair.requested && (!repair.remoteTargetCommitOid || !repair.pushLeaseExpectedOid)) {
     repair.status = 'blocked';
   } else if (repair.requested && repairBlockedByImmutableRelease) {
-    repair.status = 'blocked';
+    repair.status = applyRequested ? 'blocked' : 'ready-equivalent-replay';
   } else if (repair.requested && repair.remoteTagExists) {
     repair.status = applyRequested ? 'blocked' : 'ready';
   }
@@ -976,11 +981,6 @@ export async function runReleaseConductor(options = {}) {
         code: 'repair-target-tag-missing',
         message: `Repair mode requires existing authoritative tag ${targetTag}, but no authoritative tag ref was found on ${tagPushRemote.remoteName}.`
       });
-    } else if (repairBlockedByImmutableRelease) {
-      blockers.push({
-        code: 'repair-target-release-immutable',
-        message: buildImmutableRepairBlockedMessage({ targetTag, immutableRelease })
-      });
     } else if (!repair.remoteTargetCommitOid || !repair.pushLeaseExpectedOid) {
       blockers.push({
         code: 'repair-target-unresolved',
@@ -995,6 +995,42 @@ export async function runReleaseConductor(options = {}) {
         code: 'missing-version-for-tag',
         message: 'Apply mode requires --version to propose/create a release tag.'
       });
+    } else if (args.repairExistingTag && repairBlockedByImmutableRelease) {
+      publicationReplay.modeInputValue = RELEASE_PUBLICATION_MODE_VERIFY_EXISTING_RELEASE;
+      const dispatchResult = runCommandFn(
+        'gh',
+        [
+          'workflow',
+          'run',
+          RELEASE_PUBLICATION_WORKFLOW,
+          '--ref',
+          RELEASE_PUBLICATION_WORKFLOW_REF,
+          '-f',
+          `${RELEASE_PUBLICATION_TAG_INPUT}=${targetTag}`,
+          '-f',
+          `${RELEASE_PUBLICATION_MODE_INPUT}=${RELEASE_PUBLICATION_MODE_VERIFY_EXISTING_RELEASE}`
+        ],
+        {
+          cwd: repoRoot,
+          allowFailure: true
+        }
+      );
+      if (dispatchResult.status === 0) {
+        proposalOnly = false;
+        repair.status = 'equivalent-replay-dispatched';
+        publicationReplay.dispatched = true;
+        publicationReplay.status = 'dispatched';
+      } else {
+        publicationReplay.status = 'dispatch-failed';
+        publicationReplay.error =
+          asOptional(dispatchResult.stderr) ??
+          asOptional(dispatchResult.stdout) ??
+          'release workflow dispatch failed';
+        blockers.push({
+          code: 'release-replay-dispatch-failed',
+          message: `Release publication replay dispatch failed for ${targetTag}: ${publicationReplay.error}`
+        });
+      }
     } else if (!signingMaterial.available) {
       blockers.push({
         code: 'tag-signing-material-missing',
@@ -1050,6 +1086,7 @@ export async function runReleaseConductor(options = {}) {
                 tagPushed = true;
                 proposalOnly = false;
                 repair.status = 'repaired';
+                publicationReplay.modeInputValue = RELEASE_PUBLICATION_MODE_PUBLISH;
                 const dispatchResult = runCommandFn(
                   'gh',
                   [
@@ -1059,7 +1096,9 @@ export async function runReleaseConductor(options = {}) {
                     '--ref',
                     RELEASE_PUBLICATION_WORKFLOW_REF,
                     '-f',
-                    `${RELEASE_PUBLICATION_TAG_INPUT}=${targetTag}`
+                    `${RELEASE_PUBLICATION_TAG_INPUT}=${targetTag}`,
+                    '-f',
+                    `${RELEASE_PUBLICATION_MODE_INPUT}=${RELEASE_PUBLICATION_MODE_PUBLISH}`
                   ],
                   {
                     cwd: repoRoot,
@@ -1101,7 +1140,7 @@ export async function runReleaseConductor(options = {}) {
         repairBlockedByImmutableRelease
           ? {
               code: 'existing-tag-repair-blocked-by-immutable-release',
-              message: buildImmutableRepairBlockedMessage({ targetTag, immutableRelease })
+              message: buildImmutableRepairReplayMessage({ targetTag, immutableRelease })
             }
           : {
               code: 'existing-tag-requires-repair-mode',


### PR DESCRIPTION
## Summary
- route `release-conductor` repair requests for immutable published tags into protected-tag-safe `release.yml` replay instead of blocked in-place tag mutation
- add `publication_mode` to `release.yml` so workflow_dispatch can verify an existing immutable release without mutating the GitHub Release or dispatching tools-image publication
- update release-conductor report schema, workflow contracts, and release docs to record the replay mode explicitly

## Validation
- `node --test tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs tools/priority/__tests__/release-conductor-workflow-contract.test.mjs tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs hooks:pre-commit`
- `git diff --check`

## Live Evidence
- local dry-run: `node tools/npm/run-script.mjs priority:release:conductor -- --dry-run --repair-existing-tag --channel rc --version 0.6.4-rc.2`
- resulting report: `tests/results/_agent/release/release-conductor-report.json`
- key fields:
  - `release.immutableRelease.status = published-release-immutable`
  - `release.repair.status = ready-equivalent-replay`
  - `decision.status = pass`

Refs #1943
Refs #1951
