### PR TITLE
Run Windows VI history proof on self-hosted ingress

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1534,6 +1534,7 @@ jobs:
           'capability-ingress',
           'docker-lane'
         )
+        $requiredHealthReceipts = @()
         pwsh -NoLogo -NoProfile -File tools/Resolve-SelfHostedWindowsLanePlan.ps1 `
           -Repository '${{ github.repository }}' `
           -RequiredLabels $requiredLabels `
@@ -1541,7 +1542,7 @@ jobs:
           -RunnerImage 'self-hosted-windows-docker-lane' `
           -ExpectedContext 'desktop-windows' `
           -ExpectedOs 'windows' `
-          -RequiredHealthReceipts @() `
+          -RequiredHealthReceipts $requiredHealthReceipts `
           -Notes @(
             'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
             'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1496,6 +1496,9 @@ jobs:
       execution_model: ${{ steps.plan.outputs.execution_model }}
       runner_image: ${{ steps.plan.outputs.runner_image }}
       expected_context: ${{ steps.plan.outputs.expected_context }}
+      expected_os: ${{ steps.plan.outputs.expected_os }}
+      required_labels: ${{ steps.plan.outputs.required_labels }}
+      matching_runner_count: ${{ steps.plan.outputs.matching_runner_count }}
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1513,18 +1513,37 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - name: Resolve portable hosted Windows lane
+    - name: Resolve self-hosted Windows Docker lane
       id: plan
       shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       run: |
         $resultsRoot = 'tests/results/_agent/vi-history-dispatch'
         New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
-        $planPath = Join-Path $resultsRoot 'validate-vi-history-windows-hosted-plan.json'
-        pwsh -NoLogo -NoProfile -File tools/Resolve-HostedWindowsLanePlan.ps1 `
-          -RunnerImage 'windows-2022' `
-          -ContainerImage 'nationalinstruments/labview:2026q1-windows' `
-          -ExpectedContext 'default' `
+        $planPath = Join-Path $resultsRoot 'validate-vi-history-windows-docker-plan.json'
+        $requiredLabels = @(
+          'self-hosted',
+          'Windows',
+          'X64',
+          'comparevi',
+          'capability-ingress',
+          'docker-lane'
+        )
+        pwsh -NoLogo -NoProfile -File tools/Resolve-SelfHostedWindowsLanePlan.ps1 `
+          -Repository '${{ github.repository }}' `
+          -RequiredLabels $requiredLabels `
+          -ExecutionModel 'self-hosted-windows-docker-lane' `
+          -RunnerImage 'self-hosted-windows-docker-lane' `
+          -ExpectedContext 'desktop-windows' `
           -ExpectedOs 'windows' `
+          -RequiredHealthReceipts @() `
+          -Notes @(
+            'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
+            'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'
+          ) `
+          -Token $env:GITHUB_TOKEN `
           -OutputJsonPath $planPath `
           -GitHubOutputPath $env:GITHUB_OUTPUT `
           -StepSummaryPath $env:GITHUB_STEP_SUMMARY
@@ -1534,15 +1553,16 @@ jobs:
       run: |
         if ($env:GITHUB_STEP_SUMMARY) {
           $lines = @(
-            '### VI History Scenarios (Windows hosted plan)',
+            '### VI History Scenarios (Windows self-hosted Docker plan)',
             '',
             ('- execute_lanes: `{0}`' -f '${{ needs.vi-history-scenarios-plan.outputs.execute_lanes }}'),
             ('- lane_available: `{0}`' -f '${{ steps.plan.outputs.available }}'),
             ('- lane_status: `{0}`' -f '${{ steps.plan.outputs.status }}'),
             ('- skip_reason: `{0}`' -f '${{ steps.plan.outputs.skip_reason }}'),
-            ('- hosted_model: `{0}`' -f '${{ steps.plan.outputs.execution_model }}'),
+            ('- execution_model: `{0}`' -f '${{ steps.plan.outputs.execution_model }}'),
             ('- runner_image: `{0}`' -f '${{ steps.plan.outputs.runner_image }}'),
-            '- hosted model: agents can dispatch this portable hosted Windows lane while continuing on local Linux or Windows Docker Desktop lanes.'
+            ('- required_labels: `{0}`' -f '${{ steps.plan.outputs.required_labels }}'),
+            '- self-hosted docker model: validate 64-bit LabVIEW in the Windows container while the LV32 lane runs in parallel as the native host-plane reference.'
           )
           $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
         }
@@ -1551,20 +1571,24 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: validate-vi-history-windows-hosted-plan
-        path: tests/results/_agent/vi-history-dispatch/validate-vi-history-windows-hosted-plan.json
+        name: validate-vi-history-windows-docker-plan
+        path: tests/results/_agent/vi-history-dispatch/validate-vi-history-windows-docker-plan.json
         if-no-files-found: error
 
   vi-history-scenarios-windows:
     needs: [smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan, vi-history-scenarios-windows-plan]
     if: needs.smoke-gate.outputs.skip != 'true' && needs.vi-history-scenarios-plan.outputs.execute_lanes == 'true' && needs.vi-history-scenarios-windows-plan.outputs.available == 'true'
-    runs-on: windows-2022
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress, docker-lane]
+    continue-on-error: true
     timeout-minutes: 50
     permissions:
+      actions: read
       contents: read
     env:
       NI_WINDOWS_IMAGE: nationalinstruments/labview:2026q1-windows
       NI_WINDOWS_LABVIEW_PATH: C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
     defaults:
       run:
         shell: pwsh
@@ -1573,13 +1597,14 @@ jobs:
       run: |
         if ($env:GITHUB_STEP_SUMMARY) {
           $lines = @(
-            '### VI History Scenarios (Windows lane)',
+            '### VI History Scenarios (Windows self-hosted Docker lane)',
             '',
             ('- execute_lanes: `{0}`' -f '${{ needs.vi-history-scenarios-plan.outputs.execute_lanes }}'),
-            ('- hosted_status: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.status }}'),
+            ('- plan_status: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.status }}'),
             ('- runner_image: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.runner_image }}'),
             ('- expected_context: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.expected_context }}'),
-            '- image pull budget: Windows image hydration is materially slower than the Linux lane, so keep local lanes active while hosted proof runs.'
+            ('- required_labels: `{0}`' -f '${{ needs.vi-history-scenarios-windows-plan.outputs.required_labels }}'),
+            '- self-hosted 64-bit proof runs on the ingress host and pairs with the parallel LV32 lane so 32-bit host-plane drift has an immediate native reference.'
           )
           $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
         }
@@ -1601,7 +1626,31 @@ jobs:
       with:
         phase: J2
         results-dir: tests/results
