### PR TITLE
Honor docker override across NI Linux proof tooling

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1534,6 +1534,7 @@ jobs:
           'capability-ingress',
           'docker-lane'
         )
+        $requiredHealthReceipts = @()
         pwsh -NoLogo -NoProfile -File tools/Resolve-SelfHostedWindowsLanePlan.ps1 `
           -Repository '${{ github.repository }}' `
           -RequiredLabels $requiredLabels `
@@ -1541,7 +1542,7 @@ jobs:
           -RunnerImage 'self-hosted-windows-docker-lane' `
           -ExpectedContext 'desktop-windows' `
           -ExpectedOs 'windows' `
-          -RequiredHealthReceipts @() `
+          -RequiredHealthReceipts $requiredHealthReceipts `
           -Notes @(
             'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
             'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'

--- a/tests/Assert-DockerRuntimeDeterminism.Tests.ps1
+++ b/tests/Assert-DockerRuntimeDeterminism.Tests.ps1
@@ -171,6 +171,7 @@ exit 0
       DOCKER_STUB_CONTEXT = $env:DOCKER_STUB_CONTEXT
       DOCKER_STUB_CONTEXT_SHOW_EMPTY = $env:DOCKER_STUB_CONTEXT_SHOW_EMPTY
       DOCKER_STUB_CONTEXT_USE_FAIL_TARGET = $env:DOCKER_STUB_CONTEXT_USE_FAIL_TARGET
+      DOCKER_COMMAND_OVERRIDE = $env:DOCKER_COMMAND_OVERRIDE
       DOCKER_HOST = $env:DOCKER_HOST
     }
   }
@@ -229,6 +230,48 @@ exit 0
     $snapshot.observed.PSObject.Properties.Name | Should -Contain 'dockerBackendProcesses'
     $snapshot.result.reason | Should -Match 'parseReason=(daemon-unavailable|docker-info-command-failed)'
     $snapshot.result.reason | Should -Match 'exitCode=1'
