### PR TITLE
[ci]: update template pivot gate to consume current supported template proof authority (#1971)

### DIFF
--- a/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
+++ b/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
@@ -114,7 +114,10 @@ when needed, synthesizes authority from the latest supported template proof
 aligned to the canonical template head before projecting the local `.local.json`
 overlay. Local consumers such as
 `tools/priority/template-pivot-gate.mjs` must prefer that overlay when it is
-present.
+present. The pivot gate now treats that supported-proof authority as the source
+of truth for `templateDependency.version/ref`, so the gate consumes the current
+canonical template head instead of a static `v0.1.1` pin when the supported
+proof is aligned and healthy.
 
 Generate the report with:
 
@@ -219,6 +222,12 @@ The gate only reports `ready` when all of the following are true:
 - `tests/results/_agent/handoff/release-summary.json` is valid and its version
   matches `X.Y.Z-rc.N`
 - `tests/results/_agent/handoff/entrypoint-status.json` reports `status = pass`
+- `tests/results/_agent/promotion/template-agent-verification-report.local.json`
+  reports `authorityProjection.source = supported-template-proof`, proves
+  `supportedProofHeadSha = canonicalHeadSha`, and carries
+  `provenance.templateDependency.version/ref = canonicalHeadSha` for
+  `LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate` with the checked-in
+  `cookiecutterVersion`
 - the policy still requires a future agent, disallows operator steering, and
   requires precise session feedback at pivot time
 

--- a/docs/knowledgebase/Cookiecutter-Certification-Scaffolds.md
+++ b/docs/knowledgebase/Cookiecutter-Certification-Scaffolds.md
@@ -148,8 +148,10 @@ Hosted Ubuntu renders the pinned template dependency inside the tools image.
 Hosted Windows verifies the same pinned release host-native so the conveyor belt
 has both a container-backed render plane and a mirrored verification plane. A
 follow-on hosted verification job then emits the machine-readable template-agent
-verification report so downstream proving and the template pivot gate consume
-the same pinned dependency provenance.
+verification report so downstream proving can retain the pinned dependency
+provenance while the template pivot gate may instead consume the latest
+supported template proof aligned to the canonical template head through the
+local authoritative overlay.
 
 ## Natural Follow-Ons
 

--- a/docs/schemas/template-pivot-gate-policy-v1.schema.json
+++ b/docs/schemas/template-pivot-gate-policy-v1.schema.json
@@ -111,14 +111,20 @@
       "additionalProperties": false,
       "required": [
         "repository",
-        "version",
-        "ref",
-        "cookiecutterVersion"
+        "cookiecutterVersion",
+        "resolutionMode"
       ],
       "properties": {
         "repository": {
           "type": "string",
           "minLength": 1
+        },
+        "resolutionMode": {
+          "type": "string",
+          "enum": [
+            "pinned-template-dependency",
+            "supported-proof-authority"
+          ]
         },
         "version": {
           "type": "string",
@@ -131,8 +137,49 @@
         "cookiecutterVersion": {
           "type": "string",
           "minLength": 1
+        },
+        "requiredAuthoritySource": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requireCanonicalHeadAlignment": {
+          "type": "boolean"
+        },
+        "requiredExecutionPlane": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requiredLaneId": {
+          "type": "string",
+          "minLength": 1
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "version",
+            "ref"
+          ],
+          "properties": {
+            "resolutionMode": {
+              "const": "pinned-template-dependency"
+            }
+          }
+        },
+        {
+          "required": [
+            "requiredAuthoritySource",
+            "requireCanonicalHeadAlignment",
+            "requiredExecutionPlane",
+            "requiredLaneId"
+          ],
+          "properties": {
+            "resolutionMode": {
+              "const": "supported-proof-authority"
+            }
+          }
+        }
+      ]
     },
     "decision": {
       "type": "object",

--- a/docs/schemas/template-pivot-gate-report-v1.schema.json
+++ b/docs/schemas/template-pivot-gate-report-v1.schema.json
@@ -67,26 +67,43 @@
           "additionalProperties": false,
           "required": [
             "repository",
-            "version",
-            "ref",
-            "cookiecutterVersion"
+            "resolutionMode",
+            "cookiecutterVersion",
+            "requireCanonicalHeadAlignment"
           ],
           "properties": {
             "repository": {
               "type": "string",
               "minLength": 1
             },
-            "version": {
+            "resolutionMode": {
               "type": "string",
-              "minLength": 1
+              "enum": [
+                "pinned-template-dependency",
+                "supported-proof-authority"
+              ]
+            },
+            "version": {
+              "type": ["string", "null"]
             },
             "ref": {
-              "type": "string",
-              "minLength": 1
+              "type": ["string", "null"]
             },
             "cookiecutterVersion": {
               "type": "string",
               "minLength": 1
+            },
+            "requiredAuthoritySource": {
+              "type": ["string", "null"]
+            },
+            "requireCanonicalHeadAlignment": {
+              "type": ["boolean", "null"]
+            },
+            "requiredExecutionPlane": {
+              "type": ["string", "null"]
+            },
+            "requiredLaneId": {
+              "type": ["string", "null"]
             }
           }
         },
@@ -324,6 +341,7 @@
         "targetRepository",
         "consumerRailBranch",
         "templateDependency",
+        "authorityProjection",
         "execution",
         "ready"
       ],
