### PR TITLE
Add VI history review sequence guidance

### DIFF
--- a/docs/schemas/comparevi-tools-history-facade-v1.schema.json
+++ b/docs/schemas/comparevi-tools-history-facade-v1.schema.json
@@ -156,6 +156,7 @@
         "reviewPriority",
         "latestPair",
         "latestSignalPair",
+        "reviewSequence",
         "signalPairs",
         "collapsedPairs",
         "focusBuckets",
@@ -187,7 +188,9 @@
           "required": [
             "index",
             "baseRef",
-            "headRef"
+            "headRef",
+            "baseSubject",
+            "headSubject"
           ],
           "properties": {
             "index": {
@@ -199,9 +202,46 @@
             },
             "headRef": {
               "type": "string"
+            },
+            "baseSubject": {
+              "type": "string"
+            },
+            "headSubject": {
+              "type": "string"
             }
           },
           "additionalProperties": false
+        },
+        "reviewSequence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "index",
+              "baseRef",
+              "headRef",
+              "baseSubject",
+              "headSubject"
+            ],
+            "properties": {
+              "index": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "baseRef": {
+                "type": "string"
+              },
+              "headRef": {
+                "type": "string"
+              },
+              "baseSubject": {
+                "type": "string"
+              },
+              "headSubject": {
+                "type": "string"
+              }
+            }
+          }
         },
         "signalPairs": {
           "type": "array",

--- a/tests/Render-VIHistoryReport.Tests.ps1
+++ b/tests/Render-VIHistoryReport.Tests.ps1
@@ -216,6 +216,10 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $markdown | Should -Match '\| Coverage Class \| `catalog-partial` \|'
         $markdown | Should -Match '\| Mode Sensitivity \| `single-mode-observed` \|'
         $markdown | Should -Match '\| Outcome Labels \| `clean`, `signal-diff` \|'
+        $markdown | Should -Match '## Decision guidance'
+        $markdown | Should -Match 'Review first'
+        $markdown | Should -Match 'Review sequence'
+        $markdown | Should -Match 'pair 2 \(Base commit -> Head commit\)'
         $markdown | Should -Match '\| Mode \| Processed \| Diffs \| Signal \| Collapsed Noise \| Missing \| Categories \| Buckets \| Flags \|'
         $markdown | Should -Match '\| Mode \| Pair \| Lineage \| Base \| Head \| Diff \| Duration \(s\) \| Categories \| Buckets \| Report \| Highlights \|'
         $markdown | Should -Match 'Touch history'
@@ -234,6 +238,9 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $html | Should -Match 'single-mode-observed'
         $html | Should -Match 'Outcome Labels'
         $html | Should -Match '<code>clean</code>, <code>signal-diff</code>'
+        $html | Should -Match 'Review first'
+        $html | Should -Match 'Review sequence'
+        $html | Should -Match 'pair 2 \(Base commit -&gt; Head commit\)'
         $html | Should -Match '<th>Signal</th>'
         $html | Should -Match '<th>Collapsed Noise</th>'
         $html | Should -Match '<th>Lineage</th>'
@@ -264,6 +271,13 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $historySummary.target.sourceBranchRef | Should -Be 'feature/history-source'
         $historySummary.target.branchBudget.maxCommitCount | Should -Be 64
         $historySummary.target.branchBudget.commitCount | Should -Be 3
+        $historySummary.decisionGuidance.latestSignalPair.index | Should -Be 2
+        $historySummary.decisionGuidance.latestSignalPair.baseSubject | Should -Be 'Base commit'
+        $historySummary.decisionGuidance.latestSignalPair.headSubject | Should -Be 'Head commit'
+        @($historySummary.decisionGuidance.reviewSequence).Count | Should -Be 1
+        $historySummary.decisionGuidance.reviewSequence[0].index | Should -Be 2
+        $historySummary.decisionGuidance.reviewSequence[0].baseSubject | Should -Be 'Base commit'
+        $historySummary.decisionGuidance.reviewSequence[0].headSubject | Should -Be 'Head commit'
     }
 
     It 'preserves branch budget numeric fields when the source object is a hashtable' {

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -1288,6 +1288,17 @@ $decisionReviewPriority = if ($signalComparisonEntries.Count -gt 0) {
 } else {
   'no-diff'
 }
+$decisionReviewSequence = @(
+  $signalComparisonEntries | ForEach-Object {
+    [ordered]@{
+      index = [int](Coalesce $_.index 0)
+      baseRef = [string](Coalesce (Coalesce $_.base.short $_.base.full) '')
+      headRef = [string](Coalesce (Coalesce $_.head.short $_.head.full) '')
+      baseSubject = [string](Coalesce $_.base.subject '')
+      headSubject = [string](Coalesce $_.head.subject '')
+    }
+  }
+)
 $latestSignalComparisonEntry = if ($signalComparisonEntries.Count -gt 0) { $signalComparisonEntries[0] } else { $null }
 $decisionLatestStatus = 'n/a'
 if ($latestComparisonEntry) {
@@ -1316,6 +1327,14 @@ if ($sortedComparisons.Count -gt 0) {
     $latestSignalBaseRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) 'n/a')
     $latestSignalHeadRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) 'n/a')
     $summaryLines.Add(('- Review first: `pair {0}` (`{1}` -> `{2}`)' -f (Coalesce $latestSignalComparisonEntry.index 'n/a'), $latestSignalBaseRef, $latestSignalHeadRef))
