### PR TITLE
fix: restore queue health recovery progression

### DIFF
--- a/tools/priority/__tests__/queue-supervisor.test.mjs
+++ b/tools/priority/__tests__/queue-supervisor.test.mjs
@@ -405,6 +405,25 @@ test('evaluateAdaptiveInflight applies hysteresis before upgrading from stabiliz
   assert.equal(secondRecovery.hysteresis.transition, 'upgrade-applied');
 });
 
+test('evaluateAdaptiveInflight restores upgrade streak from persisted hysteresis state', () => {
+  const recovered = evaluateAdaptiveInflight({
+    maxInflight: 5,
+    minInflight: 2,
+    adaptiveCap: true,
+    health: { successRate: 0.95, minSuccessRate: 0.8 },
+    runtimeFleet: { totals: { queued: 0, inProgress: 0, stalled: 0 }, thresholds: { maxQueuedRuns: 6, maxInProgressRuns: 8 } },
+    retryPressure: { retryRatio: 0, quarantineRatio: 0 },
+    previousControllerState: {
+      mode: 'stabilize',
+      hysteresis: {
+        upgradeStreak: 1
+      }
+    }
+  });
+  assert.equal(recovered.tier, 'guarded');
+  assert.equal(recovered.hysteresis.transition, 'upgrade-applied');
+});
+
 test('evaluateBurstWindow activates on release triggers and carries refill cycles', () => {
   const initial = evaluateBurstWindow({
     burstMode: 'auto',
@@ -614,6 +633,36 @@ test('evaluateHealthGate pauses when success rate drops or red window exceeds th
   });
   assert.equal(redWindow.paused, true);
   assert.ok(redWindow.reasons.includes('trunk-red-window-exceeded'));
+});
+
+test('evaluateHealthGate ignores stale workflow failures outside the health lookback window', () => {
+  const now = new Date('2026-03-30T22:00:00.000Z');
+  const result = evaluateHealthGate({
+    workflowRunsByName: {
+      Validate: [
+        { conclusion: 'success', status: 'completed', created_at: '2026-03-30T18:57:23Z', updated_at: '2026-03-30T19:13:12Z' },
+        { conclusion: 'success', status: 'completed', created_at: '2026-03-29T22:01:19Z', updated_at: '2026-03-29T22:17:18Z' }
+      ],
+      'Policy Guard (Upstream)': [
+        { conclusion: 'success', status: 'completed', created_at: '2026-03-30T18:57:23Z', updated_at: '2026-03-30T18:58:03Z' }
+      ],
+      'Fixture Drift Validation': [
+        { conclusion: 'failure', status: 'completed', created_at: '2026-03-29T22:13:26Z', updated_at: '2026-03-29T22:15:13Z' },
+        { conclusion: 'failure', status: 'completed', created_at: '2025-10-07T08:32:27Z', updated_at: '2025-10-07T08:35:06Z' },
+        { conclusion: 'failure', status: 'completed', created_at: '2025-10-07T08:12:14Z', updated_at: '2025-10-07T08:14:27Z' },
+        { conclusion: 'failure', status: 'completed', created_at: '2025-10-07T07:58:25Z', updated_at: '2025-10-07T08:00:46Z' }
+      ],
+      'commit-integrity': [
+        { conclusion: 'success', status: 'completed', created_at: '2026-03-29T22:24:27Z', updated_at: '2026-03-29T22:24:44Z' }
+      ]
+    },
+    now
+  });
+
+  assert.equal(result.paused, false);
+  assert.equal(result.sampleSize, 5);
+  assert.equal(result.successful, 4);
+  assert.equal(result.successRate, 0.8);
 });
 
 test('evaluateRuntimeFleetHealth pauses on saturation and stalled runs', () => {

--- a/tools/priority/queue-supervisor.mjs
+++ b/tools/priority/queue-supervisor.mjs
@@ -36,6 +36,7 @@ const DEFAULT_MIN_INFLIGHT = 2;
 const DEFAULT_HEALTH_SAMPLE = 10;
 const DEFAULT_HEALTH_MIN_SUCCESS_RATE = 0.8;
 const DEFAULT_HEALTH_MAX_RED_MINUTES = 30;
+const DEFAULT_HEALTH_LOOKBACK_DAYS = 30;
 const DEFAULT_MAX_QUEUED_RUNS = 6;
 const DEFAULT_MAX_IN_PROGRESS_RUNS = 8;
 const DEFAULT_STALL_THRESHOLD_MINUTES = 45;
@@ -820,7 +821,8 @@ export function evaluateHealthGate({
   workflowRunsByName,
   now = new Date(),
   minSuccessRate = DEFAULT_HEALTH_MIN_SUCCESS_RATE,
-  maxRedMinutes = DEFAULT_HEALTH_MAX_RED_MINUTES
+  maxRedMinutes = DEFAULT_HEALTH_MAX_RED_MINUTES,
+  lookbackDays = DEFAULT_HEALTH_LOOKBACK_DAYS
 }) {
   const runs = [];
   for (const [workflow, workflowRuns] of Object.entries(workflowRunsByName ?? {})) {
@@ -836,12 +838,24 @@ export function evaluateHealthGate({
     }
   }
 
-  runs.sort((a, b) => Date.parse(b.createdAt || 0) - Date.parse(a.createdAt || 0));
-  const sampleSize = runs.length;
-  const successful = runs.filter((run) => run.conclusion === 'success').length;
+  runs.sort((a, b) => runTimestampMs(b) - runTimestampMs(a));
+  const lookbackMs =
+    Number.isFinite(lookbackDays) && lookbackDays > 0
+      ? lookbackDays * 24 * 60 * 60 * 1000
+      : null;
+  const filteredRuns =
+    lookbackMs == null
+      ? runs
+      : runs.filter((run) => {
+          const stamp = runTimestampMs(run);
+          return Number.isFinite(stamp) && now.valueOf() - stamp <= lookbackMs;
+        });
+
+  const sampleSize = filteredRuns.length;
+  const successful = filteredRuns.filter((run) => run.conclusion === 'success').length;
   const successRate = sampleSize === 0 ? 0 : successful / sampleSize;
-  const latest = runs[0] ?? null;
-  const lastSuccess = runs.find((run) => run.conclusion === 'success') ?? null;
+  const latest = filteredRuns[0] ?? null;
+  const lastSuccess = filteredRuns.find((run) => run.conclusion === 'success') ?? null;
 
   let redMinutes = 0;
   if (latest && latest.conclusion !== 'success') {
@@ -1208,6 +1222,20 @@ function applyControllerHysteresis({
   };
 }
 
+function readPreviousControllerUpgradeStreak(previousControllerState) {
+  const direct = Number(previousControllerState?.upgradeStreak);
+  if (Number.isFinite(direct) && direct >= 0) {
+    return Math.trunc(direct);
+  }
+
+  const nested = Number(previousControllerState?.hysteresis?.upgradeStreak);
+  if (Number.isFinite(nested) && nested >= 0) {
+    return Math.trunc(nested);
+  }
+
+  return 0;
+}
+
 export function evaluateAdaptiveInflight({
   maxInflight,
   minInflight = DEFAULT_MIN_INFLIGHT,
@@ -1277,7 +1305,7 @@ export function evaluateAdaptiveInflight({
   const hysteresis = applyControllerHysteresis({
     desiredMode: desired.desiredMode,
     previousMode: previousControllerState?.mode,
-    previousUpgradeStreak: previousControllerState?.upgradeStreak,
+    previousUpgradeStreak: readPreviousControllerUpgradeStreak(previousControllerState),
     requiredUpgradeStreak: CONTROLLER_REQUIRED_UPGRADE_STREAK
   });
   const effectiveMaxInflight = caps[hysteresis.mode] ?? configuredMin;
@@ -1786,6 +1814,7 @@ export async function runQueueSupervisor(options = {}) {
     reasons: adaptiveInflight.reasons,
     metrics: adaptiveInflight.metrics,
     thresholds: adaptiveInflight.thresholds,
+    upgradeStreak: adaptiveInflight.hysteresis?.upgradeStreak ?? 0,
     hysteresis: adaptiveInflight.hysteresis,
     retryPressure,
     paused: uniquePausedReasons.length > 0,


### PR DESCRIPTION
## Summary
- ignore stale workflow failures outside a 30-day health lookback when computing queue health
- restore throughput-controller hysteresis progression from persisted controller state
- persist the current upgrade streak explicitly and cover both behaviors with regression tests

## Validation
- `node --test tools/priority/__tests__/queue-supervisor.test.mjs`
- `node tools/npm/run-script.mjs priority:queue:supervisor -- --dry-run --repo LabVIEW-Community-CI-CD/compare-vi-cli-action --report tests/results/_agent/queue/queue-supervisor-report.json`
- `node tools/npm/run-script.mjs priority:release:conductor -- --repo LabVIEW-Community-CI-CD/compare-vi-cli-action --channel stable --version 0.6.9`

## Live result
- queue health now recovers to `guarded` instead of remaining stuck in `stabilize`
- the release conductor dry-run now passes its blocking gates and leaves only the expected green-dwell advisory
