### PR TITLE
Preserve VI history category specificity

### DIFF
--- a/tests/CompareVI.History.Tests.ps1
+++ b/tests/CompareVI.History.Tests.ps1
@@ -512,6 +512,7 @@ exit 0
       $aggregate.stats.signalDiffs | Should -Be 0
       $aggregate.stats.noiseCollapsed | Should -BeGreaterThan 0
       $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Contain 'VI Attribute'
+      $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'Cosmetic'
       $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'unspecified'
       [int]$aggregate.stats.bucketCounts.metadata | Should -BeGreaterThan 0
       $outputText | Should -Match 'LVCompare detected differences'
@@ -766,6 +767,7 @@ exit 0
     $manifest.flags | Should -Contain '-nobdcosm'
     $manifest.stats.stopReason | Should -Be 'max-pairs'
     $manifest.comparisons.Count | Should -Be 0
+    $manifest.stats.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'Cosmetic'
   }
 
   It 'captures xml report when alternate format requested' {
@@ -1513,11 +1515,12 @@ exit 0
         FixtureRel    = Join-Path 'fixtures' 'vi-report' 'block-diagram'
         ExpectPattern = 'Block Diagram Cosmetic'
         ExpectedCategories = @('cosmetic')
+        ExpectedDetailSlug = 'block-diagram-cosmetic'
       }
     )
 
     It "surfaces highlights when <Param> suppression is removed (<Name>)" -TestCases $fixtureCases {
-      param($Name, $Param, $FixtureRel, $ExpectPattern, $ExpectedCategories)
+      param($Name, $Param, $FixtureRel, $ExpectPattern, $ExpectedCategories, $ExpectedDetailSlug)
       if (-not $_pairs) { Set-ItResult -Skipped -Because 'Missing commit data'; return }
 
       $pair = $_pairs[0]
@@ -1580,6 +1583,14 @@ exit 0
         $variantManifest = Get-Content -LiteralPath $variantManifestPath -Raw | ConvertFrom-Json
         if ($targetFlag) {
           ($variantManifest.flags -contains $targetFlag) | Should -BeFalse
+        }
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedDetailSlug)) {
+          $variantComparison = @($variantManifest.comparisons)[0]
+          $variantComparison | Should -Not -BeNullOrEmpty
+          $variantComparison.result.categories | Should -Contain $ExpectPattern
+          $detailSlugs = @($variantComparison.result.categoryDetails | ForEach-Object { [string]$_.slug })
+          $detailSlugs | Should -Contain $ExpectedDetailSlug
+          $detailSlugs | Should -Not -Contain 'cosmetic'
         }
 
         $historyReport = Get-Content -LiteralPath (Join-Path $variantDir 'history-report.md') -Raw

--- a/tests/VICategoryBuckets.Tests.ps1
+++ b/tests/VICategoryBuckets.Tests.ps1
@@ -14,6 +14,14 @@ Describe 'VICategoryBuckets module' -Tag 'Unit' {
         $meta.bucketClassification | Should -Be 'neutral'
     }
 