+  }
+  if ($decisionReviewSequence.Count -gt 0) {
+    $reviewSequenceLabels = @(
+      $decisionReviewSequence | ForEach-Object {
+        'pair {0} ({1} -> {2})' -f $_.index, (Coalesce $_.baseSubject 'n/a'), (Coalesce $_.headSubject 'n/a')
+      }
+    )
+    $summaryLines.Add(('- Review sequence: `{0}`' -f ([string]::Join('; ', $reviewSequenceLabels))))
   }
   if ($signalComparisonEntries.Count -gt 0) {
     $summaryLines.Add(('- Signal pairs: `{0}`' -f ([string]::Join(', ', @($signalComparisonEntries | ForEach-Object { [string](Coalesce $_.index 'n/a') })))))
@@ -1676,6 +1695,14 @@ if ($emitHtml -and $HtmlPath) {
       $latestSignalHeadRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) 'n/a')
       [void]$htmlBuilder.AppendLine(('    <li><strong>Review first</strong><span><code>pair {0}</code> (<code>{1}</code> -&gt; <code>{2}</code>)</span></li>' -f (ConvertTo-HtmlSafe (Coalesce $latestSignalComparisonEntry.index 'n/a')), (ConvertTo-HtmlSafe $latestSignalBaseRef), (ConvertTo-HtmlSafe $latestSignalHeadRef)))
     }
+    if ($decisionReviewSequence.Count -gt 0) {
+      $reviewSequenceLabels = @(
+        $decisionReviewSequence | ForEach-Object {
+          'pair {0} ({1} -> {2})' -f $_.index, (Coalesce $_.baseSubject 'n/a'), (Coalesce $_.headSubject 'n/a')
+        }
+      )
+      [void]$htmlBuilder.AppendLine(('    <li><strong>Review sequence</strong><span><code>{0}</code></span></li>' -f (ConvertTo-HtmlSafe ([string]::Join('; ', $reviewSequenceLabels)))))
+    }
     if ($signalComparisonEntries.Count -gt 0) {
       [void]$htmlBuilder.AppendLine(('    <li><strong>Signal pairs</strong><span><code>{0}</code></span></li>' -f (ConvertTo-HtmlSafe ([string]::Join(', ', @($signalComparisonEntries | ForEach-Object { [string](Coalesce $_.index 'n/a') }))))))
     } else {
@@ -1979,7 +2006,20 @@ $historySummary = [ordered]@{
       index = if ($latestSignalComparisonEntry) { [int](Coalesce $latestSignalComparisonEntry.index 0) } else { 0 }
       baseRef = if ($latestSignalComparisonEntry) { [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) '') } else { '' }
       headRef = if ($latestSignalComparisonEntry) { [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) '') } else { '' }
+      baseSubject = if ($latestSignalComparisonEntry) { [string](Coalesce $latestSignalComparisonEntry.base.subject '') } else { '' }
+      headSubject = if ($latestSignalComparisonEntry) { [string](Coalesce $latestSignalComparisonEntry.head.subject '') } else { '' }
     }
+    reviewSequence = @(
+      $decisionReviewSequence | ForEach-Object {
+        [ordered]@{
+          index = [int](Coalesce $_.index 0)
+          baseRef = [string](Coalesce $_.baseRef '')
+          headRef = [string](Coalesce $_.headRef '')
+          baseSubject = [string](Coalesce $_.baseSubject '')
+          headSubject = [string](Coalesce $_.headSubject '')
+        }
+      }
+    )
     signalPairs = @($signalComparisonEntries | ForEach-Object { [int](Coalesce $_.index 0) })
     collapsedPairs = @($collapsedComparisonEntries | ForEach-Object { [int](Coalesce $_.index 0) })
     focusBuckets = @($decisionFocusBuckets.ToArray())


### PR DESCRIPTION
## Summary
- add a human-readable review sequence to VI history decision guidance
- persist commit subjects for the newest meaningful pair in the history facade schema
- extend renderer coverage for review-first and review-sequence output

## Proof
- `pwsh -NoLogo -NoProfile -Command "Set-Location '/tmp/compare-vi-cli-action-wt-touch-history'; Invoke-Pester -Path 'tests/Render-VIHistoryReport.Tests.ps1' -Output Detailed -CI"`
- `pwsh -NoLogo -NoProfile -File /tmp/comparevi-history/scripts/Invoke-CompareVIHistoryManualExplorationFastLoop.ps1 -ConsumerRepositoryRoot /tmp/ni-labview-icon-editor -ConsumerRef develop -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -NoisePolicy collapse -Mode full -ResultsDir 'tests/results/ref-compare/history-exploration/local-fast-loop/vip-preinstall-default-touch-history-v25' -ToolingRoot /tmp/compare-vi-cli-action-wt-touch-history -InvokeScriptPath /tmp/labview-icon-editor-demo/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`
