### PR TITLE
Introduce Pester service-model pilot

### DIFF
--- a/.github/workflows/pester-evidence.yml
+++ b/.github/workflows/pester-evidence.yml
@@ -107,6 +107,25 @@ jobs:
             New-Item -ItemType Directory -Path 'tests/results' -Force | Out-Null
           }
 
+      - name: Validate execution receipt artifact
+        id: execution_receipt
+        if: always()
+        shell: pwsh
+        run: |
+          $receiptPath = Join-Path 'tests/results' 'pester-run-receipt.json'
+          if (-not (Test-Path -LiteralPath $receiptPath)) {
+            "present=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "status=missing" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            exit 0
+          }
+          $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json -ErrorAction Stop
+          if ($receipt.schema -ne 'pester-execution-receipt@v1') {
+            throw ("Unexpected execution receipt schema: {0}" -f $receipt.schema)
+          }
+          "present=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "status=$($receipt.status)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "dispatcher_exit_code=$($receipt.dispatcherExitCode)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Publish Pester summary
         if: always()
         continue-on-error: true
@@ -228,6 +247,8 @@ jobs:
           $summaryPath = Join-Path $resultsDir 'pester-summary.json'
           $classification = 'seam-defect'
           $reasons = New-Object System.Collections.Generic.List[string]
+          $executionReceiptPresent = '${{ steps.execution_receipt.outputs.present }}'
+          $executionReceiptStatus = '${{ steps.execution_receipt.outputs.status }}'
           if ('${{ inputs.readiness_status }}' -ne 'ready') {
             $reasons.Add(("readiness-status={0}" -f '${{ inputs.readiness_status }}')) | Out-Null
           }
@@ -236,9 +257,18 @@ jobs:
           }
           $dispatcherExitCode = '${{ inputs.dispatcher_exit_code }}'
           if ([string]::IsNullOrWhiteSpace($dispatcherExitCode)) { $dispatcherExitCode = '-1' }
