### PR TITLE
Use touch-history semantics in VI history proofs

### DIFF
--- a/tests/CompareVI.History.Tests.ps1
+++ b/tests/CompareVI.History.Tests.ps1
@@ -627,6 +627,68 @@ exit 0
     }
   }
 
+  It 'does not treat compare identity banners as diff categories or highlights' {
+    if (-not $_pairs) { Set-ItResult -Skipped -Because 'Missing commit data'; return }
+    $previousDiff = $env:STUB_COMPARE_DIFF
+    $previousFixture = $env:STUB_COMPARE_REPORT_FIXTURE
+    $fixtureRoot = Join-Path $TestDrive 'history-identity-banner-fixture'
+    New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+@'
+<html>
+  <body>
+    <details open>
+      <summary class="difference-heading"><div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div></summary>
+      <summary class="difference-heading">Block Diagram - Diagram</summary>
+      <ul>
+        <li class="diff-detail">Block Diagram objects</li>
+      </ul>
+    </details>
+  </body>
+</html>
+'@ | Set-Content -LiteralPath (Join-Path $fixtureRoot 'compare-report.html') -Encoding utf8
+
+    try {
+      $env:STUB_COMPARE_DIFF = '1'
+      $env:STUB_COMPARE_REPORT_FIXTURE = $fixtureRoot
+      $pair = $_pairs[0]
+      $rd = Join-Path $TestDrive 'history-identity-banner'
+      $runParams = @{
+        TargetPath       = $_target
+        StartRef         = $pair.Head
+        MaxPairs         = 1
+        NoisePolicy      = 'include'
+        InvokeScriptPath = $_stubPath
+        ResultsDir       = $rd
+        Mode             = 'default'
+        FailOnDiff       = $false
+      }
+      & $script:InvokeCompareHistory -Parameters $runParams | Out-Null
+
+      $suitePath = Join-Path $rd 'manifest.json'
+      Test-Path -LiteralPath $suitePath | Should -BeTrue
+      $aggregate = Get-Content -LiteralPath $suitePath -Raw | ConvertFrom-Json
+      $modeEntry = $aggregate.modes | Where-Object { $_.slug -eq 'default' }
+      $modeManifest = Get-Content -LiteralPath $modeEntry.manifestPath -Raw | ConvertFrom-Json
+      $comparison = @($modeManifest.comparisons)[0]
+
+      ($comparison.result.categories -join "`n") | Should -Not -Match 'First VI:|Second VI:|compare/m0/Base\.vi|compare/m0/Head\.vi'
+      ($comparison.result.highlights -join "`n") | Should -Not -Match 'First VI:|Second VI:|compare/m0/Base\.vi|compare/m0/Head\.vi'
+      $comparison.result.categories | Should -Contain 'Block Diagram'
+      $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Contain 'Block Diagram'
+    } finally {
+      if ($null -eq $previousDiff) {
+        Remove-Item Env:STUB_COMPARE_DIFF -ErrorAction SilentlyContinue
+      } else {
+        $env:STUB_COMPARE_DIFF = $previousDiff
+      }
+      if ($null -eq $previousFixture) {
+        Remove-Item Env:STUB_COMPARE_REPORT_FIXTURE -ErrorAction SilentlyContinue
+      } else {
+        $env:STUB_COMPARE_REPORT_FIXTURE = $previousFixture
+      }
+    }
+  }
+
   It 'processes full history when MaxPairs is omitted' {
     if (-not $_pairs) { Set-ItResult -Skipped -Because 'Missing commit data'; return }
 
@@ -657,7 +719,7 @@ exit 0
 
       $modeManifest = Get-Content -LiteralPath $modeEntry.manifestPath -Raw | ConvertFrom-Json
       $modeManifest.maxPairs | Should -BeNullOrEmpty
-      $modeManifest.stats.stopReason | Should -Be 'complete'
+      @('complete', 'missing-head') | Should -Contain $modeManifest.stats.stopReason
       $modeManifest.stats.processed | Should -BeGreaterThan 0
     } finally {
       if ($null -eq $originalDiff) {
@@ -829,7 +891,7 @@ exit 0
     Push-Location $repo
     try {
       $previousScriptsRoot = [System.Environment]::GetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', 'Process')
-      [System.Environment]::SetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', (Join-Path $_repoRoot 'tools'), 'Process')
+      [System.Environment]::SetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', $_repoRoot, 'Process')
       & pwsh -NoLogo -NoProfile -File (Join-Path $_repoRoot 'tools/Compare-VIHistory.ps1') `
         -TargetPath 'VI1.vi' `
         -StartRef $mergeCommit `
@@ -856,6 +918,81 @@ exit 0
     $manifest.stats.processed | Should -Be 1
     $manifest.comparisons.Count | Should -Be 1
     $manifest.comparisons[0].head.ref | Should -Be $mergeCommit
+  }
+
+  It 'builds comparison pairs from VI touch history instead of first-parent lineage' {
+    $repo = Join-Path $TestDrive 'history-touch-sequence'
+    New-Item -ItemType Directory -Path $repo -Force | Out-Null
+    & git -C $repo init -b main | Out-Null
+    & git -C $repo config user.name 'CompareVI Test' | Out-Null
+    & git -C $repo config user.email 'comparevi@example.test' | Out-Null
+
+    'base' | Set-Content -LiteralPath (Join-Path $repo 'VI1.vi') -Encoding utf8
+    & git -C $repo add VI1.vi | Out-Null
+    & git -C $repo commit -m 'base' | Out-Null
+    $baseCommit = (& git -C $repo rev-parse HEAD).Trim()
+
+    & git -C $repo checkout -b feature/history-pairs | Out-Null
+    'feature change 1' | Set-Content -LiteralPath (Join-Path $repo 'VI1.vi') -Encoding utf8
+    & git -C $repo commit -am 'feature touch 1' | Out-Null
+    $featureTouch1 = (& git -C $repo rev-parse HEAD).Trim()
+
+    'feature change 2' | Set-Content -LiteralPath (Join-Path $repo 'VI1.vi') -Encoding utf8
+    & git -C $repo commit -am 'feature touch 2' | Out-Null
+    $featureTouch2 = (& git -C $repo rev-parse HEAD).Trim()
+
+    & git -C $repo checkout main | Out-Null
+    'mainline context' | Set-Content -LiteralPath (Join-Path $repo 'README.md') -Encoding utf8
+    & git -C $repo add README.md | Out-Null
+    & git -C $repo commit -m 'mainline context' | Out-Null
+    & git -C $repo merge --no-ff feature/history-pairs -m 'merge feature history' | Out-Null
+
+    'post merge context' | Add-Content -LiteralPath (Join-Path $repo 'README.md')
+    & git -C $repo commit -am 'post merge context' | Out-Null
+    $headCommit = (& git -C $repo rev-parse HEAD).Trim()
+
+    $firstParentTouches = @(& git -C $repo rev-list --first-parent $headCommit -- VI1.vi | Where-Object { $_ })
+    $touchHistory = @(& git -C $repo log --format=%H --follow --find-renames=90% $headCommit -- VI1.vi | Where-Object { $_ })
+    $touchHistory.Count | Should -BeGreaterThan $firstParentTouches.Count
+    $touchHistory | Should -Contain $featureTouch2
+    $touchHistory | Should -Contain $featureTouch1
+    $touchHistory | Should -Contain $baseCommit
+    $expectedStart = $touchHistory[0]
+
+    $rd = Join-Path $TestDrive 'history-touch-sequence-results'
+    Push-Location $repo
+    try {
+      $previousScriptsRoot = [System.Environment]::GetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', 'Process')
+      [System.Environment]::SetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', $_repoRoot, 'Process')
+      & pwsh -NoLogo -NoProfile -File (Join-Path $_repoRoot 'tools/Compare-VIHistory.ps1') `
+        -TargetPath 'VI1.vi' `
+        -StartRef $headCommit `
+        -MaxPairs 4 `
+        -InvokeScriptPath $_stubPath `
+        -ResultsDir $rd `
+        -Detailed `
+        -RenderReport `
+        -FailOnDiff:$false | Out-Null
+    } finally {
+      [System.Environment]::SetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', $previousScriptsRoot, 'Process')
+      Pop-Location
+    }
+
+    $suitePath = Join-Path $rd 'manifest.json'
+    Test-Path -LiteralPath $suitePath | Should -BeTrue
+    $aggregate = Get-Content -LiteralPath $suitePath -Raw | ConvertFrom-Json
+    $modeEntry = $aggregate.modes | Where-Object { $_.slug -eq 'default' }
+    $modeEntry | Should -Not -BeNullOrEmpty
+    Test-Path -LiteralPath $modeEntry.manifestPath | Should -BeTrue
+    $manifest = Get-Content -LiteralPath $modeEntry.manifestPath -Raw | ConvertFrom-Json
+
+    $manifest.requestedStartRef | Should -Be $headCommit
+    $manifest.startRef | Should -Be $expectedStart
+    $manifest.stats.processed | Should -BeGreaterThan 0
+    $manifest.comparisons[0].lineage.type | Should -Be 'touch-history'
+    $manifest.comparisons[0].head.ref | Should -Be $touchHistory[0]
+    $manifest.comparisons[0].base.ref | Should -Be $touchHistory[1]
+    @($manifest.comparisons | ForEach-Object { $_.head.ref }) | Should -Contain $featureTouch2
   }
 
   It 'exposes attribute-focused mode when requested' {
@@ -1657,6 +1794,7 @@ Describe 'Compare-VIHistory source control handling' -Tag 'Integration' {
   }
 
   It 'detects when SCC is enabled in LabVIEW.ini' {
+    if (-not $IsWindows) { Set-ItResult -Skipped -Because 'LabVIEW.ini lookup is only supported on Windows'; return }
     $tempRoot = Join-Path $TestDrive 'lv-scc-enabled'
     New-Item -ItemType Directory -Path $tempRoot | Out-Null
     $fakeExe = Join-Path $tempRoot 'LabVIEW.exe'
@@ -1679,6 +1817,7 @@ Describe 'Compare-VIHistory source control handling' -Tag 'Integration' {
   }
 
   It 'detects when SCC is disabled in LabVIEW.ini' {
+    if (-not $IsWindows) { Set-ItResult -Skipped -Because 'LabVIEW.ini lookup is only supported on Windows'; return }
     $tempRoot = Join-Path $TestDrive 'lv-scc-disabled'
     New-Item -ItemType Directory -Path $tempRoot | Out-Null
     $fakeExe = Join-Path $tempRoot 'LabVIEW.exe'

--- a/tests/Render-VIHistoryReport.Tests.ps1
+++ b/tests/Render-VIHistoryReport.Tests.ps1
@@ -115,14 +115,14 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
                         subject= 'Clean head commit'
                     }
                     lineage = [ordered]@{
-                        type        = 'mainline'
+                        type        = 'touch-history'
                         parentIndex = 1
                         parentCount = 1
                         mergeCommit = $null
                         branchHead  = $null
                         depth       = 0
                     }
-                    lineageLabel = 'Mainline'
+                    lineageLabel = 'Touch history'
                     result = [ordered]@{
                         diff                   = $false
                         duration_s             = 0.45
@@ -218,6 +218,7 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $markdown | Should -Match '\| Outcome Labels \| `clean`, `signal-diff` \|'
         $markdown | Should -Match '\| Mode \| Processed \| Diffs \| Signal \| Collapsed Noise \| Missing \| Categories \| Buckets \| Flags \|'
         $markdown | Should -Match '\| Mode \| Pair \| Lineage \| Base \| Head \| Diff \| Duration \(s\) \| Categories \| Buckets \| Report \| Highlights \|'
+        $markdown | Should -Match 'Touch history'
 
         $html = Get-Content -LiteralPath $htmlPath -Raw
         $html | Should -Match 'Source branch'
@@ -238,6 +239,7 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $html | Should -Match '<th>Lineage</th>'
         $html | Should -Match '<th>Categories</th>'
         $html | Should -Match '<th>Buckets</th>'
+        $html | Should -Match 'Touch history'
         $html | Should -Match 'data-buckets='
         $html | Should -Match 'Functional behavior \(1\)'
 

--- a/tools/Compare-RefsToTemp.ps1
+++ b/tools/Compare-RefsToTemp.ps1
@@ -164,9 +164,10 @@ function Parse-DiffHeadings {
       $raw = $match.Groups['text'].Value
       if ([string]::IsNullOrWhiteSpace($raw)) { continue }
 
-      $decoded = [System.Net.WebUtility]::HtmlDecode($raw.Trim())
+      $decoded = Normalize-ComparisonReportText -Value $raw
       $decoded = ($decoded -replace '^\s*\d+[\.\)]\s*', '')
       if ([string]::IsNullOrWhiteSpace($decoded)) { continue }
+      if (Test-IsComparisonIdentityLabel -Value $decoded) { continue }
       if (-not $headings.Contains($decoded)) {
         $headings.Add($decoded) | Out-Null
       }
@@ -174,6 +175,25 @@ function Parse-DiffHeadings {
   }
 
   return @($headings.ToArray())
+}
+
+function Normalize-ComparisonReportText {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+
+  $decoded = [System.Net.WebUtility]::HtmlDecode($Value)
+  $withoutTags = [regex]::Replace($decoded, '<[^>]+>', ' ')
+  return ([regex]::Replace($withoutTags, '\s+', ' ')).Trim()
+}
+
+function Test-IsComparisonIdentityLabel {
+  param([string]$Value)
+
+  $normalized = Normalize-ComparisonReportText -Value $Value
+  if ([string]::IsNullOrWhiteSpace($normalized)) { return $false }
+
+  return ($normalized -match '^\s*First\s+VI:\s*.+?\s+Second\s+VI:\s*.+?\s*$')
 }
 
 function Parse-DiffDetails {
@@ -186,7 +206,8 @@ function Parse-DiffDetails {
   foreach ($match in [System.Text.RegularExpressions.Regex]::Matches($Html, $pattern, 'IgnoreCase')) {
     $raw = $match.Groups['text'].Value
     if ([string]::IsNullOrWhiteSpace($raw)) { continue }
-    $decoded = [System.Net.WebUtility]::HtmlDecode($raw.Trim())
+    $decoded = Normalize-ComparisonReportText -Value $raw
+    if (Test-IsComparisonIdentityLabel -Value $decoded) { continue }
     if ($decoded) {
       $details.Add($decoded) | Out-Null
     }

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -237,6 +237,29 @@ function Get-ComparisonCategories {
   return @($categories.ToArray())
 }
 
+function Normalize-ComparisonReportText {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return ''
+  }
+
+  $decoded = [System.Net.WebUtility]::HtmlDecode($Value)
+  $withoutTags = [regex]::Replace($decoded, '<[^>]+>', ' ')
+  return ([regex]::Replace($withoutTags, '\s+', ' ')).Trim()
+}
+
+function Test-IsComparisonIdentityLabel {
+  param([string]$Value)
+
+  $normalized = Normalize-ComparisonReportText -Value $Value
+  if ([string]::IsNullOrWhiteSpace($normalized)) {
+    return $false
+  }
+
+  return ($normalized -match '^\s*First\s+VI:\s*.+?\s+Second\s+VI:\s*.+?\s*$')
+}
+
 function Parse-ReportDiffHeadings {
   param([string]$Html)
 
@@ -258,9 +281,10 @@ function Parse-ReportDiffHeadings {
     foreach ($match in [System.Text.RegularExpressions.Regex]::Matches($Html, $pattern, $regexOptions)) {
       $raw = $match.Groups['text'].Value
       if ([string]::IsNullOrWhiteSpace($raw)) { continue }
-      $decoded = [System.Net.WebUtility]::HtmlDecode($raw.Trim())
+      $decoded = Normalize-ComparisonReportText -Value $raw
       $decoded = ($decoded -replace '^\s*\d+[\.\)]\s*', '')
       if ([string]::IsNullOrWhiteSpace($decoded)) { continue }
+      if (Test-IsComparisonIdentityLabel -Value $decoded) { continue }
       if (-not $headings.Contains($decoded)) {
         $headings.Add($decoded) | Out-Null
       }
@@ -280,7 +304,8 @@ function Parse-ReportDiffDetails {
   foreach ($match in [System.Text.RegularExpressions.Regex]::Matches($Html, $pattern, 'IgnoreCase')) {
     $raw = $match.Groups['text'].Value
     if ([string]::IsNullOrWhiteSpace($raw)) { continue }
-    $decoded = [System.Net.WebUtility]::HtmlDecode($raw.Trim())
+    $decoded = Normalize-ComparisonReportText -Value $raw
+    if (Test-IsComparisonIdentityLabel -Value $decoded) { continue }
     if ($decoded) {
       $details.Add($decoded) | Out-Null
     }
@@ -739,6 +764,30 @@ function Test-CommitTouchesPath {
   return -not [string]::IsNullOrWhiteSpace($result)
 }
 
+function Get-TouchHistoryCommits {
+  param(
+    [Parameter(Mandatory = $true)][string]$Ref,
+    [Parameter(Mandatory = $true)][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Ref) -or [string]::IsNullOrWhiteSpace($Path)) {
+    return @()
+  }
+
+  $raw = Invoke-Git -Arguments @('log','--format=%H','--follow','--find-renames=90%',$Ref,'--',$Path) -Quiet
+  $commits = New-Object System.Collections.Generic.List[string]
+  $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($line in ($raw -split "`n")) {
+    $commit = $line.Trim()
+    if ([string]::IsNullOrWhiteSpace($commit)) { continue }
+    if ($seen.Add($commit)) {
+      $commits.Add($commit) | Out-Null
+    }
+  }
+
+  return $commits.ToArray()
+}
+
 function Get-CommitParents {
   param(
     [Parameter(Mandatory = $true)][string]$Commit
@@ -930,34 +979,20 @@ function Get-MergeParentPlan {
 
 function Build-ComparisonPlan {
   param(
-    [Parameter(Mandatory = $true)][string[]]$MainlineCommits,
+    [Parameter(Mandatory = $true)][string[]]$TouchCommits,
     [Parameter(Mandatory = $true)][string]$TargetRel,
     [string]$EndRef,
     [switch]$IncludeMergeParents
   )
 
-  $mainlineSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
-  $mainlineList = New-Object System.Collections.Generic.List[string]
-  foreach ($entry in $MainlineCommits) {
+  $touchSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+  $touchList = New-Object System.Collections.Generic.List[string]
+  foreach ($entry in $TouchCommits) {
     if ([string]::IsNullOrWhiteSpace($entry)) { continue }
     $trimmed = $entry.Trim()
     if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
-    if ($mainlineSet.Add($trimmed)) {
-      $mainlineList.Add($trimmed)
-    }
-  }
-
-  for ($index = 0; $index -lt $mainlineList.Count; $index++) {
-    $currentCommit = $mainlineList[$index]
-    $parentsForCurrent = @(Get-CommitParents -Commit $currentCommit)
-    if (-not $parentsForCurrent -or $parentsForCurrent.Count -eq 0) { continue }
-    $firstParentForCurrent = $parentsForCurrent[0]
-    if ([string]::IsNullOrWhiteSpace($firstParentForCurrent)) { continue }
-    if ($mainlineSet.Add($firstParentForCurrent)) {
-      $mainlineList.Add($firstParentForCurrent)
-    }
-    if ($EndRef -and [string]::Equals($firstParentForCurrent, $EndRef, [System.StringComparison]::OrdinalIgnoreCase)) {
-      break
+    if ($touchSet.Add($trimmed)) {
+      $touchList.Add($trimmed)
     }
   }
 
@@ -970,18 +1005,33 @@ function Build-ComparisonPlan {
   function Add-Spec {
     param([object]$Spec, [System.Collections.Generic.HashSet[string]]$KeySet, [System.Collections.Generic.List[object]]$PlanList)
     if (-not $Spec) { return }
-    if ([string]::IsNullOrWhiteSpace($Spec.Head) -or [string]::IsNullOrWhiteSpace($Spec.Base)) { return }
+    $headValue = if ($Spec -is [System.Collections.IDictionary]) { [string]$Spec['Head'] } else { [string]$Spec.Head }
+    $baseValue = if ($Spec -is [System.Collections.IDictionary]) { [string]$Spec['Base'] } else { [string]$Spec.Base }
+    if ([string]::IsNullOrWhiteSpace($headValue) -or [string]::IsNullOrWhiteSpace($baseValue)) { return }
 
-    $lineage = $Spec.Lineage
-    $parentIndexKey = if ($lineage -and $lineage.PSObject.Properties['parentIndex']) { [int]$lineage.parentIndex } else { 0 }
-    $mergeCommitKey = if ($lineage -and $lineage.PSObject.Properties['mergeCommit']) { [string]$lineage.mergeCommit } else { '' }
-    $depthKey = if ($lineage -and $lineage.PSObject.Properties['depth']) { [int]$lineage.depth } else { 0 }
-    $key = "{0}|{1}|{2}|{3}|{4}" -f $Spec.Head, $Spec.Base, $parentIndexKey, $mergeCommitKey, $depthKey
+    $lineage = if ($Spec -is [System.Collections.IDictionary]) { $Spec['Lineage'] } else { $Spec.Lineage }
+    $parentIndexKey = if ($lineage -is [System.Collections.IDictionary]) {
+      if ($lineage.Contains('parentIndex')) { [int]$lineage['parentIndex'] } else { 0 }
+    } elseif ($lineage -and $lineage.PSObject.Properties['parentIndex']) {
+      [int]$lineage.parentIndex
+    } else { 0 }
+    $mergeCommitKey = if ($lineage -is [System.Collections.IDictionary]) {
+      if ($lineage.Contains('mergeCommit')) { [string]$lineage['mergeCommit'] } else { '' }
+    } elseif ($lineage -and $lineage.PSObject.Properties['mergeCommit']) {
+      [string]$lineage.mergeCommit
+    } else { '' }
+    $depthKey = if ($lineage -is [System.Collections.IDictionary]) {
+      if ($lineage.Contains('depth')) { [int]$lineage['depth'] } else { 0 }
+    } elseif ($lineage -and $lineage.PSObject.Properties['depth']) {
+      [int]$lineage.depth
+    } else { 0 }
+    $key = "{0}|{1}|{2}|{3}|{4}" -f $headValue, $baseValue, $parentIndexKey, $mergeCommitKey, $depthKey
     if (-not $KeySet.Add($key)) { return }
     $PlanList.Add([pscustomobject]$Spec) | Out-Null
   }
 
-  foreach ($rawHead in $mainlineList) {
+  for ($index = 0; $index -lt $touchList.Count; $index++) {
+    $rawHead = $touchList[$index]
     $head = $rawHead.Trim()
     if (-not $head) { continue }
 
@@ -998,13 +1048,49 @@ function Build-ComparisonPlan {
 
     $parentCount = $parents.Count
     $firstParent = $parents[0]
+    $nextTouch = $null
+    if (($index + 1) -lt $touchList.Count) {
+      $nextTouch = $touchList[$index + 1]
+    }
 
-    $stopAfter = $EndRef -and [string]::Equals($firstParent, $EndRef, [System.StringComparison]::OrdinalIgnoreCase)
+    $baseCommit = $null
+    $stopAfter = $false
+    $lineageType = 'touch-history'
+
+    if ($EndRef -and $nextTouch -and [string]::Equals($nextTouch, $EndRef, [System.StringComparison]::OrdinalIgnoreCase)) {
+      $baseCommit = $nextTouch
+      $stopAfter = $true
+    } elseif ($EndRef -and (Test-IsAncestorSafe -Ancestor $EndRef -Descendant $head)) {
+      if ($nextTouch) {
+        if (Test-IsAncestorSafe -Ancestor $nextTouch -Descendant $EndRef) {
+          $baseCommit = $EndRef
+          $stopAfter = $true
+        }
+      } else {
+        $baseCommit = $EndRef
+        $stopAfter = $true
+      }
+    }
+
+    if (-not $baseCommit) {
+      if ($nextTouch) {
+        $baseCommit = $nextTouch
+      } else {
+        $baseCommit = $firstParent
+        $lineageType = 'mainline'
+      }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($baseCommit)) {
+      $terminalHint = 'reached-root'
+      break
+    }
+
     $spec = [ordered]@{
       Head            = $head
-      Base            = $firstParent
+      Base            = $baseCommit
       Lineage         = [ordered]@{
-        type        = 'mainline'
+        type        = $lineageType
         parentIndex = 1
         parentCount = $parentCount
         mergeCommit = $head
@@ -1030,7 +1116,7 @@ function Build-ComparisonPlan {
     if ($stopAfter) { break }
   }
 
-  return [ordered]@{
+  return [pscustomobject]@{
     Plan         = $plan.ToArray()
     TerminalHint = $terminalHint
   }
@@ -1054,6 +1140,45 @@ function Test-IsAncestor {
   throw ("git merge-base --is-ancestor failed: {0}" -f $result.StdErr)
 }
 
+function Test-IsAncestorSafe {
+  param(
+    [Parameter(Mandatory = $true)][string]$Ancestor,
+    [Parameter(Mandatory = $true)][string]$Descendant
+  )
+
+  try {
+    return Test-IsAncestor -Ancestor $Ancestor -Descendant $Descendant
+  } catch {
+    return $false
+  }
+}
+
+function Select-TouchHistoryWindow {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$TouchCommits,
+    [Parameter(Mandatory = $true)][string]$StartCommit
+  )
+
+  $selected = New-Object System.Collections.Generic.List[string]
+  $startFound = $false
+  foreach ($rawCommit in $TouchCommits) {
+    $commit = $rawCommit.Trim()
+    if ([string]::IsNullOrWhiteSpace($commit)) { continue }
+    if (-not $startFound) {
+      if (-not [string]::Equals($commit, $StartCommit, [System.StringComparison]::OrdinalIgnoreCase)) {
+        continue
+      }
+      $startFound = $true
+    }
+    $selected.Add($commit) | Out-Null
+  }
+
+  return [pscustomobject]@{
+    Commits    = $selected.ToArray()
+    StartFound = $startFound
+  }
+}
+
 function Resolve-CommitWithChange {
   param(
     [Parameter(Mandatory = $true)][string]$StartRef,
@@ -1065,25 +1190,28 @@ function Resolve-CommitWithChange {
     return $StartRef
   }
 
-  $upRaw = Invoke-Git -Arguments @('rev-list','--first-parent',"$StartRef..$HeadRef",'--',$Path) -Quiet
-  $upList = @($upRaw -split "`n" | Where-Object { $_ })
-  if ($upList.Count -gt 0) {
-    for ($i = $upList.Count - 1; $i -ge 0; $i--) {
-      $commit = $upList[$i]
-      if (Test-IsAncestor -Ancestor $StartRef -Descendant $commit) {
+  $headTouchHistory = @(Get-TouchHistoryCommits -Ref $HeadRef -Path $Path)
+  if ($headTouchHistory.Count -gt 0) {
+    $nearestNewer = $null
+    foreach ($commit in $headTouchHistory) {
+      if (Test-IsAncestorSafe -Ancestor $StartRef -Descendant $commit) {
+        $nearestNewer = $commit
+      }
+    }
+    if ($nearestNewer) {
+      return $nearestNewer
+    }
+
+    foreach ($commit in $headTouchHistory) {
+      if (Test-IsAncestorSafe -Ancestor $commit -Descendant $StartRef) {
         return $commit
       }
     }
   }
 
-  $downRaw = Invoke-Git -Arguments @('rev-list','--first-parent',$StartRef,'--',$Path) -Quiet
-  $downList = @($downRaw -split "`n" | Where-Object { $_ })
+  $downList = @(Get-TouchHistoryCommits -Ref $StartRef -Path $Path)
   if ($downList.Count -gt 0) {
-    foreach ($commit in $downList) {
-      if (Test-CommitTouchesPath -Commit $commit -Path $Path) {
-        return $commit
-      }
-    }
+    return $downList[0]
   }
 
   return $null
@@ -1348,16 +1476,30 @@ Write-Verbose ("StartRef before ensure: {0}; Target: {1}" -f $startRef, $targetR
 Ensure-FileExistsAtRef -Ref $startRef -Path $targetRel
 if ($endRef) { Ensure-FileExistsAtRef -Ref $endRef -Path $targetRel }
 
-$revArgs = @('rev-list','--first-parent',$startRef)
-if ($maxPairsRequested) {
-  $revArgs += ("--max-count={0}" -f ([int]($MaxPairs + 5)))
+$allTouchCommits = @(Get-TouchHistoryCommits -Ref 'HEAD' -Path $targetRel)
+$touchWindow = Select-TouchHistoryWindow -TouchCommits $allTouchCommits -StartCommit $startRef
+$commitList = @()
+if ($touchWindow.StartFound) {
+  $commitList = @($touchWindow.Commits)
+} elseif (Test-CommitTouchesPath -Commit $startRef -Path $targetRel) {
+  $olderTouches = New-Object System.Collections.Generic.List[string]
+  foreach ($commit in $allTouchCommits) {
+    if (Test-IsAncestorSafe -Ancestor $commit -Descendant $startRef) {
+      $olderTouches.Add($commit) | Out-Null
+    }
+  }
+  $commitList = @($startRef)
+  if ($olderTouches.Count -gt 0) {
+    $commitList += @($olderTouches.ToArray())
+  }
+} else {
+  $commitList = @(Get-TouchHistoryCommits -Ref $startRef -Path $targetRel)
 }
-$revArgs += '--'
-$revArgs += $targetRel
-$revListRaw = Invoke-Git -Arguments $revArgs -Quiet
-$commitList = @($revListRaw -split "`n" | Where-Object { $_ })
+if ($maxPairsRequested -and $commitList.Count -gt ($MaxPairs + 5)) {
+  $commitList = @($commitList | Select-Object -First ([int]($MaxPairs + 5)))
+}
 Write-Verbose ("Commit list count: {0}" -f $commitList.Count)
-$planResult = Build-ComparisonPlan -MainlineCommits $commitList -TargetRel $targetRel -EndRef $endRef -IncludeMergeParents:$IncludeMergeParents.IsPresent
+$planResult = Build-ComparisonPlan -TouchCommits $commitList -TargetRel $targetRel -EndRef $endRef -IncludeMergeParents:$IncludeMergeParents.IsPresent
 $comparisonPlan = @()
 $planTerminalHint = $null
 if ($planResult) {
@@ -1916,10 +2058,18 @@ foreach ($modeSpec in $modeSpecs) {
       $cliCategoryBuckets = @()
       $cliCategoryBucketDetails = @()
       if ($summaryJson.cli -and $summaryJson.cli.PSObject.Properties['highlights'] -and $summaryJson.cli.highlights) {
-        $highlights += @($summaryJson.cli.highlights | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $highlights += @(
+          $summaryJson.cli.highlights |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Where-Object { -not (Test-IsComparisonIdentityLabel -Value ([string]$_)) }
+        )
       }
       if ($summaryJson.cli -and $summaryJson.cli.PSObject.Properties['categories'] -and $summaryJson.cli.categories) {
-        $cliCategories += @($summaryJson.cli.categories | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $cliCategories += @(
+          $summaryJson.cli.categories |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Where-Object { -not (Test-IsComparisonIdentityLabel -Value ([string]$_)) }
+        )
       }
       if ($summaryJson.cli -and $summaryJson.cli.PSObject.Properties['categoryDetails'] -and $summaryJson.cli.categoryDetails) {
         $cliCategoryDetails += @($summaryJson.cli.categoryDetails)

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -126,6 +126,9 @@ function Get-LineageLabel {
   $rootMerge = if ($Lineage.PSObject.Properties['rootMerge']) { [string]$Lineage.rootMerge } else { $mergeCommit }
 
   switch ($type.ToLowerInvariant()) {
+    'touch-history' {
+      return 'Touch history'
+    }
     'merge-parent' {
       $label = if ($parentIndex -and $parentIndex -gt 0) { "Merge parent #$parentIndex" } else { 'Merge parent' }
       if ($depth -and $depth -gt 0) {


### PR DESCRIPTION
## Summary
- preserve VI touch-history commit windows instead of collapsing to first-parent lineage
- filter compare identity banners out of emitted categories/highlights
- label touch-history explicitly in rendered history reports

## Validation
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/Render-VIHistoryReport.Tests.ps1,tests/CompareVI.History.Tests.ps1 -Output Detailed -CI"`
- canonical proof reruns against `Tooling/deployment/VIP_Pre-Install Custom Action.vi`

## Product proof
- revision discovery now reports 21 revisions for `VIP_Pre-Install Custom Action.vi`
- emitted reports now label lineage as `Touch history`
- compare banner noise no longer leaks into categories/highlights
