### PR TITLE
[ci]: repair LV32 shadow proof receipt generation for #1974

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1975,15 +1975,18 @@ jobs:
           'runner-label-contract-labview-2026.json',
           'runner-label-contract-lv32.json'
         ) | ForEach-Object { Join-Path $resultsRoot $_ }
-        pwsh -NoLogo -NoProfile -File tools/Write-VIHistoryLV32ShadowProofReceipt.ps1 `
-          -LaneName 'vi-history-scenarios-windows-lv32' `
-          -RunnerLabelContractPaths $runnerContractPaths `
-          -HostPlaneReportPath '${{ steps.host-plane.outputs.host_plane_report_path }}' `
-          -CompareSummaryPath '${{ steps.history-shadow.outputs.history_summary_path }}' `
-          -CompareReportPath '${{ steps.history-shadow.outputs.history_report_path }}' `
-          -OutputJsonPath $env:VI_HISTORY_LV32_RECEIPT_PATH `
-          -GitHubOutputPath $env:GITHUB_OUTPUT `
-          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+        $receiptScriptPath = Join-Path $env:GITHUB_WORKSPACE 'tools/Write-VIHistoryLV32ShadowProofReceipt.ps1'
+        $receiptArgs = @{
+          LaneName = 'vi-history-scenarios-windows-lv32'
+          RunnerLabelContractPaths = $runnerContractPaths
+          HostPlaneReportPath = '${{ steps.host-plane.outputs.host_plane_report_path }}'
+          CompareSummaryPath = '${{ steps.history-shadow.outputs.history_summary_path }}'
+          CompareReportPath = '${{ steps.history-shadow.outputs.history_report_path }}'
+          OutputJsonPath = $env:VI_HISTORY_LV32_RECEIPT_PATH
+          GitHubOutputPath = $env:GITHUB_OUTPUT
+          StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+        }
+        & $receiptScriptPath @receiptArgs
     - name: Runner Unblock Guard
       if: always()
       uses: ./.github/actions/runner-unblock-guard

--- a/tools/Write-VIHistoryLV32ShadowProofReceipt.ps1
+++ b/tools/Write-VIHistoryLV32ShadowProofReceipt.ps1
@@ -152,6 +152,9 @@ $compareSummaryStatus = ConvertTo-NormalizedText (Get-PropertyValue -InputObject
 if ([string]::IsNullOrWhiteSpace($compareSummaryStatus) -and $compareSummary) {
   $compareSummaryStatus = ConvertTo-NormalizedText (Get-PropertyValue -InputObject (Get-PropertyValue -InputObject $compareSummary -Name 'summary') -Name 'status')
 }
+if ([string]::IsNullOrWhiteSpace($compareSummaryStatus) -and $compareSummary) {
+  $compareSummaryStatus = ConvertTo-NormalizedText (Get-PropertyValue -InputObject (Get-PropertyValue -InputObject $compareSummary -Name 'execution') -Name 'status')
+}
 
 $requiredLabels = @(
   'self-hosted',

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -117,6 +117,9 @@ test('validate workflow self-hosted Windows LV32 VI-history lane is gated by inv
   assert.match(lv32Section, /Invoke-LVCompare\.ps1/);
   assert.match(lv32Section, /Write VI history LV32 shadow proof receipt/);
   assert.match(lv32Section, /Write-VIHistoryLV32ShadowProofReceipt\.ps1/);
+  assert.match(lv32Section, /\$receiptArgs = @\{/);
+  assert.match(lv32Section, /RunnerLabelContractPaths = \$runnerContractPaths/);
+  assert.match(lv32Section, /& \$receiptScriptPath @receiptArgs/);
   assert.match(lv32Section, /LABVIEW_PATH:\s*\$\{\{\s*steps\.host-plane\.outputs\.labview_path\s*\}\}/);
   assert.doesNotMatch(lv32Section, /windows-2022/);
 });

--- a/tools/priority/__tests__/vi-history-lv32-shadow-proof-receipt.test.mjs
+++ b/tools/priority/__tests__/vi-history-lv32-shadow-proof-receipt.test.mjs
@@ -152,10 +152,31 @@ test('Write-VIHistoryLV32ShadowProofReceipt writes a promotion-ready receipt whe
 
   writeJson(compareSummaryPath, {
     schema: 'comparevi-tools/history-facade@v1',
-    status: 'passed',
-    reportPath: compareReportPath,
+    generatedAtUtc: '2026-03-26T01:12:33.2480163Z',
+    execution: {
+      status: 'ok',
+      reportFormat: 'html',
+      resultsDir: path.join(tempDir, 'history'),
+      manifestPath: path.join(tempDir, 'history', 'manifest.json'),
+      requestedModes: ['default'],
+      executedModes: ['default']
+    },
     summary: {
-      status: 'pass'
+      modes: 1,
+      comparisons: 0,
+      diffs: 0,
+      signalDiffs: 0,
+      noiseCollapsed: 0,
+      missing: 0,
+      errors: 0,
+      categories: [],
+      bucketProfile: [],
+      categoryCountKeys: [],
+      bucketCountKeys: []
+    },
+    reports: {
+      markdownPath: path.join(tempDir, 'history-report.md'),
+      htmlPath: compareReportPath
     }
   });
   fs.writeFileSync(compareReportPath, '<html><body>shadow proof</body></html>', 'utf8');


### PR DESCRIPTION
## Summary
- invoke the LV32 shadow-proof receipt writer in-process with PowerShell splatting so the runner-label contract array binds correctly
- teach the receipt writer to treat the real VI-history summary shape (`execution.status = ok`) as a passing proof
- cover both fixes with focused workflow and receipt tests

## Root cause
The first repaired merged-head rerun after `#1977` got much further:
- `vi-history-scenarios-windows-lv32-plan`: `success`
- `Capture LabVIEW 2026 host-plane diagnostics`: `success`
- `Run VI history shadow proof on the self-hosted LV32 runner`: `success`

The remaining failure moved to `Write VI history LV32 shadow proof receipt`.

There were two concrete issues:
1. the workflow invoked `Write-VIHistoryLV32ShadowProofReceipt.ps1` via `pwsh -File ... -RunnerLabelContractPaths $runnerContractPaths`, which broke PowerShell array binding for the runner-contract paths
2. once invoked correctly, the receipt writer still marked the real `history-summary.json` shape as `fail` because it only looked for top-level/summary `status`, not `execution.status = ok`

## Validation
- `node --test tools/priority/__tests__/vi-history-lv32-shadow-proof-receipt.test.mjs tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs tools/priority/__tests__/docker-labview-path-contract.test.mjs`
- local replay of `tools/Write-VIHistoryLV32ShadowProofReceipt.ps1` against the downloaded artifact bundle from merged-head run `23572420478`
- `pwsh -NoLogo -NoProfile -File tools/Check-WorkflowDrift.ps1`
- `node tools/npm/run-script.mjs docs:manifest:validate`
- `git diff --check`