+    It 'preserves known slug inputs without degrading category specificity' {
+        $meta = Get-VICategoryMetadata -Name 'block-diagram-cosmetic'
+        $meta | Should -Not -BeNullOrEmpty
+        $meta.slug | Should -Be 'block-diagram-cosmetic'
+        $meta.label | Should -Be 'Block diagram (cosmetic)'
+        $meta.bucketSlug | Should -Be 'ui-visual'
+    }
+
     It 'collects bucket details for multiple categories' {
         $inputCategories = @(
             'Block Diagram Functional',

--- a/tools/Compare-RefsToTemp.ps1
+++ b/tools/Compare-RefsToTemp.ps1
@@ -28,12 +28,6 @@ $ErrorActionPreference = 'Stop'
 try { git --version | Out-Null } catch { throw 'git is required on PATH to fetch file content at refs.' }
 
 $repoRoot = (Get-Location).Path
-try {
-  $categoryModule = Join-Path $repoRoot 'tools' 'VICategoryBuckets.psm1'
-  if (Test-Path -LiteralPath $categoryModule -PathType Leaf) {
-    Import-Module $categoryModule -Force
-  }
-} catch {}
 
 function Resolve-CompareVIScriptsRoot {
   param([string]$PrimaryRoot)
@@ -54,6 +48,21 @@ function Resolve-CompareVIScriptsRoot {
   }
   return $PrimaryRoot
 }
+
+try {
+  $categoryModuleCandidates = New-Object System.Collections.Generic.List[string]
+  $categoryModuleCandidates.Add((Join-Path $repoRoot 'tools' 'VICategoryBuckets.psm1')) | Out-Null
+  $resolvedScriptsRoot = Resolve-CompareVIScriptsRoot -PrimaryRoot $repoRoot
+  if (-not [string]::IsNullOrWhiteSpace($resolvedScriptsRoot)) {
+    $categoryModuleCandidates.Add((Join-Path $resolvedScriptsRoot 'tools' 'VICategoryBuckets.psm1')) | Out-Null
+  }
+  foreach ($candidate in @($categoryModuleCandidates | Select-Object -Unique)) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      Import-Module $candidate -Force
+      break
+    }
+  }
+} catch {}
 
 function Split-ArgString {
   param([string]$Value)
@@ -275,6 +284,61 @@ function Infer-DiffCategoriesFromDetails {
   return @($inferred.ToArray())
 }
 
+function Normalize-ReportCategories {
+  param([System.Collections.IEnumerable]$Categories)
+
+  if (-not $Categories -or -not (Get-Command -Name Get-VICategoryBuckets -ErrorAction SilentlyContinue)) {
+    return @(
+      $Categories |
+        Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+        Select-Object -Unique
+    )
+  }
+
+  $categoryInfo = Get-VICategoryBuckets -Names @($Categories)
+  if ($null -eq $categoryInfo -or -not $categoryInfo.Details) {
+    return @(
+      $Categories |
+        Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+        Select-Object -Unique
+    )
+  }
+
+  $details = @($categoryInfo.Details)
+  if ($details.Count -gt 1) {
+    $specificDetails = @($details | Where-Object { [string]$_.slug -ne 'cosmetic' })
+    if ($specificDetails.Count -gt 0) {
+      $details = $specificDetails
+    }
+  }
+
+  return @(
+    $details |
+      ForEach-Object {
+        switch ([string]$_.slug) {
+          'block-diagram' { 'Block Diagram' }
+          'block-diagram-functional' { 'Block Diagram Functional' }
+          'block-diagram-cosmetic' { 'Block Diagram Cosmetic' }
+          'connector-pane' { 'Connector Pane' }
+          'front-panel' { 'Front Panel' }
+          'front-panel-position-size' { 'Front Panel Position/Size' }
+          'control-changes' { 'Front Panel Controls' }
+          'window' { 'Window Properties' }
+          'attributes' { 'Attributes' }
+          'vi-attribute' { 'VI Attribute' }
+          'documentation' { 'Documentation' }
+          'execution' { 'Execution Settings' }
+          'icon' { 'Icon' }
+          'unspecified' { 'Unspecified' }
+          'cosmetic' { 'Cosmetic' }
+          default { if ([string]::IsNullOrWhiteSpace([string]$_.label)) { [string]$_.slug } else { [string]$_.label } }
+        }
+      } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+      Select-Object -Unique
+  )
+}
+
 function Get-ReportCategoryMetadata {
   param([string]$ReportPath)
 
@@ -335,6 +399,12 @@ function Get-ReportCategoryMetadata {
         $categories.Add($name) | Out-Null
       }
     }
+  }
+
+  $normalizedCategories = @(Normalize-ReportCategories -Categories @($categories.ToArray()))
+  $categories = New-Object System.Collections.Generic.List[string]
+  foreach ($name in $normalizedCategories) {
+    $categories.Add([string]$name) | Out-Null
   }
 
   $categoryDetails = @()

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -435,6 +435,12 @@ function Get-ComparisonCategoriesFromReport {
     }
   }
 
+  $normalizedCategories = @(Normalize-ComparisonCategoryList -Categories @($categories.ToArray()))
+  $categories = New-Object System.Collections.Generic.List[string]
+  foreach ($name in $normalizedCategories) {
+    $categories.Add([string]$name) | Out-Null
+  }
+
   $categoryDetails = @()
   $categoryBuckets = @()
   $categoryBucketDetails = @()
@@ -503,6 +509,81 @@ function Get-ComparisonCategoryDisplayName {
   } catch {}
 
   return $Name
