### PR TITLE
Make LV32 shadow proof non-blocking

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1825,6 +1825,7 @@ jobs:
     needs: [smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan, vi-history-scenarios-windows-lv32-plan]
     if: needs.smoke-gate.outputs.skip != 'true' && needs.vi-history-scenarios-plan.outputs.execute_lanes == 'true' && needs.vi-history-scenarios-windows-lv32-plan.outputs.available == 'true'
     runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress, labview-2026, lv32]
+    continue-on-error: true
     timeout-minutes: 60
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
- mark the self-hosted LV32 VI history shadow proof job as continue-on-error
- align workflow behavior with the existing non-required shadow-proof contract
- stop advisory LV32 runner failures from ejecting otherwise valid PRs from merge queue

## Validation
- yaml parse for .github/workflows/validate.yml
- git diff --check