### PR TITLE
[workflow-policy]: penalize awaiting-instruction agents in background saturation KPI (#1967)

### DIFF
--- a/docs/documentation-manifest.json
+++ b/docs/documentation-manifest.json
@@ -390,6 +390,19 @@
         ]
     },
     {
+      "name": "Background Agent Saturation KPI Contracts",
+      "category": "supporting",
+      "status": "reference",
+      "description": "Runtime agent-state snapshot and handoff saturation receipt contracts, plus the weighting logic and focused tests that partially penalize awaiting-instruction background agents instead of treating them as fully productive or fully done.",
+      "files": [
+        "docs/schemas/background-agent-state-snapshot-v1.schema.json",
+        "docs/schemas/background-agent-saturation-v1.schema.json",
+        "tools/priority/background-agent-saturation.mjs",
+        "tools/priority/__tests__/background-agent-saturation.test.mjs",
+        "tools/priority/__tests__/background-agent-saturation-schema.test.mjs"
+      ]
+    },
+    {
       "name": "Headless Sample Corpus Contracts",
       "category": "supporting",
       "status": "reference",

--- a/docs/schemas/background-agent-saturation-v1.schema.json
+++ b/docs/schemas/background-agent-saturation-v1.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/background-agent-saturation-v1.schema.json",
+  "title": "Background Agent Saturation v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "owner",
+    "mode",
+    "targetSaturation",
+    "acceptableBand",
+    "measurementWindow",
+    "availableAgents",
+    "observedAgents",
+    "productiveAgents",
+    "awaitingInstructionAgents",
+    "doneAgents",
+    "stateCounts",
+    "weights",
+    "weightedProductiveAgents",
+    "rawOccupancy",
+    "rollingSaturation",
+    "effectiveSaturation",
+    "status",
+    "constraintReason",
+    "applicable",
+    "priorityRule",
+    "countingRule",
+    "evidence",
+    "notes",
+    "agents"
+  ],
+  "properties": {
+    "schema": {
+      "const": "agent-handoff/background-agent-saturation-v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": ["string", "null"]
+    },
+    "mode": {
+      "type": "string",
+      "minLength": 1
+    },
+    "targetSaturation": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "acceptableBand": {
+      "$ref": "#/$defs/band"
+    },
+    "measurementWindow": {
+      "type": "string",
+      "minLength": 1
+    },
+    "availableAgents": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "observedAgents": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "productiveAgents": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "awaitingInstructionAgents": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "doneAgents": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "stateCounts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "productive",
+        "awaitingInstruction",
+        "done",
+        "idle",
+        "blocked",
+        "duplicate",
+        "pollingOnly",
+        "speculativeChurn",
+        "other"
+      ],
+      "properties": {
+        "productive": { "type": "integer", "minimum": 0 },
+        "awaitingInstruction": { "type": "integer", "minimum": 0 },
+        "done": { "type": "integer", "minimum": 0 },
+        "idle": { "type": "integer", "minimum": 0 },
+        "blocked": { "type": "integer", "minimum": 0 },
+        "duplicate": { "type": "integer", "minimum": 0 },
+        "pollingOnly": { "type": "integer", "minimum": 0 },
+        "speculativeChurn": { "type": "integer", "minimum": 0 },
+        "other": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "weights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["productive", "awaitingInstruction", "done"],
+      "properties": {
+        "productive": { "type": "number", "minimum": 0, "maximum": 1 },
+        "awaitingInstruction": { "type": "number", "minimum": 0, "maximum": 1 },
+        "done": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "weightedProductiveAgents": {
+      "type": "number",
+      "minimum": 0
+    },
+    "rawOccupancy": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "rollingSaturation": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "effectiveSaturation": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "constrained", "not-applicable"]
+    },
+    "constraintReason": {
+      "type": ["string", "null"]
+    },
+    "applicable": {
+      "type": "boolean"
+    },
+    "priorityRule": {
+      "type": "string",
+      "minLength": 1
+    },
+    "countingRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["productive", "weights", "excluded"],
+      "properties": {
+        "productive": { "type": "string", "minLength": 1 },
+        "weights": {
+          "type": "object",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "excluded": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["snapshotPath", "priorityCache", "router", "noStandingPriority"],
+      "properties": {
+        "snapshotPath": { "type": ["string", "null"] },
+        "priorityCache": { "type": "string", "minLength": 1 },
+        "router": { "type": "string", "minLength": 1 },
+        "noStandingPriority": { "type": "string", "minLength": 1 }
+      }
+    },
+    "notes": {
+      "$ref": "#/$defs/stringArray"
+    },
+    "agents": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/agent" }
+    }
+  },
+  "$defs": {
+    "band": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min", "max"],
+      "properties": {
+        "min": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "max": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "state", "weight", "taskSummary", "detail"],
+      "properties": {
+        "id": { "type": ["string", "null"] },
+        "name": { "type": ["string", "null"] },
+        "state": { "type": "string", "minLength": 1 },
+        "weight": { "type": "number", "minimum": 0, "maximum": 1 },
+        "taskSummary": { "type": ["string", "null"] },
+        "detail": { "type": ["string", "null"] }
+      }
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/docs/schemas/background-agent-state-snapshot-v1.schema.json
+++ b/docs/schemas/background-agent-state-snapshot-v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/compare-vi-cli-action/schemas/background-agent-state-snapshot-v1.schema.json",
+  "title": "Background Agent State Snapshot v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "owner",
+    "mode",
+    "targetSaturation",
+    "acceptableBand",
+    "measurementWindow",
+    "availableAgents",
+    "agents"
+  ],
+  "properties": {
+    "schema": {
+      "const": "priority/background-agent-state-snapshot@v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "owner": {
+      "type": ["string", "null"]
+    },
+    "mode": {
+      "type": ["string", "null"]
+    },
+    "targetSaturation": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1
+    },
+    "acceptableBand": {
+      "$ref": "#/$defs/band"
+    },
+    "measurementWindow": {
+      "type": ["string", "null"]
+    },
+    "availableAgents": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "constraintReason": {
+      "type": ["string", "null"]
+    },
+    "notes": {
+      "$ref": "#/$defs/stringArray"
+    },
+    "agents": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/agent" }
+    }
+  },
+  "$defs": {
+    "band": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["min", "max"],
+      "properties": {
+        "min": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "max": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "state", "taskSummary", "detail"],
+      "properties": {
+        "id": { "type": ["string", "null"] },
+        "name": { "type": ["string", "null"] },
+        "state": { "type": "string", "minLength": 1 },
+        "taskSummary": { "type": ["string", "null"] },
+        "detail": { "type": ["string", "null"] }
+      }
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "priority:governor:portfolio": "node tools/priority/autonomous-governor-portfolio-summary.mjs",
     "priority:subagent:episode": "node tools/priority/subagent-episode.mjs",
     "priority:context:concentrate": "node tools/priority/sagan-context-concentrator.mjs",
+    "priority:agent:saturation": "node tools/priority/background-agent-saturation.mjs",
     "priority:monitoring:inject-work": "node tools/priority/monitoring-work-injection.mjs",
     "priority:wake:adjudicate": "node tools/priority/wake-adjudication.mjs",
     "priority:wake:accounting": "node tools/priority/wake-investment-accounting.mjs",

--- a/tools/priority/__tests__/background-agent-saturation-schema.test.mjs
+++ b/tools/priority/__tests__/background-agent-saturation-schema.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  MODE_DEFAULTS,
+  SNAPSHOT_SCHEMA,
+  runBackgroundAgentSaturation
+} from '../background-agent-saturation.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+test('background agent saturation schema validates a generated receipt', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'background-agent-saturation-schema-'));
+  const snapshotPath = path.join(root, 'tests', 'results', '_agent', 'runtime', 'background-agent-state.json');
+  const outputPath = path.join(root, 'tests', 'results', '_agent', 'handoff', 'background-agent-saturation.json');
+
+  writeJson(snapshotPath, {
+    schema: SNAPSHOT_SCHEMA,
+    generatedAt: '2026-03-25T19:50:00Z',
+    owner: 'Sagan',
+    mode: 'aggressive',
+    targetSaturation: MODE_DEFAULTS.aggressive.target,
+    acceptableBand: MODE_DEFAULTS.aggressive.band,
+    measurementWindow: 'rolling-30m',
+    availableAgents: 6,
+    agents: [
+      { id: 'a1', name: 'Alpha', state: 'productive', taskSummary: 'Validation prep', detail: null },
+      { id: 'a2', name: 'Beta', state: 'awaiting instruction', taskSummary: 'Queued for next bounded slice', detail: null },
+      { id: 'a3', name: 'Gamma', state: 'done', taskSummary: 'Completed issue draft', detail: null }
+    ]
+  });
+  writeJson(path.join(root, '.agent_priority_cache.json'), { number: 1967, state: 'OPEN' });
+  writeJson(path.join(root, 'tests', 'results', '_agent', 'issue', 'router.json'), {
+    schema: 'agent/priority-router@v1',
+    issue: 1967
+  });
+
+  const { report } = await runBackgroundAgentSaturation(
+    {
+      repoRoot: root,
+      snapshotPath,
+      outputPath
+    },
+    {
+      now: new Date('2026-03-25T19:51:00Z')
+    }
+  );
+
+  const schema = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'docs', 'schemas', 'background-agent-saturation-v1.schema.json'), 'utf8')
+  );
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(report);
+  assert.equal(valid, true, JSON.stringify(validate.errors, null, 2));
+});