-          if (Test-Path -LiteralPath $summaryPath) {
+          if ($executionReceiptPresent -ne 'true') {
+            $reasons.Add('execution-receipt-missing') | Out-Null
+          } elseif ($executionReceiptStatus -eq 'seam-defect') {
+            $reasons.Add('execution-receipt-seam-defect') | Out-Null
+          } elseif ($executionReceiptStatus -eq 'test-failures') {
+            $classification = 'test-failures'
+          } elseif (Test-Path -LiteralPath $summaryPath) {
             try {
               $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+              if ('${{ steps.execution_receipt.outputs.dispatcher_exit_code }}' -and '${{ steps.execution_receipt.outputs.dispatcher_exit_code }}' -ne $dispatcherExitCode) {
+                $reasons.Add('dispatcher-exit-mismatch') | Out-Null
+              }
               if (($summary.failed + $summary.errors) -gt 0 -or $dispatcherExitCode -ne '0') {
                 $classification = 'test-failures'
               } else {
@@ -281,4 +311,3 @@ jobs:
       - name: Propagate gate outcome
         if: ${{ steps.classify.outputs.classification != 'ok' && inputs.continue_on_error != 'true' }}
         run: exit 1
-

--- a/.github/workflows/pester-evidence.yml
+++ b/.github/workflows/pester-evidence.yml
@@ -1,0 +1,284 @@
+name: Pester evidence
+
+on:
+  workflow_call:
+    inputs:
+      raw_artifact_name:
+        required: false
+        type: string
+        default: 'pester-run-raw'
+      dispatcher_exit_code:
+        required: false
+        type: string
+        default: ''
+      readiness_status:
+        required: false
+        type: string
+        default: 'unknown'
+      execution_job_result:
+        required: false
+        type: string
+        default: ''
+      continue_on_error:
+        required: false
+        type: string
+        default: 'false'
+    outputs:
+      classification:
+        description: 'Final evidence classification'
+        value: ${{ jobs.evidence.outputs.classification }}
+      total:
+        description: 'Total tests discovered'
+        value: ${{ jobs.evidence.outputs.total }}
+      passed:
+        description: 'Passed tests count'
+        value: ${{ jobs.evidence.outputs.passed }}
+      failed:
+        description: 'Failed tests count'
+        value: ${{ jobs.evidence.outputs.failed }}
+      errors:
+        description: 'Errors count'
+        value: ${{ jobs.evidence.outputs.errors }}
+      duration_s:
+        description: 'Duration in seconds'
+        value: ${{ jobs.evidence.outputs.duration_s }}
+  workflow_dispatch:
+    inputs:
+      raw_artifact_name:
+        description: 'Raw execution artifact name'
+        required: false
+        default: 'pester-run-raw'
+        type: string
+      dispatcher_exit_code:
+        description: 'Dispatcher exit code from execution workflow'
+        required: false
+        default: ''
+        type: string
+      readiness_status:
+        description: 'Readiness receipt status'
+        required: false
+        default: 'unknown'
+        type: string
+      execution_job_result:
+        description: 'Execution job result'
+        required: false
+        default: ''
+        type: string
+      continue_on_error:
+        description: 'Treat failing evidence as notice-only'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
+
+jobs:
+  evidence:
+    runs-on: ubuntu-latest
+    outputs:
+      classification: ${{ steps.classify.outputs.classification }}
+      total: ${{ steps.export.outputs.total }}
+      passed: ${{ steps.export.outputs.passed }}
+      failed: ${{ steps.export.outputs.failed }}
+      errors: ${{ steps.export.outputs.errors }}
+      duration_s: ${{ steps.export.outputs.duration_s }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve raw artifact name
+        id: artifact_name
+        shell: pwsh
+        run: |
+          $artifactName = '${{ inputs.raw_artifact_name }}'
+          if ([string]::IsNullOrWhiteSpace($artifactName)) { $artifactName = 'pester-run-raw' }
+          "name=$artifactName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Download raw execution artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ steps.artifact_name.outputs.name }}
+          path: .
+
+      - name: Ensure results directory
+        shell: pwsh
+        run: |
+          if (-not (Test-Path -LiteralPath 'tests/results')) {
+            New-Item -ItemType Directory -Path 'tests/results' -Force | Out-Null
+          }
+
+      - name: Publish Pester summary
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: pwsh -File scripts/Write-PesterSummaryToStepSummary.ps1 -ResultsDir 'tests/results'
+
+      - name: Validate Pester summary schema-lite (notice-only)
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $json = Join-Path 'tests/results' 'pester-summary.json'
+          if (Test-Path $json) {
+            $schemas = @(
+              'docs/schemas/pester-summary-v1_7_1.schema.json',
+              'docs/schemas/pester-summary-v1_7.schema.json',
+              'docs/schemas/pester-summary-v1_6.schema.json',
+              'docs/schemas/pester-summary-v1_5.schema.json',
+              'docs/schemas/pester-summary-v1_4.schema.json',
+              'docs/schemas/pester-summary-v1_3.schema.json',
+              'docs/schemas/pester-summary-v1_2.schema.json',
+              'docs/schemas/pester-summary-v1_1.schema.json'
+            )
+            foreach ($schema in $schemas) {
+              if (Test-Path $schema) {
+                pwsh -File tools/Invoke-JsonSchemaLite.ps1 -JsonPath $json -SchemaPath $schema
+                if ($LASTEXITCODE -eq 0) { break }
+              }
+            }
+          }
+
+      - name: Ensure session index (fallback)
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: pwsh -File tools/Ensure-SessionIndex.ps1 -ResultsDir 'tests/results' -SummaryJson 'pester-summary.json'
+
+      - name: Wire Probe (S1)
+        if: always()
+        uses: ./.github/actions/wire-probe
+        with:
+          phase: S1
+          results-dir: tests/results
+
+      - name: Export Pester totals as outputs
+        id: export
+        if: always()
+        shell: pwsh
+        run: |
+          $sum = Join-Path 'tests/results' 'pester-summary.json'
+          if (Test-Path $sum) {
+            $js = Get-Content $sum -Raw | ConvertFrom-Json
+            "total=$($js.total)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "passed=$($js.passed)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "failed=$($js.failed)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "errors=$($js.errors)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "duration_s=$($js.duration_s)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          } else {
+            "total=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "passed=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "failed=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "errors=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "duration_s=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
+
+      - name: Session index post
+        if: always()
+        uses: ./.github/actions/session-index-post
+        with:
+          results-dir: tests/results
+          validate-schema: true
+          upload: true
+          artifact-name: session-index
+
+      - name: Append session summary
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: pwsh -File tools/Write-SessionIndexSummary.ps1 -ResultsDir 'tests/results'
+
+      - name: Append top Pester failures
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: pwsh -File tools/Write-PesterTopFailures.ps1 -ResultsDir 'tests/results' -Top 10
+
+      - name: Write compact totals JSON
+        if: always()
+        shell: pwsh
+        run: |
+          $outDir = 'tests/results'
+          $sum = Join-Path $outDir 'pester-summary.json'
+          $obj = [ordered]@{
+            schema = 'pester-totals/v1'
+            includeIntegration = $null
+            status = 'missing-summary'
+          }
+          if (Test-Path $sum) {
+            try {
+              $js = Get-Content $sum -Raw | ConvertFrom-Json -ErrorAction Stop
+              $obj.total = $js.total
+              $obj.passed = $js.passed
+              $obj.failed = $js.failed
+              $obj.errors = $js.errors
+              $obj.duration_s = $js.duration_s
+              $obj.status = if (($js.failed + $js.errors) -gt 0) { 'fail' } else { 'ok' }
+            } catch {
+              $obj.status = 'unknown'
+            }
+          }
+          $obj | ConvertTo-Json -Depth 5 | Out-File -FilePath (Join-Path $outDir 'pester-totals.json') -Encoding utf8
+
+      - name: Classify evidence outcome
+        id: classify
+        if: always()
+        shell: pwsh
+        run: |
+          $resultsDir = 'tests/results'
+          $summaryPath = Join-Path $resultsDir 'pester-summary.json'
+          $classification = 'seam-defect'
+          $reasons = New-Object System.Collections.Generic.List[string]
+          if ('${{ inputs.readiness_status }}' -ne 'ready') {
+            $reasons.Add(("readiness-status={0}" -f '${{ inputs.readiness_status }}')) | Out-Null
+          }
+          if ('${{ inputs.execution_job_result }}' -eq 'skipped') {
+            $reasons.Add('execution-job-skipped') | Out-Null
+          }
+          $dispatcherExitCode = '${{ inputs.dispatcher_exit_code }}'
+          if ([string]::IsNullOrWhiteSpace($dispatcherExitCode)) { $dispatcherExitCode = '-1' }
+          if (Test-Path -LiteralPath $summaryPath) {
+            try {
+              $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+              if (($summary.failed + $summary.errors) -gt 0 -or $dispatcherExitCode -ne '0') {
+                $classification = 'test-failures'
+              } else {
+                $classification = 'ok'
+              }
+            } catch {
+              $classification = 'seam-defect'
+              $reasons.Add('summary-unparseable') | Out-Null
+            }
+          } else {
+            $reasons.Add('summary-missing') | Out-Null
+          }
+          $receipt = [ordered]@{
+            schema             = 'pester-evidence-classification@v1'
+            generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
+            readinessStatus    = '${{ inputs.readiness_status }}'
+            executionJobResult = '${{ inputs.execution_job_result }}'
+            dispatcherExitCode = [int]$dispatcherExitCode
+            summaryPresent     = Test-Path -LiteralPath $summaryPath
+            classification     = $classification
+            reasons            = @($reasons)
+          }
+          $receipt | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $resultsDir 'pester-evidence-classification.json') -Encoding UTF8
+          "classification=$classification" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Generate dev dashboard report
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: pwsh -File tools/Invoke-DevDashboard.ps1 -Group 'pester-selfhosted' -ResultsRoot 'tests/results'
+
+      - name: Upload evidence artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pester-evidence
+          path: tests/results
+          if-no-files-found: warn
+
+      - name: Propagate gate outcome
+        if: ${{ steps.classify.outputs.classification != 'ok' && inputs.continue_on_error != 'true' }}
+        run: exit 1
+

--- a/.github/workflows/pester-gate.yml
+++ b/.github/workflows/pester-gate.yml
@@ -1,6 +1,28 @@
 name: Pester gate (service model pilot)
 
 on:
+  workflow_call:
+    inputs:
+      include_integration:
+        required: false
+        default: 'false'
+        type: string
+      include_patterns:
+        required: false
+        default: ''
+        type: string
+      sample_id:
+        required: false
+        default: ''
+        type: string
+      checkout_repository:
+        required: false
+        default: ''
+        type: string
+      checkout_ref:
+        required: false
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       include_integration:
@@ -19,6 +41,16 @@ on:
         required: false
         default: ''
         type: string
+      checkout_repository:
+        description: 'Repository to checkout for the pilot run'
+        required: false
+        default: ''
+        type: string
+      checkout_ref:
+        description: 'Git ref or SHA to checkout for the pilot run'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || github.ref }}
@@ -29,6 +61,8 @@ jobs:
     uses: ./.github/workflows/selfhosted-readiness.yml
     with:
       sample_id: ${{ inputs.sample_id || '' }}
+      checkout_repository: ${{ inputs.checkout_repository || github.repository }}
+      checkout_ref: ${{ inputs.checkout_ref || github.sha }}
 
   pester-run:
     needs: readiness
@@ -40,6 +74,8 @@ jobs:
       sample_id: ${{ inputs.sample_id || '' }}
       readiness_status: ${{ needs.readiness.outputs.receipt_status }}
       readiness_artifact_name: ${{ needs.readiness.outputs.receipt_artifact_name }}
+      checkout_repository: ${{ inputs.checkout_repository || github.repository }}
+      checkout_ref: ${{ inputs.checkout_ref || github.sha }}
 
   pester-evidence:
     needs: [readiness, pester-run]

--- a/.github/workflows/pester-gate.yml
+++ b/.github/workflows/pester-gate.yml
@@ -39,6 +39,7 @@ jobs:
       include_patterns: ${{ inputs.include_patterns || '' }}
       sample_id: ${{ inputs.sample_id || '' }}
       readiness_status: ${{ needs.readiness.outputs.receipt_status }}
+      readiness_artifact_name: ${{ needs.readiness.outputs.receipt_artifact_name }}
 
   pester-evidence:
     needs: [readiness, pester-run]
@@ -49,4 +50,3 @@ jobs:
       dispatcher_exit_code: ${{ needs.pester-run.outputs.dispatcher_exit_code }}
       readiness_status: ${{ needs.readiness.outputs.receipt_status }}
       execution_job_result: ${{ needs.pester-run.result }}
-

--- a/.github/workflows/pester-gate.yml
+++ b/.github/workflows/pester-gate.yml
@@ -1,0 +1,52 @@
+name: Pester gate (service model pilot)
+
+on:
+  workflow_dispatch:
+    inputs:
+      include_integration:
+        description: "Include Integration-tagged tests in the execution pack"
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
+      include_patterns:
+        description: 'Optional repo-relative IncludePatterns selector'
+        required: false
+        default: ''
+        type: string
+      sample_id:
+        description: 'Sampling correlation id (prevents cancels)'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  readiness:
+    uses: ./.github/workflows/selfhosted-readiness.yml
+    with:
+      sample_id: ${{ inputs.sample_id || '' }}
+
+  pester-run:
+    needs: readiness
+    if: always()
+    uses: ./.github/workflows/pester-run.yml
+    with:
+      include_integration: ${{ inputs.include_integration || 'false' }}
+      include_patterns: ${{ inputs.include_patterns || '' }}
+      sample_id: ${{ inputs.sample_id || '' }}
+      readiness_status: ${{ needs.readiness.outputs.receipt_status }}
+
+  pester-evidence:
+    needs: [readiness, pester-run]
+    if: always()
+    uses: ./.github/workflows/pester-evidence.yml
+    with:
+      raw_artifact_name: ${{ needs.pester-run.outputs.raw_artifact_name }}
+      dispatcher_exit_code: ${{ needs.pester-run.outputs.dispatcher_exit_code }}
+      readiness_status: ${{ needs.readiness.outputs.receipt_status }}
+      execution_job_result: ${{ needs.pester-run.result }}
+

--- a/.github/workflows/pester-run.yml
+++ b/.github/workflows/pester-run.yml
@@ -22,6 +22,12 @@ on:
         required: false
         type: string
         default: 'pester-readiness'
+      checkout_repository:
+        required: false
+        type: string
+      checkout_ref:
+        required: false
+        type: string
     outputs:
       dispatcher_exit_code:
         description: 'Dispatcher exit code from the self-hosted execution pass'
@@ -57,6 +63,16 @@ on:
         required: false
         default: 'pester-readiness'
         type: string
+      checkout_repository:
+        description: 'Repository to checkout for execution'
+        required: false
+        default: ''
+        type: string
+      checkout_ref:
+        description: 'Git ref or SHA to checkout for execution'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-pester-run-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
@@ -69,6 +85,9 @@ jobs:
       include_integration: ${{ steps.b.outputs.normalized }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref || github.sha }}
       - name: Apply determinism profile
         uses: ./.github/actions/determinism-profile
         with:

--- a/.github/workflows/pester-run.yml
+++ b/.github/workflows/pester-run.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: 'unknown'
+      readiness_artifact_name:
+        required: false
+        type: string
+        default: 'pester-readiness'
     outputs:
       dispatcher_exit_code:
         description: 'Dispatcher exit code from the self-hosted execution pass'
@@ -47,6 +51,11 @@ on:
         description: 'Readiness receipt status'
         required: false
         default: 'unknown'
+        type: string
+      readiness_artifact_name:
+        description: 'Readiness receipt artifact name'
+        required: false
+        default: 'pester-readiness'
         type: string
 
 concurrency:
@@ -104,6 +113,40 @@ jobs:
           if (-not $env:WORKFLOW_TOKEN) { throw 'github.token is empty' }
           "GH_TOKEN=$env:WORKFLOW_TOKEN" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "GITHUB_TOKEN=$env:WORKFLOW_TOKEN" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Download readiness receipt artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.readiness_artifact_name }}
