### PR TITLE
fix(workflow-policy): exclude monthly breach umbrellas from standing rail (#1963)

### DIFF
--- a/.github/workflows/monthly-stability-release.yml
+++ b/.github/workflows/monthly-stability-release.yml
@@ -282,6 +282,7 @@ jobs:
             --candidate-workflow monthly-stability-release.yml \
             --output tests/results/_agent/slo/monthly-slo-metrics.json \
             --route-on-breach \
+            --route-labels "slo,ci,governance,standing-excluded" \
             --route-title-prefix "[SLO] Monthly stability breach"
 
       - name: Build monthly release scorecard

--- a/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
+++ b/tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs
@@ -225,3 +225,10 @@ test('monthly release workflow marks itself as the SLO remediation candidate', (
 
   assert.match(workflowRaw, /--candidate-workflow monthly-stability-release\.yml/);
 });
+
+test('monthly release workflow routes breach umbrellas as standing-excluded governance issues', () => {
+  const workflowPath = path.join(workflowsRoot, 'monthly-stability-release.yml');
+  const workflowRaw = readFileSync(workflowPath, 'utf8');
+
+  assert.match(workflowRaw, /--route-labels "slo,ci,governance,standing-excluded"/);
+});


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1963
- Issue title: [workflow-policy]: keep monthly stability breach umbrellas out of standing-priority auto-selection
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1963
- Standing priority at PR creation: Yes (#1963)
- Base branch: `develop`
- Head branch: `issue/origin-1963-monthly-stability-breach-standing-excluded`
- Template variant: `workflow-policy`
- Auto-close intent: `Closes #1963`

# Summary

This change keeps monthly SLO governance umbrellas off the active standing rail.

- `monthly-stability-release.yml` now routes `[SLO] Monthly stability breach ...` issues with `standing-excluded`
- a workflow contract test now locks that routing label in place

That preserves the concrete coding rail for actionable child issues while letting the monthly breach ticket stay open as governance tracking.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
  - `.github/workflows/monthly-stability-release.yml`
- Check names, required-status contracts, or merge-queue behavior affected:
  - no required check names changed
  - standing auto-selection now sees routed monthly breach issues as ineligible because they carry `standing-excluded`
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
  - monthly breach issues now include `standing-excluded` alongside the existing governance labels
- Manual dispatch, comment command, or branch-protection effects:
  - no branch-protection change
  - no dispatch semantics change beyond routed issue labeling

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs tools/priority/__tests__/slo-metrics.test.mjs tools/priority/__tests__/standing-priority-resolution.test.mjs`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs hooks:pre-commit`
  - `git diff --check`
- Contract, schema, or guard tests:
  - `tools/priority/__tests__/workflow-pwsh-continuation-contract.test.mjs`
  - `tools/priority/__tests__/slo-metrics.test.mjs`
  - `tools/priority/__tests__/standing-priority-resolution.test.mjs`
- Live workflow or dry-run evidence:
  - `tests/results/_agent/slo/slo-metrics-live.json` currently shows `promotionGate.status = pass`
  - `#1962` was decomposed back to a governance umbrella and `#1963` is the concrete standing rail

## Rollout and Rollback

- Rollout notes:
  - future monthly stability breach issues will be created/commented with `standing-excluded`
  - bootstrap will stop auto-promoting those governance umbrellas when the queue is otherwise empty
- Rollback path:
  - revert the workflow label argument and contract test
- Residual risks:
  - this is intentionally scoped to monthly stability breach umbrellas only; other SLO issue families remain unchanged

## Reviewer Focus

- Please verify:
  - the workflow label string is scoped to monthly stability breach routing only
  - we are not changing concrete release-promotion SLO rails like `#1943`
- Policy assumptions to double-check:
  - `standing-excluded` remains the correct repo signal for governance umbrellas that should stay out of auto-selection
- Follow-up issues or guardrails:
  - `#1962` stays open as the historical monthly governance rollup

Closes #1963