--- a/tools/priority/__tests__/background-agent-saturation.test.mjs
+++ b/tools/priority/__tests__/background-agent-saturation.test.mjs
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  DEFAULT_OUTPUT_PATH,
+  DEFAULT_SNAPSHOT_PATH,
+  MODE_DEFAULTS,
+  REPORT_SCHEMA,
+  SNAPSHOT_SCHEMA,
+  buildBackgroundAgentSaturationReport,
+  parseArgs,
+  runBackgroundAgentSaturation
+} from '../background-agent-saturation.mjs';
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+test('parseArgs applies defaults for snapshot and output paths', () => {
+  const parsed = parseArgs(['node', 'background-agent-saturation.mjs', '--repo-root', 'C:/repo']);
+  assert.match(parsed.snapshotPath, new RegExp(DEFAULT_SNAPSHOT_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(parsed.outputPath, new RegExp(DEFAULT_OUTPUT_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+test('buildBackgroundAgentSaturationReport weights awaiting-instruction less harshly than done', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'background-agent-saturation-build-'));
+  writeJson(path.join(root, '.agent_priority_cache.json'), {
+    number: 1967,
+    state: 'OPEN'
+  });
+  writeJson(path.join(root, 'tests', 'results', '_agent', 'issue', 'router.json'), {
+    schema: 'agent/priority-router@v1',
+    issue: 1967
+  });
+  const report = buildBackgroundAgentSaturationReport(
+    {
+      schema: SNAPSHOT_SCHEMA,
+      generatedAt: '2026-03-25T19:40:00Z',
+      owner: 'Sagan',
+      mode: 'custom',
+      targetSaturation: 0.98,
+      acceptableBand: { min: 0.83, max: 1.0 },
+      measurementWindow: 'rolling-30m',
+      availableAgents: 6,
+      agents: [
+        { id: 'a1', name: 'Alpha', state: 'productive', taskSummary: 'Root-cause analysis', detail: null },
+        { id: 'a2', name: 'Beta', state: 'awaiting instruction', taskSummary: 'Waiting for next bounded task', detail: null },
+        { id: 'a3', name: 'Gamma', state: 'done', taskSummary: 'Completed report', detail: null },
+        { id: 'a4', name: 'Delta', state: 'blocked', taskSummary: 'Blocked on CI', detail: null }
+      ]
+    },
+    { repoRoot: root }
+  );
+
+  assert.equal(report.schema, REPORT_SCHEMA);
+  assert.equal(report.productiveAgents, 1);
+  assert.equal(report.awaitingInstructionAgents, 1);
+  assert.equal(report.doneAgents, 1);
+  assert.equal(report.weightedProductiveAgents, 1.25);
+  assert.equal(report.effectiveSaturation, 0.2083);
+  assert.equal(report.rawOccupancy, 0.6667);
+  assert.equal(report.weights.awaitingInstruction, 0.25);
+  assert.equal(report.status, 'active');
+});
+
+test('runBackgroundAgentSaturation marks queue-empty repos as constrained while keeping weighted counts', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'background-agent-saturation-constrained-'));
+  writeJson(path.join(root, 'tests', 'results', '_agent', 'runtime', 'background-agent-state.json'), {
+    schema: SNAPSHOT_SCHEMA,
+    generatedAt: '2026-03-25T19:45:00Z',
+    owner: 'Sagan',
+    mode: 'balanced',
+    targetSaturation: MODE_DEFAULTS.balanced.target,
+    acceptableBand: MODE_DEFAULTS.balanced.band,
+    measurementWindow: 'rolling-30m',
+    availableAgents: 6,
+    agents: [
+      { id: 'a1', name: 'Alpha', state: 'awaiting-instruction', taskSummary: 'Ready for next slice', detail: null },
+      { id: 'a2', name: 'Beta', state: 'done', taskSummary: 'Closed out prior slice', detail: null }
+    ]
+  });
+  writeJson(path.join(root, 'tests', 'results', '_agent', 'issue', 'router.json'), {
+    schema: 'agent/priority-router@v1',
+    issue: null
+  });
+  writeJson(path.join(root, 'tests', 'results', '_agent', 'issue', 'no-standing-priority.json'), {
+    reason: 'queue-empty',
+    openIssueCount: 0
+  });
+
+  const { report, outputPath } = await runBackgroundAgentSaturation({ repoRoot: root }, { now: new Date('2026-03-25T19:46:00Z') });
+
+  assert.equal(report.status, 'constrained');
+  assert.equal(report.constraintReason, 'queue-empty');
+  assert.equal(report.awaitingInstructionAgents, 1);
+  assert.equal(report.doneAgents, 1);
+  assert.equal(report.weightedProductiveAgents, 0.25);
+  assert.equal(report.effectiveSaturation, 0.0417);
+  assert.equal(fs.existsSync(outputPath), true);
+});