+  }
+
+  It 'honors DOCKER_COMMAND_OVERRIDE before a failing docker on PATH' {
+    $work = Join-Path $TestDrive 'docker-command-override'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerWslStubs -WorkRoot $work
+
+    $fallbackBin = Join-Path $work 'fallback-bin'
+    New-Item -ItemType Directory -Path $fallbackBin -Force | Out-Null
+    if ($IsWindows) {
+      @"
+@echo off
+echo fallback docker should not run 1>&2
+exit /b 9
+"@ | Set-Content -LiteralPath (Join-Path $fallbackBin 'docker.cmd') -Encoding ascii
+      $env:PATH = "{0};{1}" -f $fallbackBin, $env:PATH
+    } else {
+      @'
+#!/usr/bin/env bash
+echo fallback docker should not run 1>&2
+exit 9
+'@ | Set-Content -LiteralPath (Join-Path $fallbackBin 'docker') -Encoding utf8
+      & chmod +x (Join-Path $fallbackBin 'docker')
+      $env:PATH = "{0}:{1}" -f $fallbackBin, $env:PATH
+    }
+
+    Set-Item Env:DOCKER_COMMAND_OVERRIDE (Join-Path $work 'bin' 'docker.ps1')
+    Set-Item Env:DOCKER_STUB_INFO_MODE 'parsed-linux'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-linux'
+
+    $snapshotPath = Join-Path $work 'runtime.json'
+    $output = & pwsh -NoLogo -NoProfile -File $script:GuardScript `
+      -ExpectedOsType linux `
+      -ExpectedContext desktop-linux `
+      -AutoRepair:$false `
+      -SnapshotPath $snapshotPath `
+      -GitHubOutputPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $snapshot = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json -Depth 12
+    $snapshot.result.status | Should -Be 'ok'
+    $snapshot.observed.osType | Should -Be 'linux'
   }
 
   It 'classifies parse-defect when docker info output is non-empty but unparseable' {

--- a/tools/Assert-DockerRuntimeDeterminism.ps1
+++ b/tools/Assert-DockerRuntimeDeterminism.ps1
@@ -113,6 +113,38 @@ function Split-OutputLines {
   return @($Text -split "(`r`n|`n|`r)" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
+function Resolve-DockerCommandSource {
+  $override = $env:DOCKER_COMMAND_OVERRIDE
+  if (-not [string]::IsNullOrWhiteSpace($override) -and (Test-Path -LiteralPath $override -PathType Leaf)) {
+    return [System.IO.Path]::GetFullPath($override)
+  }
+
+  $pathSeparator = [System.IO.Path]::PathSeparator
+  $pathEntries = @($env:PATH -split [regex]::Escape([string]$pathSeparator))
+  $candidates = if ($IsWindows) {
+    @('docker.exe', 'docker.cmd', 'docker.ps1', 'docker.bat', 'docker')
+  } else {
+    @('docker', 'docker.sh', 'docker.exe', 'docker.ps1', 'docker.cmd')
+  }
+
+  foreach ($entry in $pathEntries) {
+    if ([string]::IsNullOrWhiteSpace($entry)) { continue }
+    foreach ($name in $candidates) {
+      $candidatePath = Join-Path $entry $name
+      if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+        return [System.IO.Path]::GetFullPath($candidatePath)
+      }
+    }
+  }
+
+  $command = Get-Command -Name 'docker' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($null -eq $command -or [string]::IsNullOrWhiteSpace([string]$command.Source)) {
+    return $null
+  }
+
+  return [System.IO.Path]::GetFullPath([string]$command.Source)
+}
+
 function Invoke-ProcessWithTimeout {
   [CmdletBinding()]
   param(
@@ -123,16 +155,31 @@ function Invoke-ProcessWithTimeout {
 
   $safeTimeout = [math]::Max(5, [int]$TimeoutSeconds)
   $resolvedFilePath = $FilePath
+  $effectiveArguments = @($Arguments)
+  if ([string]::Equals($FilePath, 'docker', [System.StringComparison]::OrdinalIgnoreCase)) {
+    $dockerCommandSource = Resolve-DockerCommandSource
+    if (-not [string]::IsNullOrWhiteSpace($dockerCommandSource)) {
+      $dockerCommandExtension = [System.IO.Path]::GetExtension($dockerCommandSource)
+      if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerCommandExtension, '.ps1')) {
+        $resolvedFilePath = (Get-Command -Name 'pwsh' -ErrorAction Stop | Select-Object -First 1).Source
+        $effectiveArguments = @('-NoLogo', '-NoProfile', '-File', $dockerCommandSource) + @($Arguments)
+      } else {
+        $resolvedFilePath = $dockerCommandSource
+      }
+    }
+  }
   try {
-    $resolvedCommand = Get-Command -Name $FilePath -CommandType Application -ErrorAction Stop | Select-Object -First 1
-    if ($resolvedCommand -and $resolvedCommand.Source) {
-      $resolvedFilePath = [string]$resolvedCommand.Source
-    } elseif ($resolvedCommand -and $resolvedCommand.Path) {
-      $resolvedFilePath = [string]$resolvedCommand.Path
+    if ([string]::Equals($resolvedFilePath, $FilePath, [System.StringComparison]::Ordinal)) {
+      $resolvedCommand = Get-Command -Name $FilePath -CommandType Application -ErrorAction Stop | Select-Object -First 1
+      if ($resolvedCommand -and $resolvedCommand.Source) {
+        $resolvedFilePath = [string]$resolvedCommand.Source
+      } elseif ($resolvedCommand -and $resolvedCommand.Path) {
+        $resolvedFilePath = [string]$resolvedCommand.Path
+      }
     }
   } catch {}
 
-  $argText = if ($Arguments -and $Arguments.Count -gt 0) { [string]::Join(' ', $Arguments) } else { '' }
+  $argText = if ($effectiveArguments -and $effectiveArguments.Count -gt 0) { [string]::Join(' ', $effectiveArguments) } else { '' }
   $commandText = if ([string]::IsNullOrWhiteSpace($argText)) { $resolvedFilePath } else { "$resolvedFilePath $argText" }
 
   $result = [ordered]@{
@@ -150,7 +197,7 @@ function Invoke-ProcessWithTimeout {
   $psi.RedirectStandardOutput = $true
   $psi.RedirectStandardError = $true
   $psi.CreateNoWindow = $true
-  foreach ($arg in @($Arguments)) {
+  foreach ($arg in @($effectiveArguments)) {
     [void]$psi.ArgumentList.Add([string]$arg)
   }
 

--- a/tools/Run-NILinuxContainerCompare.ps1
+++ b/tools/Run-NILinuxContainerCompare.ps1
@@ -155,7 +155,7 @@ function Resolve-DockerCommandSource {
   $candidates = if ($IsWindows) {
     @('docker.exe', 'docker.cmd', 'docker.ps1', 'docker.bat', 'docker')
   } else {
-    @('docker', 'docker.sh')
+    @('docker', 'docker.sh', 'docker.exe', 'docker.ps1', 'docker.cmd')
   }
   foreach ($entry in $pathEntries) {
     if ([string]::IsNullOrWhiteSpace($entry)) { continue }
@@ -171,6 +171,24 @@ function Resolve-DockerCommandSource {
     throw 'Unable to resolve docker command source path.'
   }
   return [string]$command.Source
+}
+
+function Invoke-DirectDockerCommand {
+  param([Parameter(Mandatory)][string[]]$DockerArgs)
+
+  $dockerCommandSource = Resolve-DockerCommandSource
+  $dockerCommandExtension = [System.IO.Path]::GetExtension($dockerCommandSource)
+  $stdout = @()
+  if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerCommandExtension, '.ps1')) {
+    $stdout = @(& pwsh -NoLogo -NoProfile -File $dockerCommandSource @DockerArgs)
+  } else {
+    $stdout = @(& $dockerCommandSource @DockerArgs)
+  }
+
+  return [pscustomobject]@{
+    ExitCode = [int]$LASTEXITCODE
+    StdOut = @($stdout)
+  }
 }
 
 function Get-EffectiveCompareFlags {
@@ -377,8 +395,8 @@ function Resolve-OutputReportPath {
 
 function Test-DockerImageExists {
   param([Parameter(Mandatory)][string]$Tag)
-  & docker image inspect $Tag *> $null
-  return ($LASTEXITCODE -eq 0)
+  $inspectResult = Invoke-DirectDockerCommand -DockerArgs @('image', 'inspect', $Tag) 2>$null
+  return ($inspectResult.ExitCode -eq 0)
 }
 
 function Get-OrAddMountPath {
@@ -403,6 +421,44 @@ function Convert-HostFileToContainerPath {
   $hostDir = Split-Path -Parent $HostFilePath
   $containerDir = Get-OrAddMountPath -Map $MountMap -Index $MountIndex -HostDirectory $hostDir
   return (Join-Path $containerDir (Split-Path -Leaf $HostFilePath)).Replace('\', '/')
+}
+
+function Resolve-DockerBindMountHostPath {
+  param(
+    [Parameter(Mandatory)][string]$HostPath,
+    [AllowEmptyString()][string]$DockerCommandSource
+  )
+
+  $resolvedHostPath = [System.IO.Path]::GetFullPath($HostPath)
+  if ([string]::IsNullOrWhiteSpace($DockerCommandSource)) {
+    return $resolvedHostPath
+  }
+
+  $dockerCommandExtension = [System.IO.Path]::GetExtension($DockerCommandSource)
+  if (-not [System.StringComparer]::OrdinalIgnoreCase.Equals($dockerCommandExtension, '.exe')) {
+    return $resolvedHostPath
+  }
+
+  if (-not $resolvedHostPath.StartsWith('/')) {
+    return $resolvedHostPath
+  }
+
+  $wslCommand = Get-Command -Name 'wsl.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($null -eq $wslCommand -or [string]::IsNullOrWhiteSpace([string]$wslCommand.Source)) {
+    return $resolvedHostPath
+  }
+
+  $translatedOutput = & $wslCommand.Source wslpath -w $resolvedHostPath 2>$null
+  if ($LASTEXITCODE -ne 0) {
+    return $resolvedHostPath
+  }
+
+  $translatedPath = [string](@($translatedOutput) | Select-Object -Last 1)
+  if ([string]::IsNullOrWhiteSpace($translatedPath)) {
+    return $resolvedHostPath
+  }
+
+  return $translatedPath.Trim()
 }
 
 function Test-HostPathWithinRoot {
@@ -460,10 +516,11 @@ function Convert-HostPathToExistingContainerPath {
 function Get-DockerContainerRecord {
   param([Parameter(Mandatory)][string]$ContainerName)
 
-  $inspectOutput = & docker inspect $ContainerName 2>$null
-  if ($LASTEXITCODE -ne 0) {
+  $inspectResult = Invoke-DirectDockerCommand -DockerArgs @('inspect', $ContainerName) 2>$null
+  if ($inspectResult.ExitCode -ne 0) {
     return $null
   }
+  $inspectOutput = @($inspectResult.StdOut)
 
   try {
     $records = $inspectOutput | ConvertFrom-Json -Depth 12 -ErrorAction Stop
@@ -1739,8 +1796,8 @@ function Invoke-DockerExecWithTimeout {
     while (-not $process.HasExited) {
       if ((Get-Date) -ge $deadline) {
         try { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue } catch {}
-        try { & docker exec $ContainerName sh -lc 'pkill -f LabVIEWCLI || true' *> $null } catch {}
-        try { & docker stop --time 1 $ContainerName *> $null } catch {}
+        try { Invoke-DirectDockerCommand -DockerArgs @('exec', $ContainerName, 'sh', '-lc', 'pkill -f LabVIEWCLI || true') *> $null } catch {}
+        try { Invoke-DirectDockerCommand -DockerArgs @('stop', '--time', '1', $ContainerName) *> $null } catch {}
         $capturedOutput = Complete-DockerProcessInvocation -Invocation $invocation
         return [pscustomobject]@{
           TimedOut = $true
@@ -2467,6 +2524,7 @@ try {
     $containerBaseVi = ''
     $containerHeadVi = ''
     $containerReportPath = ''
+    $dockerCommandSource = Resolve-DockerCommandSource
     if ($useExistingContainer) {
       $reuseRepoHostPathResolved = if ([string]::IsNullOrWhiteSpace($ReuseRepoHostPath)) {
         if ($viHistoryEnabled -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRuntimeBootstrap.viHistory.repoHostPath)) {
@@ -2661,11 +2719,13 @@ try {
     }
     if (-not $useExistingContainer) {
       foreach ($entry in ($mounts.GetEnumerator() | Sort-Object Name)) {
-        $volumeSpec = '{0}:{1}' -f $entry.Name, $entry.Value
+        $mountHostPath = Resolve-DockerBindMountHostPath -HostPath ([string]$entry.Name) -DockerCommandSource $dockerCommandSource
+        $volumeSpec = '{0}:{1}' -f $mountHostPath, $entry.Value
         $dockerArgs += @('-v', $volumeSpec)
       }
       foreach ($runtimeMount in $resolvedRuntimeInjectionMounts) {
-        $dockerArgs += @('-v', ('{0}:{1}' -f $runtimeMount.hostPath, $runtimeMount.containerPath))
+        $runtimeMountHostPath = Resolve-DockerBindMountHostPath -HostPath ([string]$runtimeMount.hostPath) -DockerCommandSource $dockerCommandSource
+        $dockerArgs += @('-v', ('{0}:{1}' -f $runtimeMountHostPath, $runtimeMount.containerPath))
       }
     }
     if (-not [string]::IsNullOrWhiteSpace($containerBaseVi)) {

--- a/tools/priority/__tests__/resolve-selfhosted-windows-lane-plan.test.mjs
+++ b/tools/priority/__tests__/resolve-selfhosted-windows-lane-plan.test.mjs
@@ -119,5 +119,5 @@ test('Resolve-SelfHostedWindowsLanePlan reports unavailable when the LV32 labels
   assert.equal(plan.available, false);
   assert.equal(plan.status, 'missing-label');
   assert.equal(plan.matchingRunnerCount, 0);
-  assert.match(plan.skipReason, /no online self-hosted Windows LV32 runner/i);
+  assert.match(plan.skipReason, /no online self-hosted Windows runner matched the required capability labels/i);
 });


### PR DESCRIPTION
## Summary
- honor `DOCKER_COMMAND_OVERRIDE` consistently in the NI Linux proof tooling and determinism guard
- normalize WSL host bind-mount paths when the active docker command is `docker.exe`
- make direct Docker probes use the resolved command source instead of raw `docker`
- add regression coverage for override-aware determinism probing

## Validation
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path '/tmp/compare-vi-cli-action-wt-develop/tests/Run-NILinuxContainerCompare.Tests.ps1' -Output Normal -CI"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path '/tmp/compare-vi-cli-action-wt-develop/tests/Assert-DockerRuntimeDeterminism.Tests.ps1' -Output Normal -CI"` (new override test passes; file still has pre-existing Linux-host failures for Windows-lane expectations)
- local canonical proof succeeded for `Tooling/deployment/VIP_Pre-Install Custom Action.vi`
