### PR TITLE
fix: make replay-mode release scorecard honor protected-tag-safe replay (#1943)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -728,6 +728,7 @@ jobs:
       issues: write
     env:
       RELEASE_TAG: ${{ needs.release.outputs.target_tag }}
+      RELEASE_PUBLICATION_MODE: ${{ needs.certification-matrix.outputs.publication_mode }}
     steps:
       - uses: actions/checkout@v5
 
@@ -741,7 +742,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: release-supply-chain-trust-${{ github.run_id }}
-          path: tests/results/_agent/supply-chain
+          path: tests/results/_agent
 
       - name: Download shared-source resolution artifact
         uses: actions/download-artifact@v8
@@ -936,6 +937,7 @@ jobs:
           set -euo pipefail
           channel="stable"
           downstream_promotion_path="${{ steps.downstream_proving_artifacts.outputs.downstream_proving_scorecard_path }}"
+          downstream_proving_selection_path='tests/results/_agent/release/downstream-proving-selection.json'
           if printf '%s' "${RELEASE_TAG}" | grep -q -- '-rc\.'; then
             channel="rc"
           fi
@@ -950,12 +952,16 @@ jobs:
             --slo tests/results/_agent/slo/release-slo-metrics.json
             --rollback tests/results/_agent/release/rollback-drill-health.json
             --trust tests/results/_agent/supply-chain/release-trust-gate.json
-            --downstream-proving-selection tests/results/_agent/release/downstream-proving-selection.json
-            --require-downstream-proving
             --output tests/results/_agent/release/release-scorecard.json
           )
-          if [ -n "${downstream_promotion_path}" ]; then
-            scorecard_args+=(--downstream-promotion "${downstream_promotion_path}")
+          if [[ "${RELEASE_PUBLICATION_MODE}" == 'publish' ]]; then
+            scorecard_args+=(
+              --downstream-proving-selection "${downstream_proving_selection_path}"
+              --require-downstream-proving
+            )
+            if [ -n "${downstream_promotion_path}" ]; then
+              scorecard_args+=(--downstream-promotion "${downstream_promotion_path}")
+            fi
           fi
           if ! printf '%s' "${RELEASE_TAG}" | grep -Eq -- '-tools\.[0-9]+$'; then
             signed_tag_args+=(--require-signed-tag)

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -156,6 +156,9 @@ test('release workflow resolves downloaded artifacts through the shared helper b
   assert.match(workflowRaw, /name: Resolve release source commit/);
   assert.match(workflowRaw, /git fetch --force --tags origin "refs\/tags\/\$\{RELEASE_TAG\}:refs\/tags\/\$\{RELEASE_TAG\}"/);
   assert.match(workflowRaw, /git rev-parse "\$\{RELEASE_TAG\}\^\{commit\}"/);
+  assert.match(workflowRaw, /RELEASE_PUBLICATION_MODE:\s*\$\{\{\s*needs\.certification-matrix\.outputs\.publication_mode\s*\}\}/);
+  assert.match(workflowRaw, /name: Download supply-chain trust artifact/);
+  assert.match(workflowRaw, /path:\s*tests\/results\/_agent/);
   assert.match(workflowRaw, /name: Resolve downstream proving artifact selection/);
   assert.match(workflowRaw, /resolve-downstream-proving-artifact\.mjs/);
   assert.match(workflowRaw, /--workflow downstream-promotion\.yml/);
@@ -163,15 +166,16 @@ test('release workflow resolves downloaded artifacts through the shared helper b
   assert.match(workflowRaw, /tests\/results\/_agent\/release\/downstream-proving-selection\.json/);
   assert.match(workflowRaw, /name: Validate downstream proving selection schema/);
   assert.match(workflowRaw, /docs\/schemas\/downstream-proving-selection-v1\.schema\.json/);
-  assert.match(workflowRaw, /--downstream-proving-selection tests\/results\/_agent\/release\/downstream-proving-selection\.json/);
   assert.match(workflowRaw, /steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path/);
   assert.match(workflowRaw, /downstream_promotion_path="\$\{\{\s*steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path\s*\}\}"/);
+  assert.match(workflowRaw, /downstream_proving_selection_path='tests\/results\/_agent\/release\/downstream-proving-selection\.json'/);
+  assert.match(workflowRaw, /if \[\[ "\$\{RELEASE_PUBLICATION_MODE\}" == 'publish' \]\]; then/);
+  assert.match(workflowRaw, /scorecard_args\+=\(\s*--downstream-proving-selection "\$\{downstream_proving_selection_path\}"\s*--require-downstream-proving\s*\)/ms);
   assert.match(workflowRaw, /if \[ -n "\$\{downstream_promotion_path\}" \]; then/);
   assert.match(workflowRaw, /scorecard_args\+=\(--downstream-promotion "\$\{downstream_promotion_path\}"\)/);
   assert.match(workflowRaw, /tools\/release-review\/Evaluate-ReleaseReviewPolicy\.ps1/);
   assert.match(workflowRaw, /tests\/results\/release-contract\/review-comment\.md/);
   assert.match(workflowRaw, /--candidate-workflow release\.yml/);
-  assert.match(workflowRaw, /--require-downstream-proving/);
   assert.doesNotMatch(workflowRaw, /--downstream-promotion "\$\{\{\s*steps\.downstream_proving_artifacts\.outputs\.downstream_proving_scorecard_path\s*\}\}"/);
   assert.match(workflowRaw, /signed_tag_args=\(\)/);
   assert.match(workflowRaw, /scorecard_args=\(/);


### PR DESCRIPTION
## Summary
- download the supply-chain trust artifact back into `tests/results/_agent` so replay-mode release-contract sees the trust report at the path the scorecard expects
- make `release-contract` pass `RELEASE_PUBLICATION_MODE` into scorecard assembly and only require downstream proving inputs during `publish`
- keep signed-tag verification active in replay mode so protected-tag-safe replay still proves the existing authoritative tag signature

## Validation
- `node --test tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs tools/priority/__tests__/release-conductor-workflow-contract.test.mjs tools/priority/__tests__/release-scorecard.test.mjs tools/priority/__tests__/release-scorecard-schema.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs hooks:pre-commit`
- `git diff --check`

## Live proof
- `Release Conductor` apply replay now passes and dispatches `release.yml`: run `23540456818`
- the first replayed `release.yml` run proved the remaining blocker was replay-mode scorecard policy, not protected-tag authority: run `23540479383`
- local replay-mode proof against that real artifact set now passes: `tests/results/_agent/release/replay-mode-scorecard-proof.json`