--- a/tools/priority/background-agent-saturation.mjs
+++ b/tools/priority/background-agent-saturation.mjs
@@ -1,0 +1,568 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(MODULE_DIR, '..', '..');
+
+export const SNAPSHOT_SCHEMA = 'priority/background-agent-state-snapshot@v1';
+export const REPORT_SCHEMA = 'agent-handoff/background-agent-saturation-v1';
+export const DEFAULT_SNAPSHOT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'runtime',
+  'background-agent-state.json'
+);
+export const DEFAULT_OUTPUT_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'handoff',
+  'background-agent-saturation.json'
+);
+export const DEFAULT_PRIORITY_CACHE_PATH = '.agent_priority_cache.json';
+export const DEFAULT_ROUTER_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'issue',
+  'router.json'
+);
+export const DEFAULT_NO_STANDING_PRIORITY_PATH = path.join(
+  'tests',
+  'results',
+  '_agent',
+  'issue',
+  'no-standing-priority.json'
+);
+
+export const MODE_DEFAULTS = {
+  conserve: { target: 0.33, band: { min: 0.17, max: 0.5 } },
+  balanced: { target: 0.67, band: { min: 0.5, max: 0.83 } },
+  aggressive: { target: 0.83, band: { min: 0.67, max: 1.0 } },
+  'max-burn': { target: 1.0, band: { min: 0.83, max: 1.0 } }
+};
+
+export const STATE_WEIGHTS = {
+  productive: 1.0,
+  'awaiting-instruction': 0.25,
+  done: 0.0,
+  idle: 0.0,
+  blocked: 0.0,
+  duplicate: 0.0,
+  'polling-only': 0.0,
+  'speculative-churn': 0.0,
+  other: 0.0
+};
+
+const PRODUCTIVE_STATES = new Set([
+  'productive',
+  'active',
+  'running',
+  'in-progress',
+  'in_progress',
+  'working',
+  'reported'
+]);
+
+const AWAITING_STATES = new Set([
+  'awaiting instruction',
+  'awaiting-instruction',
+  'awaiting_input',
+  'awaiting-input',
+  'awaiting input',
+  'awaiting-instructions',
+  'waiting-for-instructions'
+]);
+
+const DONE_STATES = new Set([
+  'done',
+  'completed',
+  'complete',
+  'pass',
+  'passed',
+  'success',
+  'successful',
+  'closed',
+  'retired'
+]);
+
+const IDLE_STATES = new Set(['idle', 'unassigned']);
+const BLOCKED_STATES = new Set(['blocked']);
+const DUPLICATE_STATES = new Set(['duplicate']);
+const POLLING_ONLY_STATES = new Set(['polling-only', 'polling only']);
+const SPECULATIVE_CHURN_STATES = new Set(['speculative-churn', 'speculative churn']);
+
+function normalizeText(value) {
+  if (value == null) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeInteger(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function normalizeNumber(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeRatio(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, Number(value.toFixed(4))));
+}
+
+function toPortablePath(filePath) {
+  return String(filePath).replace(/\\/g, '/');
+}
+
+function toDisplayPath(repoRoot, filePath) {
+  if (!filePath) {
+    return null;
+  }
+  const resolvedRepoRoot = path.resolve(repoRoot);
+  const resolvedPath = path.resolve(filePath);
+  const relative = path.relative(resolvedRepoRoot, resolvedPath);
+  if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
+    return toPortablePath(relative);
+  }
+  return toPortablePath(resolvedPath);
+}
+
+function readOptionalJson(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+}
+
+function writeJson(filePath, payload) {
+  const resolvedPath = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+function ensureSchema(payload, filePath, schema) {
+  if (payload?.schema !== schema) {
+    throw new Error(`Expected ${schema} at ${filePath}.`);
+  }
+  return payload;
+}
+
+function classifyAgentState(value) {
+  const normalized = (normalizeText(value) || 'other').toLowerCase();
+  if (PRODUCTIVE_STATES.has(normalized)) {
+    return 'productive';
+  }
+  if (AWAITING_STATES.has(normalized)) {
+    return 'awaiting-instruction';
+  }
+  if (DONE_STATES.has(normalized)) {
+    return 'done';
+  }
+  if (IDLE_STATES.has(normalized)) {
+    return 'idle';
+  }
+  if (BLOCKED_STATES.has(normalized)) {
+    return 'blocked';
+  }
+  if (DUPLICATE_STATES.has(normalized)) {
+    return 'duplicate';
+  }
+  if (POLLING_ONLY_STATES.has(normalized)) {
+    return 'polling-only';
+  }
+  if (SPECULATIVE_CHURN_STATES.has(normalized)) {
+    return 'speculative-churn';
+  }
+  return 'other';
+}
+
+function defaultBandForMode(mode, targetSaturation) {
+  const defaults = MODE_DEFAULTS[mode];
+  if (defaults) {
+    return defaults.band;
+  }
+  const target = normalizeNumber(targetSaturation) ?? MODE_DEFAULTS.balanced.target;
+  return {
+    min: normalizeRatio(target - 0.15),
+    max: 1.0
+  };
+}
+
+function defaultTargetForMode(mode) {
+  return MODE_DEFAULTS[mode]?.target ?? MODE_DEFAULTS.balanced.target;
+}
+
+export function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    repoRoot: DEFAULT_REPO_ROOT,
+    snapshotPath: DEFAULT_SNAPSHOT_PATH,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    priorityCachePath: DEFAULT_PRIORITY_CACHE_PATH,
+    routerPath: DEFAULT_ROUTER_PATH,
+    noStandingPriorityPath: DEFAULT_NO_STANDING_PRIORITY_PATH,
+    owner: null,
+    mode: null,
+    targetSaturation: null,
+    availableAgents: null,
+    measurementWindow: 'rolling-30m',
+    help: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    const next = args[index + 1];
+    const needsValue = new Set([
+      '--repo-root',
+      '--snapshot',
+      '--output',
+      '--priority-cache',
+      '--router',
+      '--no-standing-priority',
+      '--owner',
+      '--mode',
+      '--target-saturation',
+      '--available-agents',
+      '--measurement-window'
+    ]);
+    if (needsValue.has(token)) {
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value for ${token}.`);
+      }
+      index += 1;
+      switch (token) {
+        case '--repo-root':
+          options.repoRoot = next;
+          break;
+        case '--snapshot':
+          options.snapshotPath = next;
+          break;
+        case '--output':
+          options.outputPath = next;
+          break;
+        case '--priority-cache':
+          options.priorityCachePath = next;
+          break;
+        case '--router':
+          options.routerPath = next;
+          break;
+        case '--no-standing-priority':
+          options.noStandingPriorityPath = next;
+          break;
+        case '--owner':
+          options.owner = next;
+          break;
+        case '--mode':
+          options.mode = next;
+          break;
+        case '--target-saturation':
+          options.targetSaturation = next;
+          break;
+        case '--available-agents':
+          options.availableAgents = next;
+          break;
+        case '--measurement-window':
+          options.measurementWindow = next;
+          break;
+        default:
+          break;
+      }
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return options;
+}
+
+function buildAgentEntries(snapshotAgents = []) {
+  return snapshotAgents.map((agent, index) => {
+    const state = classifyAgentState(agent?.state);
+    return {
+      id: normalizeText(agent?.id) || `agent-${index + 1}`,
+      name: normalizeText(agent?.name),
+      state,
+      weight: STATE_WEIGHTS[state] ?? 0,
+      taskSummary: normalizeText(agent?.taskSummary),
+      detail: normalizeText(agent?.detail)
+    };
+  });
+}
+
+function countAgentStates(agents) {
+  const counts = {
+    productive: 0,
+    awaitingInstruction: 0,
+    done: 0,
+    idle: 0,
+    blocked: 0,
+    duplicate: 0,
+    pollingOnly: 0,
+    speculativeChurn: 0,
+    other: 0
+  };
+
+  for (const agent of agents) {
+    switch (agent.state) {
+      case 'productive':
+        counts.productive += 1;
+        break;
+      case 'awaiting-instruction':
+        counts.awaitingInstruction += 1;
+        break;
+      case 'done':
+        counts.done += 1;
+        break;
+      case 'idle':
+        counts.idle += 1;
+        break;
+      case 'blocked':
+        counts.blocked += 1;
+        break;
+      case 'duplicate':
+        counts.duplicate += 1;
+        break;
+      case 'polling-only':
+        counts.pollingOnly += 1;
+        break;
+      case 'speculative-churn':
+        counts.speculativeChurn += 1;
+        break;
+      default:
+        counts.other += 1;
+        break;
+    }
+  }
+
+  return counts;
+}
+
+function resolveConstraint({ noStandingPriority, router }) {
+  if (noStandingPriority?.reason === 'queue-empty' && !normalizeInteger(router?.issue)) {
+    return {
+      status: 'constrained',
+      reason: 'queue-empty'
+    };
+  }
+  return {
+    status: 'active',
+    reason: null
+  };
+}
+
+export function buildBackgroundAgentSaturationReport(snapshotInput = {}, options = {}, deps = {}) {
+  const repoRoot = path.resolve(options.repoRoot || DEFAULT_REPO_ROOT);
+  const now = deps.now || new Date();
+  const readJsonFn = deps.readJsonFn || readOptionalJson;
+  const snapshot = snapshotInput || {};
+
+  if (snapshot.schema) {
+    ensureSchema(snapshot, options.snapshotPath || DEFAULT_SNAPSHOT_PATH, SNAPSHOT_SCHEMA);
+  }
+
+  const owner = normalizeText(options.owner) || normalizeText(snapshot.owner) || 'Sagan';
+  const mode = normalizeText(options.mode) || normalizeText(snapshot.mode) || 'balanced';
+  const targetSaturation =
+    normalizeNumber(options.targetSaturation) ??
+    normalizeNumber(snapshot.targetSaturation) ??
+    defaultTargetForMode(mode);
+
+  const snapshotBand = snapshot.acceptableBand && typeof snapshot.acceptableBand === 'object'
+    ? {
+        min: normalizeNumber(snapshot.acceptableBand.min),
+        max: normalizeNumber(snapshot.acceptableBand.max)
+      }
+    : null;
+  const band = snapshotBand?.min != null && snapshotBand?.max != null
+    ? snapshotBand
+    : defaultBandForMode(mode, targetSaturation);
+
+  const agents = buildAgentEntries(Array.isArray(snapshot.agents) ? snapshot.agents : []);
+  const observedAgents = agents.length;
+  const availableAgents =
+    normalizeInteger(options.availableAgents) ??
+    normalizeInteger(snapshot.availableAgents) ??
+    observedAgents;
+  const counts = countAgentStates(agents);
+  const weightedProductiveAgents = Number(
+    agents.reduce((sum, agent) => sum + (STATE_WEIGHTS[agent.state] ?? 0), 0).toFixed(4)
+  );
+  const rawOccupancy = availableAgents > 0 ? normalizeRatio(observedAgents / availableAgents) : 0;
+  const effectiveSaturation = availableAgents > 0 ? normalizeRatio(weightedProductiveAgents / availableAgents) : 0;
+
+  const priorityCachePath = path.resolve(repoRoot, options.priorityCachePath || DEFAULT_PRIORITY_CACHE_PATH);
+  const routerPath = path.resolve(repoRoot, options.routerPath || DEFAULT_ROUTER_PATH);
+  const noStandingPriorityPath = path.resolve(repoRoot, options.noStandingPriorityPath || DEFAULT_NO_STANDING_PRIORITY_PATH);
+  const priorityCache = readJsonFn(priorityCachePath);
+  const router = readJsonFn(routerPath);
+  const noStandingPriority = readJsonFn(noStandingPriorityPath);
+  const resolvedConstraint = resolveConstraint({ noStandingPriority, router });
+  const explicitConstraintReason = normalizeText(snapshot.constraintReason);
+  const constraintReason = explicitConstraintReason || resolvedConstraint.reason;
+  const status = availableAgents <= 0 ? 'not-applicable' : constraintReason ? 'constrained' : resolvedConstraint.status;
+
+  return {
+    schema: REPORT_SCHEMA,
+    generatedAt: now.toISOString(),
+    owner,
+    mode,
+    targetSaturation,
+    acceptableBand: {
+      min: normalizeRatio(band.min),
+      max: normalizeRatio(band.max)
+    },
+    measurementWindow: normalizeText(options.measurementWindow) || normalizeText(snapshot.measurementWindow) || 'rolling-30m',
+    availableAgents,
+    observedAgents,
+    productiveAgents: counts.productive,
+    awaitingInstructionAgents: counts.awaitingInstruction,
+    doneAgents: counts.done,
+    stateCounts: counts,
+    weights: {
+      productive: STATE_WEIGHTS.productive,
+      awaitingInstruction: STATE_WEIGHTS['awaiting-instruction'],
+      done: STATE_WEIGHTS.done
+    },
+    weightedProductiveAgents,
+    rawOccupancy,
+    rollingSaturation: effectiveSaturation,
+    effectiveSaturation,
+    status,
+    constraintReason,
+    applicable: availableAgents > 0,
+    priorityRule: 'throughput-and-proof-quality-outrank-saturation',
+    countingRule: {
+      productive: 'distinct bounded work that materially advances the active rail or pre-validates the next bounded slice',
+      weights: {
+        productive: STATE_WEIGHTS.productive,
+        'awaiting-instruction': STATE_WEIGHTS['awaiting-instruction'],
+        done: STATE_WEIGHTS.done,
+        idle: STATE_WEIGHTS.idle,
+        blocked: STATE_WEIGHTS.blocked,
+        duplicate: STATE_WEIGHTS.duplicate,
+        'polling-only': STATE_WEIGHTS['polling-only'],
+        'speculative-churn': STATE_WEIGHTS['speculative-churn'],
+        other: STATE_WEIGHTS.other
+      },
+      excluded: ['idle', 'blocked', 'duplicate', 'polling-only', 'speculative-churn']
+    },
+    evidence: {
+      snapshotPath: toDisplayPath(repoRoot, path.resolve(repoRoot, options.snapshotPath || DEFAULT_SNAPSHOT_PATH)),
+      priorityCache: toDisplayPath(repoRoot, priorityCachePath),
+      router: toDisplayPath(repoRoot, routerPath),
+      noStandingPriority: toDisplayPath(repoRoot, noStandingPriorityPath)
+    },
+    notes: [
+      `Mode ${mode} uses target saturation ${targetSaturation}.`,
+      'Awaiting-instruction agents incur a partial penalty (0.25) instead of counting as fully productive.',
+      'Done agents count as fully non-productive for effective saturation.'
+    ].concat(Array.isArray(snapshot.notes) ? snapshot.notes.map((entry) => normalizeText(entry)).filter(Boolean) : []),
+    agents
+  };
+}
+
+export async function runBackgroundAgentSaturation(options = {}, deps = {}) {
+  const repoRoot = path.resolve(options.repoRoot || DEFAULT_REPO_ROOT);
+  const snapshotPath = path.resolve(repoRoot, options.snapshotPath || DEFAULT_SNAPSHOT_PATH);
+  const outputPath = path.resolve(repoRoot, options.outputPath || DEFAULT_OUTPUT_PATH);
+  const readJsonFn = deps.readJsonFn || readOptionalJson;
+  const writeJsonFn = deps.writeJsonFn || writeJson;
+  const now = deps.now || new Date();
+  const snapshot = readJsonFn(snapshotPath) || {};
+  const report = buildBackgroundAgentSaturationReport(snapshot, {
+    ...options,
+    repoRoot,
+    snapshotPath
+  }, {
+    ...deps,
+    now,
+    readJsonFn
+  });
+  const writtenPath = writeJsonFn(outputPath, report);
+  return { report, outputPath: writtenPath };
+}
+
+function printHelp() {
+  console.log('Usage: node tools/priority/background-agent-saturation.mjs [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --repo-root <path>            Repository root (default: current repo).');
+  console.log(`  --snapshot <path>             Agent-state snapshot path (default: ${DEFAULT_SNAPSHOT_PATH}).`);
+  console.log(`  --output <path>               Output handoff path (default: ${DEFAULT_OUTPUT_PATH}).`);
+  console.log('  --priority-cache <path>       Optional priority cache path.');
+  console.log('  --router <path>               Optional router path.');
+  console.log('  --no-standing-priority <path> Optional no-standing-priority path.');
+  console.log('  --owner <name>                Override report owner.');
+  console.log('  --mode <name>                 Saturation mode (conserve|balanced|aggressive|max-burn|custom).');
+  console.log('  --target-saturation <ratio>   Override target saturation.');
+  console.log('  --available-agents <count>    Override available background-agent count.');
+  console.log('  --measurement-window <text>   Override measurement window label.');
+  console.log('  -h, --help                    Show this help text.');
+}
+
+export async function main(argv = process.argv) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    console.error(`[background-agent-saturation] ${error.message}`);
+    printHelp();
+    return 1;
+  }
+
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  try {
+    const { report, outputPath } = await runBackgroundAgentSaturation(options);
+    console.log(
+      `[background-agent-saturation] wrote ${outputPath} (${report.status}, saturation=${report.effectiveSaturation})`
+    );
+    return 0;
+  } catch (error) {
+    console.error(`[background-agent-saturation] ${error.message}`);
+    return 1;
+  }
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main(process.argv)
+    .then((code) => {
+      if (code !== 0) {
+        process.exitCode = code;
+      }
+    })
+    .catch((error) => {
+      console.error(`[background-agent-saturation] ${error.message}`);
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1967
- Issue title: [workflow-policy]: penalize awaiting-instruction agents in background saturation KPI
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1967
- Standing priority at PR creation: Yes (#1967)
- Base branch: `develop`
- Head branch: `issue/origin-1967-workflow-policy-penalize-awaiting-instruction-agents-in-background-saturation-kpi`
- Template variant: `workflow-policy`
- Auto-close intent: `Closes #1967`

# Summary

This adds a checked-in Background-Agent Productive Saturation producer so the handoff KPI stops treating occupancy as a coarse binary.

The new receipt now:
- reads a runtime background-agent state snapshot
- applies explicit per-state weights
- penalizes `awaiting instruction` at `0.25`
- penalizes `done` at `0.0`
- records raw counts and weighted/effective saturation in the handoff artifact

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
  - no GitHub workflow behavior changed
  - added `priority:agent:saturation` as a repo-local handoff/KPI producer
- Check names, required-status contracts, or merge-queue behavior affected:
  - none
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
  - none
- Manual dispatch, comment command, or branch-protection effects:
  - none

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/background-agent-saturation.test.mjs tools/priority/__tests__/background-agent-saturation-schema.test.mjs`
  - `node tools/npm/run-script.mjs docs:manifest:validate`
  - `node tools/npm/run-script.mjs hooks:pre-commit`
  - `node tools/npm/run-script.mjs priority:agent:saturation`
  - `git diff --check`
- Contract, schema, or guard tests:
  - focused producer tests and schema validation for the new receipt
- Live workflow or dry-run evidence:
  - `tests/results/_agent/runtime/background-agent-state.json`
  - `tests/results/_agent/handoff/background-agent-saturation.json`

## Rollout and Rollback

- Rollout notes:
  - future turns can update `tests/results/_agent/runtime/background-agent-state.json` and regenerate the handoff receipt through `priority:agent:saturation`
- Rollback path:
  - revert the new producer, schemas, and package/docs wiring
- Residual risks:
  - the runtime snapshot is still authored by the active session; this PR formalizes the producer and weighting logic, not automatic agent-state capture from the host tool

## Reviewer Focus

- Please verify:
  - `awaiting instruction` counts as partially penalized rather than fully productive or fully done
  - the output receipt now carries both raw counts and weighted/effective saturation
  - queue-empty repos still report the KPI as constrained rather than inventing work
- Policy assumptions to double-check:
  - `0.25` is the right default penalty weight for `awaiting instruction`
- Follow-up issues or guardrails:
  - `#1967` is the weighting change itself
  - a later slice can automate runtime snapshot capture if we want this KPI produced without a session-authored snapshot

Closes #1967