+          path: tests/readiness
+
+      - name: Validate readiness receipt
+        id: readiness_receipt
+        shell: pwsh
+        run: |
+          $receiptPath = 'tests/readiness/selfhosted-readiness.json'
+          if (-not (Test-Path -LiteralPath $receiptPath)) {
+            throw "Readiness receipt missing: $receiptPath"
+          }
+          $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json -ErrorAction Stop
+          if ($receipt.schema -ne 'pester-selfhosted-readiness-receipt@v1') {
+            throw ("Unexpected readiness receipt schema: {0}" -f $receipt.schema)
+          }
+          if ($receipt.status -ne 'ready') {
+            throw ("Readiness receipt status is not ready: {0}" -f $receipt.status)
+          }
+          $freshnessWindowSeconds = 900
+          if ($receipt.PSObject.Properties.Name -contains 'freshnessWindowSeconds') {
+            $freshnessWindowSeconds = [int]$receipt.freshnessWindowSeconds
+          }
+          $generatedAtUtc = [DateTime]::Parse($receipt.generatedAtUtc).ToUniversalTime()
+          $ageSeconds = [math]::Floor(([DateTime]::UtcNow - $generatedAtUtc).TotalSeconds)
+          if ($ageSeconds -gt $freshnessWindowSeconds) {
+            throw ("Readiness receipt stale: age {0}s exceeds freshness window {1}s" -f $ageSeconds, $freshnessWindowSeconds)
+          }
+          "path=$receiptPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "generated_at_utc=$($generatedAtUtc.ToString('o'))" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "freshness_window_seconds=$freshnessWindowSeconds" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Acquire session lock
         shell: pwsh
@@ -222,14 +265,6 @@ jobs:
         shell: pwsh
         run: pwsh -NoLogo -NoProfile -File tools/Session-Lock.ps1 -Action Release
 
-      - name: Upload raw Pester execution artifact
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: pester-run-raw
-          path: tests/results
-          if-no-files-found: warn
-
       - name: Write execution receipt
         id: execution_receipt
         if: always()
@@ -245,6 +280,7 @@ jobs:
           if ($dispatcherExitCode -eq '') {
             $dispatcherExitCode = '-1'
           }
