### PR TITLE
[ci]: repair LV32 host-plane report capture for #1974

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1908,9 +1908,10 @@ jobs:
       run: |
         $resultsRoot = Join-Path $env:GITHUB_WORKSPACE 'tests/results/local-parity/windows/lv32-shadow-proof'
         New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
-        $reportPath = node tools/npm/run-script.mjs env:labview:2026:host-planes
-        if ([string]::IsNullOrWhiteSpace($reportPath)) {
-          throw 'env:labview:2026:host-planes did not return a host-plane report path.'
+        $reportPath = Join-Path $env:GITHUB_WORKSPACE 'tests/results/_agent/host-planes/labview-2026-host-plane-report.json'
+        pwsh -NoLogo -NoProfile -File tools/Write-LabVIEW2026HostPlaneDiagnostics.ps1 -OutputPath $reportPath | Out-Null
+        if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+          throw ("LabVIEW 2026 host-plane diagnostics report was not written to {0}" -f $reportPath)
         }
         $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -Depth 12
         if ($report.native.planes.x32.status -ne 'ready') {

--- a/tools/priority/__tests__/docker-labview-path-contract.test.mjs
+++ b/tools/priority/__tests__/docker-labview-path-contract.test.mjs
@@ -37,7 +37,8 @@ test('validate workflow pins explicit LabVIEW paths for hosted Linux and Windows
   assert.match(workflow, /vi-history-scenarios-windows-lv32:/);
   assert.match(workflow, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress, labview-2026, lv32\]/);
   assert.match(workflow, /Assert-RunnerLabelContract\.ps1/);
-  assert.match(workflow, /env:labview:2026:host-planes/);
+  assert.match(workflow, /Write-LabVIEW2026HostPlaneDiagnostics\.ps1/);
+  assert.match(workflow, /-OutputPath \$reportPath/);
   assert.match(workflow, /Compare-VIHistory\.ps1/);
   assert.match(workflow, /Invoke-LVCompare\.ps1/);
   assert.match(workflow, /Write-VIHistoryLV32ShadowProofReceipt\.ps1/);

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -110,7 +110,8 @@ test('validate workflow self-hosted Windows LV32 VI-history lane is gated by inv
   assert.match(lv32Section, /GITHUB_TOKEN:\s+\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
   assert.match(lv32Section, /GH_TOKEN:\s+\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
   assert.match(lv32Section, /Capture LabVIEW 2026 host-plane diagnostics/);
-  assert.match(lv32Section, /env:labview:2026:host-planes/);
+  assert.match(lv32Section, /Write-LabVIEW2026HostPlaneDiagnostics\.ps1/);
+  assert.match(lv32Section, /-OutputPath \$reportPath/);
   assert.match(lv32Section, /Run VI history shadow proof on the self-hosted LV32 runner/);
   assert.match(lv32Section, /Compare-VIHistory\.ps1/);
   assert.match(lv32Section, /Invoke-LVCompare\.ps1/);


### PR DESCRIPTION
## Summary
- repair the LV32 host-plane diagnostics step to write to a known report path instead of capturing stdout from `run-script.mjs`
- keep the existing LV32 runner selection and label-contract flow unchanged
- update the focused workflow contract tests to match the direct diagnostics invocation

## Root cause
The first merged-head `develop` proof after `#1976` admitted the real `vi-history-scenarios-windows-lv32` job onto `GHOST-comparevi-capability-ingress`, but `Capture LabVIEW 2026 host-plane diagnostics` failed because:
- the workflow assigned `$reportPath = node tools/npm/run-script.mjs env:labview:2026:host-planes`
- `run-script.mjs` launches npm with inherited stdio
- on the self-hosted runner, that left `$reportPath` empty when the step later tried `Get-Content -LiteralPath $reportPath`

This change removes that fragile capture path and calls `tools/Write-LabVIEW2026HostPlaneDiagnostics.ps1` directly with an explicit `-OutputPath`.

## Validation
- `node --test tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/Check-WorkflowDrift.ps1`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `git diff --check`
