### PR TITLE
Identify latest VI history signal pair

### DIFF
--- a/docs/schemas/comparevi-tools-history-facade-v1.schema.json
+++ b/docs/schemas/comparevi-tools-history-facade-v1.schema.json
@@ -155,6 +155,7 @@
       "required": [
         "reviewPriority",
         "latestPair",
+        "latestSignalPair",
         "signalPairs",
         "collapsedPairs",
         "focusBuckets",
@@ -176,6 +177,27 @@
               "minimum": 0
             },
             "status": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "latestSignalPair": {
+          "type": "object",
+          "required": [
+            "index",
+            "baseRef",
+            "headRef"
+          ],
+          "properties": {
+            "index": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "baseRef": {
+              "type": "string"
+            },
+            "headRef": {
               "type": "string"
             }
           },

--- a/tests/CompareVI.History.Tests.ps1
+++ b/tests/CompareVI.History.Tests.ps1
@@ -1450,6 +1450,7 @@ exit 0
       @($historySummary.decisionGuidance.collapsedPairs) | Should -Be @(1)
       $historySummary.decisionGuidance.latestPair.index | Should -Be 1
       $historySummary.decisionGuidance.latestPair.status | Should -Be 'collapsed-noise'
+      $historySummary.decisionGuidance.latestSignalPair.index | Should -Be 0
       @($historySummary.decisionGuidance.PSObject.Properties.Name) | Should -Contain 'contextBuckets'
 
       $historyMd = Get-Content -LiteralPath (Join-Path $rd 'history-report.md') -Raw
@@ -1464,6 +1465,7 @@ exit 0
       $historyMd | Should -Match '## Decision guidance'
       $historyMd | Should -Match 'Review priority'
       $historyMd | Should -Match 'Latest pair'
+      $historyMd | Should -Not -Match 'Review first'
       $historyMd | Should -Match '## Commit pairs'
       $historyMd | Should -Match 'collapsed noise'
       $historyMd | Should -Match 'Touch history'
@@ -1483,6 +1485,7 @@ exit 0
       $historyHtml | Should -Match '<h2>Decision guidance</h2>'
       $historyHtml | Should -Match 'Review priority'
       $historyHtml | Should -Match 'Latest pair'
+      $historyHtml | Should -Not -Match 'Review first'
       $historyHtml | Should -Match '<h2>Commit pairs</h2>'
       $historyHtml | Should -Match 'Collapsed noise'
       $historyHtml | Should -Match 'Touch history'

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -1288,6 +1288,7 @@ $decisionReviewPriority = if ($signalComparisonEntries.Count -gt 0) {
 } else {
   'no-diff'
 }
+$latestSignalComparisonEntry = if ($signalComparisonEntries.Count -gt 0) { $signalComparisonEntries[0] } else { $null }
 $decisionLatestStatus = 'n/a'
 if ($latestComparisonEntry) {
   $latestResultNode = $latestComparisonEntry.result
@@ -1310,6 +1311,11 @@ if ($sortedComparisons.Count -gt 0) {
   $summaryLines.Add(('- Review priority: `{0}`' -f $decisionReviewPriority))
   if ($latestComparisonEntry) {
     $summaryLines.Add(('- Latest pair: `pair {0}` is `{1}`' -f (Coalesce $latestComparisonEntry.index 'n/a'), $decisionLatestStatus))
+  }
+  if ($latestSignalComparisonEntry) {
+    $latestSignalBaseRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) 'n/a')
+    $latestSignalHeadRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) 'n/a')
+    $summaryLines.Add(('- Review first: `pair {0}` (`{1}` -> `{2}`)' -f (Coalesce $latestSignalComparisonEntry.index 'n/a'), $latestSignalBaseRef, $latestSignalHeadRef))
   }
   if ($signalComparisonEntries.Count -gt 0) {
     $summaryLines.Add(('- Signal pairs: `{0}`' -f ([string]::Join(', ', @($signalComparisonEntries | ForEach-Object { [string](Coalesce $_.index 'n/a') })))))
@@ -1665,6 +1671,11 @@ if ($emitHtml -and $HtmlPath) {
     if ($latestComparisonEntry) {
       [void]$htmlBuilder.AppendLine(('    <li><strong>Latest pair</strong><span><code>pair {0}</code> is <code>{1}</code></span></li>' -f (ConvertTo-HtmlSafe (Coalesce $latestComparisonEntry.index 'n/a')), (ConvertTo-HtmlSafe $decisionLatestStatus)))
     }
+    if ($latestSignalComparisonEntry) {
+      $latestSignalBaseRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) 'n/a')
+      $latestSignalHeadRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) 'n/a')
+      [void]$htmlBuilder.AppendLine(('    <li><strong>Review first</strong><span><code>pair {0}</code> (<code>{1}</code> -&gt; <code>{2}</code>)</span></li>' -f (ConvertTo-HtmlSafe (Coalesce $latestSignalComparisonEntry.index 'n/a')), (ConvertTo-HtmlSafe $latestSignalBaseRef), (ConvertTo-HtmlSafe $latestSignalHeadRef)))
+    }
     if ($signalComparisonEntries.Count -gt 0) {
       [void]$htmlBuilder.AppendLine(('    <li><strong>Signal pairs</strong><span><code>{0}</code></span></li>' -f (ConvertTo-HtmlSafe ([string]::Join(', ', @($signalComparisonEntries | ForEach-Object { [string](Coalesce $_.index 'n/a') }))))))
     } else {
@@ -1963,6 +1974,11 @@ $historySummary = [ordered]@{
     latestPair = [ordered]@{
       index = if ($latestComparisonEntry) { [int](Coalesce $latestComparisonEntry.index 0) } else { 0 }
       status = [string]$decisionLatestStatus
+    }
+    latestSignalPair = [ordered]@{
+      index = if ($latestSignalComparisonEntry) { [int](Coalesce $latestSignalComparisonEntry.index 0) } else { 0 }
+      baseRef = if ($latestSignalComparisonEntry) { [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) '') } else { '' }
+      headRef = if ($latestSignalComparisonEntry) { [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) '') } else { '' }
     }
     signalPairs = @($signalComparisonEntries | ForEach-Object { [int](Coalesce $_.index 0) })
     collapsedPairs = @($collapsedComparisonEntries | ForEach-Object { [int](Coalesce $_.index 0) })


### PR DESCRIPTION
## Summary
- surface the newest meaningful pair separately from the newest chronological pair
- keep the history schema aligned with the new `latestSignalPair` decision guidance
- extend history tests to assert the review-first guidance for collapsed-noise latest pairs

## Proof
- `pwsh -NoLogo -NoProfile -Command "Set-Location '/tmp/compare-vi-cli-action-wt-touch-history'; Invoke-Pester -Path 'tests/CompareVI.History.Tests.ps1','tests/Render-VIHistoryReport.Tests.ps1' -Output Detailed -CI"`
- `pwsh -NoLogo -NoProfile -File /tmp/comparevi-history/scripts/Invoke-CompareVIHistoryManualExplorationFastLoop.ps1 -ConsumerRepositoryRoot /tmp/ni-labview-icon-editor -ConsumerRef develop -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -NoisePolicy collapse -Mode full -ResultsDir 'tests/results/ref-compare/history-exploration/local-fast-loop/vip-preinstall-default-touch-history-v22' -ToolingRoot /tmp/compare-vi-cli-action-wt-touch-history -InvokeScriptPath /tmp/labview-icon-editor-demo/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`