+}
+
+function Get-CanonicalComparisonCategoryName {
+  param([string]$Name)
+
+  if ([string]::IsNullOrWhiteSpace($Name)) { return $null }
+
+  $meta = $null
+  try {
+    $meta = Get-VICategoryMetadata -Name $Name
+  } catch {
+    $meta = $null
+  }
+
+  if ($meta) {
+    switch ([string]$meta.slug) {
+      'block-diagram' { return 'Block Diagram' }
+      'block-diagram-functional' { return 'Block Diagram Functional' }
+      'block-diagram-cosmetic' { return 'Block Diagram Cosmetic' }
+      'connector-pane' { return 'Connector Pane' }
+      'front-panel' { return 'Front Panel' }
+      'front-panel-position-size' { return 'Front Panel Position/Size' }
+      'control-changes' { return 'Front Panel Controls' }
+      'window' { return 'Window Properties' }
+      'attributes' { return 'Attributes' }
+      'vi-attribute' { return 'VI Attribute' }
+      'documentation' { return 'Documentation' }
+      'execution' { return 'Execution Settings' }
+      'icon' { return 'Icon' }
+      'unspecified' { return 'Unspecified' }
+      'cosmetic' { return 'Cosmetic' }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$meta.label)) {
+      return [string]$meta.label
+    }
+  }
+
+  return [string]$Name
+}
+
+function Normalize-ComparisonCategoryList {
+  param([System.Collections.IEnumerable]$Categories)
+
+  if (-not $Categories) { return @() }
+
+  $categoryInfo = $null
+  try {
+    $categoryInfo = Get-VICategoryBuckets -Names @($Categories)
+  } catch {
+    $categoryInfo = $null
+  }
+
+  if ($null -eq $categoryInfo -or -not $categoryInfo.Details) {
+    return @(
+      $Categories |
+        Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+        Select-Object -Unique
+    )
+  }
+
+  $details = @($categoryInfo.Details)
+  if ($details.Count -gt 1) {
+    $specificDetails = @($details | Where-Object { [string]$_.slug -ne 'cosmetic' })
+    if ($specificDetails.Count -gt 0) {
+      $details = $specificDetails
+    }
+  }
+
+  return @(
+    $details |
+      ForEach-Object { Get-CanonicalComparisonCategoryName -Name ([string]$_.slug) } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+      Select-Object -Unique
+  )
 }
 
 function Update-TallyFromDetails {
@@ -2102,6 +2183,7 @@ foreach ($modeSpec in $modeSpecs) {
       $outNode = $summaryJson.out
       if ((@($cliCategories).Count -eq 0 -or @($cliCategoryDetails).Count -eq 0) -and $outNode) {
         $reportCandidate = $null
+        $reportCategoryMetadata = $null
         if ($outNode.PSObject.Properties['reportHtml'] -and $outNode.reportHtml) {
           $reportCandidate = [string]$outNode.reportHtml
         } elseif ($outNode.PSObject.Properties['reportPath'] -and $outNode.reportPath) {
@@ -2145,29 +2227,30 @@ foreach ($modeSpec in $modeSpecs) {
             Select-Object -Unique
         )
       }
+      $categories = @(Normalize-ComparisonCategoryList -Categories $categories)
 
       $categoryInfo = $null
       if (@($categories).Count -gt 0) {
         $categoryInfo = Get-VICategoryBuckets -Names $categories
       }
-      $resolvedCategoryDetails = if (@($cliCategoryDetails).Count -gt 0) {
-        @($cliCategoryDetails)
-      } elseif ($categoryInfo -and $categoryInfo.Details) {
+      $resolvedCategoryDetails = if ($categoryInfo -and $categoryInfo.Details) {
         @($categoryInfo.Details)
+      } elseif (@($cliCategoryDetails).Count -gt 0) {
+        @($cliCategoryDetails)
       } else {
         @()
       }
-      $resolvedCategoryBuckets = if (@($cliCategoryBuckets).Count -gt 0) {
-        @($cliCategoryBuckets | Select-Object -Unique)
-      } elseif ($categoryInfo -and $categoryInfo.BucketSlugs) {
+      $resolvedCategoryBuckets = if ($categoryInfo -and $categoryInfo.BucketSlugs) {
         @($categoryInfo.BucketSlugs)
+      } elseif (@($cliCategoryBuckets).Count -gt 0) {
+        @($cliCategoryBuckets | Select-Object -Unique)
       } else {
         @()
       }
-      $resolvedCategoryBucketDetails = if (@($cliCategoryBucketDetails).Count -gt 0) {
-        @($cliCategoryBucketDetails)
-      } elseif ($categoryInfo -and $categoryInfo.BucketDetails) {
+      $resolvedCategoryBucketDetails = if ($categoryInfo -and $categoryInfo.BucketDetails) {
         @($categoryInfo.BucketDetails)
+      } elseif (@($cliCategoryBucketDetails).Count -gt 0) {
+        @($cliCategoryBucketDetails)
       } else {
         @()
       }

--- a/tools/VICategoryBuckets.psm1
+++ b/tools/VICategoryBuckets.psm1
@@ -105,19 +105,21 @@ function Resolve-VICategorySlug {
     if ([string]::IsNullOrWhiteSpace($Name)) { return $null }
 
     $token = $Name.Trim().ToLowerInvariant()
+    if ($script:CategoryDefinitions.ContainsKey($token)) { return $token }
+    $normalizedToken = $token -replace '[-_]+', ' '
 
-    if ($token -match 'block diagram' -and $token -match 'cosmetic') { return 'block-diagram-cosmetic' }
-    if ($token -match 'block diagram' -and $token -match 'functional') { return 'block-diagram-functional' }
-    if ($token -match 'block diagram') { return 'block-diagram' }
-    if ($token -match 'connector') { return 'connector-pane' }
-    if ($token -match 'vi attribute' -or $token -match 'attributes') { return 'vi-attribute' }
-    if ($token -match 'front panel position') { return 'front-panel-position-size' }
-    if ($token -match 'front panel' -or $token -match 'control changes') { return 'front-panel' }
-    if ($token -match 'cosmetic') { return 'cosmetic' }
-    if ($token -match 'window') { return 'window' }
-    if ($token -match 'icon') { return 'icon' }
-    if ($token -match 'documentation') { return 'documentation' }
-    if ($token -match 'execution') { return 'execution' }
+    if ($normalizedToken -match 'block diagram' -and $normalizedToken -match 'cosmetic') { return 'block-diagram-cosmetic' }
+    if ($normalizedToken -match 'block diagram' -and $normalizedToken -match 'functional') { return 'block-diagram-functional' }
+    if ($normalizedToken -match 'block diagram') { return 'block-diagram' }
+    if ($normalizedToken -match 'connector') { return 'connector-pane' }
+    if ($normalizedToken -match 'vi attribute' -or $normalizedToken -match 'attributes') { return 'vi-attribute' }
+    if ($normalizedToken -match 'front panel position') { return 'front-panel-position-size' }
+    if ($normalizedToken -match 'front panel' -or $normalizedToken -match 'control changes') { return 'front-panel' }
+    if ($normalizedToken -match 'cosmetic') { return 'cosmetic' }
+    if ($normalizedToken -match 'window') { return 'window' }
+    if ($normalizedToken -match 'icon') { return 'icon' }
+    if ($normalizedToken -match 'documentation') { return 'documentation' }
+    if ($normalizedToken -match 'execution') { return 'execution' }
 
     return ($token -replace '[^a-z0-9]+', '-').Trim('-')
 }


### PR DESCRIPTION
## Summary
- preserve category specificity for slug-shaped inputs in `VICategoryBuckets`
- load `VICategoryBuckets.psm1` in `Compare-RefsToTemp` from the backend tooling root instead of the consumer repo cwd
- keep history category details and regression coverage aligned so `Block Diagram Cosmetic` survives through summary, history manifest, and report rendering

## Validation
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/VICategoryBuckets.Tests.ps1','tests/CompareVI.History.Tests.ps1','tests/Render-VIHistoryReport.Tests.ps1' -Output Detailed -CI"`
- canonical proof replay on `ni/labview-icon-editor` for `Tooling/deployment/VIP_Pre-Install Custom Action.vi`
  - `vip-preinstall-default-touch-history-v9`
  - `vip-preinstall-block-diagram-touch-history-v9`
  - lower-level summary confirmation via `vip-preinstall-default-touch-history-v10`
