### PR TITLE
fix(workflow-policy): suppress stale queue blockers in pivot monitoring (#1965)

### DIFF
--- a/tools/priority/__tests__/autonomous-governor-summary.test.mjs
+++ b/tools/priority/__tests__/autonomous-governor-summary.test.mjs
@@ -422,6 +422,42 @@ test('runAutonomousGovernorSummary reports monitoring-active when no wake lifecy
   assert.equal(report.summary.releaseSigningStatus, 'missing');
 });
 
+test('runAutonomousGovernorSummary suppresses stale delivery runtime blockers during queue-empty pivot monitoring', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'governor-summary-monitoring-stale-runtime-'));
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'issue', 'no-standing-priority.json'), createQueueEmpty());
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'continuity-summary.json'), createContinuitySummary());
+  writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'handoff', 'monitoring-mode.json'), createMonitoringMode());
+  writeJson(
+    path.join(tmpDir, 'tests', 'results', '_agent', 'runtime', 'delivery-agent-state.json'),
+    createDeliveryRuntimeState({
+      status: 'blocked',
+      laneLifecycle: 'blocked',
+      activeLane: {
+        issue: 959,
+        prUrl: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/pull/1017',
+        laneLifecycle: 'blocked',
+        actionType: 'merge-pr',
+        outcome: 'merge-blocked',
+        blockerClass: 'merge',
+        nextWakeCondition: 'mergeable-pr',
+        reason: 'Stale merge blocker carried from an old delivery-runtime receipt.'
+      }
+    })
+  );
+
+  const { report } = await runAutonomousGovernorSummary({ repoRoot: tmpDir });
+
+  assert.equal(report.summary.governorMode, 'monitoring-active');
+  assert.equal(report.summary.nextAction, 'future-agent-may-pivot');
+  assert.equal(report.compare.deliveryRuntime.status, 'none');
+  assert.equal(report.compare.deliveryRuntime.prUrl, null);
+  assert.equal(report.compare.deliveryRuntime.issueNumber, null);
+  assert.equal(report.summary.queueHandoffStatus, 'none');
+  assert.equal(report.summary.queueHandoffNextWakeCondition, null);
+  assert.equal(report.summary.queueHandoffPrUrl, null);
+  assert.equal(report.summary.queueAuthoritySource, 'none');
+});
+
 test('runAutonomousGovernorSummary carries explicit release signing blocker state into the governor summary', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'governor-summary-release-signing-'));
   writeJson(path.join(tmpDir, 'tests', 'results', '_agent', 'issue', 'no-standing-priority.json'), createQueueEmpty());

--- a/tools/priority/autonomous-governor-summary.mjs
+++ b/tools/priority/autonomous-governor-summary.mjs
@@ -757,6 +757,26 @@ function deriveDeliveryRuntime(deliveryRuntimeState) {
   };
 }
 
+function suppressDeliveryRuntimeForMonitoring(deliveryRuntime) {
+  const emptyDeliveryRuntime = deriveDeliveryRuntime(null);
+  return {
+    ...emptyDeliveryRuntime,
+    runtimeStatus: deliveryRuntime.runtimeStatus,
+    queueAuthorityRefresh: deliveryRuntime.queueAuthorityRefresh
+  };
+}
+
+function shouldSuppressStaleDeliveryRuntime({ queueState, continuity, monitoringMode, wake }) {
+  return (
+    queueState.status === 'queue-empty' &&
+    continuity.status === 'maintained' &&
+    continuity.turnBoundary === 'safe-idle' &&
+    asOptional(monitoringMode?.summary?.status) === 'active' &&
+    asOptional(monitoringMode?.summary?.futureAgentAction) === 'future-agent-may-pivot' &&
+    wake.terminalState === null
+  );
+}
+
 function deriveQueueAuthority({ repoRoot, repository, deliveryRuntime, readOptionalJsonFn }) {
   const prNumber = parsePullRequestNumber(deliveryRuntime.prUrl);
   const queueRefreshReceiptPath = resolveLatestQueueRefreshReceiptPath(repoRoot, prNumber);
@@ -997,7 +1017,10 @@ function buildReport({
   const wake = deriveWake(wakeLifecycle);
   const funding = deriveFunding(wakeInvestmentAccounting);
   const releaseSigningReadiness = deriveReleaseSigningReadiness(releaseSigningReadinessReport);
-  const deliveryRuntime = deriveDeliveryRuntime(deliveryRuntimeState);
+  const rawDeliveryRuntime = deriveDeliveryRuntime(deliveryRuntimeState);
+  const deliveryRuntime = shouldSuppressStaleDeliveryRuntime({ queueState, continuity, monitoringMode, wake })
+    ? suppressDeliveryRuntimeForMonitoring(rawDeliveryRuntime)
+    : rawDeliveryRuntime;
   const queueAuthority = deriveQueueAuthority({
     repoRoot,
     repository,


### PR DESCRIPTION
## Summary
- suppresses stale delivery-runtime merge blocker metadata during authoritative queue-empty pivot monitoring
- preserves queue-authority refresh telemetry while clearing stale active-lane blocker fields
- adds a regression test for the stale PR `#1017` monitoring case

## Problem
During queue-empty monitoring mode, the autonomous governor summary could still advertise stale queue-authority blocker state from an old delivery-runtime receipt. That left the handoff contradictory: compare was idle and pivot-ready, but the same summary still reported `merge-blocked`, a stale PR URL, and `delivery-runtime` as the active queue authority source.

## Fix
- add a narrow suppression path in `tools/priority/autonomous-governor-summary.mjs`
- apply it only when all of these are true:
  - queue state is `queue-empty`
  - continuity is `maintained` at `safe-idle`
  - monitoring mode is active with `future-agent-may-pivot`
  - there is no active wake terminal state
- keep `queueAuthorityRefresh` telemetry intact so receipt detail remains available
- add a regression test that reproduces the stale blocked-runtime scenario and asserts the queue handoff collapses to `none` / `null`

## Validation
- `node --test tools/priority/__tests__/autonomous-governor-summary.test.mjs tools/priority/__tests__/autonomous-governor-portfolio-summary.test.mjs`
- `Invoke-Pester tests/Import-HandoffState.Tests.ps1 -Output Detailed`
- `git diff --check`
