### PR TITLE
Reveal collapsed VI history pairs

### DIFF
--- a/tests/CompareVI.History.Tests.ps1
+++ b/tests/CompareVI.History.Tests.ps1
@@ -502,6 +502,7 @@ exit 0
       $modeManifest.stats.signalDiffs | Should -Be 0
       $modeManifest.stats.noiseCollapsed | Should -BeGreaterThan 0
       @($modeManifest.comparisons).Count | Should -Be 0
+      @($modeManifest.collapsedComparisons).Count | Should -BeGreaterThan 0
       $modeManifest.stats.collapsedNoise.count | Should -Be $modeManifest.stats.noiseCollapsed
       $modeManifest.stats.collapsedNoise.categoryCounts.PSObject.Properties.Name | Should -Contain 'vi-attribute'
       $modeManifest.stats.collapsedNoise.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'unspecified'
@@ -512,12 +513,17 @@ exit 0
       $aggregate.stats.signalDiffs | Should -Be 0
       $aggregate.stats.noiseCollapsed | Should -BeGreaterThan 0
       $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Contain 'VI Attribute'
+      $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'Attributes'
       $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'Cosmetic'
       $aggregate.stats.categoryCounts.PSObject.Properties.Name | Should -Not -Contain 'unspecified'
       [int]$aggregate.stats.bucketCounts.metadata | Should -BeGreaterThan 0
       $outputText | Should -Match 'LVCompare detected differences'
       $outputText | Should -Match 'VI attribute \(\d+\)'
       $outputText | Should -Not -Match 'unspecified'
