### PR TITLE
Expose VI history decision chronology

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,11 @@ renders, `history-report-html`). Downstream workflows and reusable snippets can
 consume those keys to surface the Markdown/HTML report or to dispatch follow-up
 automation without spelunking the artifacts. When the renderer is unavailable,
 `Compare-VIHistory.ps1` writes a lightweight fallback report so the Markdown
-output key always resolves to a readable summary.
+output key always resolves to a readable summary. The stable
+`history-summary-json` facade and rendered history report now also surface the
+decision statement, the newest meaningful pair, and pair chronology (refs,
+subjects, and commit dates) so reviewers can answer what changed, when it
+changed, and whether it matters without opening raw manifests first.
 
 Provide the optional `notify_issue` input when dispatching the workflow to post
 the same summary table to a GitHub issue for stakeholders.

--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -220,6 +220,9 @@ gh workflow run vi-compare-refs.yml `
   `Invoke-CompareVIHistoryFacade`. When HTML rendering is skipped or fails, the Markdown path still points at the
   fallback report so consumers always have a summary to ingest. A compressed `category-counts-json` blob is also
   published so downstream automation can react to runs dominated by cosmetic noise without re-reading the manifests.
+  The facade's `decisionGuidance` block now carries a human-readable `decisionStatement`, the newest surfaced pair,
+  and the review sequence with refs, subjects, and commit dates so downstream consumers can answer what changed, when,
+  and whether it matters from one stabilized payload.
 - History summary JSON (`tests/results/pr-vi-history/vi-history-summary.json`) now adds:
   - `targets[].reportImages` for per-target extraction metadata.
   - `pairTimeline[]` with additive per-pair contract fields:

--- a/docs/schemas/comparevi-tools-history-facade-v1.schema.json
+++ b/docs/schemas/comparevi-tools-history-facade-v1.schema.json
@@ -174,7 +174,13 @@
           "type": "object",
           "required": [
             "index",
-            "status"
+            "status",
+            "baseRef",
+            "headRef",
+            "baseSubject",
+            "headSubject",
+            "baseDate",
+            "headDate"
           ],
           "properties": {
             "index": {
@@ -182,6 +188,24 @@
               "minimum": 0
             },
             "status": {
+              "type": "string"
+            },
+            "baseRef": {
+              "type": "string"
+            },
+            "headRef": {
+              "type": "string"
+            },
+            "baseSubject": {
+              "type": "string"
+            },
+            "headSubject": {
+              "type": "string"
+            },
+            "baseDate": {
+              "type": "string"
+            },
+            "headDate": {
               "type": "string"
             }
           },
@@ -194,7 +218,9 @@
             "baseRef",
             "headRef",
             "baseSubject",
-            "headSubject"
+            "headSubject",
+            "baseDate",
+            "headDate"
           ],
           "properties": {
             "index": {
@@ -212,6 +238,12 @@
             },
             "headSubject": {
               "type": "string"
+            },
+            "baseDate": {
+              "type": "string"
+            },
+            "headDate": {
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -225,7 +257,9 @@
               "baseRef",
               "headRef",
               "baseSubject",
-              "headSubject"
+              "headSubject",
+              "baseDate",
+              "headDate"
             ],
             "properties": {
               "index": {
@@ -242,6 +276,12 @@
                 "type": "string"
               },
               "headSubject": {
+                "type": "string"
+              },
+              "baseDate": {
+                "type": "string"
+              },
+              "headDate": {
                 "type": "string"
               }
             }

--- a/docs/schemas/comparevi-tools-history-facade-v1.schema.json
+++ b/docs/schemas/comparevi-tools-history-facade-v1.schema.json
@@ -153,6 +153,7 @@
     "decisionGuidance": {
       "type": "object",
       "required": [
+        "decisionStatement",
         "reviewPriority",
         "latestPair",
         "latestSignalPair",
@@ -163,6 +164,9 @@
         "contextBuckets"
       ],
       "properties": {
+        "decisionStatement": {
+          "type": "string"
+        },
         "reviewPriority": {
           "type": "string"
         },

--- a/tests/CompareVI.History.Tests.ps1
+++ b/tests/CompareVI.History.Tests.ps1
@@ -574,6 +574,27 @@ exit 0
 
       $aggregate.stats.signalDiffs | Should -Be 1
       $aggregate.stats.noiseCollapsed | Should -Be 0
+
+      $historySummaryPath = Join-Path $rd 'history-summary.json'
+      Test-Path -LiteralPath $historySummaryPath | Should -BeTrue
+      $historySummary = Get-Content -LiteralPath $historySummaryPath -Raw | ConvertFrom-Json -Depth 12
+      $historySummary.decisionGuidance.decisionStatement | Should -Match '^Start at pair 1; it is the newest meaningful change\. It touches '
+      $historySummary.decisionGuidance.latestPair.status | Should -Be 'signal-review'
+      $historySummary.decisionGuidance.latestPair.baseDate | Should -Not -BeNullOrEmpty
+      $historySummary.decisionGuidance.latestPair.headDate | Should -Not -BeNullOrEmpty
+      $historySummary.decisionGuidance.latestSignalPair.index | Should -Be 1
+      $historySummary.decisionGuidance.latestSignalPair.baseDate | Should -Not -BeNullOrEmpty
+      $historySummary.decisionGuidance.latestSignalPair.headDate | Should -Not -BeNullOrEmpty
+      @($historySummary.decisionGuidance.reviewSequence).Count | Should -Be 1
+      $historySummary.decisionGuidance.reviewSequence[0].baseDate | Should -Not -BeNullOrEmpty
+      $historySummary.decisionGuidance.reviewSequence[0].headDate | Should -Not -BeNullOrEmpty
+
+      $historyMd = Get-Content -LiteralPath (Join-Path $rd 'history-report.md') -Raw
+      $historyMd | Should -Match 'Decision statement'
+      $historyMd | Should -Match 'Review first'
+      $historyMd | Should -Match 'Review sequence'
+      $historyMd | Should -Match 'pair 1 \('
+      $historyMd | Should -Match 'T\d{2}:\d{2}:\d{2}'
     } finally {
       if ($null -eq $previousDiff) {
         Remove-Item Env:STUB_COMPARE_DIFF -ErrorAction SilentlyContinue

--- a/tests/Render-VIHistoryReport.Tests.ps1
+++ b/tests/Render-VIHistoryReport.Tests.ps1
@@ -108,11 +108,13 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
                         full   = 'aaa111111111'
                         short  = 'aaa1111'
                         subject= 'Clean base commit'
+                        date   = '2026-03-09T09:00:00Z'
                     }
                     head  = @{
                         full   = 'bbb222222222'
                         short  = 'bbb2222'
                         subject= 'Clean head commit'
+                        date   = '2026-03-10T10:00:00Z'
                     }
                     lineage = [ordered]@{
                         type        = 'touch-history'
@@ -142,11 +144,13 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
                         full   = 'abc123456789'
                         short  = 'abc1234'
                         subject= 'Base commit'
+                        date   = '2026-03-11T11:00:00Z'
                     }
                     head  = @{
                         full   = 'def987654321'
                         short  = 'def9876'
                         subject= 'Head commit'
+                        date   = '2026-03-12T12:00:00Z'
                     }
                     lineage = [ordered]@{
                         type        = 'merge-parent'
@@ -221,9 +225,11 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $markdown | Should -Match 'Start at pair 2; it is the newest meaningful change'
         $markdown | Should -Match 'Review first'
         $markdown | Should -Match 'Review sequence'
-        $markdown | Should -Match 'pair 2 \(Base commit -> Head commit\)'
+        $markdown | Should -Match 'pair 2 \(abc1234 \(Base commit; 2026-03-11T11:00:00\+00:00\) -> def9876 \(Head commit; 2026-03-12T12:00:00\+00:00\)\)'
+        $markdown | Should -Match 'pair 2 \(Base commit @ 2026-03-11T11:00:00\+00:00 -> Head commit @ 2026-03-12T12:00:00\+00:00\)'
         $markdown | Should -Match '\| Mode \| Processed \| Diffs \| Signal \| Collapsed Noise \| Missing \| Categories \| Buckets \| Flags \|'
         $markdown | Should -Match '\| Mode \| Pair \| Lineage \| Base \| Head \| Diff \| Duration \(s\) \| Categories \| Buckets \| Report \| Highlights \|'
+        $markdown | Should -Match 'aaa1111 \(Clean base commit; 2026-03-09T09:00:00\+00:00\)'
         $markdown | Should -Match 'Touch history'
 
         $html = Get-Content -LiteralPath $htmlPath -Raw
@@ -244,7 +250,8 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $html | Should -Match 'Decision statement'
         $html | Should -Match 'Start at pair 2; it is the newest meaningful change'
         $html | Should -Match 'Review sequence'
-        $html | Should -Match 'pair 2 \(Base commit -&gt; Head commit\)'
+        $html | Should -Match 'pair 2 \(abc1234 \(Base commit; 2026-03-11T11:00:00\+00:00\) -&gt; def9876 \(Head commit; 2026-03-12T12:00:00\+00:00\)\)'
+        $html | Should -Match 'pair 2 \(Base commit @ 2026-03-11T11:00:00\+00:00 -&gt; Head commit @ 2026-03-12T12:00:00\+00:00\)'
         $html | Should -Match '<th>Signal</th>'
         $html | Should -Match '<th>Collapsed Noise</th>'
         $html | Should -Match '<th>Lineage</th>'
@@ -271,18 +278,24 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $historySummaryLine | Should -Not -BeNullOrEmpty
         $historySummaryPath = (($historySummaryLine -split '=', 2)[1]).Trim()
         Test-Path -LiteralPath $historySummaryPath | Should -BeTrue
-        $historySummary = Get-Content -LiteralPath $historySummaryPath -Raw | ConvertFrom-Json -Depth 12
+        $historySummary = Get-Content -LiteralPath $historySummaryPath -Raw | ConvertFrom-Json -Depth 12 -DateKind String
         $historySummary.target.sourceBranchRef | Should -Be 'feature/history-source'
         $historySummary.target.branchBudget.maxCommitCount | Should -Be 64
         $historySummary.target.branchBudget.commitCount | Should -Be 3
+        $historySummary.decisionGuidance.latestPair.baseDate | Should -Be '2026-03-09T09:00:00+00:00'
+        $historySummary.decisionGuidance.latestPair.headDate | Should -Be '2026-03-10T10:00:00+00:00'
         $historySummary.decisionGuidance.decisionStatement | Should -Be 'Start at pair 2; it is the newest meaningful change. It touches Functional behavior.'
         $historySummary.decisionGuidance.latestSignalPair.index | Should -Be 2
         $historySummary.decisionGuidance.latestSignalPair.baseSubject | Should -Be 'Base commit'
         $historySummary.decisionGuidance.latestSignalPair.headSubject | Should -Be 'Head commit'
+        $historySummary.decisionGuidance.latestSignalPair.baseDate | Should -Be '2026-03-11T11:00:00+00:00'
+        $historySummary.decisionGuidance.latestSignalPair.headDate | Should -Be '2026-03-12T12:00:00+00:00'
         @($historySummary.decisionGuidance.reviewSequence).Count | Should -Be 1
         $historySummary.decisionGuidance.reviewSequence[0].index | Should -Be 2
         $historySummary.decisionGuidance.reviewSequence[0].baseSubject | Should -Be 'Base commit'
         $historySummary.decisionGuidance.reviewSequence[0].headSubject | Should -Be 'Head commit'
+        $historySummary.decisionGuidance.reviewSequence[0].baseDate | Should -Be '2026-03-11T11:00:00+00:00'
+        $historySummary.decisionGuidance.reviewSequence[0].headDate | Should -Be '2026-03-12T12:00:00+00:00'
     }
 
     It 'preserves branch budget numeric fields when the source object is a hashtable' {

--- a/tests/Render-VIHistoryReport.Tests.ps1
+++ b/tests/Render-VIHistoryReport.Tests.ps1
@@ -217,6 +217,8 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $markdown | Should -Match '\| Mode Sensitivity \| `single-mode-observed` \|'
         $markdown | Should -Match '\| Outcome Labels \| `clean`, `signal-diff` \|'
         $markdown | Should -Match '## Decision guidance'
+        $markdown | Should -Match 'Decision statement'
+        $markdown | Should -Match 'Start at pair 2; it is the newest meaningful change'
         $markdown | Should -Match 'Review first'
         $markdown | Should -Match 'Review sequence'
         $markdown | Should -Match 'pair 2 \(Base commit -> Head commit\)'
@@ -239,6 +241,8 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $html | Should -Match 'Outcome Labels'
         $html | Should -Match '<code>clean</code>, <code>signal-diff</code>'
         $html | Should -Match 'Review first'
+        $html | Should -Match 'Decision statement'
+        $html | Should -Match 'Start at pair 2; it is the newest meaningful change'
         $html | Should -Match 'Review sequence'
         $html | Should -Match 'pair 2 \(Base commit -&gt; Head commit\)'
         $html | Should -Match '<th>Signal</th>'
@@ -271,6 +275,7 @@ Describe 'Render-VIHistoryReport.ps1' -Tag 'Unit' {
         $historySummary.target.sourceBranchRef | Should -Be 'feature/history-source'
         $historySummary.target.branchBudget.maxCommitCount | Should -Be 64
         $historySummary.target.branchBudget.commitCount | Should -Be 3
+        $historySummary.decisionGuidance.decisionStatement | Should -Be 'Start at pair 2; it is the newest meaningful change. It touches Functional behavior.'
         $historySummary.decisionGuidance.latestSignalPair.index | Should -Be 2
         $historySummary.decisionGuidance.latestSignalPair.baseSubject | Should -Be 'Base commit'
         $historySummary.decisionGuidance.latestSignalPair.headSubject | Should -Be 'Head commit'

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -106,6 +106,102 @@ function Get-ShortSha {
   return $Value.Substring(0, $Length)
 }
 
+function Format-DecisionTimestamp {
+  param($Value)
+
+  if ($null -eq $Value) { return '' }
+
+  if ($Value -is [DateTimeOffset]) {
+    return $Value.ToString('yyyy-MM-ddTHH:mm:ssK')
+  }
+
+  if ($Value -is [DateTime]) {
+    return ([DateTimeOffset]$Value).ToString('yyyy-MM-ddTHH:mm:ssK')
+  }
+
+  $text = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($text)) { return '' }
+
+  try {
+    $parsed = [DateTimeOffset]::Parse($text, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
+    return $parsed.ToString('yyyy-MM-ddTHH:mm:ssK')
+  } catch {
+    return $text
+  }
+}
+
+function New-DecisionPairMetadata {
+  param([AllowNull()][object]$Entry)
+
+  if (-not $Entry) {
+    return [ordered]@{
+      index = 0
+      baseRef = ''
+      headRef = ''
+      baseSubject = ''
+      headSubject = ''
+      baseDate = ''
+      headDate = ''
+    }
+  }
+
+  return [ordered]@{
+    index = [int](Coalesce $Entry.index 0)
+    baseRef = [string](Coalesce (Coalesce $Entry.base.short $Entry.base.full) '')
+    headRef = [string](Coalesce (Coalesce $Entry.head.short $Entry.head.full) '')
+    baseSubject = [string](Coalesce $Entry.base.subject '')
+    headSubject = [string](Coalesce $Entry.head.subject '')
+    baseDate = [string](Format-DecisionTimestamp -Value $Entry.base.date)
+    headDate = [string](Format-DecisionTimestamp -Value $Entry.head.date)
+  }
+}
+
+function Format-DecisionCommitLabel {
+  param(
+    [string]$Ref,
+    [string]$Subject,
+    [string]$Date
+  )
+
+  $label = [string](Coalesce $Ref 'n/a')
+  $details = New-Object System.Collections.Generic.List[string]
+  if (-not [string]::IsNullOrWhiteSpace($Subject)) {
+    $details.Add($Subject) | Out-Null
+  }
+  if (-not [string]::IsNullOrWhiteSpace($Date)) {
+    $details.Add($Date) | Out-Null
+  }
+  if ($details.Count -gt 0) {
+    $label = '{0} ({1})' -f $label, ([string]::Join('; ', @($details.ToArray())))
+  }
+  return $label
+}
+
+function Format-DecisionPairTimelineLabel {
+  param(
+    [AllowNull()][object]$Pair,
+    [switch]$UseSubjectsOnly
+  )
+
+  if (-not $Pair) { return 'pair n/a' }
+
+  if ($UseSubjectsOnly.IsPresent) {
+    $baseLabel = if (-not [string]::IsNullOrWhiteSpace([string]$Pair.baseSubject)) { [string]$Pair.baseSubject } else { [string](Coalesce $Pair.baseRef 'n/a') }
+    if (-not [string]::IsNullOrWhiteSpace([string]$Pair.baseDate)) {
+      $baseLabel = '{0} @ {1}' -f $baseLabel, [string]$Pair.baseDate
+    }
+    $headLabel = if (-not [string]::IsNullOrWhiteSpace([string]$Pair.headSubject)) { [string]$Pair.headSubject } else { [string](Coalesce $Pair.headRef 'n/a') }
+    if (-not [string]::IsNullOrWhiteSpace([string]$Pair.headDate)) {
+      $headLabel = '{0} @ {1}' -f $headLabel, [string]$Pair.headDate
+    }
+  } else {
+    $baseLabel = Format-DecisionCommitLabel -Ref ([string](Coalesce $Pair.baseRef 'n/a')) -Subject ([string](Coalesce $Pair.baseSubject '')) -Date ([string](Coalesce $Pair.baseDate ''))
+    $headLabel = Format-DecisionCommitLabel -Ref ([string](Coalesce $Pair.headRef 'n/a')) -Subject ([string](Coalesce $Pair.headSubject '')) -Date ([string](Coalesce $Pair.headDate ''))
+  }
+
+  return 'pair {0} ({1} -> {2})' -f (Coalesce $Pair.index 'n/a'), $baseLabel, $headLabel
+}
+
 function Get-LineageLabel {
   param(
     [object]$Lineage,
@@ -1288,18 +1384,14 @@ $decisionReviewPriority = if ($signalComparisonEntries.Count -gt 0) {
 } else {
   'no-diff'
 }
+$decisionLatestPair = New-DecisionPairMetadata -Entry $latestComparisonEntry
+$latestSignalComparisonEntry = if ($signalComparisonEntries.Count -gt 0) { $signalComparisonEntries[0] } else { $null }
+$decisionLatestSignalPair = New-DecisionPairMetadata -Entry $latestSignalComparisonEntry
 $decisionReviewSequence = @(
   $signalComparisonEntries | ForEach-Object {
-    [ordered]@{
-      index = [int](Coalesce $_.index 0)
-      baseRef = [string](Coalesce (Coalesce $_.base.short $_.base.full) '')
-      headRef = [string](Coalesce (Coalesce $_.head.short $_.head.full) '')
-      baseSubject = [string](Coalesce $_.base.subject '')
-      headSubject = [string](Coalesce $_.head.subject '')
-    }
+    New-DecisionPairMetadata -Entry $_
   }
 )
-$latestSignalComparisonEntry = if ($signalComparisonEntries.Count -gt 0) { $signalComparisonEntries[0] } else { $null }
 $decisionLatestStatus = 'n/a'
 if ($latestComparisonEntry) {
   $latestResultNode = $latestComparisonEntry.result
@@ -1340,17 +1432,15 @@ if ($sortedComparisons.Count -gt 0) {
   $summaryLines.Add(('- Decision statement: {0}' -f $decisionStatement))
   $summaryLines.Add(('- Review priority: `{0}`' -f $decisionReviewPriority))
   if ($latestComparisonEntry) {
-    $summaryLines.Add(('- Latest pair: `pair {0}` is `{1}`' -f (Coalesce $latestComparisonEntry.index 'n/a'), $decisionLatestStatus))
+    $summaryLines.Add(('- Latest pair: `{0}` is `{1}`' -f (Format-DecisionPairTimelineLabel -Pair $decisionLatestPair), $decisionLatestStatus))
   }
   if ($latestSignalComparisonEntry) {
-    $latestSignalBaseRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) 'n/a')
-    $latestSignalHeadRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) 'n/a')
-    $summaryLines.Add(('- Review first: `pair {0}` (`{1}` -> `{2}`)' -f (Coalesce $latestSignalComparisonEntry.index 'n/a'), $latestSignalBaseRef, $latestSignalHeadRef))
+    $summaryLines.Add(('- Review first: `{0}`' -f (Format-DecisionPairTimelineLabel -Pair $decisionLatestSignalPair)))
   }
   if ($decisionReviewSequence.Count -gt 0) {
     $reviewSequenceLabels = @(
       $decisionReviewSequence | ForEach-Object {
-        'pair {0} ({1} -> {2})' -f $_.index, (Coalesce $_.baseSubject 'n/a'), (Coalesce $_.headSubject 'n/a')
+        Format-DecisionPairTimelineLabel -Pair $_ -UseSubjectsOnly
       }
     )
     $summaryLines.Add(('- Review sequence: `{0}`' -f ([string]::Join('; ', $reviewSequenceLabels))))
@@ -1391,10 +1481,8 @@ if ($comparisons.Count -gt 0) {
     }
     if ([string]::IsNullOrWhiteSpace($lineageLabel)) { $lineageLabel = 'Mainline' }
 
-    $baseRef = Coalesce $entry.base.short $entry.base.full
-    if ($entry.base.subject) { $baseRef = '{0} ({1})' -f $baseRef, $entry.base.subject }
-    $headRef = Coalesce $entry.head.short $entry.head.full
-    if ($entry.head.subject) { $headRef = '{0} ({1})' -f $headRef, $entry.head.subject }
+    $baseRef = Format-DecisionCommitLabel -Ref ([string](Coalesce $entry.base.short $entry.base.full)) -Subject ([string](Coalesce $entry.base.subject '')) -Date (Format-DecisionTimestamp -Value $entry.base.date)
+    $headRef = Format-DecisionCommitLabel -Ref ([string](Coalesce $entry.head.short $entry.head.full)) -Subject ([string](Coalesce $entry.head.subject '')) -Date (Format-DecisionTimestamp -Value $entry.head.date)
     $resultNode = $entry.result
     $hasDiffValue = $resultNode -and $resultNode.PSObject.Properties['diff']
     $diffValue = $hasDiffValue -and ($resultNode.diff -eq $true)
@@ -1708,17 +1796,15 @@ if ($emitHtml -and $HtmlPath) {
     [void]$htmlBuilder.AppendLine(('    <li><strong>Decision statement</strong><span>{0}</span></li>' -f (ConvertTo-HtmlSafe $decisionStatement)))
     [void]$htmlBuilder.AppendLine(('    <li><strong>Review priority</strong><span>{0}</span></li>' -f (Format-HtmlCodeList -Values @($decisionReviewPriority))))
     if ($latestComparisonEntry) {
-      [void]$htmlBuilder.AppendLine(('    <li><strong>Latest pair</strong><span><code>pair {0}</code> is <code>{1}</code></span></li>' -f (ConvertTo-HtmlSafe (Coalesce $latestComparisonEntry.index 'n/a')), (ConvertTo-HtmlSafe $decisionLatestStatus)))
+      [void]$htmlBuilder.AppendLine(('    <li><strong>Latest pair</strong><span><code>{0}</code> is <code>{1}</code></span></li>' -f (ConvertTo-HtmlSafe (Format-DecisionPairTimelineLabel -Pair $decisionLatestPair)), (ConvertTo-HtmlSafe $decisionLatestStatus)))
     }
     if ($latestSignalComparisonEntry) {
-      $latestSignalBaseRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) 'n/a')
-      $latestSignalHeadRef = [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) 'n/a')
-      [void]$htmlBuilder.AppendLine(('    <li><strong>Review first</strong><span><code>pair {0}</code> (<code>{1}</code> -&gt; <code>{2}</code>)</span></li>' -f (ConvertTo-HtmlSafe (Coalesce $latestSignalComparisonEntry.index 'n/a')), (ConvertTo-HtmlSafe $latestSignalBaseRef), (ConvertTo-HtmlSafe $latestSignalHeadRef)))
+      [void]$htmlBuilder.AppendLine(('    <li><strong>Review first</strong><span><code>{0}</code></span></li>' -f (ConvertTo-HtmlSafe (Format-DecisionPairTimelineLabel -Pair $decisionLatestSignalPair))))
     }
     if ($decisionReviewSequence.Count -gt 0) {
       $reviewSequenceLabels = @(
         $decisionReviewSequence | ForEach-Object {
-          'pair {0} ({1} -> {2})' -f $_.index, (Coalesce $_.baseSubject 'n/a'), (Coalesce $_.headSubject 'n/a')
+          Format-DecisionPairTimelineLabel -Pair $_ -UseSubjectsOnly
         }
       )
       [void]$htmlBuilder.AppendLine(('    <li><strong>Review sequence</strong><span><code>{0}</code></span></li>' -f (ConvertTo-HtmlSafe ([string]::Join('; ', $reviewSequenceLabels)))))
@@ -2020,15 +2106,23 @@ $historySummary = [ordered]@{
     decisionStatement = [string]$decisionStatement
     reviewPriority = [string]$decisionReviewPriority
     latestPair = [ordered]@{
-      index = if ($latestComparisonEntry) { [int](Coalesce $latestComparisonEntry.index 0) } else { 0 }
+      index = [int](Coalesce $decisionLatestPair.index 0)
       status = [string]$decisionLatestStatus
+      baseRef = [string](Coalesce $decisionLatestPair.baseRef '')
+      headRef = [string](Coalesce $decisionLatestPair.headRef '')
+      baseSubject = [string](Coalesce $decisionLatestPair.baseSubject '')
+      headSubject = [string](Coalesce $decisionLatestPair.headSubject '')
+      baseDate = [string](Coalesce $decisionLatestPair.baseDate '')
+      headDate = [string](Coalesce $decisionLatestPair.headDate '')
     }
     latestSignalPair = [ordered]@{
-      index = if ($latestSignalComparisonEntry) { [int](Coalesce $latestSignalComparisonEntry.index 0) } else { 0 }
-      baseRef = if ($latestSignalComparisonEntry) { [string](Coalesce (Coalesce $latestSignalComparisonEntry.base.short $latestSignalComparisonEntry.base.full) '') } else { '' }
-      headRef = if ($latestSignalComparisonEntry) { [string](Coalesce (Coalesce $latestSignalComparisonEntry.head.short $latestSignalComparisonEntry.head.full) '') } else { '' }
-      baseSubject = if ($latestSignalComparisonEntry) { [string](Coalesce $latestSignalComparisonEntry.base.subject '') } else { '' }
-      headSubject = if ($latestSignalComparisonEntry) { [string](Coalesce $latestSignalComparisonEntry.head.subject '') } else { '' }
+      index = [int](Coalesce $decisionLatestSignalPair.index 0)
+      baseRef = [string](Coalesce $decisionLatestSignalPair.baseRef '')
+      headRef = [string](Coalesce $decisionLatestSignalPair.headRef '')
+      baseSubject = [string](Coalesce $decisionLatestSignalPair.baseSubject '')
+      headSubject = [string](Coalesce $decisionLatestSignalPair.headSubject '')
+      baseDate = [string](Coalesce $decisionLatestSignalPair.baseDate '')
+      headDate = [string](Coalesce $decisionLatestSignalPair.headDate '')
     }
     reviewSequence = @(
       $decisionReviewSequence | ForEach-Object {
@@ -2038,6 +2132,8 @@ $historySummary = [ordered]@{
           headRef = [string](Coalesce $_.headRef '')
           baseSubject = [string](Coalesce $_.baseSubject '')
           headSubject = [string](Coalesce $_.headSubject '')
+          baseDate = [string](Coalesce $_.baseDate '')
+          headDate = [string](Coalesce $_.headDate '')
         }
       }
     )

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -1315,10 +1315,29 @@ if ($latestComparisonEntry) {
     $decisionLatestStatus = 'clean'
   }
 }
+$decisionStatement = ''
+if ($latestComparisonEntry -and $decisionLatestStatus -eq 'collapsed-noise' -and $latestSignalComparisonEntry) {
+  $decisionStatement = 'Newest VI touch is metadata-only.'
+  if ($decisionFocusBuckets.Count -gt 0) {
+    $decisionStatement = '{0} Start at pair {1}; newest meaningful change touches {2}.' -f $decisionStatement, (Coalesce $latestSignalComparisonEntry.index 'n/a'), ([string]::Join(', ', @($decisionFocusBuckets.ToArray())))
+  } else {
+    $decisionStatement = '{0} Start at pair {1}; it is the newest meaningful change.' -f $decisionStatement, (Coalesce $latestSignalComparisonEntry.index 'n/a')
+  }
+} elseif ($latestSignalComparisonEntry) {
+  $decisionStatement = 'Start at pair {0}; it is the newest meaningful change.' -f (Coalesce $latestSignalComparisonEntry.index 'n/a')
+  if ($decisionFocusBuckets.Count -gt 0) {
+    $decisionStatement = '{0} It touches {1}.' -f $decisionStatement, ([string]::Join(', ', @($decisionFocusBuckets.ToArray())))
+  }
+} elseif ($collapsedComparisonEntries.Count -gt 0) {
+  $decisionStatement = 'All observed pairs are metadata-only under the current noise policy.'
+} else {
+  $decisionStatement = 'No meaningful differences were observed in the selected history window.'
+}
 if ($sortedComparisons.Count -gt 0) {
   $summaryLines.Add('')
   $summaryLines.Add('## Decision guidance')
   $summaryLines.Add('')
+  $summaryLines.Add(('- Decision statement: {0}' -f $decisionStatement))
   $summaryLines.Add(('- Review priority: `{0}`' -f $decisionReviewPriority))
   if ($latestComparisonEntry) {
     $summaryLines.Add(('- Latest pair: `pair {0}` is `{1}`' -f (Coalesce $latestComparisonEntry.index 'n/a'), $decisionLatestStatus))
@@ -1686,6 +1705,7 @@ if ($emitHtml -and $HtmlPath) {
   if ($sortedComparisons.Count -gt 0) {
     [void]$htmlBuilder.AppendLine('  <h2>Decision guidance</h2>')
     [void]$htmlBuilder.AppendLine('  <ul>')
+    [void]$htmlBuilder.AppendLine(('    <li><strong>Decision statement</strong><span>{0}</span></li>' -f (ConvertTo-HtmlSafe $decisionStatement)))
     [void]$htmlBuilder.AppendLine(('    <li><strong>Review priority</strong><span>{0}</span></li>' -f (Format-HtmlCodeList -Values @($decisionReviewPriority))))
     if ($latestComparisonEntry) {
       [void]$htmlBuilder.AppendLine(('    <li><strong>Latest pair</strong><span><code>pair {0}</code> is <code>{1}</code></span></li>' -f (ConvertTo-HtmlSafe (Coalesce $latestComparisonEntry.index 'n/a')), (ConvertTo-HtmlSafe $decisionLatestStatus)))
@@ -1997,6 +2017,7 @@ $historySummary = [ordered]@{
     outcomeLabels = @(Get-SortedUniqueStringArray -Value $outcomeLabels)
   }
   decisionGuidance = [ordered]@{
+    decisionStatement = [string]$decisionStatement
     reviewPriority = [string]$decisionReviewPriority
     latestPair = [ordered]@{
       index = if ($latestComparisonEntry) { [int](Coalesce $latestComparisonEntry.index 0) } else { 0 }


### PR DESCRIPTION
## Summary
- carry the decision-statement slice on top of the merged review-sequence guidance
- surface commit dates alongside refs and subjects in VI history decision guidance and the stabilized history facade
- extend renderer, integration, and public contract coverage so reviewers can answer what changed, when, and whether it matters from one surface

## Proof
- `pwsh -NoLogo -NoProfile -Command "Set-Location '/tmp/compare-vi-cli-action-wt-touch-history'; Invoke-Pester -Path 'tests/Render-VIHistoryReport.Tests.ps1' -Output Detailed -CI"`
- `pwsh -NoLogo -NoProfile -Command "Set-Location '/tmp/compare-vi-cli-action-wt-touch-history'; Invoke-Pester -Path 'tests/CompareVI.History.Tests.ps1' -Output Detailed -CI"`
- `pwsh -NoLogo -NoProfile -File /tmp/comparevi-history/scripts/Invoke-CompareVIHistoryManualExplorationFastLoop.ps1 -ConsumerRepositoryRoot /tmp/ni-labview-icon-editor -ConsumerRef develop -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -NoisePolicy collapse -Mode full -ResultsDir '/tmp/compare-vi-cli-action-wt-touch-history/tests/results/ref-compare/history-exploration/local-fast-loop/vip-preinstall-decision-guidance-timeline' -ToolingRoot /tmp/compare-vi-cli-action-wt-touch-history -InvokeScriptPath /tmp/labview-icon-editor-demo/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`