+          $readinessReceiptPresent = Test-Path -LiteralPath '${{ steps.readiness_receipt.outputs.path }}'
           if ((Test-Path -LiteralPath $summaryPath) -and $dispatcherExitCode -eq '0') {
             $status = 'completed'
           } elseif (Test-Path -LiteralPath $summaryPath) {
@@ -254,6 +290,10 @@ jobs:
             schema             = 'pester-execution-receipt@v1'
             generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
             readinessStatus    = '${{ inputs.readiness_status }}'
+            readinessReceiptPath = '${{ steps.readiness_receipt.outputs.path }}'
+            readinessReceiptPresent = $readinessReceiptPresent
+            readinessReceiptGeneratedAtUtc = '${{ steps.readiness_receipt.outputs.generated_at_utc }}'
+            readinessReceiptFreshnessWindowSeconds = '${{ steps.readiness_receipt.outputs.freshness_window_seconds }}'
             dispatcherExitCode = [int]$dispatcherExitCode
             summaryPresent     = Test-Path -LiteralPath $summaryPath
             status             = $status
@@ -264,3 +304,10 @@ jobs:
           "dispatcher_exit_code=$dispatcherExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "raw_artifact_name=pester-run-raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
+      - name: Upload raw Pester execution artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pester-run-raw
+          path: tests/results
+          if-no-files-found: warn

--- a/.github/workflows/pester-run.yml
+++ b/.github/workflows/pester-run.yml
@@ -1,0 +1,266 @@
+name: Pester run
+
+on:
+  workflow_call:
+    inputs:
+      include_integration:
+        required: false
+        type: string
+        default: 'false'
+      include_patterns:
+        required: false
+        type: string
+        default: ''
+      sample_id:
+        required: false
+        type: string
+      readiness_status:
+        required: false
+        type: string
+        default: 'unknown'
+    outputs:
+      dispatcher_exit_code:
+        description: 'Dispatcher exit code from the self-hosted execution pass'
+        value: ${{ jobs.pester.outputs.dispatcher_exit_code }}
+      raw_artifact_name:
+        description: 'Artifact name containing raw execution outputs'
+        value: ${{ jobs.pester.outputs.raw_artifact_name }}
+  workflow_dispatch:
+    inputs:
+      include_integration:
+        description: "Include Integration-tagged tests in the execution pack"
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
+      include_patterns:
+        description: 'Optional repo-relative IncludePatterns selector'
+        required: false
+        default: ''
+        type: string
+      sample_id:
+        description: 'Sampling correlation id (prevents cancels)'
+        required: false
+        default: ''
+        type: string
+      readiness_status:
+        description: 'Readiness receipt status'
+        required: false
+        default: 'unknown'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-pester-run-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  normalize:
+    runs-on: ubuntu-latest
+    outputs:
+      include_integration: ${{ steps.b.outputs.normalized }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Apply determinism profile
+        uses: ./.github/actions/determinism-profile
+        with:
+          strict: 'true'
+      - name: Normalize include_integration
+        id: b
+        uses: ./.github/actions/bool-normalize
+        with:
+          value: ${{ inputs.include_integration || 'false' }}
+
+  pester:
+    name: Pester (execution only)
+    if: ${{ inputs.readiness_status == 'ready' }}
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
+    needs: normalize
+    env:
+      LV_SUPPRESS_UI: ${{ vars.LV_SUPPRESS_UI || '1' }}
+      LV_NO_ACTIVATE: ${{ vars.LV_NO_ACTIVATE || '1' }}
+      LV_CURSOR_RESTORE: ${{ vars.LV_CURSOR_RESTORE || '1' }}
+      LV_IDLE_WAIT_SECONDS: ${{ vars.LV_IDLE_WAIT_SECONDS || '2' }}
+      LV_IDLE_MAX_WAIT_SECONDS: ${{ vars.LV_IDLE_MAX_WAIT_SECONDS || '5' }}
+      STUCK_GUARD: ${{ vars.STUCK_GUARD || '1' }}
+      CLEAN_LV_BEFORE: ${{ vars.CLEAN_LV_BEFORE || 'true' }}
+      CLEAN_LV_AFTER: ${{ vars.CLEAN_LV_AFTER || 'true' }}
+      CLEAN_LV_INCLUDE_COMPARE: ${{ vars.CLEAN_LV_INCLUDE_COMPARE || vars.CLEAN_LVCOMPARE || 'true' }}
+      LVCOMPARE_PATH: ${{ vars.LVCOMPARE_PATH || '' }}
+    outputs:
+      dispatcher_exit_code: ${{ steps.execution_receipt.outputs.dispatcher_exit_code }}
+      raw_artifact_name: ${{ steps.execution_receipt.outputs.raw_artifact_name }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Node dependencies
+        shell: pwsh
+        run: node tools/npm/cli.mjs ci
+
+      - name: Export workflow token for priority sync
+        shell: pwsh
+        env:
+          WORKFLOW_TOKEN: ${{ github.token }}
+        run: |
+          if (-not $env:WORKFLOW_TOKEN) { throw 'github.token is empty' }
+          "GH_TOKEN=$env:WORKFLOW_TOKEN" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "GITHUB_TOKEN=$env:WORKFLOW_TOKEN" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Acquire session lock
+        shell: pwsh
+        run: pwsh -NoLogo -NoProfile -File tools/Session-Lock.ps1 -Action Acquire -Group 'pester-selfhosted' -QueueWaitSeconds 15 -QueueMaxAttempts 40 -StaleSeconds 300 -HeartbeatSeconds 15
+
+      - name: LV Guard (pre)
+        uses: ./.github/actions/runner-unblock-guard
+        with:
+          snapshot-path: tests/results/lv-guard-pre.json
+          cleanup: ${{ env.CLEAN_LV_BEFORE == 'true' }}
+          process-names: 'LVCompare,LabVIEW'
+
+      - name: Prepare fixture copies (base/head)
+        if: ${{ needs.normalize.outputs.include_integration == 'true' }}
+        id: fixtures
+        uses: ./.github/actions/prepare-fixtures
+
+      - name: Export fixture env for tests
+        if: ${{ needs.normalize.outputs.include_integration == 'true' }}
+        shell: pwsh
+        run: |
+          if ('${{ steps.fixtures.outputs.base }}' -and '${{ steps.fixtures.outputs.head }}') {
+            "LV_BASE_VI=${{ steps.fixtures.outputs.base }}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            "LV_HEAD_VI=${{ steps.fixtures.outputs.head }}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          } else {
+            Write-Host '::warning::prepare-fixtures did not emit expected outputs; proceeding without LV_* env.'
+          }
+
+      - name: Apply dispatcher profile
+        id: dprofile
+        uses: ./.github/actions/dispatcher-profile
+        with:
+          timeout-seconds: '0'
+          emit-failures-json-always: 'true'
+          detect-leaks: 'true'
+          fail-on-leaks: 'false'
+          kill-leaks: 'false'
+          leak-grace-seconds: '3'
+          clean-labview-before: 'false'
+          clean-after: 'false'
+          track-artifacts: 'true'
+
+      - name: Wire Probe (T1)
+        if: ${{ vars.WIRE_PROBES != '0' }}
+        uses: ./.github/actions/wire-probe
+        with:
+          phase: T1
+          results-dir: tests/results
+
+      - name: Run Pester tests via local dispatcher
+        id: dispatcher
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $logPath = 'tests/results/pester-dispatcher.log'
+          $logDir = Split-Path -Parent $logPath
+          if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Force -Path $logDir | Out-Null }
+          if (Test-Path -LiteralPath $logPath) { Remove-Item -LiteralPath $logPath -Force }
+          $dispatcherPath = Join-Path (Get-Location) 'Invoke-PesterTests.ps1'
+          if (-not (Test-Path -LiteralPath $dispatcherPath -PathType Leaf)) {
+            throw "Dispatcher script not found at $dispatcherPath"
+          }
+          $bound = [ordered]@{}
+          $bound.TestsPath = 'tests'
+          $includeIntegration = '${{ needs.normalize.outputs.include_integration }}'
+          if ($includeIntegration) {
+            switch ($includeIntegration.ToString().ToLowerInvariant()) {
+              { $_ -in @('true','1','yes','y','on','include') } { $bound.IntegrationMode = 'include' }
+              { $_ -in @('false','0','no','n','off','exclude') } { $bound.IntegrationMode = 'exclude' }
+              'auto' { $bound.IntegrationMode = 'auto' }
+            }
+          }
+          $bound.ResultsPath = 'tests/results'
+          if ($env:DISPATCHER_LIVE_OUTPUT -ne '0') { $bound.LiveOutput = $true }
+          if ('${{ steps.dprofile.outputs.emit_failures_json_always }}' -eq 'true') { $bound.EmitFailuresJsonAlways = $true }
+          if ('${{ inputs.include_patterns }}' -ne '') {
+            $bound.IncludePatterns = (Split-Path -Leaf '${{ inputs.include_patterns }}')
+          }
+          $timeoutSeconds = '${{ steps.dprofile.outputs.timeout_seconds }}'
+          if ($timeoutSeconds -and $timeoutSeconds -match '^-?\d+(\.\d+)?$') {
+            $bound.TimeoutSeconds = [double]$timeoutSeconds
+          }
+          $lockScript = Join-Path (Get-Location) 'tools/Session-Lock.ps1'
+          $heartbeatSeconds = 15
+          $heartbeatJob = Start-ThreadJob -ScriptBlock {
+            param($scriptPath,$seconds)
+            while ($true) {
+              pwsh -NoLogo -NoProfile -File $scriptPath -Action Heartbeat | Out-Null
+              Start-Sleep -Seconds $seconds
+            }
+          } -ArgumentList $lockScript, $heartbeatSeconds
+          $exitCode = 0
+          try {
+            & $dispatcherPath @bound 2>&1 | Tee-Object -FilePath $logPath
+            $exitCode = $LASTEXITCODE
+          } finally {
+            if ($heartbeatJob) {
+              Stop-Job -Id $heartbeatJob.Id | Out-Null
+              Remove-Job -Id $heartbeatJob.Id -Force | Out-Null
+            }
+            pwsh -NoLogo -NoProfile -File $lockScript -Action Heartbeat | Out-Null
+          }
+          if (-not $env:GITHUB_OUTPUT) {
+            $fallbackOutput = Join-Path (Get-Location) 'tests/results/dispatcher-github-output.txt'
+            $fallbackDir = Split-Path -Parent $fallbackOutput
+            if (-not (Test-Path -LiteralPath $fallbackDir)) {
+              New-Item -ItemType Directory -Path $fallbackDir -Force | Out-Null
+            }
+            $env:GITHUB_OUTPUT = [System.IO.Path]::GetFullPath($fallbackOutput)
+          }
+          "exit_code=$exitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $global:LASTEXITCODE = 0
+
+      - name: Release session lock
+        if: always()
+        shell: pwsh
+        run: pwsh -NoLogo -NoProfile -File tools/Session-Lock.ps1 -Action Release
+
+      - name: Upload raw Pester execution artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pester-run-raw
+          path: tests/results
+          if-no-files-found: warn
+
+      - name: Write execution receipt
+        id: execution_receipt
+        if: always()
+        shell: pwsh
+        run: |
+          $resultsDir = 'tests/results'
+          if (-not (Test-Path -LiteralPath $resultsDir)) {
+            New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+          }
+          $summaryPath = Join-Path $resultsDir 'pester-summary.json'
+          $dispatcherExitCode = '${{ steps.dispatcher.outputs.exit_code }}'
+          $status = 'seam-defect'
+          if ($dispatcherExitCode -eq '') {
+            $dispatcherExitCode = '-1'
+          }
+          if ((Test-Path -LiteralPath $summaryPath) -and $dispatcherExitCode -eq '0') {
+            $status = 'completed'
+          } elseif (Test-Path -LiteralPath $summaryPath) {
+            $status = 'test-failures'
+          }
+          $receipt = [ordered]@{
+            schema             = 'pester-execution-receipt@v1'
+            generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
+            readinessStatus    = '${{ inputs.readiness_status }}'
+            dispatcherExitCode = [int]$dispatcherExitCode
+            summaryPresent     = Test-Path -LiteralPath $summaryPath
+            status             = $status
+            rawArtifactName    = 'pester-run-raw'
+          }
+          $receiptPath = Join-Path $resultsDir 'pester-run-receipt.json'
+          $receipt | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $receiptPath -Encoding UTF8
+          "dispatcher_exit_code=$dispatcherExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "raw_artifact_name=pester-run-raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+

--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -1,0 +1,105 @@
+name: Pester service-model pilot on trusted PR label
+
+on:
+  pull_request_target:
+    types: [labeled, reopened, synchronize]
+    branches: [main, develop, release/**]
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
+    inputs:
+      sample_id:
+        description: 'Sampling correlation id (prevents cancels)'
+        required: false
+        default: ''
+        type: string
+      checkout_repository:
+        description: 'Repository to checkout for the pilot run'
+        required: false
+        default: ''
+        type: string
+      checkout_ref:
+        description: 'Git ref or SHA to checkout for the pilot run'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.sample_id || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  trust-context:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      checkout_repository: ${{ steps.decide.outputs.checkout_repository }}
+      checkout_ref: ${{ steps.decide.outputs.checkout_ref }}
+      trust_mode: ${{ steps.decide.outputs.trust_mode }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Decide trusted pilot routing
+        id: decide
+        shell: pwsh
+        run: |
+          $eventName = '${{ github.event_name }}'
+          $shouldRun = 'false'
+          $checkoutRepository = '${{ github.repository }}'
+          $checkoutRef = '${{ github.sha }}'
+          $trustMode = 'base-ref'
+          $reason = 'workflow-dispatch-default'
+          if ($eventName -eq 'workflow_dispatch') {
+            if ('${{ inputs.checkout_repository }}') { $checkoutRepository = '${{ inputs.checkout_repository }}' }
+            if ('${{ inputs.checkout_ref }}') { $checkoutRef = '${{ inputs.checkout_ref }}' }
+            $shouldRun = 'true'
+          } else {
+            $labels = @('${{ join(github.event.pull_request.labels.*.name, "','") }}' -split ',' | Where-Object { $_ })
+            $hasLabel = $labels -contains 'pester-service-model'
+            $sameOwner = '${{ github.event.pull_request.head.repo.owner.login }}' -eq '${{ github.repository_owner }}'
+            if (-not $hasLabel) {
+              $reason = 'pilot-label-missing'
+            } elseif (-not $sameOwner) {
+              $reason = 'untrusted-cross-owner-fork'
+            } else {
+              $checkoutRepository = '${{ github.event.pull_request.head.repo.full_name }}'
+              $checkoutRef = '${{ github.event.pull_request.head.sha }}'
+              $trustMode = 'same-owner-head'
+              $shouldRun = 'true'
+              $reason = 'trusted-same-owner-head'
+            }
+          }
+          "should_run=$shouldRun" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "checkout_repository=$checkoutRepository" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "checkout_ref=$checkoutRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "trust_mode=$trustMode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "reason=$reason" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+  pilot:
+    needs: trust-context
+    if: ${{ needs.trust-context.outputs.should_run == 'true' }}
+    uses: ./.github/workflows/pester-gate.yml
+    with:
+      include_integration: 'true'
+      sample_id: ${{ github.event.inputs.sample_id || '' }}
+      checkout_repository: ${{ needs.trust-context.outputs.checkout_repository }}
+      checkout_ref: ${{ needs.trust-context.outputs.checkout_ref }}
+
+  skipped:
+    needs: trust-context
+    if: ${{ needs.trust-context.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Append skip summary
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_STEP_SUMMARY) {
+            $lines = @('### Pester service-model pilot', '')
+            $lines += ('- Status: skipped')
+            $lines += ('- Reason: {0}' -f '${{ needs.trust-context.outputs.reason }}')
+            $lines += ('- Trust mode: {0}' -f '${{ needs.trust-context.outputs.trust_mode }}')
+            $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }

--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Decide trusted pilot routing
         id: decide
         shell: pwsh
+        env:
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           $eventName = '${{ github.event_name }}'
           $shouldRun = 'false'
@@ -57,7 +59,14 @@ jobs:
             if ('${{ inputs.checkout_ref }}') { $checkoutRef = '${{ inputs.checkout_ref }}' }
             $shouldRun = 'true'
           } else {
-            $labels = @('${{ join(github.event.pull_request.labels.*.name, "','") }}' -split ',' | Where-Object { $_ })
+            $labels = @()
+            if ($env:PR_LABELS_JSON) {
+              try {
+                $labels = @((ConvertFrom-Json -InputObject $env:PR_LABELS_JSON -ErrorAction Stop) | Where-Object { $_ })
+              } catch {
+                throw ("Unable to parse PR labels JSON: {0}" -f $_.Exception.Message)
+              }
+            }
             $hasLabel = $labels -contains 'pester-service-model'
             $sameOwner = '${{ github.event.pull_request.head.repo.owner.login }}' -eq '${{ github.repository_owner }}'
             if (-not $hasLabel) {
@@ -83,7 +92,7 @@ jobs:
     if: ${{ needs.trust-context.outputs.should_run == 'true' }}
     uses: ./.github/workflows/pester-gate.yml
     with:
-      include_integration: 'true'
+      include_integration: ${{ 'true' }}
       sample_id: ${{ github.event.inputs.sample_id || '' }}
       checkout_repository: ${{ needs.trust-context.outputs.checkout_repository }}
       checkout_ref: ${{ needs.trust-context.outputs.checkout_ref }}

--- a/.github/workflows/selfhosted-readiness.yml
+++ b/.github/workflows/selfhosted-readiness.yml
@@ -194,6 +194,7 @@ jobs:
           $receipt = [ordered]@{
             schema         = 'pester-selfhosted-readiness-receipt@v1'
             generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+            freshnessWindowSeconds = 900
             status         = $status
             sampleId       = '${{ inputs.sample_id || github.event.inputs.sample_id || '' }}'
             probes         = [ordered]@{
@@ -216,4 +217,3 @@ jobs:
           name: pester-readiness
           path: tests/results/pester-readiness
           if-no-files-found: error
-

--- a/.github/workflows/selfhosted-readiness.yml
+++ b/.github/workflows/selfhosted-readiness.yml
@@ -6,6 +6,12 @@ on:
       sample_id:
         required: false
         type: string
+      checkout_repository:
+        required: false
+        type: string
+      checkout_ref:
+        required: false
+        type: string
     outputs:
       receipt_status:
         description: 'Overall readiness status for the self-hosted ingress plane'
@@ -17,6 +23,16 @@ on:
     inputs:
       sample_id:
         description: 'Sampling correlation id (prevents cancels)'
+        required: false
+        default: ''
+        type: string
+      checkout_repository:
+        description: 'Repository to checkout for readiness and execution context'
+        required: false
+        default: ''
+        type: string
+      checkout_ref:
+        description: 'Git ref or SHA to checkout for readiness and execution context'
         required: false
         default: ''
         type: string
@@ -37,6 +53,9 @@ jobs:
       LV_IDLE_MAX_WAIT_SECONDS: ${{ vars.LV_IDLE_MAX_WAIT_SECONDS || '5' }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Install Node dependencies
         shell: pwsh

--- a/.github/workflows/selfhosted-readiness.yml
+++ b/.github/workflows/selfhosted-readiness.yml
@@ -1,0 +1,219 @@
+name: Self-hosted readiness
+
+on:
+  workflow_call:
+    inputs:
+      sample_id:
+        required: false
+        type: string
+    outputs:
+      receipt_status:
+        description: 'Overall readiness status for the self-hosted ingress plane'
+        value: ${{ jobs.readiness.outputs.receipt_status }}
+      receipt_artifact_name:
+        description: 'Artifact name containing the readiness receipt bundle'
+        value: ${{ jobs.readiness.outputs.receipt_artifact_name }}
+  workflow_dispatch:
+    inputs:
+      sample_id:
+        description: 'Sampling correlation id (prevents cancels)'
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  readiness:
+    runs-on: [self-hosted, Windows, X64, comparevi, capability-ingress]
+    outputs:
+      receipt_status: ${{ steps.receipt.outputs.status }}
+      receipt_artifact_name: ${{ steps.receipt.outputs.artifact_name }}
+    env:
+      LVCOMPARE_PATH: ${{ vars.LVCOMPARE_PATH || '' }}
+      LV_IDLE_WAIT_SECONDS: ${{ vars.LV_IDLE_WAIT_SECONDS || '2' }}
+      LV_IDLE_MAX_WAIT_SECONDS: ${{ vars.LV_IDLE_MAX_WAIT_SECONDS || '5' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Node dependencies
+        shell: pwsh
+        run: node tools/npm/cli.mjs ci
+
+      - name: Validate runner label contract
+        id: runner_labels
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $outDir = 'tests/results/pester-readiness'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $labels = if ($env:RUNNER_LABELS) {
+            @($env:RUNNER_LABELS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+          } else {
+            @()
+          }
+          if ($labels.Count -eq 0) {
+            $labels = @('self-hosted', 'Windows', 'X64', 'comparevi', 'capability-ingress')
+          }
+          $required = @('self-hosted', 'Windows', 'X64', 'comparevi', 'capability-ingress')
+          $missing = @($required | Where-Object { $labels -notcontains $_ })
+          $status = if ($missing.Count -eq 0) { 'ready' } else { 'not-ready' }
+          $report = [ordered]@{
+            schema    = 'pester/selfhosted-runner-labels@v1'
+            status    = $status
+            labels    = $labels
+            required  = $required
+            missing   = $missing
+          }
+          $reportPath = Join-Path $outDir 'runner-label-contract.json'
+          $report | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $reportPath -Encoding UTF8
+          if ($status -ne 'ready') {
+            throw ("Runner label contract missing required labels: {0}" -f ($missing -join ', '))
+          }
+
+      - name: Probe session-lock health
+        id: session_lock
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $lockScript = Join-Path (Get-Location) 'tools/Session-Lock.ps1'
+          if (-not (Test-Path -LiteralPath $lockScript -PathType Leaf)) {
+            throw "Session-Lock.ps1 not found: $lockScript"
+          }
+          pwsh -NoLogo -NoProfile -File $lockScript -Action Acquire -Group 'pester-selfhosted-readiness' -QueueWaitSeconds 5 -QueueMaxAttempts 3 -StaleSeconds 120 -HeartbeatSeconds 5
+          try {
+            pwsh -NoLogo -NoProfile -File $lockScript -Action Heartbeat | Out-Null
+          } finally {
+            pwsh -NoLogo -NoProfile -File $lockScript -Action Release | Out-Null
+          }
+
+      - name: Resolve .NET host toolchain
+        id: dotnet
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $outDir = 'tests/results/pester-readiness'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $candidates = New-Object System.Collections.Generic.List[string]
+          if ($env:COMPAREVI_DOTNET_EXE) { $candidates.Add($env:COMPAREVI_DOTNET_EXE) | Out-Null }
+          try {
+            $cmd = Get-Command dotnet -ErrorAction Stop | Select-Object -First 1
+            if ($cmd -and $cmd.Source) { $candidates.Add([string]$cmd.Source) | Out-Null }
+          } catch {}
+          $candidates.Add('C:\Program Files\dotnet\dotnet.exe') | Out-Null
+          $candidates.Add('C:\Program Files (x86)\dotnet\dotnet.exe') | Out-Null
+          $resolved = $null
+          foreach ($candidate in $candidates) {
+            if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+            if (Test-Path -LiteralPath $candidate) {
+              $resolved = (Resolve-Path -LiteralPath $candidate).Path
+              break
+            }
+          }
+          $status = if ($resolved) { 'ready' } else { 'not-ready' }
+          $report = [ordered]@{
+            schema     = 'pester/selfhosted-dotnet@v1'
+            status     = $status
+            resolved   = $resolved
+            candidates = @($candidates | Where-Object { $_ } | Select-Object -Unique)
+          }
+          $reportPath = Join-Path $outDir 'dotnet-readiness.json'
+          $report | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $reportPath -Encoding UTF8
+          if (-not $resolved) {
+            throw '.NET SDK/CLI not available on the self-hosted ingress plane.'
+          }
+          & $resolved --info | Out-Host
+          "path=$resolved" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Probe Windows Docker runtime
+        id: docker_runtime
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $outDir = 'tests/results/pester-readiness'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $reportPath = Join-Path $outDir 'docker-runtime-manager.json'
+          pwsh -NoLogo -NoProfile -File tools/Invoke-DockerRuntimeManager.ps1 `
+            -ProbeScope windows `
+            -BootstrapWindowsImage:$false `
+            -OutputJsonPath $reportPath `
+            -SwitchRetryCount 1 `
+            -SwitchTimeoutSeconds 30
+
+      - name: Verify LVCompare and idle LabVIEW state
+        id: lvcompare
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $outDir = 'tests/results/pester-readiness'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $defaultCli = 'C:\Program Files\National Instruments\Shared\LabVIEW Compare\LVCompare.exe'
+          $candidates = @()
+          if ($env:LVCOMPARE_PATH) { $candidates += $env:LVCOMPARE_PATH }
+          $candidates += $defaultCli
+          $cli = $null
+          foreach ($p in $candidates) {
+            if ($p -and (Test-Path -LiteralPath $p)) { $cli = $p; break }
+          }
+          $lv = @(Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue)
+          $status = if ($cli -and $lv.Count -eq 0) { 'ready' } else { 'not-ready' }
+          $report = [ordered]@{
+            schema          = 'pester/selfhosted-lvcompare@v1'
+            status          = $status
+            resolvedCliPath = $cli
+            detectedLabVIEW = @($lv | ForEach-Object { [ordered]@{ pid = $_.Id; sessionId = $_.SessionId } })
+            candidates      = $candidates
+          }
+          $reportPath = Join-Path $outDir 'lvcompare-readiness.json'
+          $report | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $reportPath -Encoding UTF8
+          if (-not $cli) {
+            throw ("LVCompare.exe not found on the ingress plane. Tried: {0}" -f (($candidates | Where-Object { $_ }) -join '; '))
+          }
+          if ($lv.Count -gt 0) {
+            $pids = $lv | ForEach-Object { '{0}(session={1})' -f $_.Id,$_.SessionId }
+            throw ("LabVIEW.exe is running during readiness probe: {0}" -f ($pids -join ', '))
+          }
+
+      - name: Write readiness receipt
+        id: receipt
+        if: always()
+        shell: pwsh
+        run: |
+          $outDir = 'tests/results/pester-readiness'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $probeOutcomes = [ordered]@{
+            runnerLabels  = '${{ steps.runner_labels.outcome }}'
+            sessionLock   = '${{ steps.session_lock.outcome }}'
+            dotnet        = '${{ steps.dotnet.outcome }}'
+            dockerRuntime = '${{ steps.docker_runtime.outcome }}'
+            lvcompare     = '${{ steps.lvcompare.outcome }}'
+          }
+          $status = if (@($probeOutcomes.Values | Where-Object { $_ -ne 'success' }).Count -eq 0) { 'ready' } else { 'not-ready' }
+          $receipt = [ordered]@{
+            schema         = 'pester-selfhosted-readiness-receipt@v1'
+            generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+            status         = $status
+            sampleId       = '${{ inputs.sample_id || github.event.inputs.sample_id || '' }}'
+            probes         = [ordered]@{
+              runnerLabels  = [ordered]@{ outcome = $probeOutcomes.runnerLabels; reportPath = 'tests/results/pester-readiness/runner-label-contract.json' }
+              sessionLock   = [ordered]@{ outcome = $probeOutcomes.sessionLock }
+              dotnet        = [ordered]@{ outcome = $probeOutcomes.dotnet; reportPath = 'tests/results/pester-readiness/dotnet-readiness.json'; path = '${{ steps.dotnet.outputs.path }}' }
+              dockerRuntime = [ordered]@{ outcome = $probeOutcomes.dockerRuntime; reportPath = 'tests/results/pester-readiness/docker-runtime-manager.json' }
+              lvcompare     = [ordered]@{ outcome = $probeOutcomes.lvcompare; reportPath = 'tests/results/pester-readiness/lvcompare-readiness.json' }
+            }
+          }
+          $receiptPath = Join-Path $outDir 'selfhosted-readiness.json'
+          $receipt | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $receiptPath -Encoding UTF8
+          "status=$status" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "artifact_name=pester-readiness" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Upload readiness receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pester-readiness
+          path: tests/results/pester-readiness
+          if-no-files-found: error
+

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1534,22 +1534,44 @@ jobs:
           'capability-ingress',
           'docker-lane'
         )
-        pwsh -NoLogo -NoProfile -File tools/Resolve-SelfHostedWindowsLanePlan.ps1 `
-          -Repository '${{ github.repository }}' `
-          -RequiredLabels $requiredLabels `
-          -ExecutionModel 'self-hosted-windows-docker-lane' `
-          -RunnerImage 'self-hosted-windows-docker-lane' `
-          -ExpectedContext 'desktop-windows' `
-          -ExpectedOs 'windows' `
-          -RequiredHealthReceipts @() `
-          -Notes @(
-            'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
-            'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'
-          ) `
-          -Token $env:GITHUB_TOKEN `
-          -OutputJsonPath $planPath `
-          -GitHubOutputPath $env:GITHUB_OUTPUT `
-          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+        $requiredHealthReceipts = @()
+        $notes = @(
+          'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
+          'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'
+        )
+        $args = @(
+          '-NoLogo',
+          '-NoProfile',
+          '-File',
+          'tools/Resolve-SelfHostedWindowsLanePlan.ps1',
+          '-Repository',
+          '${{ github.repository }}',
+          '-RequiredLabels'
+        ) + $requiredLabels + @(
+          '-ExecutionModel',
+          'self-hosted-windows-docker-lane',
+          '-RunnerImage',
+          'self-hosted-windows-docker-lane',
+          '-ExpectedContext',
+          'desktop-windows',
+          '-ExpectedOs',
+          'windows',
+          '-Notes'
+        ) + $notes + @(
+          '-Token',
+          $env:GITHUB_TOKEN,
+          '-OutputJsonPath',
+          $planPath,
+          '-GitHubOutputPath',
+          $env:GITHUB_OUTPUT,
+          '-StepSummaryPath',
+          $env:GITHUB_STEP_SUMMARY
+        )
+        if ($requiredHealthReceipts.Count -gt 0) {
+          $args += '-RequiredHealthReceipts'
+          $args += $requiredHealthReceipts
+        }
+        & pwsh @args
 
     - name: Append VI history Windows runner plan
       shell: pwsh

--- a/docs/knowledgebase/Pester-Service-Model.md
+++ b/docs/knowledgebase/Pester-Service-Model.md
@@ -1,0 +1,40 @@
+# Pester Service Model
+
+The legacy Pester control plane couples four concerns into one self-hosted transaction:
+
+1. policy routing
+2. host-plane readiness
+3. test execution
+4. evidence generation
+
+That coupling is what makes the monolithic self-hosted seam expensive to reproduce and hard to localize when it stalls or emits `missing-summary`.
+
+## Pilot Split
+
+The additive pilot introduces four workflow surfaces:
+
+- `.github/workflows/pester-gate.yml`
+  - top-level router for the pilot service model
+- `.github/workflows/selfhosted-readiness.yml`
+  - host-plane readiness receipts for the self-hosted ingress surface
+- `.github/workflows/pester-run.yml`
+  - receipt-driven Pester execution only
+- `.github/workflows/pester-evidence.yml`
+  - summary, classification, session-index, dashboard, and artifact publication
+
+## Design Rules
+
+- Readiness certifies the environment. It does not execute the test pack.
+- Execution consumes readiness. It does not bootstrap Docker runtimes or install core toolchains.
+- Evidence consumes raw execution output. It classifies `seam-defect` explicitly when execution never yields a valid summary.
+- The existing required gate remains in place until the pilot proves equivalent or better behavior.
+
+## Promotion Rule
+
+The pilot can replace the monolith only after:
+
+- readiness receipts are stable on the ingress host
+- execution runs the declared pack without host bootstrap
+- evidence produces deterministic classifications
+- PR/release comparisons show better failure localization and lower operator ambiguity
+

--- a/docs/knowledgebase/Pester-Service-Model.md
+++ b/docs/knowledgebase/Pester-Service-Model.md
@@ -25,8 +25,10 @@ The additive pilot introduces four workflow surfaces:
 ## Design Rules
 
 - Readiness certifies the environment. It does not execute the test pack.
+- Readiness emits a bounded-freshness receipt artifact that execution must download and validate before dispatch.
 - Execution consumes readiness. It does not bootstrap Docker runtimes or install core toolchains.
-- Evidence consumes raw execution output. It classifies `seam-defect` explicitly when execution never yields a valid summary.
+- Execution writes an execution receipt before uploading raw artifacts so evidence can classify the real seam outcome.
+- Evidence consumes raw execution output plus the execution receipt. It classifies `seam-defect` explicitly when execution never yields a valid summary or never yields a valid execution receipt.
 - The existing required gate remains in place until the pilot proves equivalent or better behavior.
 
 ## Promotion Rule
@@ -37,4 +39,3 @@ The pilot can replace the monolith only after:
 - execution runs the declared pack without host bootstrap
 - evidence produces deterministic classifications
 - PR/release comparisons show better failure localization and lower operator ambiguity
-

--- a/docs/knowledgebase/Pester-Service-Model.md
+++ b/docs/knowledgebase/Pester-Service-Model.md
@@ -15,6 +15,8 @@ The additive pilot introduces four workflow surfaces:
 
 - `.github/workflows/pester-gate.yml`
   - top-level router for the pilot service model
+- `.github/workflows/pester-service-model-on-label.yml`
+  - trusted PR/dispatch entrypoint for proving the pilot without exposing the self-hosted ingress plane to untrusted fork heads
 - `.github/workflows/selfhosted-readiness.yml`
   - host-plane readiness receipts for the self-hosted ingress surface
 - `.github/workflows/pester-run.yml`
@@ -30,6 +32,7 @@ The additive pilot introduces four workflow surfaces:
 - Execution writes an execution receipt before uploading raw artifacts so evidence can classify the real seam outcome.
 - Evidence consumes raw execution output plus the execution receipt. It classifies `seam-defect` explicitly when execution never yields a valid summary or never yields a valid execution receipt.
 - The existing required gate remains in place until the pilot proves equivalent or better behavior.
+- Trusted PR proving must stay on `pull_request_target` with same-owner gating. Cross-owner fork heads are not allowed to drive self-hosted execution.
 
 ## Promotion Rule
 

--- a/tools/policy/runner-capability-routing.json
+++ b/tools/policy/runner-capability-routing.json
@@ -82,6 +82,26 @@
       ]
     },
     {
+      "workflow": ".github/workflows/selfhosted-readiness.yml",
+      "jobs": [
+        {
+          "id": "readiness",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
+      "workflow": ".github/workflows/pester-run.yml",
+      "jobs": [
+        {
+          "id": "pester",
+          "routingClass": "ingress-only",
+          "requiredCapabilityLabels": []
+        }
+      ]
+    },
+    {
       "workflow": ".github/workflows/runbook-validation.yml",
       "jobs": [
         {

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -15,10 +15,13 @@ test('pester gate pilot routes readiness, execution, and evidence through separa
   const workflow = readRepoFile('.github/workflows/pester-gate.yml');
 
   assert.match(workflow, /name:\s+Pester gate \(service model pilot\)/);
+  assert.match(workflow, /workflow_call:/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /jobs:\s*\n\s*readiness:\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/selfhosted-readiness\.yml/);
   assert.match(workflow, /\n\s*pester-run:\s*\n\s+needs:\s+readiness\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-run\.yml/);
   assert.match(workflow, /readiness_artifact_name:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_artifact_name\s*\}\}/);
+  assert.match(workflow, /checkout_repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
+  assert.match(workflow, /checkout_ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
 });
 
@@ -29,6 +32,8 @@ test('selfhosted readiness owns host-plane certification and emits a receipt art
   assert.match(workflow, /workflow_call:/);
   assert.match(workflow, /receipt_status:/);
   assert.match(workflow, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress\]/);
+  assert.match(workflow, /repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
+  assert.match(workflow, /ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /Validate runner label contract/);
   assert.match(workflow, /Probe session-lock health/);
   assert.match(workflow, /Resolve \.NET host toolchain/);
@@ -45,6 +50,8 @@ test('pester run is execution-only and validates the readiness receipt before di
   assert.match(workflow, /name:\s+Pester run/);
   assert.match(workflow, /name:\s+Pester \(execution only\)/);
   assert.match(workflow, /if:\s+\$\{\{\s*inputs\.readiness_status == 'ready'\s*\}\}/);
+  assert.match(workflow, /repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
+  assert.match(workflow, /ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /Download readiness receipt artifact/);
   assert.match(workflow, /Validate readiness receipt/);
   assert.match(workflow, /selfhosted-readiness\.json/);
@@ -84,4 +91,18 @@ test('knowledgebase documents the additive service model and keeps the monolith 
   assert.match(doc, /readiness receipt/i);
   assert.match(doc, /execution receipt/i);
   assert.match(doc, /existing required gate remains in place/i);
+});
+
+test('trusted PR pilot router only runs self-hosted service-model proof for workflow dispatch or same-owner labeled PR heads', () => {
+  const workflow = readRepoFile('.github/workflows/pester-service-model-on-label.yml');
+
+  assert.match(workflow, /name:\s+Pester service-model pilot on trusted PR label/);
+  assert.match(workflow, /pull_request_target:/);
+  assert.match(workflow, /types:\s*\[labeled, reopened, synchronize\]/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /labels -contains 'pester-service-model'/);
+  assert.match(workflow, /head\.repo\.owner\.login/);
+  assert.match(workflow, /\$trustMode = 'same-owner-head'/);
+  assert.match(workflow, /reason = 'untrusted-cross-owner-fork'/);
+  assert.match(workflow, /uses:\s+\.\s*\/\.github\/workflows\/pester-gate\.yml/);
 });

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -18,6 +18,7 @@ test('pester gate pilot routes readiness, execution, and evidence through separa
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /jobs:\s*\n\s*readiness:\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/selfhosted-readiness\.yml/);
   assert.match(workflow, /\n\s*pester-run:\s*\n\s+needs:\s+readiness\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-run\.yml/);
+  assert.match(workflow, /readiness_artifact_name:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_artifact_name\s*\}\}/);
   assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
 });
 
@@ -35,17 +36,21 @@ test('selfhosted readiness owns host-plane certification and emits a receipt art
   assert.match(workflow, /Verify LVCompare and idle LabVIEW state/);
   assert.match(workflow, /Upload readiness receipt/);
   assert.match(workflow, /pester-selfhosted-readiness/);
+  assert.match(workflow, /freshnessWindowSeconds = 900/);
 });
 
-test('pester run is execution-only and no longer bootstraps host readiness inline', () => {
+test('pester run is execution-only and validates the readiness receipt before dispatch', () => {
   const workflow = readRepoFile('.github/workflows/pester-run.yml');
 
   assert.match(workflow, /name:\s+Pester run/);
   assert.match(workflow, /name:\s+Pester \(execution only\)/);
   assert.match(workflow, /if:\s+\$\{\{\s*inputs\.readiness_status == 'ready'\s*\}\}/);
+  assert.match(workflow, /Download readiness receipt artifact/);
+  assert.match(workflow, /Validate readiness receipt/);
+  assert.match(workflow, /selfhosted-readiness\.json/);
   assert.match(workflow, /Run Pester tests via local dispatcher/);
-  assert.match(workflow, /Upload raw Pester execution artifact/);
   assert.match(workflow, /pester-run-receipt\.json/);
+  assert.match(workflow, /Upload raw Pester execution artifact/);
   assert.doesNotMatch(workflow, /Install Pester/);
   assert.doesNotMatch(workflow, /Invoke-DockerRuntimeManager\.ps1/);
   assert.doesNotMatch(workflow, /Write-PesterSummaryToStepSummary\.ps1/);
@@ -58,11 +63,13 @@ test('pester evidence classifies seam defects explicitly from raw execution outp
   assert.match(workflow, /name:\s+Pester evidence/);
   assert.match(workflow, /runs-on:\s+ubuntu-latest/);
   assert.match(workflow, /Download raw execution artifact/);
+  assert.match(workflow, /Validate execution receipt artifact/);
+  assert.match(workflow, /execution-receipt-missing/);
   assert.match(workflow, /Write-PesterSummaryToStepSummary\.ps1/);
   assert.match(workflow, /Ensure-SessionIndex\.ps1/);
   assert.match(workflow, /Invoke-DevDashboard\.ps1/);
   assert.match(workflow, /classification = 'seam-defect'/);
-  assert.match(workflow, /summary-missing/);
+  assert.match(workflow, /execution-receipt-seam-defect/);
   assert.match(workflow, /Upload evidence artifact/);
   assert.match(workflow, /Propagate gate outcome/);
 });
@@ -74,5 +81,7 @@ test('knowledgebase documents the additive service model and keeps the monolith 
   assert.match(doc, /selfhosted-readiness\.yml/);
   assert.match(doc, /pester-run\.yml/);
   assert.match(doc, /pester-evidence\.yml/);
+  assert.match(doc, /readiness receipt/i);
+  assert.match(doc, /execution receipt/i);
   assert.match(doc, /existing required gate remains in place/i);
 });

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('pester gate pilot routes readiness, execution, and evidence through separate reusable workflows', () => {
+  const workflow = readRepoFile('.github/workflows/pester-gate.yml');
+
+  assert.match(workflow, /name:\s+Pester gate \(service model pilot\)/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /jobs:\s*\n\s*readiness:\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/selfhosted-readiness\.yml/);
+  assert.match(workflow, /\n\s*pester-run:\s*\n\s+needs:\s+readiness\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-run\.yml/);
+  assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
+});
+
+test('selfhosted readiness owns host-plane certification and emits a receipt artifact', () => {
+  const workflow = readRepoFile('.github/workflows/selfhosted-readiness.yml');
+
+  assert.match(workflow, /name:\s+Self-hosted readiness/);
+  assert.match(workflow, /workflow_call:/);
+  assert.match(workflow, /receipt_status:/);
+  assert.match(workflow, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress\]/);
+  assert.match(workflow, /Validate runner label contract/);
+  assert.match(workflow, /Probe session-lock health/);
+  assert.match(workflow, /Resolve \.NET host toolchain/);
+  assert.match(workflow, /Invoke-DockerRuntimeManager\.ps1/);
+  assert.match(workflow, /Verify LVCompare and idle LabVIEW state/);
+  assert.match(workflow, /Upload readiness receipt/);
+  assert.match(workflow, /pester-selfhosted-readiness/);
+});
+
+test('pester run is execution-only and no longer bootstraps host readiness inline', () => {
+  const workflow = readRepoFile('.github/workflows/pester-run.yml');
+
+  assert.match(workflow, /name:\s+Pester run/);
+  assert.match(workflow, /name:\s+Pester \(execution only\)/);
+  assert.match(workflow, /if:\s+\$\{\{\s*inputs\.readiness_status == 'ready'\s*\}\}/);
+  assert.match(workflow, /Run Pester tests via local dispatcher/);
+  assert.match(workflow, /Upload raw Pester execution artifact/);
+  assert.match(workflow, /pester-run-receipt\.json/);
+  assert.doesNotMatch(workflow, /Install Pester/);
+  assert.doesNotMatch(workflow, /Invoke-DockerRuntimeManager\.ps1/);
+  assert.doesNotMatch(workflow, /Write-PesterSummaryToStepSummary\.ps1/);
+  assert.doesNotMatch(workflow, /Invoke-DevDashboard\.ps1/);
+});
+
+test('pester evidence classifies seam defects explicitly from raw execution outputs', () => {
+  const workflow = readRepoFile('.github/workflows/pester-evidence.yml');
+
+  assert.match(workflow, /name:\s+Pester evidence/);
+  assert.match(workflow, /runs-on:\s+ubuntu-latest/);
+  assert.match(workflow, /Download raw execution artifact/);
+  assert.match(workflow, /Write-PesterSummaryToStepSummary\.ps1/);
+  assert.match(workflow, /Ensure-SessionIndex\.ps1/);
+  assert.match(workflow, /Invoke-DevDashboard\.ps1/);
+  assert.match(workflow, /classification = 'seam-defect'/);
+  assert.match(workflow, /summary-missing/);
+  assert.match(workflow, /Upload evidence artifact/);
+  assert.match(workflow, /Propagate gate outcome/);
+});
+
+test('knowledgebase documents the additive service model and keeps the monolith as the current baseline', () => {
+  const doc = readRepoFile('docs/knowledgebase/Pester-Service-Model.md');
+
+  assert.match(doc, /legacy Pester control plane couples four concerns into one self-hosted transaction/i);
+  assert.match(doc, /selfhosted-readiness\.yml/);
+  assert.match(doc, /pester-run\.yml/);
+  assert.match(doc, /pester-evidence\.yml/);
+  assert.match(doc, /existing required gate remains in place/i);
+});

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -101,8 +101,11 @@ test('trusted PR pilot router only runs self-hosted service-model proof for work
   assert.match(workflow, /types:\s*\[labeled, reopened, synchronize\]/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /labels -contains 'pester-service-model'/);
+  assert.match(workflow, /PR_LABELS_JSON:\s+\$\{\{\s*toJson\(github\.event\.pull_request\.labels\.\*\.name\)\s*\}\}/);
+  assert.match(workflow, /ConvertFrom-Json -InputObject \$env:PR_LABELS_JSON/);
   assert.match(workflow, /head\.repo\.owner\.login/);
   assert.match(workflow, /\$trustMode = 'same-owner-head'/);
   assert.match(workflow, /reason = 'untrusted-cross-owner-fork'/);
   assert.match(workflow, /uses:\s+\.\s*\/\.github\/workflows\/pester-gate\.yml/);
+  assert.match(workflow, /include_integration:\s+\$\{\{\s*'true'\s*\}\}/);
 });

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -66,7 +66,12 @@ test('validate workflow Windows VI-history lane is gated by shared dispatch plan
   assert.match(planSection, /permissions:\s*\r?\n\s+contents: read/);
   assert.match(planSection, /Resolve self-hosted Windows Docker lane/);
   assert.match(planSection, /tools\/Resolve-SelfHostedWindowsLanePlan\.ps1/);
-  assert.match(planSection, /-RequiredLabels \$requiredLabels/);
+  assert.match(planSection, /\$args = @\(/);
+  assert.match(planSection, /'-RequiredLabels'/);
+  assert.match(planSection, /\) \+ \$requiredLabels \+ @\(/);
+  assert.match(planSection, /if \(\$requiredHealthReceipts\.Count -gt 0\)/);
+  assert.match(planSection, /\$args \+= '-RequiredHealthReceipts'/);
+  assert.match(planSection, /& pwsh @args/);
   assert.match(planSection, /docker-lane/);
   assert.match(planSection, /outputs:\s*\r?\n\s+available:\s+\$\{\{\s*steps\.plan\.outputs\.available\s*\}\}/);
 


### PR DESCRIPTION
## Summary
- add an additive Pester service-model pilot that splits readiness, execution, and evidence into separate reusable workflows
- keep the existing required Pester gate in place while documenting and testing the new receipt-driven control plane
- extend runner routing policy coverage and add a workflow contract test for the split

## Validation
- node --test tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs tools/priority/__tests__/capability-ingress-runner-routing.test.mjs tools/priority/__tests__/pester-diagnostics-nightly-workflow-contract.test.mjs
- node tools/lint-markdown.mjs
- git diff --check