+
+      $historyMd = Get-Content -LiteralPath (Join-Path $rd 'history-report.md') -Raw
+      $historyMd | Should -Match 'collapsed noise'
+      $historyMd | Should -Match 'Touch history'
     } finally {
       if ($null -eq $previousDiff) {
         Remove-Item Env:STUB_COMPARE_DIFF -ErrorAction SilentlyContinue
@@ -1449,7 +1455,10 @@ exit 0
       $historyMd | Should -Match '\| Coverage Class \| `catalog-aligned` \|'
       $historyMd | Should -Match '## Mode overview'
       $historyMd | Should -Match '\| Mode \| Processed \| Diffs \| Signal \| Collapsed Noise \| Missing \| Categories \| Buckets \| Flags \|'
-      $historyMd | Should -Match '## Attribute coverage'
+      $historyMd | Should -Match '## Commit pairs'
+      $historyMd | Should -Match 'collapsed noise'
+      $historyMd | Should -Match 'Touch history'
+      $historyMd | Should -Match '## Mode filter coverage'
       $historyMd | Should -Match 'History manifest:'
 
       $historyHtml = Get-Content -LiteralPath (Join-Path $rd 'history-report.html') -Raw
@@ -1463,8 +1472,9 @@ exit 0
       $historyHtml | Should -Match '<th>Signal</th>'
       $historyHtml | Should -Match '<th>Collapsed Noise</th>'
       $historyHtml | Should -Match '<h2>Commit pairs</h2>'
-      $historyHtml | Should -Match 'No commit pairs were captured'
-      $historyHtml | Should -Match '<h2>Attribute coverage</h2>'
+      $historyHtml | Should -Match 'Collapsed noise'
+      $historyHtml | Should -Match 'Touch history'
+      $historyHtml | Should -Match '<h2>Mode filter coverage</h2>'
     } finally {
       if ($null -eq $previousDiff) {
         Remove-Item Env:STUB_COMPARE_DIFF -ErrorAction SilentlyContinue

--- a/tests/VICategoryBuckets.Tests.ps1
+++ b/tests/VICategoryBuckets.Tests.ps1
@@ -14,6 +14,14 @@ Describe 'VICategoryBuckets module' -Tag 'Unit' {
         $meta.bucketClassification | Should -Be 'neutral'
     }
 
+    It 'treats generic Attributes as an alias of VI Attribute' {
+        $meta = Get-VICategoryMetadata -Name 'Attributes'
+        $meta | Should -Not -BeNullOrEmpty
+        $meta.slug | Should -Be 'vi-attribute'
+        $meta.label | Should -Be 'VI attribute'
+        $meta.bucketSlug | Should -Be 'metadata'
+    }
+
     It 'preserves known slug inputs without degrading category specificity' {
         $meta = Get-VICategoryMetadata -Name 'block-diagram-cosmetic'
         $meta | Should -Not -BeNullOrEmpty

--- a/tools/Compare-RefsToTemp.ps1
+++ b/tools/Compare-RefsToTemp.ps1
@@ -324,7 +324,7 @@ function Normalize-ReportCategories {
           'front-panel-position-size' { 'Front Panel Position/Size' }
           'control-changes' { 'Front Panel Controls' }
           'window' { 'Window Properties' }
-          'attributes' { 'Attributes' }
+          'attributes' { 'VI Attribute' }
           'vi-attribute' { 'VI Attribute' }
           'documentation' { 'Documentation' }
           'execution' { 'Execution Settings' }

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -533,7 +533,7 @@ function Get-CanonicalComparisonCategoryName {
       'front-panel-position-size' { return 'Front Panel Position/Size' }
       'control-changes' { return 'Front Panel Controls' }
       'window' { return 'Window Properties' }
-      'attributes' { return 'Attributes' }
+      'attributes' { return 'VI Attribute' }
       'vi-attribute' { return 'VI Attribute' }
       'documentation' { return 'Documentation' }
       'execution' { return 'Execution Settings' }
@@ -1837,6 +1837,7 @@ foreach ($modeSpec in $modeSpecs) {
     flags       = $modeFlags
     resultsDir  = $modeResultsResolved
     comparisons = @()
+    collapsedComparisons = @()
     stats       = [ordered]@{
       processed      = 0
       diffs          = 0
@@ -2361,6 +2362,10 @@ foreach ($modeSpec in $modeSpecs) {
         }
       }
 
+      if ($collapsedThis) {
+        $modeManifest.collapsedComparisons += $comparisonRecordObject
+      }
+
       if ($appendComparison) {
         $modeManifest.comparisons += $comparisonRecordObject
       }
@@ -2836,7 +2841,7 @@ if (-not $renderSucceeded) {
       '| --- | --- | --- |'
       '| n/a | n/a | [report](./) |'
       ''
-      '## Attribute coverage'
+      '## Mode filter coverage'
       ''
       '_History renderer unavailable; see manifest for details._'
     )
@@ -2866,7 +2871,7 @@ if (-not $renderSucceeded) {
       </table>
     </section>
     <section>
-      <h2>Attribute coverage</h2>
+      <h2>Mode filter coverage</h2>
       <p>History renderer unavailable.</p>
     </section>
   </article>

--- a/tools/Publish-VICompareSummary.ps1
+++ b/tools/Publish-VICompareSummary.ps1
@@ -232,7 +232,7 @@ if ($totalDiffs -gt 0) {
 }
 
 $lines.Add("")
-$lines.Add("#### Attribute coverage")
+$lines.Add("#### Mode filter coverage")
 $attributeCoverageAdded = $false
 foreach ($mode in $modeSummaries) {
   $modeName = Get-ObjectPropertyValue -InputObject $mode -PropertyName 'mode'
@@ -296,7 +296,7 @@ foreach ($mode in $modeSummaries) {
 }
 
 if (-not $attributeCoverageAdded) {
-  $lines.Add("- *(Attribute coverage unavailable in manifest)*")
+  $lines.Add("- *(Mode filter coverage unavailable in manifest)*")
 }
 
 $body = $lines -join "`n"

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -823,7 +823,19 @@ function Build-FallbackHistoryContext {
       continue
     }
 
-    foreach ($comparison in @($modeManifest.comparisons)) {
+    $modeComparisons = New-Object System.Collections.Generic.List[object]
+    foreach ($comparisonEntry in @($modeManifest.comparisons)) {
+      if ($comparisonEntry) {
+        $modeComparisons.Add($comparisonEntry) | Out-Null
+      }
+    }
+    foreach ($comparisonEntry in @($modeManifest.collapsedComparisons)) {
+      if ($comparisonEntry) {
+        $modeComparisons.Add($comparisonEntry) | Out-Null
+      }
+    }
+
+    foreach ($comparison in @($modeComparisons | Sort-Object { [int](Coalesce $_.index 0) })) {
       if (-not $comparison) { continue }
       $baseNode = $comparison.base
       $headNode = $comparison.head
@@ -863,6 +875,9 @@ function Build-FallbackHistoryContext {
         }
         if ($resultNode.PSObject.Properties['classification'] -and $resultNode.classification) {
           $resultPayload.classification = $resultNode.classification
+        }
+        if ($resultNode.PSObject.Properties['collapsed']) {
+          $resultPayload.collapsed = [bool]$resultNode.collapsed
         }
         if ($resultNode.PSObject.Properties['artifactDir'] -and $resultNode.artifactDir) {
           $resultPayload.artifactDir = $resultNode.artifactDir
@@ -1217,7 +1232,13 @@ if ($comparisons.Count -gt 0) {
     $diffValue = $hasDiffValue -and ($resultNode.diff -eq $true)
     $statusValue = if ($resultNode -and $resultNode.PSObject.Properties['status']) { [string]$resultNode.status } else { $null }
     $diffCell = if ($hasDiffValue) {
-      if ($diffValue) { '**diff**' } else { 'clean' }
+      if ($diffValue) {
+        if ($resultNode -and $resultNode.PSObject.Properties['collapsed'] -and [bool]$resultNode.collapsed) {
+          '_collapsed noise_'
+        } else {
+          '**diff**'
+        }
+      } else { 'clean' }
     } elseif ($statusValue) {
       ('_{0}_' -f $statusValue)
     } else {
@@ -1310,6 +1331,7 @@ if ($comparisons.Count -gt 0) {
       LineageLabel = $lineageLabel
       LineageType  = if ($lineageNode -and $lineageNode.PSObject.Properties['type']) { [string]$lineageNode.type } else { 'mainline' }
       Diff       = [bool]$diffValue
+      Collapsed  = if ($resultNode -and $resultNode.PSObject.Properties['collapsed']) { [bool]$resultNode.collapsed } else { $false }
       HasDiff    = $hasDiffValue
       Status     = $statusValue
       Duration   = $durationValue
@@ -1336,7 +1358,7 @@ if ($comparisons.Count -gt 0) {
 }
 
 $summaryLines.Add('')
-$summaryLines.Add('## Attribute coverage')
+$summaryLines.Add('## Mode filter coverage')
 $summaryLines.Add('')
 if ($modeEntries.Count -gt 0) {
   foreach ($mode in $modeEntries) {
@@ -1518,8 +1540,12 @@ if ($emitHtml -and $HtmlPath) {
     [void]$htmlBuilder.AppendLine('    <thead><tr><th>Mode</th><th>Pair</th><th>Lineage</th><th>Base</th><th>Head</th><th>Diff</th><th>Duration (s)</th><th>Categories</th><th>Buckets</th><th>Report</th><th>Highlights</th></tr></thead>')
     [void]$htmlBuilder.AppendLine('    <tbody>')
     foreach ($row in $comparisonHtmlRows) {
-      $diffClass = if ($row.Diff) { 'diff-yes' } elseif ($row.Status) { 'diff-status' } else { 'diff-no' }
-      $diffLabel = if ($row.Diff) { 'Diff' } elseif ($row.Status) { ConvertTo-HtmlSafe $row.Status } else { 'No' }
+      $diffClass = if ($row.Diff) {
+        if ($row.Collapsed) { 'diff-collapsed' } else { 'diff-yes' }
+      } elseif ($row.Status) { 'diff-status' } else { 'diff-no' }
+      $diffLabel = if ($row.Diff) {
+        if ($row.Collapsed) { 'Collapsed noise' } else { 'Diff' }
+      } elseif ($row.Status) { ConvertTo-HtmlSafe $row.Status } else { 'No' }
       $durationDisplay = '<span class="muted">n/a</span>'
       if ($row.DurationDisplay -and $row.DurationDisplay -ne 'n/a') {
         $durationDisplay = ConvertTo-HtmlSafe $row.DurationDisplay
@@ -1688,7 +1714,7 @@ if ($emitHtml -and $HtmlPath) {
     [void]$htmlBuilder.AppendLine('  <p class="muted">No commit pairs were captured for the requested history window.</p>')
   }
 
-  [void]$htmlBuilder.AppendLine('  <h2>Attribute coverage</h2>')
+  [void]$htmlBuilder.AppendLine('  <h2>Mode filter coverage</h2>')
   if ($modeEntries.Count -gt 0) {
     [void]$htmlBuilder.AppendLine('  <ul>')
     foreach ($mode in $modeEntries) {

--- a/tools/VICategoryBuckets.psm1
+++ b/tools/VICategoryBuckets.psm1
@@ -105,6 +105,7 @@ function Resolve-VICategorySlug {
     if ([string]::IsNullOrWhiteSpace($Name)) { return $null }
 
     $token = $Name.Trim().ToLowerInvariant()
+    if ($token -eq 'attributes') { return 'vi-attribute' }
     if ($script:CategoryDefinitions.ContainsKey($token)) { return $token }
     $normalizedToken = $token -replace '[-_]+', ' '
 


### PR DESCRIPTION
## Summary
- preserve collapsed noise comparisons in the backend history surface instead of hiding them from the commit-pair report
- canonicalize generic Attributes into the VI Attribute category so metadata changes stop splitting across duplicate labels
- rename the report section that only reflects mode flags to Mode filter coverage

## Validation
- Invoke-Pester -Path tests/CompareVI.History.Tests.ps1, tests/Render-VIHistoryReport.Tests.ps1 -Output Detailed -CI
- Invoke-Pester -Path tests/VICategoryBuckets.Tests.ps1 -Output Detailed -CI
- canonical proof: /tmp/ni-labview-icon-editor/tests/results/ref-compare/history-exploration/local-fast-loop/vip-preinstall-default-touch-history-v14