-    - name: Collect hosted Windows runner health
+    - name: Validate self-hosted runner label contract
+      shell: pwsh
+      run: |
+        $resultsRoot = Join-Path $env:GITHUB_WORKSPACE 'tests/results/local-parity/windows'
+        New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+        $requiredLabels = @(
+          'self-hosted',
+          'Windows',
+          'X64',
+          'comparevi',
+          'capability-ingress',
+          'docker-lane'
+        )
+        foreach ($label in $requiredLabels) {
+          $contractPath = Join-Path $resultsRoot ("runner-label-contract-{0}.json" -f $label)
+          pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 `
+            -Repository '${{ github.repository }}' `
+            -RunnerName $env:RUNNER_NAME `
+            -RequiredLabel $label `
+            -Token $env:GITHUB_TOKEN `
+            -OutputJsonPath $contractPath `
+            -GitHubOutputPath $env:GITHUB_OUTPUT `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+        }
+    - name: Collect self-hosted Windows runner health
       shell: pwsh
       run: |
         pwsh -NoLogo -NoProfile -File tools/Collect-RunnerHealth.ps1 `
@@ -1618,8 +1667,9 @@ jobs:
         pwsh -NoLogo -NoProfile -File tools/Test-WindowsNI2026q1HostPreflight.ps1 `
           -Image $env:NI_WINDOWS_IMAGE `
           -ResultsDir $resultsRoot `
-          -ExecutionSurface 'github-hosted-windows' `
-          -AllowUnavailable `
+          -ExecutionSurface 'desktop-local' `
+          -ManageDockerEngine:$true `
+          -AllowHostEngineMutation:$true `
           -OutputJsonPath $summaryPath `
           -GitHubOutputPath $env:GITHUB_OUTPUT `
           -StepSummaryPath $env:GITHUB_STEP_SUMMARY
@@ -1650,6 +1700,8 @@ jobs:
           -LabVIEWPath $env:NI_WINDOWS_LABVIEW_PATH `
           -ReportPath $reportPath `
           -TimeoutSeconds 600 `
+          -ManageDockerEngine:$false `
+          -AllowHostEngineMutation:$false `
           -RuntimeEngineReadyTimeoutSeconds 180 `
           -RuntimeEngineReadyPollSeconds 5 `
           -RuntimeSnapshotPath $runtimeSnapshot
@@ -1743,7 +1795,33 @@ jobs:
       if: always() && steps.windows-preflight.outputs.windows_host_preflight_status != 'ready'
       shell: pwsh
       run: |
-        Write-Host ("::notice::Skipping hosted Windows compare because preflight status was {0} ({1})." -f '${{ steps.windows-preflight.outputs.windows_host_preflight_status }}', '${{ steps.windows-preflight.outputs.windows_host_preflight_failure_class }}')
+        Write-Host ("::notice::Skipping self-hosted Windows Docker compare because preflight status was {0} ({1})." -f '${{ steps.windows-preflight.outputs.windows_host_preflight_status }}', '${{ steps.windows-preflight.outputs.windows_host_preflight_failure_class }}')
+
+    - name: Restore Docker Desktop context after Windows proof
+      if: always()
+      shell: pwsh
+      run: |
+        $resultsRoot = 'tests/results/local-parity/windows'
+        $preflightPath = Join-Path $resultsRoot 'windows-ni-2026q1-host-preflight.json'
+        if (-not (Test-Path -LiteralPath $preflightPath -PathType Leaf)) {
+          Write-Host ("::notice::Skipping Docker Desktop restore because preflight artifact was not found at {0}" -f $preflightPath)
+          exit 0
+        }
+        $preflight = Get-Content -LiteralPath $preflightPath -Raw | ConvertFrom-Json -Depth 20
+        $restoreContext = if ($preflight.contexts.PSObject.Properties['start'] -and -not [string]::IsNullOrWhiteSpace([string]$preflight.contexts.start)) {
+          [string]$preflight.contexts.start
+        } else {
+          'desktop-windows'
+        }
+        $restorePath = Join-Path $resultsRoot 'runtime-manager-restore-windows.json'
+        pwsh -NoLogo -NoProfile -File tools/Invoke-DockerRuntimeManager.ps1 `
+          -ProbeScope 'windows' `
+          -BootstrapWindowsImage:$false `
+          -BootstrapLinuxImage:$false `
+          -RestoreContext $restoreContext `
+          -OutputJsonPath $restorePath `
+          -GitHubOutputPath '' `
+          -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
 
     - name: Upload VI history scenario artifacts (Windows lane)
       if: always()
@@ -1759,6 +1837,8 @@ jobs:
           tests/results/local-parity/windows/container-export/**
           tests/results/local-parity/windows/windows-ni-2026q1-host-preflight.json
           tests/results/local-parity/windows/runtime-manager-compare-windows.json
+          tests/results/local-parity/windows/runtime-manager-restore-windows.json
+          tests/results/local-parity/windows/runner-label-contract-*.json
           tests/results/local-parity/windows/_agent/runner-health.json
         if-no-files-found: warn
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -478,14 +478,12 @@ For each cut:
   `comparevi-history-bundle-certification` follows the same routing.
   `vi-history-scenarios-*` runs for `compare-engine-history`, `docker-vi-history`, `mixed-runtime`, `unclassified`, and
   explicit manual dispatches; the final VI-history plan still honors `history_scenario_set`.
-- Hosted Windows mirror proof now lives in `Validate` as the non-required `vi-history-scenarios-windows` lane.
-  That lane runs on GitHub-hosted `windows-2022`, hydrates
-  `nationalinstruments/labview:2026q1-windows` with no repository runner dependency, and is expected to
-  take materially longer to pull than the Linux lane.
-- If the hosted Windows runner cannot expose a Docker Windows daemon, the lane records
-  `windows_host_preflight_status = unavailable` and skips the heavy compare instead of poisoning
-  the current queue item with a non-required proof failure.
-  Agents can dispatch the hosted lane while continuing with the manual Linux or Windows Docker Desktop/WSL2 lanes locally.
+- Windows mirror proof now lives in `Validate` as the non-required
+  `vi-history-scenarios-windows` lane on the self-hosted compare ingress host.
+  That lane validates the 64-bit Windows Docker image locally instead of burning
+  GitHub-hosted Windows image-pull time.
+- `vi-history-scenarios-windows-lv32` runs in parallel and acts as the native 32-bit
+  reference for that Windows Docker proof, so 32-bit and 64-bit feedback arrive together.
 - `node tools/npm/run-script.mjs priority:lane:concurrency:plan` now reads the host-plane report, host RAM budget,
   and optional Docker runtime snapshot to recommend a safe concurrent hosted/manual bundle before those lanes are
   dispatched.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -144,14 +144,16 @@ Notes:
 - The `windows-mirror-proof` local VI-history profile is pinned to this same image and is proof-only in the first
   slice; it is not a warm or accelerated lane.
 - Hosted CI now has a matching non-required Windows proof lane in `Validate`:
-  `vi-history-scenarios-windows`. It runs on GitHub-hosted `windows-2022`, bootstraps
+  `vi-history-scenarios-windows`. It runs on the self-hosted compare ingress
+  host with the `docker-lane` capability label, bootstraps
   `nationalinstruments/labview:2026q1-windows`, and uses the same canonical in-container LabVIEW path:
   `C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe`.
-- If the GitHub-hosted runner cannot expose a usable Docker Windows daemon, the lane now records
-  `status = unavailable` in the preflight artifact and skips the heavy compare instead of blocking
-  unrelated integration work.
-- Expect the hosted Windows image pull to be materially slower than the Linux lane.
-  Agents can dispatch the hosted lane while manually running the Linux or Windows Docker Desktop/WSL2 lanes on this host.
+- `vi-history-scenarios-windows-lv32` runs in parallel on the same ingress host and serves
+  as the native 32-bit reference for the Windows Docker proof.
+- The lane can mutate Docker Desktop into the Windows engine and restores the starting
+  context after the proof run so the ingress host does not stay stranded on the wrong daemon.
+- Expect the self-hosted Windows image proof to remain materially slower than the Linux lane,
+  but it now spends local host time instead of GitHub-hosted Windows minutes.
 - Use `node tools/npm/run-script.mjs priority:lane:concurrency:plan` to turn the current host-plane,
   host-RAM, and Docker-runtime receipts into a recommended concurrent hosted/manual lane bundle before
   dispatching work. The plan now emits a `dockerRuntimeCutover` contract so you can tell whether a Linux-based
@@ -197,6 +199,8 @@ Notes:
   `vi-history-scenarios-windows` lane locally: it runs the same NI Windows
   host preflight, then the same fixed fixture compare invocation against the
   canonical in-container LabVIEW path.
+- That replay remains the fastest way to iterate on the Windows Docker proof locally; the
+  CI lane exists to keep the parallel 64-bit proof aligned with the LV32 reference job.
 
 Common remediation:
 

--- a/docs/SELFHOSTED_CI_SETUP.md
+++ b/docs/SELFHOSTED_CI_SETUP.md
@@ -99,8 +99,20 @@ today's compare jobs is:
 - `tools/policy/runner-capability-routing.json`
 
 That matrix keeps most compare jobs ingress-only, but
-`.github/workflows/labview-cli-compare.yml` is now an explicit native 32-bit
-consumer:
+`.github/workflows/validate.yml`'s `vi-history-scenarios-windows` lane is now an
+explicit Windows Docker proof consumer:
+
+- `runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress, docker-lane]`
+- it may mutate Docker Desktop into the Windows engine to prove `nationalinstruments/labview:2026q1-windows`
+- it restores the starting Docker context after the proof completes
+
+The matrix also keeps the native 32-bit consumers explicit so they can run in
+parallel with the 64-bit Windows Docker proof:
+
+- `.github/workflows/validate.yml` `vi-history-scenarios-windows-lv32`
+- `.github/workflows/labview-cli-compare.yml`
+
+- `.github/workflows/labview-cli-compare.yml` consumer details:
 
 - `runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress, labview-2026, lv32]`
 - emit `node tools/npm/run-script.mjs env:labview:2026:host-planes`

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Feature Branch Enforcement & Merge Queue
 
-| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=20 entries, 1-minute quiet window). Required checks: `lint`, `fixtures`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `commit-integrity`. Non-required hosted proof lanes may run alongside the queue contract, including `session-index`, `issue-snapshot`, `semver`, `agent-review-policy`, `hook-parity`, and `vi-history-scenarios-windows` on GitHub-hosted `windows-2022`. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
+| `develop` (live id may drift) | `refs/heads/develop` | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=20 entries, 1-minute quiet window). Required checks: `lint`, `fixtures`, `Policy Guard (Upstream) / policy-guard`, `vi-history-scenarios-linux`, `commit-integrity`. Non-required supporting lanes may run alongside the queue contract, including `session-index`, `issue-snapshot`, `semver`, `agent-review-policy`, `hook-parity`, plus the self-hosted Windows Docker and LV32 VI-history proofs that run in parallel on the compare ingress host. Copilot review settings are no longer enforced through policy; draft/ready review semantics are repo-owned and validated by `agent-review-policy`. |
 
 ## Purpose
 
@@ -129,10 +129,16 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 - **Required checks**: `lint`, `fixtures`, `Policy Guard (Upstream) / policy-guard`,
   `vi-history-scenarios-linux`, `commit-integrity`.
 - **Supporting non-required lanes**: `session-index`, `issue-snapshot`, `semver`,
-  `agent-review-policy`, `hook-parity`, plus hosted Windows proving.
-- **Non-required hosted proof**: `vi-history-scenarios-windows` may run on GitHub-hosted
-  `windows-2022` to validate `nationalinstruments/labview:2026q1-windows`. Agents may
-  dispatch that hosted lane while manually running the Linux or Windows Docker Desktop/WSL2 lanes on this host.
+  `agent-review-policy`, `hook-parity`, plus parallel Windows 64-bit and LV32 proving.
+- **Non-required self-hosted Docker proof**: `vi-history-scenarios-windows` runs on the
+  compare ingress host with the `docker-lane` capability label to validate
+  `nationalinstruments/labview:2026q1-windows` without paying GitHub-hosted Windows
+  image-hydration time on every PR. The lane may flip Docker Desktop into the
+  Windows engine, capture the 64-bit container proof, and restore the starting
+  context afterward.
+- **Parallel LV32 reference proof**: `vi-history-scenarios-windows-lv32` runs beside the
+  Docker lane so native 32-bit LabVIEW and the 64-bit Windows container can be observed
+  together without serializing the Windows-side feedback loop.
 - **Admin bypass**: leave disabled; administrators should only intervene when `priority:policy` confirms parity.
 - **Reapply**: Use `node tools/npm/run-script.mjs priority:policy -- --apply` to push the manifest configuration when drift is detected.
 

--- a/tools/Resolve-SelfHostedWindowsLanePlan.ps1
+++ b/tools/Resolve-SelfHostedWindowsLanePlan.ps1
@@ -1,12 +1,12 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-  Resolves the availability plan for a self-hosted Windows LV32 lane.
+  Resolves the availability plan for a self-hosted Windows specialized lane.
 
 .DESCRIPTION
   Emits a deterministic planning artifact for a repository runner that must
-  advertise the required ingress plus LV32 capability labels. The helper uses
-  the repository runner inventory API or an injected inventory fixture.
+  advertise the required ingress plus optional capability labels. The helper
+  uses the repository runner inventory API or an injected inventory fixture.
 #>
 [CmdletBinding()]
 param(
@@ -19,6 +19,15 @@ param(
     'capability-ingress',
     'labview-2026',
     'lv32'
+  ),
+  [string]$ExecutionModel = 'self-hosted-windows-lv32',
+  [string]$RunnerImage = 'self-hosted-windows-lv32',
+  [string]$ExpectedContext = 'headless-labview-32',
+  [string]$ExpectedOs = 'windows',
+  [string[]]$RequiredHealthReceipts = @('labview-2026-host-plane-report'),
+  [string[]]$Notes = @(
+    'Availability means an online, idle repository runner advertises every required label.',
+    'The lane must skip rather than queue indefinitely when no matching runner is available.'
   ),
   [string]$Token = $env:GITHUB_TOKEN,
   [string]$OutputJsonPath = 'tests/results/_agent/vi-history-dispatch/validate-vi-history-windows-lv32-plan.json',
@@ -183,15 +192,12 @@ $summary = [ordered]@{
   skipReason = ''
   failureClass = 'none'
   failureMessage = ''
-  executionModel = 'self-hosted-windows-lv32'
-  runnerImage = 'self-hosted-windows-lv32'
-  expectedContext = 'headless-labview-32'
-  expectedOs = 'windows'
-  requiredHealthReceipts = @('labview-2026-host-plane-report')
-  notes = @(
-    'Availability means an online, idle repository runner advertises every required label.',
-    'The lane must skip rather than queue indefinitely when no matching runner is available.'
-  )
+  executionModel = [string]$ExecutionModel
+  runnerImage = [string]$RunnerImage
+  expectedContext = [string]$ExpectedContext
+  expectedOs = [string]$ExpectedOs
+  requiredHealthReceipts = @($RequiredHealthReceipts)
+  notes = @($Notes)
 }
 
 try {
@@ -277,7 +283,7 @@ try {
   } else {
     $summary.available = $false
     $summary.status = 'missing-label'
-    $summary.skipReason = 'no online self-hosted Windows LV32 runner matched the required capability labels'
+    $summary.skipReason = 'no online self-hosted Windows runner matched the required capability labels'
   }
 } catch {
   $summary.available = $false
@@ -315,7 +321,7 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     'none'
   }
   $summaryLines = @(
-    '### Self-Hosted Windows LV32 Lane Plan',
+    '### Self-Hosted Windows Specialized Lane Plan',
     '',
     ('- status: `{0}`' -f [string]$summary.status),
     ('- available: `{0}`' -f ([string]([bool]$summary.available)).ToLowerInvariant()),

--- a/tools/Test-WindowsNI2026q1HostPreflight.ps1
+++ b/tools/Test-WindowsNI2026q1HostPreflight.ps1
@@ -21,6 +21,8 @@ param(
   [string]$ResultsDir = 'tests/results/local-parity',
   [ValidateSet('desktop-local', 'github-hosted-windows')]
   [string]$ExecutionSurface = 'desktop-local',
+  [bool]$ManageDockerEngine = $false,
+  [bool]$AllowHostEngineMutation = $false,
   [switch]$AllowUnavailable,
   [string]$OutputJsonPath = '',
   [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
@@ -292,7 +294,8 @@ try {
     $summary.contexts.final = [string]$desktopObservation.context
     $summary.contexts.finalOsType = [string]$desktopObservation.osType
 
-    if ([string]::Equals([string]$desktopObservation.osType, 'linux', [System.StringComparison]::OrdinalIgnoreCase)) {
+    $canMutateDesktopEngine = $ManageDockerEngine -and $AllowHostEngineMutation
+    if ([string]::Equals([string]$desktopObservation.osType, 'linux', [System.StringComparison]::OrdinalIgnoreCase) -and -not $canMutateDesktopEngine) {
       $summary.status = 'failure'
       $summary.failureClass = 'docker-engine-mismatch'
       $summary.failureMessage = ("desktop-local Windows NI preflight requires Docker Desktop Windows containers. Observed context '{0}' with OSType '{1}'. Switch Docker Desktop to Windows containers (`desktop-windows`) and retry." -f ([string]$desktopObservation.context ?? ''), [string]$desktopObservation.osType)
@@ -354,8 +357,8 @@ try {
       -RuntimeProvider 'desktop' `
       -ExpectedContext 'default' `
       -AutoRepair:$true `
-      -ManageDockerEngine:$false `
-      -AllowHostEngineMutation:$false `
+      -ManageDockerEngine:$ManageDockerEngine `
+      -AllowHostEngineMutation:$AllowHostEngineMutation `
       -SnapshotPath $snapshotPath `
       -GitHubOutputPath ''
     if ($LASTEXITCODE -ne 0) {

--- a/tools/policy/runner-capability-routing.json
+++ b/tools/policy/runner-capability-routing.json
@@ -120,6 +120,13 @@
       "workflow": ".github/workflows/validate.yml",
       "jobs": [
         {
+          "id": "vi-history-scenarios-windows",
+          "routingClass": "specialized-opt-in",
+          "requiredCapabilityLabels": [
+            "docker-lane"
+          ]
+        },
+        {
           "id": "vi-history-scenarios-windows-lv32",
           "routingClass": "specialized-opt-in",
           "requiredCapabilityLabels": [

--- a/tools/priority/__tests__/docker-labview-path-contract.test.mjs
+++ b/tools/priority/__tests__/docker-labview-path-contract.test.mjs
@@ -11,7 +11,7 @@ function readRepoFile(relativePath) {
   return readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
 
-test('validate workflow pins explicit LabVIEW paths for hosted Linux and Windows VI history lanes', () => {
+test('validate workflow pins explicit LabVIEW paths for hosted Linux and self-hosted Windows VI history lanes', () => {
   const workflow = readRepoFile('.github/workflows/validate.yml');
 
   assert.match(workflow, /NI_LINUX_IMAGE:\s*nationalinstruments\/labview:2026q1-linux/);
@@ -20,15 +20,19 @@ test('validate workflow pins explicit LabVIEW paths for hosted Linux and Windows
   assert.match(workflow, /-Image \$env:NI_LINUX_IMAGE/);
   assert.match(workflow, /-LabVIEWPath \$env:NI_LINUX_LABVIEW_PATH/);
   assert.match(workflow, /vi-history-scenarios-windows-plan:/);
-  assert.match(workflow, /Resolve-HostedWindowsLanePlan\.ps1/);
+  assert.match(workflow, /Resolve-SelfHostedWindowsLanePlan\.ps1/);
   assert.match(workflow, /vi-history-scenarios-windows:/);
-  assert.match(workflow, /runs-on:\s*windows-2022/);
+  assert.match(workflow, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress, docker-lane\]/);
   assert.match(workflow, /NI_WINDOWS_IMAGE:\s*nationalinstruments\/labview:2026q1-windows/);
   assert.match(workflow, /NI_WINDOWS_LABVIEW_PATH:\s*C:\\Program Files\\National Instruments\\LabVIEW 2026\\LabVIEW\.exe/);
   assert.match(workflow, /Test-WindowsNI2026q1HostPreflight\.ps1/);
   assert.match(workflow, /Write-VIHistoryLaneEvidence\.ps1/);
   assert.match(workflow, /Run-NIWindowsContainerCompare\.ps1/);
-  assert.match(workflow, /-ExecutionSurface 'github-hosted-windows'/);
+  assert.match(workflow, /Assert-RunnerLabelContract\.ps1/);
+  assert.match(workflow, /-ExecutionSurface 'desktop-local'/);
+  assert.match(workflow, /-ManageDockerEngine:\$true/);
+  assert.match(workflow, /-AllowHostEngineMutation:\$true/);
+  assert.match(workflow, /Restore Docker Desktop context after Windows proof/);
   assert.match(workflow, /-Image \$env:NI_WINDOWS_IMAGE/);
   assert.match(workflow, /-LabVIEWPath \$env:NI_WINDOWS_LABVIEW_PATH/);
   assert.match(workflow, /validate-vi-history-scenarios-windows/);

--- a/tools/priority/__tests__/resolve-selfhosted-windows-lane-plan.test.mjs
+++ b/tools/priority/__tests__/resolve-selfhosted-windows-lane-plan.test.mjs
@@ -119,5 +119,75 @@ test('Resolve-SelfHostedWindowsLanePlan reports unavailable when the LV32 labels
   assert.equal(plan.available, false);
   assert.equal(plan.status, 'missing-label');
   assert.equal(plan.matchingRunnerCount, 0);
-  assert.match(plan.skipReason, /no online self-hosted Windows LV32 runner/i);
+  assert.match(plan.skipReason, /no online self-hosted Windows runner matched the required capability labels/i);
+});
+
+test('Resolve-SelfHostedWindowsLanePlan supports a docker-lane plan with no required health receipts', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'selfhosted-windows-docker-lane-plan-'));
+  const inventoryPath = path.join(tempDir, 'runner-inventory.json');
+  const outputPath = path.join(tempDir, 'plan.json');
+
+  writeJson(inventoryPath, {
+    runners: [
+      {
+        id: 301,
+        name: 'docker-lane-runner-01',
+        status: 'online',
+        busy: false,
+        labels: [
+          'self-hosted',
+          'Windows',
+          'X64',
+          'comparevi',
+          'capability-ingress',
+          'docker-lane'
+        ]
+      }
+    ]
+  });
+
+  execFileSync('pwsh', [
+    '-NoLogo',
+    '-NoProfile',
+    '-Command',
+    [
+      '$requiredLabels = @(',
+      "'self-hosted',",
+      "'Windows',",
+      "'X64',",
+      "'comparevi',",
+      "'capability-ingress',",
+      "'docker-lane'",
+      ');',
+      '$requiredHealthReceipts = @();',
+      `& '${scriptPath.replace(/'/g, "''")}'`,
+      "-Repository 'LabVIEW-Community-CI-CD/compare-vi-cli-action'",
+      `-RunnerInventoryPath '${inventoryPath.replace(/'/g, "''")}'`,
+      '-RequiredLabels $requiredLabels',
+      "-ExecutionModel 'self-hosted-windows-docker-lane'",
+      "-RunnerImage 'self-hosted-windows-docker-lane'",
+      "-ExpectedContext 'desktop-windows'",
+      "-ExpectedOs 'windows'",
+      '-RequiredHealthReceipts $requiredHealthReceipts',
+      `-OutputJsonPath '${outputPath.replace(/'/g, "''")}'`
+    ].join(' '),
+  ], { cwd: repoRoot, stdio: 'pipe' });
+
+  const plan = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.equal(plan.available, true);
+  assert.equal(plan.status, 'available');
+  assert.equal(plan.executionModel, 'self-hosted-windows-docker-lane');
+  assert.equal(plan.runnerImage, 'self-hosted-windows-docker-lane');
+  assert.equal(plan.expectedContext, 'desktop-windows');
+  assert.deepEqual(plan.requiredLabels, [
+    'self-hosted',
+    'Windows',
+    'X64',
+    'comparevi',
+    'capability-ingress',
+    'docker-lane'
+  ]);
+  assert.deepEqual(plan.requiredHealthReceipts, []);
+  assert.equal(plan.matchingRunnerCount, 1);
+  assert.equal(plan.matchingRunners[0].name, 'docker-lane-runner-01');
 });

--- a/tools/priority/__tests__/runner-capability-routing-policy.test.mjs
+++ b/tools/priority/__tests__/runner-capability-routing-policy.test.mjs
@@ -53,6 +53,10 @@ test('runner capability routing policy covers all current self-hosted compare wo
         assert.equal(job.routingClass, 'specialized-opt-in');
         assert.deepEqual(job.requiredCapabilityLabels, ['labview-2026', 'lv32']);
         assert.deepEqual(job.requiredHealthReceipts, ['labview-2026-host-plane-report']);
+      } else if (entry.workflow === '.github/workflows/validate.yml' && job.id === 'vi-history-scenarios-windows') {
+        assert.equal(job.routingClass, 'specialized-opt-in');
+        assert.deepEqual(job.requiredCapabilityLabels, ['docker-lane']);
+        assert.equal(job.requiredHealthReceipts, undefined);
       } else if (entry.workflow === '.github/workflows/validate.yml' && job.id === 'vi-history-scenarios-windows-lv32') {
         assert.equal(job.routingClass, 'specialized-opt-in');
         assert.deepEqual(job.requiredCapabilityLabels, ['labview-2026', 'lv32']);

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -57,35 +57,41 @@ test('validate workflow Linux VI-history lane consumes shared dispatch-plan outp
   assert.doesNotMatch(linuxSection, /pull-requests: read/);
 });
 
-test('validate workflow Windows VI-history lane is gated by shared dispatch planning and portable hosted execution', () => {
+test('validate workflow Windows VI-history lane is gated by shared dispatch planning and self-hosted docker execution', () => {
   const workflow = readRepoFile('.github/workflows/validate.yml');
   const planSection = extractWorkflowJobSection(workflow, 'vi-history-scenarios-windows-plan', 'vi-history-scenarios-windows');
   const windowsSection = extractWorkflowJobSection(workflow, 'vi-history-scenarios-windows', 'vi-history-scenarios-windows-lv32-plan');
 
   assert.match(workflow, /vi-history-scenarios-windows-plan:\s*\r?\n\s+needs:\s*\[smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan\]\r?\n\s+if:\s+needs\.smoke-gate\.outputs\.skip != 'true'/);
   assert.match(planSection, /permissions:\s*\r?\n\s+contents: read/);
-  assert.match(planSection, /Resolve portable hosted Windows lane/);
-  assert.match(planSection, /tools\/Resolve-HostedWindowsLanePlan\.ps1/);
-  assert.match(planSection, /-RunnerImage 'windows-2022'/);
+  assert.match(planSection, /Resolve self-hosted Windows Docker lane/);
+  assert.match(planSection, /tools\/Resolve-SelfHostedWindowsLanePlan\.ps1/);
+  assert.match(planSection, /-RequiredLabels \$requiredLabels/);
+  assert.match(planSection, /docker-lane/);
   assert.match(planSection, /outputs:\s*\r?\n\s+available:\s+\$\{\{\s*steps\.plan\.outputs\.available\s*\}\}/);
 
   assert.match(workflow, /vi-history-scenarios-windows:\s*\r?\n\s+needs:\s*\[smoke-gate, lint, session-index, session-index-v2-contract, vi-history-scenarios-plan, vi-history-scenarios-windows-plan\]\r?\n\s+if:\s+needs\.smoke-gate\.outputs\.skip != 'true' && needs\.vi-history-scenarios-plan\.outputs\.execute_lanes == 'true' && needs\.vi-history-scenarios-windows-plan\.outputs\.available == 'true'/);
-  assert.match(windowsSection, /runs-on:\s*windows-2022/);
+  assert.match(windowsSection, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress, docker-lane\]/);
+  assert.match(windowsSection, /continue-on-error:\s*true/);
   assert.match(windowsSection, /Print VI history Windows runtime alignment/);
-  assert.match(windowsSection, /Collect hosted Windows runner health/);
+  assert.match(windowsSection, /Validate self-hosted runner label contract/);
+  assert.match(windowsSection, /Assert-RunnerLabelContract\.ps1/);
+  assert.match(windowsSection, /Collect self-hosted Windows runner health/);
   assert.match(windowsSection, /Collect-RunnerHealth\.ps1/);
   assert.match(windowsSection, /Project VI history Windows Docker-side evidence/);
   assert.match(windowsSection, /tools\/Write-VIHistoryLaneEvidence\.ps1/);
   assert.match(windowsSection, /Test-WindowsNI2026q1HostPreflight\.ps1/);
-  assert.match(windowsSection, /-ExecutionSurface 'github-hosted-windows'/);
-  assert.match(windowsSection, /-AllowUnavailable/);
+  assert.match(windowsSection, /-ExecutionSurface 'desktop-local'/);
+  assert.match(windowsSection, /-ManageDockerEngine:\$true/);
+  assert.match(windowsSection, /-AllowHostEngineMutation:\$true/);
   assert.match(windowsSection, /id:\s*windows-preflight/);
   assert.match(windowsSection, /Run-NIWindowsContainerCompare\.ps1/);
   assert.match(windowsSection, /if:\s*steps\.windows-preflight\.outputs\.windows_host_preflight_status == 'ready'/);
+  assert.match(windowsSection, /Restore Docker Desktop context after Windows proof/);
+  assert.match(windowsSection, /Invoke-DockerRuntimeManager\.ps1/);
   assert.match(windowsSection, /tests\/results\/local-parity\/windows\/_agent\/runner-health\.json/);
   assert.match(windowsSection, /ni-windows-container-stdout\.txt/);
   assert.match(windowsSection, /ni-windows-container-stderr\.txt/);
-  assert.doesNotMatch(windowsSection, /Assert-RunnerLabelContract\.ps1/);
 });
 
 test('validate workflow self-hosted Windows LV32 VI-history lane is gated by inventory planning and headless proof receipts', () => {

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -67,6 +67,8 @@ test('validate workflow Windows VI-history lane is gated by shared dispatch plan
   assert.match(planSection, /Resolve self-hosted Windows Docker lane/);
   assert.match(planSection, /tools\/Resolve-SelfHostedWindowsLanePlan\.ps1/);
   assert.match(planSection, /-RequiredLabels \$requiredLabels/);
+  assert.match(planSection, /\$requiredHealthReceipts = @\(\)/);
+  assert.match(planSection, /-RequiredHealthReceipts \$requiredHealthReceipts/);
   assert.match(planSection, /docker-lane/);
   assert.match(planSection, /outputs:\s*\r?\n\s+available:\s+\$\{\{\s*steps\.plan\.outputs\.available\s*\}\}/);
 


### PR DESCRIPTION
## Summary
- move `vi-history-scenarios-windows` onto the self-hosted ingress `docker-lane` instead of GitHub-hosted `windows-2022`
- keep `vi-history-scenarios-windows-lv32` running in parallel as the native 32-bit reference lane
- update runner-planning, preflight contracts, routing policy, and maintainer docs to match the split

## Why
- Windows image hydration is burning hosted CI time without adding unique queue value
- the ingress host already has the right local Windows Docker path for the 64-bit container proof
- running the 64-bit Windows Docker lane beside LV32 gives immediate 32/64 comparison without serializing the feedback loop

## Validation
- `node --test tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs tools/priority/__tests__/docker-labview-path-contract.test.mjs tools/priority/__tests__/runner-capability-routing-policy.test.mjs`
- `git diff --check`