@@ -355,6 +373,7 @@
           "additionalProperties": false,
           "required": [
             "repository",
+            "resolutionMode",
             "version",
             "ref",
             "cookiecutterVersion",
@@ -364,6 +383,9 @@
             "repository": {
               "type": ["string", "null"]
             },
+            "resolutionMode": {
+              "type": ["string", "null"]
+            },
             "version": {
               "type": ["string", "null"]
             },
@@ -371,6 +393,46 @@
               "type": ["string", "null"]
             },
             "cookiecutterVersion": {
+              "type": ["string", "null"]
+            },
+            "matchesPolicy": {
+              "type": "boolean"
+            }
+          }
+        },
+        "authorityProjection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "source",
+            "canonicalRepository",
+            "canonicalHeadSha",
+            "supportedRepository",
+            "supportedRole",
+            "supportedProofRunUrl",
+            "supportedProofHeadSha",
+            "matchesPolicy"
+          ],
+          "properties": {
+            "source": {
+              "type": ["string", "null"]
+            },
+            "canonicalRepository": {
+              "type": ["string", "null"]
+            },
+            "canonicalHeadSha": {
+              "type": ["string", "null"]
+            },
+            "supportedRepository": {
+              "type": ["string", "null"]
+            },
+            "supportedRole": {
+              "type": ["string", "null"]
+            },
+            "supportedProofRunUrl": {
+              "type": ["string", "null"]
+            },
+            "supportedProofHeadSha": {
               "type": ["string", "null"]
             },
             "matchesPolicy": {
@@ -388,7 +450,8 @@
             "laneId",
             "agentId",
             "fundingWindowId",
-            "complete"
+            "complete",
+            "matchesPolicy"
           ],
           "properties": {
             "executionPlane": {
@@ -410,6 +473,9 @@
               "type": ["string", "null"]
             },
             "complete": {
+              "type": "boolean"
+            },
+            "matchesPolicy": {
               "type": "boolean"
             }
           }

--- a/tools/policy/template-pivot-gate.json
+++ b/tools/policy/template-pivot-gate.json
@@ -6,9 +6,12 @@
   "targetBranch": "develop",
   "templateDependency": {
     "repository": "LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate",
-    "version": "v0.1.1",
-    "ref": "v0.1.1",
-    "cookiecutterVersion": "2.7.1"
+    "resolutionMode": "supported-proof-authority",
+    "cookiecutterVersion": "2.7.1",
+    "requiredAuthoritySource": "supported-template-proof",
+    "requireCanonicalHeadAlignment": true,
+    "requiredExecutionPlane": "hosted-github-actions",
+    "requiredLaneId": "supported-template-proof"
   },
   "queueEmpty": {
     "requiredSchema": "standing-priority/no-standing@v1",

--- a/tools/priority/__tests__/template-pivot-gate-schema.test.mjs
+++ b/tools/priority/__tests__/template-pivot-gate-schema.test.mjs
@@ -34,9 +34,12 @@ test('template pivot gate report matches the checked-in schema', async () => {
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.1',
-      ref: 'v0.1.1',
-      cookiecutterVersion: '2.7.1'
+      resolutionMode: 'supported-proof-authority',
+      cookiecutterVersion: '2.7.1',
+      requiredAuthoritySource: 'supported-template-proof',
+      requireCanonicalHeadAlignment: true,
+      requiredExecutionPlane: 'hosted-github-actions',
+      requiredLaneId: 'supported-template-proof'
     },
     queueEmpty: {
       requiredSchema: 'standing-priority/no-standing@v1',
@@ -148,18 +151,27 @@ test('template pivot gate report matches the checked-in schema', async () => {
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.1',
-        ref: 'v0.1.1',
+        version: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+        ref: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
-        executionPlane: 'linux-tools-image',
-        containerImage: 'ghcr.io/labview-community-ci-cd/comparevi-tools:v0.1.0',
-        generatedConsumerWorkspaceRoot: 'E:\\comparevi-template-consumers\\run-1',
-        laneId: 'lane-template-verify',
-        agentId: 'darwin',
-        fundingWindowId: 'HQ1VJLMV-0027'
+        executionPlane: 'hosted-github-actions',
+        containerImage: null,
+        generatedConsumerWorkspaceRoot: null,
+        laneId: 'supported-template-proof',
+        agentId: 'compare-monitoring-mode',
+        fundingWindowId: null
       }
+    },
+    authorityProjection: {
+      source: 'supported-template-proof',
+      supportedRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork',
+      supportedRole: 'org-consumer-fork',
+      canonicalRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      canonicalHeadSha: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+      supportedProofRunUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork/actions/runs/23567964307',
+      supportedProofHeadSha: 'c3ae46c2b0a02b514b4b08d426302953a87243bc'
     },
     goals: {
       maxVerificationLagIterations: 1,

--- a/tools/priority/__tests__/template-pivot-gate.test.mjs
+++ b/tools/priority/__tests__/template-pivot-gate.test.mjs
@@ -417,9 +417,12 @@ test('runTemplatePivotGate prefers a local authoritative template verification o
     targetBranch: 'develop',
     templateDependency: {
       repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-      version: 'v0.1.1',
-      ref: 'v0.1.1',
-      cookiecutterVersion: '2.7.1'
+      resolutionMode: 'supported-proof-authority',
+      cookiecutterVersion: '2.7.1',
+      requiredAuthoritySource: 'supported-template-proof',
+      requireCanonicalHeadAlignment: true,
+      requiredExecutionPlane: 'hosted-github-actions',
+      requiredLaneId: 'supported-template-proof'
     },
     queueEmpty: {
       requiredSchema: 'standing-priority/no-standing@v1',
@@ -563,18 +566,27 @@ test('runTemplatePivotGate prefers a local authoritative template verification o
     provenance: {
       templateDependency: {
         repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
-        version: 'v0.1.1',
-        ref: 'v0.1.1',
+        version: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+        ref: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
         cookiecutterVersion: '2.7.1'
       },
       execution: {
-        executionPlane: 'linux-tools-image',
-        containerImage: 'ghcr.io/labview-community-ci-cd/comparevi-tools:v0.1.0',
-        generatedConsumerWorkspaceRoot: 'E:\\comparevi-template-consumers\\run-1',
-        laneId: 'lane-template-verify',
-        agentId: 'darwin',
-        fundingWindowId: 'HQ1VJLMV-0027'
+        executionPlane: 'hosted-github-actions',
+        containerImage: null,
+        generatedConsumerWorkspaceRoot: null,
+        laneId: 'supported-template-proof',
+        agentId: 'compare-monitoring-mode',
+        fundingWindowId: null
       }
+    },
+    authorityProjection: {
+      source: 'supported-template-proof',
+      supportedRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork',
+      supportedRole: 'org-consumer-fork',
+      canonicalRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      canonicalHeadSha: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+      supportedProofRunUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork/actions/runs/23567964307',
+      supportedProofHeadSha: 'c3ae46c2b0a02b514b4b08d426302953a87243bc'
     },
     goals: {},
     metrics: {
@@ -606,6 +618,11 @@ test('runTemplatePivotGate prefers a local authoritative template verification o
   assert.equal(report.summary.status, 'ready');
   assert.equal(report.inputs.templateAgentVerificationReportPath, path.relative(process.cwd(), templateAgentVerificationLocalReportPath).replace(/\\/g, '/'));
   assert.equal(report.evidence.templateAgentVerification.summaryStatus, 'pass');
+  assert.equal(report.policy.templateDependency.resolutionMode, 'supported-proof-authority');
+  assert.equal(report.evidence.templateAgentVerification.templateDependency.matchesPolicy, true);
+  assert.equal(report.evidence.templateAgentVerification.authorityProjection.matchesPolicy, true);
+  assert.equal(report.evidence.templateAgentVerification.execution.complete, false);
+  assert.equal(report.evidence.templateAgentVerification.execution.matchesPolicy, true);
 });
 
 test('runTemplatePivotGate fails closed when the queue is not proven empty or release is not an rc build', async () => {
@@ -886,6 +903,200 @@ test('runTemplatePivotGate blocks when template-agent verification is present bu
   assert.equal(report.summary.status, 'blocked');
   assert.ok(report.summary.blockers.some((entry) => entry.code === 'template-agent-verification-not-pass'));
   assert.equal(report.evidence.templateAgentVerification.summaryStatus, 'blocked');
+  assert.equal(report.evidence.templateAgentVerification.ready, false);
+});
+
+test('runTemplatePivotGate fails closed when supported proof drifts away from the canonical template head', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-pivot-gate-supported-proof-drift-'));
+  const policyPath = path.join(tmpDir, 'template-pivot-gate.json');
+  const queueEmptyReportPath = path.join(tmpDir, 'no-standing-priority.json');
+  const releaseSummaryPath = path.join(tmpDir, 'release-summary.json');
+  const handoffEntrypointStatusPath = path.join(tmpDir, 'entrypoint-status.json');
+  const templateAgentVerificationReportPath = path.join(tmpDir, 'template-agent-verification-report.local.json');
+  const outputPath = path.join(tmpDir, 'template-pivot-gate-report.json');
+
+  writeJson(policyPath, {
+    schema: 'priority/template-pivot-gate-policy@v1',
+    schemaVersion: '1.0.0',
+    sourceRepository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+    targetBranch: 'develop',
+    templateDependency: {
+      repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      resolutionMode: 'supported-proof-authority',
+      cookiecutterVersion: '2.7.1',
+      requiredAuthoritySource: 'supported-template-proof',
+      requireCanonicalHeadAlignment: true,
+      requiredExecutionPlane: 'hosted-github-actions',
+      requiredLaneId: 'supported-template-proof'
+    },
+    queueEmpty: {
+      requiredSchema: 'standing-priority/no-standing@v1',
+      requiredReason: 'queue-empty',
+      requiredOpenIssueCount: 0
+    },
+    releaseCandidate: {
+      requiredSchema: 'agent-handoff/release-v1',
+      requireValid: true,
+      versionPattern: '^\\d+\\.\\d+\\.\\d+-rc\\.\\d+$',
+      versionPatternDescription: 'X.Y.Z-rc.N'
+    },
+    handoffEntrypoint: {
+      requiredSchema: 'agent-handoff/entrypoint-status-v1',
+      requiredStatus: 'pass'
+    },
+    decision: {
+      futureAgentOnly: true,
+      operatorSteeringAllowed: false,
+      requirePreciseSessionFeedback: true
+    },
+    artifacts: {
+      policySchema: 'docs/schemas/template-pivot-gate-policy-v1.schema.json',
+      reportSchema: 'docs/schemas/template-pivot-gate-report-v1.schema.json',
+      defaultOutputPath: outputPath,
+      queueEmptyReportPath,
+      releaseSummaryPath,
+      handoffEntrypointStatusPath,
+      templateAgentVerificationReportPath
+    }
+  });
+  writeJson(queueEmptyReportPath, {
+    schema: 'standing-priority/no-standing@v1',
+    message: 'queue empty',
+    reason: 'queue-empty',
+    openIssueCount: 0
+  });
+  writeJson(releaseSummaryPath, {
+    schema: 'agent-handoff/release-v1',
+    version: '0.6.4-rc.2',
+    valid: true,
+    issues: [],
+    checkedAt: '2026-03-25T23:00:00.000Z'
+  });
+  writeJson(handoffEntrypointStatusPath, {
+    schema: 'agent-handoff/entrypoint-status-v1',
+    generatedAt: '2026-03-25T23:01:00.000Z',
+    handoffPath: 'AGENT_HANDOFF.txt',
+    maxLines: 80,
+    actualLineCount: 42,
+    status: 'pass',
+    checks: {
+      primaryHeading: true,
+      lineBudget: true,
+      requiredHeadings: true,
+      liveArtifactGuidance: true,
+      stableEntrypointGuidance: true,
+      noStatusLogGuidance: true,
+      machineGeneratedArtifactGuidance: true,
+      noDatedHistorySections: true
+    },
+    commands: {
+      bootstrap: 'pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1',
+      standingPriority: 'pwsh -NoLogo -NoProfile -File tools/Get-StandingPriority.ps1 -Plain',
+      printHandoff: 'pwsh -NoLogo -NoProfile -File tools/Print-AgentHandoff.ps1 -ApplyToggles',
+      projectPortfolio: 'node tools/npm/run-script.mjs priority:project:portfolio:check',
+      developSync: 'node tools/npm/run-script.mjs priority:develop:sync'
+    },
+    artifacts: {
+      priorityCache: '.agent_priority_cache.json',
+      router: 'tests/results/_agent/issue/router.json',
+      noStandingPriority: 'tests/results/_agent/issue/no-standing-priority.json',
+      dockerReviewLoopSummary: 'tests/results/_agent/verification/docker-review-loop-summary.json',
+      entrypointStatus: 'tests/results/_agent/handoff/entrypoint-status.json',
+      handoffGlob: 'tests/results/_agent/handoff/*.json',
+      sessionGlob: 'tests/results/_agent/sessions/*.json'
+    },
+    violations: []
+  });
+  writeJson(templateAgentVerificationReportPath, {
+    schema: 'priority/template-agent-verification-report@v1',
+    generatedAt: '2026-03-25T23:02:00.000Z',
+    repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+    summary: {
+      status: 'pass',
+      blockerCount: 0,
+      recommendation: 'continue-template-agent-loop'
+    },
+    iteration: {
+      label: 'supported template proof for compare 64620ee1',
+      ref: 'develop:64620ee1',
+      headSha: '64620ee1a3e510cec7322a5e6f30c2d54dc55b7a'
+    },
+    lane: {
+      enabled: true,
+      reservedSlotCount: 1,
+      minimumImplementationSlots: 3,
+      implementationSlotsRemaining: 19,
+      executionMode: 'hosted-first',
+      targetRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      consumerRailBranch: 'downstream/develop'
+    },
+    verification: {
+      provider: 'hosted-github-workflow',
+      status: 'pass',
+      durationSeconds: null,
+      runUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork/actions/runs/23567964307'
+    },
+    provenance: {
+      templateDependency: {
+        repository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+        version: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+        ref: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+        cookiecutterVersion: '2.7.1'
+      },
+      execution: {
+        executionPlane: 'hosted-github-actions',
+        containerImage: null,
+        generatedConsumerWorkspaceRoot: null,
+        laneId: 'supported-template-proof',
+        agentId: 'compare-monitoring-mode',
+        fundingWindowId: null
+      }
+    },
+    authorityProjection: {
+      source: 'supported-template-proof',
+      supportedRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork',
+      supportedRole: 'org-consumer-fork',
+      canonicalRepository: 'LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate',
+      canonicalHeadSha: 'c3ae46c2b0a02b514b4b08d426302953a87243bc',
+      supportedProofRunUrl: 'https://github.com/LabVIEW-Community-CI-CD/LabviewGitHubCiTemplate-fork/actions/runs/23567964307',
+      supportedProofHeadSha: '5f474549d23debfdfd0782efc0b2e77ed76358bf'
+    },
+    goals: {
+      maxVerificationLagIterations: 1,
+      maxHostedDurationMinutes: 30,
+      requireMachineReadableRecommendation: true
+    },
+    metrics: {
+      targetSlotCount: 20,
+      reservedSlotCount: 1,
+      implementationSlotsRemaining: 19,
+      durationWithinGoal: null,
+      recommendationPresent: true
+    },
+    blockers: []
+  });
+
+  const { report } = await runTemplatePivotGate(
+    {
+      policyPath,
+      queueEmptyReportPath,
+      releaseSummaryPath,
+      handoffEntrypointStatusPath,
+      templateAgentVerificationReportPath,
+      outputPath,
+      repo: 'LabVIEW-Community-CI-CD/compare-vi-cli-action'
+    },
+    {
+      resolveRepoSlugFn: (value) => value
+    }
+  );
+
+  assert.equal(report.summary.status, 'blocked');
+  assert.ok(
+    report.summary.blockers.some((entry) => entry.code === 'template-dependency-supported-proof-head-mismatch')
+  );
+  assert.equal(report.evidence.templateAgentVerification.authorityProjection.matchesPolicy, false);
   assert.equal(report.evidence.templateAgentVerification.ready, false);
 });
 

--- a/tools/priority/template-pivot-gate.mjs
+++ b/tools/priority/template-pivot-gate.mjs
@@ -155,16 +155,52 @@ function resolvePreferredTemplateAgentVerificationReportPath(filePath) {
 }
 
 function normalizeTemplateDependency(value) {
+  const resolutionMode =
+    asOptional(value?.resolutionMode) ||
+    (asOptional(value?.version) && asOptional(value?.ref) ? 'pinned-template-dependency' : null);
   return {
     repository: asOptional(value?.repository),
+    resolutionMode,
     version: asOptional(value?.version),
     ref: asOptional(value?.ref),
-    cookiecutterVersion: asOptional(value?.cookiecutterVersion)
+    cookiecutterVersion: asOptional(value?.cookiecutterVersion),
+    requiredAuthoritySource: asOptional(value?.requiredAuthoritySource),
+    requireCanonicalHeadAlignment:
+      typeof value?.requireCanonicalHeadAlignment === 'boolean' ? value.requireCanonicalHeadAlignment : null,
+    requiredExecutionPlane: asOptional(value?.requiredExecutionPlane),
+    requiredLaneId: asOptional(value?.requiredLaneId)
   };
 }
 
 function allFieldsPresent(object, fields) {
   return fields.every((field) => asOptional(object?.[field]) != null);
+}
+
+function evaluateTemplateDependencyPolicyReadiness(policyTemplateDependency) {
+  if (policyTemplateDependency.resolutionMode === 'pinned-template-dependency') {
+    return allFieldsPresent(policyTemplateDependency, [
+      'repository',
+      'resolutionMode',
+      'version',
+      'ref',
+      'cookiecutterVersion'
+    ]);
+  }
+
+  if (policyTemplateDependency.resolutionMode === 'supported-proof-authority') {
+    return (
+      allFieldsPresent(policyTemplateDependency, [
+        'repository',
+        'resolutionMode',
+        'cookiecutterVersion',
+        'requiredAuthoritySource',
+        'requiredExecutionPlane',
+        'requiredLaneId'
+      ]) && typeof policyTemplateDependency.requireCanonicalHeadAlignment === 'boolean'
+    );
+  }
+
+  return false;
 }
 
 export function parseArgs(argv = process.argv) {
@@ -264,11 +300,19 @@ export async function runTemplatePivotGate(
   const blockers = [];
   const releaseCandidateRegex = new RegExp(policy.releaseCandidate.versionPattern);
   const policyTemplateDependency = normalizeTemplateDependency(policy.templateDependency);
-  const templateDependencyFields = ['repository', 'version', 'ref', 'cookiecutterVersion'];
-  const templateDependencyPolicyReady = allFieldsPresent(policyTemplateDependency, templateDependencyFields);
+  const templateDependencyPolicyReady = evaluateTemplateDependencyPolicyReadiness(policyTemplateDependency);
   const templateAgentVerificationTemplateDependency = normalizeTemplateDependency(
     templateAgentVerification?.provenance?.templateDependency
   );
+  const templateAgentVerificationAuthorityProjection = {
+    source: asOptional(templateAgentVerification?.authorityProjection?.source),
+    canonicalRepository: asOptional(templateAgentVerification?.authorityProjection?.canonicalRepository),
+    canonicalHeadSha: asOptional(templateAgentVerification?.authorityProjection?.canonicalHeadSha),
+    supportedRepository: asOptional(templateAgentVerification?.authorityProjection?.supportedRepository),
+    supportedRole: asOptional(templateAgentVerification?.authorityProjection?.supportedRole),
+    supportedProofRunUrl: asOptional(templateAgentVerification?.authorityProjection?.supportedProofRunUrl),
+    supportedProofHeadSha: asOptional(templateAgentVerification?.authorityProjection?.supportedProofHeadSha)
+  };
   const templateAgentVerificationExecution = {
     executionPlane: asOptional(templateAgentVerification?.provenance?.execution?.executionPlane),
     containerImage: asOptional(templateAgentVerification?.provenance?.execution?.containerImage),
@@ -287,11 +331,32 @@ export async function runTemplatePivotGate(
     'agentId',
     'fundingWindowId'
   ]);
+  const templateAgentVerificationExecutionMatchesPolicy =
+    policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+      ? templateAgentVerificationExecution.executionPlane === policyTemplateDependency.requiredExecutionPlane &&
+        templateAgentVerificationExecution.laneId === policyTemplateDependency.requiredLaneId
+      : templateAgentVerificationExecutionReady;
   const templateAgentVerificationTemplateDependencyReady =
     templateDependencyPolicyReady &&
-    templateDependencyFields.every(
-      (field) => templateAgentVerificationTemplateDependency[field] === policyTemplateDependency[field]
-    );
+    (policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+      ? templateAgentVerificationTemplateDependency.repository === policyTemplateDependency.repository &&
+        templateAgentVerificationTemplateDependency.cookiecutterVersion ===
+          policyTemplateDependency.cookiecutterVersion &&
+        templateAgentVerificationAuthorityProjection.source === policyTemplateDependency.requiredAuthoritySource &&
+        templateAgentVerificationAuthorityProjection.canonicalRepository === policyTemplateDependency.repository &&
+        asOptional(templateAgentVerificationAuthorityProjection.canonicalHeadSha) != null &&
+        templateAgentVerificationTemplateDependency.version === templateAgentVerificationAuthorityProjection.canonicalHeadSha &&
+        templateAgentVerificationTemplateDependency.ref === templateAgentVerificationAuthorityProjection.canonicalHeadSha &&
+        asOptional(templateAgentVerificationAuthorityProjection.supportedProofRunUrl) != null &&
+        (!policyTemplateDependency.requireCanonicalHeadAlignment ||
+          (asOptional(templateAgentVerificationAuthorityProjection.supportedProofHeadSha) != null &&
+            templateAgentVerificationAuthorityProjection.supportedProofHeadSha ===
+              templateAgentVerificationAuthorityProjection.canonicalHeadSha))
+      : templateAgentVerificationTemplateDependency.repository === policyTemplateDependency.repository &&
+        templateAgentVerificationTemplateDependency.version === policyTemplateDependency.version &&
+        templateAgentVerificationTemplateDependency.ref === policyTemplateDependency.ref &&
+        templateAgentVerificationTemplateDependency.cookiecutterVersion ===
+          policyTemplateDependency.cookiecutterVersion);
 
   const queueEmptyReady =
     queueEmpty?.schema === policy.queueEmpty.requiredSchema && queueEmpty?.reason === policy.queueEmpty.requiredReason;
@@ -385,7 +450,7 @@ export async function runTemplatePivotGate(
     templateAgentVerification?.verification?.status === 'pass' &&
     asOptional(templateAgentVerification?.lane?.targetRepository) === targetRepository &&
     templateAgentVerificationTemplateDependencyReady &&
-    templateAgentVerificationExecutionReady;
+    templateAgentVerificationExecutionMatchesPolicy;
   if (!templateAgentVerification) {
     blockers.push(
       createBlocker(
@@ -427,7 +492,7 @@ export async function runTemplatePivotGate(
     blockers.push(
       createBlocker(
         'template-dependency-policy-missing',
-        'Template pivot gate policy must pin the template dependency repository, version, ref, and cookiecutter version.'
+        'Template pivot gate policy must define either a pinned template dependency or a supported-proof authority contract.'
       )
     );
   } else if (templateAgentVerificationTemplateDependency.repository !== policyTemplateDependency.repository) {
@@ -436,24 +501,6 @@ export async function runTemplatePivotGate(
         'template-dependency-repository-mismatch',
         `Template dependency repository must be ${policyTemplateDependency.repository}; received ${
           templateAgentVerificationTemplateDependency.repository ?? 'null'
-        }.`
-      )
-    );
-  } else if (templateAgentVerificationTemplateDependency.version !== policyTemplateDependency.version) {
-    blockers.push(
-      createBlocker(
-        'template-dependency-version-mismatch',
-        `Template dependency version must be ${policyTemplateDependency.version}; received ${
-          templateAgentVerificationTemplateDependency.version ?? 'null'
-        }.`
-      )
-    );
-  } else if (templateAgentVerificationTemplateDependency.ref !== policyTemplateDependency.ref) {
-    blockers.push(
-      createBlocker(
-        'template-dependency-ref-mismatch',
-        `Template dependency ref must be ${policyTemplateDependency.ref}; received ${
-          templateAgentVerificationTemplateDependency.ref ?? 'null'
         }.`
       )
     );
@@ -468,11 +515,100 @@ export async function runTemplatePivotGate(
         }.`
       )
     );
-  } else if (!templateAgentVerificationExecutionReady) {
+  } else if (
+    policyTemplateDependency.resolutionMode === 'supported-proof-authority' &&
+    templateAgentVerificationAuthorityProjection.source !== policyTemplateDependency.requiredAuthoritySource
+  ) {
     blockers.push(
       createBlocker(
-        'template-agent-execution-provenance-incomplete',
-        'Template-agent verification report must include execution-plane, container-image, consumer-workspace-root, lane-id, agent-id, and funding-window provenance.'
+        'template-dependency-authority-source-mismatch',
+        `Template dependency authority source must be ${policyTemplateDependency.requiredAuthoritySource}; received ${
+          templateAgentVerificationAuthorityProjection.source ?? 'null'
+        }.`
+      )
+    );
+  } else if (
+    policyTemplateDependency.resolutionMode === 'supported-proof-authority' &&
+    templateAgentVerificationAuthorityProjection.canonicalRepository !== policyTemplateDependency.repository
+  ) {
+    blockers.push(
+      createBlocker(
+        'template-dependency-canonical-repository-mismatch',
+        `Template dependency canonical repository must be ${policyTemplateDependency.repository}; received ${
+          templateAgentVerificationAuthorityProjection.canonicalRepository ?? 'null'
+        }.`
+      )
+    );
+  } else if (
+    policyTemplateDependency.resolutionMode === 'supported-proof-authority' &&
+    !templateAgentVerificationAuthorityProjection.canonicalHeadSha
+  ) {
+    blockers.push(
+      createBlocker(
+        'template-dependency-canonical-head-missing',
+        'Template dependency canonical head SHA must be present when the pivot gate consumes supported proof authority.'
+      )
+    );
+  } else if (
+    (policyTemplateDependency.resolutionMode === 'supported-proof-authority' &&
+      templateAgentVerificationTemplateDependency.version !==
+        templateAgentVerificationAuthorityProjection.canonicalHeadSha) ||
+    (policyTemplateDependency.resolutionMode !== 'supported-proof-authority' &&
+      templateAgentVerificationTemplateDependency.version !== policyTemplateDependency.version)
+  ) {
+    blockers.push(
+      createBlocker(
+        'template-dependency-version-mismatch',
+        policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+          ? `Template dependency version must match the canonical template head ${templateAgentVerificationAuthorityProjection.canonicalHeadSha ?? 'null'}; received ${
+              templateAgentVerificationTemplateDependency.version ?? 'null'
+            }.`
+          : `Template dependency version must be ${policyTemplateDependency.version}; received ${
+              templateAgentVerificationTemplateDependency.version ?? 'null'
+            }.`
+      )
+    );
+  } else if (
+    (policyTemplateDependency.resolutionMode === 'supported-proof-authority' &&
+      templateAgentVerificationTemplateDependency.ref !== templateAgentVerificationAuthorityProjection.canonicalHeadSha) ||
+    (policyTemplateDependency.resolutionMode !== 'supported-proof-authority' &&
+      templateAgentVerificationTemplateDependency.ref !== policyTemplateDependency.ref)
+  ) {
+    blockers.push(
+      createBlocker(
+        'template-dependency-ref-mismatch',
+        policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+          ? `Template dependency ref must match the canonical template head ${templateAgentVerificationAuthorityProjection.canonicalHeadSha ?? 'null'}; received ${
+              templateAgentVerificationTemplateDependency.ref ?? 'null'
+            }.`
+          : `Template dependency ref must be ${policyTemplateDependency.ref}; received ${
+              templateAgentVerificationTemplateDependency.ref ?? 'null'
+            }.`
+      )
+    );
+  } else if (
+    policyTemplateDependency.resolutionMode === 'supported-proof-authority' &&
+    policyTemplateDependency.requireCanonicalHeadAlignment &&
+    templateAgentVerificationAuthorityProjection.supportedProofHeadSha !==
+      templateAgentVerificationAuthorityProjection.canonicalHeadSha
+  ) {
+    blockers.push(
+      createBlocker(
+        'template-dependency-supported-proof-head-mismatch',
+        `Supported proof head must match the canonical template head ${
+          templateAgentVerificationAuthorityProjection.canonicalHeadSha ?? 'null'
+        }; received ${templateAgentVerificationAuthorityProjection.supportedProofHeadSha ?? 'null'}.`
+      )
+    );
+  } else if (!templateAgentVerificationExecutionMatchesPolicy) {
+    blockers.push(
+      createBlocker(
+        policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+          ? 'template-agent-execution-policy-mismatch'
+          : 'template-agent-execution-provenance-incomplete',
+        policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+          ? `Template-agent verification execution must report executionPlane=${policyTemplateDependency.requiredExecutionPlane} and laneId=${policyTemplateDependency.requiredLaneId}.`
+          : 'Template-agent verification report must include execution-plane, container-image, consumer-workspace-root, lane-id, agent-id, and funding-window provenance.'
       )
     );
   }
@@ -491,9 +627,14 @@ export async function runTemplatePivotGate(
       requirePreciseSessionFeedback: policy.decision.requirePreciseSessionFeedback,
       templateDependency: {
         repository: policyTemplateDependency.repository,
+        resolutionMode: policyTemplateDependency.resolutionMode,
         version: policyTemplateDependency.version,
         ref: policyTemplateDependency.ref,
-        cookiecutterVersion: policyTemplateDependency.cookiecutterVersion
+        cookiecutterVersion: policyTemplateDependency.cookiecutterVersion,
+        requiredAuthoritySource: policyTemplateDependency.requiredAuthoritySource,
+        requireCanonicalHeadAlignment: policyTemplateDependency.requireCanonicalHeadAlignment,
+        requiredExecutionPlane: policyTemplateDependency.requiredExecutionPlane,
+        requiredLaneId: policyTemplateDependency.requiredLaneId
       },
       releaseCandidateVersionPattern: policy.releaseCandidate.versionPattern,
       releaseCandidateVersionPatternDescription: policy.releaseCandidate.versionPatternDescription
@@ -539,10 +680,24 @@ export async function runTemplatePivotGate(
         consumerRailBranch: asOptional(templateAgentVerification?.lane?.consumerRailBranch),
         templateDependency: {
           repository: templateAgentVerificationTemplateDependency.repository,
+          resolutionMode: policyTemplateDependency.resolutionMode,
           version: templateAgentVerificationTemplateDependency.version,
           ref: templateAgentVerificationTemplateDependency.ref,
           cookiecutterVersion: templateAgentVerificationTemplateDependency.cookiecutterVersion,
           matchesPolicy: templateAgentVerificationTemplateDependencyReady
+        },
+        authorityProjection: {
+          source: templateAgentVerificationAuthorityProjection.source,
+          canonicalRepository: templateAgentVerificationAuthorityProjection.canonicalRepository,
+          canonicalHeadSha: templateAgentVerificationAuthorityProjection.canonicalHeadSha,
+          supportedRepository: templateAgentVerificationAuthorityProjection.supportedRepository,
+          supportedRole: templateAgentVerificationAuthorityProjection.supportedRole,
+          supportedProofRunUrl: templateAgentVerificationAuthorityProjection.supportedProofRunUrl,
+          supportedProofHeadSha: templateAgentVerificationAuthorityProjection.supportedProofHeadSha,
+          matchesPolicy:
+            policyTemplateDependency.resolutionMode === 'supported-proof-authority'
+              ? templateAgentVerificationTemplateDependencyReady
+              : true
         },
         execution: {
           executionPlane: templateAgentVerificationExecution.executionPlane,
@@ -551,7 +706,8 @@ export async function runTemplatePivotGate(
           laneId: templateAgentVerificationExecution.laneId,
           agentId: templateAgentVerificationExecution.agentId,
           fundingWindowId: templateAgentVerificationExecution.fundingWindowId,
-          complete: templateAgentVerificationExecutionReady
+          complete: templateAgentVerificationExecutionReady,
+          matchesPolicy: templateAgentVerificationExecutionMatchesPolicy
         },
         ready: templateAgentVerificationReady
       }


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #1971
- Issue title: [ci]: update template pivot gate to consume current supported template proof authority
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/1971
- Standing priority at PR creation: Yes (#1971)
- Base branch: `develop`
- Head branch: `issue/origin-1971-ci-update-template-pivot-gate-to-consume-current-supported-template-proof-authority`
- Template variant: `workflow-policy`
- Auto-close intent: add `Closes #...` manually only when merge should resolve the linked issue.

# Summary

Describe the workflow, policy, or governance outcome and the operator-facing reason for the change.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
- Check names, required-status contracts, or merge-queue behavior affected:
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
- Manual dispatch, comment command, or branch-protection effects:

## Validation Evidence

- Commands run:
  - `./bin/actionlint -color`
- Contract, schema, or guard tests:
  - `node --test ...`
- Live workflow or dry-run evidence:
  - `tests/results/...`

## Rollout and Rollback

- Rollout notes:
- Rollback path:
- Residual risks:

## Reviewer Focus

- Please verify:
- Policy assumptions to double-check:
- Follow-up issues or guardrails:
