### PR TITLE
fix: keep workflow-run conductor proposal-only without version inputs (#1943)

### DIFF
--- a/.github/workflows/release-conductor.yml
+++ b/.github/workflows/release-conductor.yml
@@ -168,9 +168,11 @@ jobs:
           if ($eventName -eq 'workflow_dispatch') {
             $apply = ('${{ inputs.apply }}' -eq 'true')
           } elseif ($eventName -eq 'workflow_run') {
-            $apply = $conductorEnabled
-            if (-not $apply) {
+            $apply = $false
+            if (-not $conductorEnabled) {
               Write-Host 'Release conductor apply mode disabled; workflow_run will remain proposal-only.'
+            } else {
+              Write-Host 'Release conductor workflow_run does not carry explicit release version inputs; running proposal-only.'
             }
           }
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -482,9 +482,10 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   For queue-aware release proposals, run `node tools/npm/run-script.mjs priority:release:conductor -- --dry-run`.
   Apply mode requires `RELEASE_CONDUCTOR_ENABLED=1`; if signing material is unavailable, the conductor now fails closed
   before tag creation and emits readiness evidence without mutating tags.
-  Hosted `schedule` and `workflow_run` conductor lanes stay proposal-only when apply mode is disabled, and dry-runs
-  record advisory-only queue-evidence / no-recent-success diagnostics instead of failing for missing queue artifacts or
-  idle dwell windows.
+  Hosted `schedule` conductor lanes stay proposal-only, and hosted `workflow_run` conductor lanes also stay
+  proposal-only because the trigger does not carry explicit release version inputs. Use `workflow_dispatch` for
+  authoritative apply or protected-tag-safe replay, and expect dry-runs to record advisory-only queue-evidence /
+  no-recent-success diagnostics instead of failing for missing queue artifacts or idle dwell windows.
   Use `node tools/npm/run-script.mjs priority:remediation:slo` to compute remediation SLO governance metrics
   (MTTD, route latency, MTTR by priority, reopen rate, queue/trunk/release signals) and emit
   `tests/results/_agent/slo/remediation-slo-report.json` plus governor state

--- a/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/release-conductor-workflow-contract.test.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
-test('release conductor workflow keeps workflow_run proposal-only when apply mode is disabled', async () => {
+test('release conductor workflow keeps workflow_run proposal-only because it lacks explicit version inputs', async () => {
   const workflowPath = path.join(repoRoot, '.github', 'workflows', 'release-conductor.yml');
   const workflow = await readFile(workflowPath, 'utf8');
 
@@ -31,7 +31,7 @@ test('release conductor workflow keeps workflow_run proposal-only when apply mod
   assert.match(workflow, /RELEASE_TAG_SIGNING_IDENTITY_SOURCE=\$identity_source/);
   assert.match(
     workflow,
-    /elseif \(\$eventName -eq 'workflow_run'\) \{\s+\$apply = \$conductorEnabled\s+if \(-not \$apply\) \{\s+Write-Host 'Release conductor apply mode disabled; workflow_run will remain proposal-only\.'\s+\}\s+\}/ms
+    /elseif \(\$eventName -eq 'workflow_run'\) \{\s+\$apply = \$false\s+if \(-not \$conductorEnabled\) \{\s+Write-Host 'Release conductor apply mode disabled; workflow_run will remain proposal-only\.'\s+\} else \{\s+Write-Host 'Release conductor workflow_run does not carry explicit release version inputs; running proposal-only\.'\s+\}\s+\}/ms
   );
   assert.match(workflow, /RELEASE_TAG_SIGNING_BACKEND:\s+\$\{\{\s*env\.RELEASE_TAG_SIGNING_BACKEND \|\| ''\s*\}\}/);
   assert.match(workflow, /RELEASE_TAG_SIGNING_SOURCE:\s+\$\{\{\s*env\.RELEASE_TAG_SIGNING_SOURCE \|\| ''\s*\}\}/);

--- a/tools/priority/__tests__/release-conductor.test.mjs
+++ b/tools/priority/__tests__/release-conductor.test.mjs
@@ -391,6 +391,76 @@ test('runReleaseConductor still blocks dry-run when the dwell window contains wo
   assert.ok(report.decision.blockers.some((entry) => entry.code === 'green-dwell-failed'));
 });
 
+test('runReleaseConductor allows proposal-only dry-run without an explicit version', async () => {
+  const readJsonOptionalFn = async (filePath) => {
+    const normalized = String(filePath);
+    if (normalized.includes('queue-supervisor-report.json')) {
+      return {
+        exists: true,
+        error: null,
+        path: filePath,
+        payload: {
+          paused: false,
+          throughputController: { mode: 'healthy' },
+          retryHistory: {}
+        }
+      };
+    }
+    return {
+      exists: true,
+      error: null,
+      path: filePath,
+      payload: {
+        schema: 'priority/policy-live-state@v1',
+        generatedAt: '2026-03-06T10:00:00Z',
+        state: {}
+      }
+    };
+  };
+
+  const runGhJsonFn = (args) => {
+    if (args[0] === 'api') {
+      return makeWorkflowRunsResponse(String(args[1]));
+    }
+    throw new Error(`unexpected gh args: ${args.join(' ')}`);
+  };
+
+  const { report, exitCode } = await runReleaseConductor({
+    repoRoot: process.cwd(),
+    now: new Date('2026-03-06T12:00:00.000Z'),
+    args: {
+      apply: false,
+      dryRun: true,
+      repairExistingTag: false,
+      reportPath: 'tests/results/_agent/release/release-conductor-report.json',
+      queueReportPath: 'tests/results/_agent/queue/queue-supervisor-report.json',
+      policySnapshotPath: 'tests/results/_agent/policy/policy-state-snapshot.json',
+      repo: 'owner/repo',
+      stream: 'comparevi-cli',
+      channel: 'stable',
+      version: null,
+      dwellMinutes: 60,
+      quarantineStaleHours: 24,
+      help: false
+    },
+    environment: {
+      GITHUB_REPOSITORY: 'owner/repo',
+      RELEASE_CONDUCTOR_ENABLED: '1'
+    },
+    runGhJsonFn,
+    runCommandFn: () => ({ status: 0, stdout: '', stderr: '' }),
+    readJsonOptionalFn,
+    writeReportFn: async (reportPath) => reportPath
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report.decision.status, 'pass');
+  assert.equal(report.release.proposalOnly, true);
+  assert.equal(report.release.version, null);
+  assert.equal(report.release.targetTag, null);
+  assert.deepEqual(report.decision.blockers, []);
+});
+
 test('runReleaseConductor creates and publishes a signed tag when apply is enabled and signing key is available', async () => {
   const readJsonOptionalFn = async (filePath) => {
     const normalized = String(filePath);


### PR DESCRIPTION
## Summary
- keep `release-conductor.yml` workflow-run triggers proposal-only even when `RELEASE_CONDUCTOR_ENABLED=1`
- document that workflow-run does not carry explicit release version inputs and that authoritative apply/replay stays on `workflow_dispatch`
- lock the behavior with workflow contract coverage plus a unit test proving proposal-only dry-run succeeds without a version

## Validation
- `node --test tools/priority/__tests__/release-conductor.test.mjs tools/priority/__tests__/release-conductor-workflow-contract.test.mjs tools/priority/__tests__/release-conductor-schema.test.mjs`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `node tools/npm/run-script.mjs lint:md:changed`
- `node tools/npm/run-script.mjs hooks:pre-commit`
- `git diff --check`

## Live evidence
- protected-tag-safe replay now succeeds end to end:
  - `Release Conductor` run `23542830936`
  - `Release on tag` run `23542860452`
- the remaining background failure on the same head is the automatic workflow-run path entering apply mode without a version:
  - `Release Conductor` run `23542746425`
  - blocker: `missing-version-for-tag`
- this slice makes that workflow-run path degrade safely to proposal-only instead of reopening the incident with preventable failure noise
