### PR TITLE
[ops]: harden Pester service-model skip-path contracts

### DIFF
--- a/.github/workflows/pester-evidence.yml
+++ b/.github/workflows/pester-evidence.yml
@@ -60,7 +60,7 @@ on:
         default: 'unknown'
         type: string
       execution_job_result:
-        description: 'Execution job result'
+        description: 'Execution contract outcome'
         required: false
         default: ''
         type: string
@@ -254,6 +254,15 @@ jobs:
           }
           if ('${{ inputs.execution_job_result }}' -eq 'skipped') {
             $reasons.Add('execution-job-skipped') | Out-Null
+          } elseif ('${{ inputs.execution_job_result }}' -eq 'cancelled') {
+            $reasons.Add('execution-job-cancelled') | Out-Null
+          } elseif ('${{ inputs.execution_job_result }}' -eq 'seam-defect') {
+            $reasons.Add('execution-job-seam-defect') | Out-Null
+          } elseif ('${{ inputs.execution_job_result }}' -eq 'unknown') {
+            $reasons.Add('execution-job-unknown') | Out-Null
+          }
+          if ('${{ steps.download.outcome }}' -ne 'success') {
+            $reasons.Add(("raw-artifact-download={0}" -f '${{ steps.download.outcome }}')) | Out-Null
           }
           $dispatcherExitCode = '${{ inputs.dispatcher_exit_code }}'
           if ([string]::IsNullOrWhiteSpace($dispatcherExitCode)) { $dispatcherExitCode = '-1' }
@@ -286,6 +295,7 @@ jobs:
             generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
             readinessStatus    = '${{ inputs.readiness_status }}'
             executionJobResult = '${{ inputs.execution_job_result }}'
+            rawArtifactDownload = '${{ steps.download.outcome }}'
             dispatcherExitCode = [int]$dispatcherExitCode
             summaryPresent     = Test-Path -LiteralPath $summaryPath
             classification     = $classification

--- a/.github/workflows/pester-evidence.yml
+++ b/.github/workflows/pester-evidence.yml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: 'pester-run-raw'
+      execution_receipt_artifact_name:
+        required: false
+        type: string
+        default: 'pester-execution-contract'
       dispatcher_exit_code:
         required: false
         type: string
@@ -49,6 +53,11 @@ on:
         required: false
         default: 'pester-run-raw'
         type: string
+      execution_receipt_artifact_name:
+        description: 'Execution contract artifact name'
+        required: false
+        default: 'pester-execution-contract'
+        type: string
       dispatcher_exit_code:
         description: 'Dispatcher exit code from execution workflow'
         required: false
@@ -89,11 +98,24 @@ jobs:
         shell: pwsh
         run: |
           $artifactName = '${{ inputs.raw_artifact_name }}'
-          if ([string]::IsNullOrWhiteSpace($artifactName)) { $artifactName = 'pester-run-raw' }
+          $shouldDownload = 'true'
+          if ('${{ inputs.execution_job_result }}' -in @('skipped','cancelled')) {
+            $shouldDownload = 'false'
+          } elseif ([string]::IsNullOrWhiteSpace($artifactName)) {
+            $artifactName = 'pester-run-raw'
+          }
           "name=$artifactName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "should_download=$shouldDownload" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Download execution receipt artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.execution_receipt_artifact_name }}
+          path: tests/execution-contract
 
       - name: Download raw execution artifact
         id: download
+        if: ${{ steps.artifact_name.outputs.should_download == 'true' }}
         continue-on-error: true
         uses: actions/download-artifact@v5
         with:
@@ -112,7 +134,7 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          $receiptPath = Join-Path 'tests/results' 'pester-run-receipt.json'
+          $receiptPath = Join-Path 'tests/execution-contract' 'pester-run-receipt.json'
           if (-not (Test-Path -LiteralPath $receiptPath)) {
             "present=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
             "status=missing" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
@@ -261,7 +283,7 @@ jobs:
           } elseif ('${{ inputs.execution_job_result }}' -eq 'unknown') {
             $reasons.Add('execution-job-unknown') | Out-Null
           }
-          if ('${{ steps.download.outcome }}' -ne 'success') {
+          if ('${{ steps.artifact_name.outputs.should_download }}' -eq 'true' -and '${{ steps.download.outcome }}' -ne 'success') {
             $reasons.Add(("raw-artifact-download={0}" -f '${{ steps.download.outcome }}')) | Out-Null
           }
           $dispatcherExitCode = '${{ inputs.dispatcher_exit_code }}'
@@ -295,7 +317,7 @@ jobs:
             generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
             readinessStatus    = '${{ inputs.readiness_status }}'
             executionJobResult = '${{ inputs.execution_job_result }}'
-            rawArtifactDownload = '${{ steps.download.outcome }}'
+            rawArtifactDownload = if ('${{ steps.artifact_name.outputs.should_download }}' -eq 'true') { '${{ steps.download.outcome }}' } else { 'skipped' }
             dispatcherExitCode = [int]$dispatcherExitCode
             summaryPresent     = Test-Path -LiteralPath $summaryPath
             classification     = $classification

--- a/.github/workflows/pester-gate.yml
+++ b/.github/workflows/pester-gate.yml
@@ -72,8 +72,8 @@ jobs:
       include_integration: ${{ inputs.include_integration || 'false' }}
       include_patterns: ${{ inputs.include_patterns || '' }}
       sample_id: ${{ inputs.sample_id || '' }}
-      readiness_status: ${{ needs.readiness.outputs.receipt_status }}
-      readiness_artifact_name: ${{ needs.readiness.outputs.receipt_artifact_name }}
+      readiness_status: ${{ needs.readiness.outputs.receipt_status || needs.readiness.result || 'unknown' }}
+      readiness_artifact_name: ${{ needs.readiness.outputs.receipt_artifact_name || 'pester-readiness' }}
       checkout_repository: ${{ inputs.checkout_repository || github.repository }}
       checkout_ref: ${{ inputs.checkout_ref || github.sha }}
 
@@ -84,5 +84,5 @@ jobs:
     with:
       raw_artifact_name: ${{ needs.pester-run.outputs.raw_artifact_name }}
       dispatcher_exit_code: ${{ needs.pester-run.outputs.dispatcher_exit_code }}
-      readiness_status: ${{ needs.readiness.outputs.receipt_status }}
-      execution_job_result: ${{ needs.pester-run.result }}
+      readiness_status: ${{ needs.readiness.outputs.receipt_status || needs.readiness.result || 'unknown' }}
+      execution_job_result: ${{ needs.pester-run.outputs.execution_status || needs.pester-run.result }}

--- a/.github/workflows/pester-gate.yml
+++ b/.github/workflows/pester-gate.yml
@@ -83,6 +83,7 @@ jobs:
     uses: ./.github/workflows/pester-evidence.yml
     with:
       raw_artifact_name: ${{ needs.pester-run.outputs.raw_artifact_name }}
+      execution_receipt_artifact_name: ${{ needs.pester-run.outputs.execution_receipt_artifact_name || 'pester-execution-contract' }}
       dispatcher_exit_code: ${{ needs.pester-run.outputs.dispatcher_exit_code }}
       readiness_status: ${{ needs.readiness.outputs.receipt_status || needs.readiness.result || 'unknown' }}
       execution_job_result: ${{ needs.pester-run.outputs.execution_status || needs.pester-run.result }}

--- a/.github/workflows/pester-run.yml
+++ b/.github/workflows/pester-run.yml
@@ -38,6 +38,9 @@ on:
       execution_status:
         description: 'Execution contract outcome for the self-hosted execution pass'
         value: ${{ jobs.finalize.outputs.execution_status }}
+      execution_receipt_artifact_name:
+        description: 'Artifact name containing the execution contract receipt'
+        value: ${{ jobs.finalize.outputs.execution_receipt_artifact_name }}
   workflow_dispatch:
     inputs:
       include_integration:
@@ -120,6 +123,7 @@ jobs:
     outputs:
       dispatcher_exit_code: ${{ steps.execution_receipt.outputs.dispatcher_exit_code }}
       raw_artifact_name: ${{ steps.execution_receipt.outputs.raw_artifact_name }}
+      execution_receipt_status: ${{ steps.execution_receipt.outputs.status }}
     steps:
       - uses: actions/checkout@v5
 
@@ -323,6 +327,7 @@ jobs:
           }
           $receiptPath = Join-Path $resultsDir 'pester-run-receipt.json'
           $receipt | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $receiptPath -Encoding UTF8
+          "status=$status" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "dispatcher_exit_code=$dispatcherExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "raw_artifact_name=pester-run-raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
@@ -342,31 +347,75 @@ jobs:
       dispatcher_exit_code: ${{ steps.emit.outputs.dispatcher_exit_code }}
       raw_artifact_name: ${{ steps.emit.outputs.raw_artifact_name }}
       execution_status: ${{ steps.emit.outputs.execution_status }}
+      execution_receipt_artifact_name: ${{ steps.emit.outputs.execution_receipt_artifact_name }}
     steps:
       - name: Emit execution contract
         id: emit
         shell: pwsh
         run: |
+          $resultsDir = Join-Path 'tests/results' 'pester-execution-contract'
+          New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
           $executionStatus = 'unknown'
+          $receiptStatus = '${{ needs.pester.outputs.execution_receipt_status }}'
+          $rawArtifactName = ''
           if ('${{ inputs.readiness_status }}' -ne 'ready') {
             $executionStatus = 'skipped'
+            if ([string]::IsNullOrWhiteSpace($receiptStatus)) { $receiptStatus = 'skipped' }
           } else {
             switch ('${{ needs.pester.result }}') {
-              'success' { $executionStatus = 'completed' }
-              'failure' { $executionStatus = 'seam-defect' }
-              'cancelled' { $executionStatus = 'cancelled' }
-              'skipped' { $executionStatus = 'skipped' }
-              default { $executionStatus = 'unknown' }
+              'success' {
+                $executionStatus = 'completed'
+                $rawArtifactName = 'pester-run-raw'
+                if ([string]::IsNullOrWhiteSpace($receiptStatus)) { $receiptStatus = 'completed' }
+              }
+              'failure' {
+                $executionStatus = 'seam-defect'
+                $rawArtifactName = 'pester-run-raw'
+                if ([string]::IsNullOrWhiteSpace($receiptStatus)) { $receiptStatus = 'seam-defect' }
+              }
+              'cancelled' {
+                $executionStatus = 'cancelled'
+                if ([string]::IsNullOrWhiteSpace($receiptStatus)) { $receiptStatus = 'cancelled' }
+              }
+              'skipped' {
+                $executionStatus = 'skipped'
+                if ([string]::IsNullOrWhiteSpace($receiptStatus)) { $receiptStatus = 'skipped' }
+              }
+              default {
+                $executionStatus = 'unknown'
+                if ([string]::IsNullOrWhiteSpace($receiptStatus)) { $receiptStatus = 'unknown' }
+              }
             }
           }
           $dispatcherExitCode = '${{ needs.pester.outputs.dispatcher_exit_code }}'
           if ([string]::IsNullOrWhiteSpace($dispatcherExitCode)) {
-            if ($executionStatus -eq 'completed') {
+            if ($receiptStatus -eq 'completed') {
               $dispatcherExitCode = '0'
             } else {
               $dispatcherExitCode = '-1'
             }
           }
+          $receipt = [ordered]@{
+            schema             = 'pester-execution-receipt@v1'
+            generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
+            readinessStatus    = '${{ inputs.readiness_status }}'
+            executionJobResult = '${{ needs.pester.result }}'
+            dispatcherExitCode = [int]$dispatcherExitCode
+            status             = $receiptStatus
+            rawArtifactName    = $rawArtifactName
+            rawArtifactExpected = -not [string]::IsNullOrWhiteSpace($rawArtifactName)
+            source             = 'pester-run/finalize'
+          }
+          $receiptPath = Join-Path $resultsDir 'pester-run-receipt.json'
+          $receipt | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $receiptPath -Encoding UTF8
           "execution_status=$executionStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "dispatcher_exit_code=$dispatcherExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "raw_artifact_name=pester-run-raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "raw_artifact_name=$rawArtifactName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "execution_receipt_artifact_name=pester-execution-contract" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Upload execution contract artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pester-execution-contract
+          path: tests/results/pester-execution-contract
+          if-no-files-found: error

--- a/.github/workflows/pester-run.yml
+++ b/.github/workflows/pester-run.yml
@@ -31,10 +31,13 @@ on:
     outputs:
       dispatcher_exit_code:
         description: 'Dispatcher exit code from the self-hosted execution pass'
-        value: ${{ jobs.pester.outputs.dispatcher_exit_code }}
+        value: ${{ jobs.finalize.outputs.dispatcher_exit_code }}
       raw_artifact_name:
         description: 'Artifact name containing raw execution outputs'
-        value: ${{ jobs.pester.outputs.raw_artifact_name }}
+        value: ${{ jobs.finalize.outputs.raw_artifact_name }}
+      execution_status:
+        description: 'Execution contract outcome for the self-hosted execution pass'
+        value: ${{ jobs.finalize.outputs.execution_status }}
   workflow_dispatch:
     inputs:
       include_integration:
@@ -330,3 +333,40 @@ jobs:
           name: pester-run-raw
           path: tests/results
           if-no-files-found: warn
+
+  finalize:
+    runs-on: ubuntu-latest
+    needs: [normalize, pester]
+    if: always()
+    outputs:
+      dispatcher_exit_code: ${{ steps.emit.outputs.dispatcher_exit_code }}
+      raw_artifact_name: ${{ steps.emit.outputs.raw_artifact_name }}
+      execution_status: ${{ steps.emit.outputs.execution_status }}
+    steps:
+      - name: Emit execution contract
+        id: emit
+        shell: pwsh
+        run: |
+          $executionStatus = 'unknown'
+          if ('${{ inputs.readiness_status }}' -ne 'ready') {
+            $executionStatus = 'skipped'
+          } else {
+            switch ('${{ needs.pester.result }}') {
+              'success' { $executionStatus = 'completed' }
+              'failure' { $executionStatus = 'seam-defect' }
+              'cancelled' { $executionStatus = 'cancelled' }
+              'skipped' { $executionStatus = 'skipped' }
+              default { $executionStatus = 'unknown' }
+            }
+          }
+          $dispatcherExitCode = '${{ needs.pester.outputs.dispatcher_exit_code }}'
+          if ([string]::IsNullOrWhiteSpace($dispatcherExitCode)) {
+            if ($executionStatus -eq 'completed') {
+              $dispatcherExitCode = '0'
+            } else {
+              $dispatcherExitCode = '-1'
+            }
+          }
+          "execution_status=$executionStatus" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "dispatcher_exit_code=$dispatcherExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "raw_artifact_name=pester-run-raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/docs/knowledgebase/Pester-Service-Model.md
+++ b/docs/knowledgebase/Pester-Service-Model.md
@@ -30,6 +30,7 @@ The additive pilot introduces four workflow surfaces:
 - Readiness emits a bounded-freshness receipt artifact that execution must download and validate before dispatch.
 - Execution consumes readiness. It does not bootstrap Docker runtimes or install core toolchains.
 - Execution writes an execution receipt before uploading raw artifacts so evidence can classify the real seam outcome.
+- Execution must also emit a skip-safe execution contract from an always-on finalize path so reusable-workflow outputs do not collapse when the execution job never starts.
 - Evidence consumes raw execution output plus the execution receipt. It classifies `seam-defect` explicitly when execution never yields a valid summary or never yields a valid execution receipt.
 - The existing required gate remains in place until the pilot proves equivalent or better behavior.
 - Trusted PR proving must stay on `pull_request_target` with same-owner gating. Cross-owner fork heads are not allowed to drive self-hosted execution.

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -19,10 +19,12 @@ test('pester gate pilot routes readiness, execution, and evidence through separa
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /jobs:\s*\n\s*readiness:\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/selfhosted-readiness\.yml/);
   assert.match(workflow, /\n\s*pester-run:\s*\n\s+needs:\s+readiness\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-run\.yml/);
-  assert.match(workflow, /readiness_artifact_name:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_artifact_name\s*\}\}/);
+  assert.match(workflow, /readiness_artifact_name:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_artifact_name\s*\|\|\s*'pester-readiness'/);
+  assert.match(workflow, /readiness_status:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_status\s*\|\|\s*needs\.readiness\.result/);
   assert.match(workflow, /checkout_repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
   assert.match(workflow, /checkout_ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
+  assert.match(workflow, /execution_job_result:\s+\$\{\{\s*needs\.pester-run\.outputs\.execution_status\s*\|\|\s*needs\.pester-run\.result/);
 });
 
 test('selfhosted readiness owns host-plane certification and emits a receipt artifact', () => {
@@ -50,6 +52,7 @@ test('pester run is execution-only and validates the readiness receipt before di
   assert.match(workflow, /name:\s+Pester run/);
   assert.match(workflow, /name:\s+Pester \(execution only\)/);
   assert.match(workflow, /if:\s+\$\{\{\s*inputs\.readiness_status == 'ready'\s*\}\}/);
+  assert.match(workflow, /execution_status:/);
   assert.match(workflow, /repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
   assert.match(workflow, /ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /Download readiness receipt artifact/);
@@ -58,6 +61,7 @@ test('pester run is execution-only and validates the readiness receipt before di
   assert.match(workflow, /Run Pester tests via local dispatcher/);
   assert.match(workflow, /pester-run-receipt\.json/);
   assert.match(workflow, /Upload raw Pester execution artifact/);
+  assert.match(workflow, /Emit execution contract/);
   assert.doesNotMatch(workflow, /Install Pester/);
   assert.doesNotMatch(workflow, /Invoke-DockerRuntimeManager\.ps1/);
   assert.doesNotMatch(workflow, /Write-PesterSummaryToStepSummary\.ps1/);
@@ -76,6 +80,7 @@ test('pester evidence classifies seam defects explicitly from raw execution outp
   assert.match(workflow, /Ensure-SessionIndex\.ps1/);
   assert.match(workflow, /Invoke-DevDashboard\.ps1/);
   assert.match(workflow, /classification = 'seam-defect'/);
+  assert.match(workflow, /raw-artifact-download=/);
   assert.match(workflow, /execution-receipt-seam-defect/);
   assert.match(workflow, /Upload evidence artifact/);
   assert.match(workflow, /Propagate gate outcome/);

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -25,6 +25,7 @@ test('pester gate pilot routes readiness, execution, and evidence through separa
   assert.match(workflow, /checkout_ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
   assert.match(workflow, /execution_job_result:\s+\$\{\{\s*needs\.pester-run\.outputs\.execution_status\s*\|\|\s*needs\.pester-run\.result/);
+  assert.match(workflow, /execution_receipt_artifact_name:\s+\$\{\{\s*needs\.pester-run\.outputs\.execution_receipt_artifact_name/);
 });
 
 test('selfhosted readiness owns host-plane certification and emits a receipt artifact', () => {
@@ -53,6 +54,7 @@ test('pester run is execution-only and validates the readiness receipt before di
   assert.match(workflow, /name:\s+Pester \(execution only\)/);
   assert.match(workflow, /if:\s+\$\{\{\s*inputs\.readiness_status == 'ready'\s*\}\}/);
   assert.match(workflow, /execution_status:/);
+  assert.match(workflow, /execution_receipt_artifact_name:/);
   assert.match(workflow, /repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
   assert.match(workflow, /ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
   assert.match(workflow, /Download readiness receipt artifact/);
@@ -62,6 +64,7 @@ test('pester run is execution-only and validates the readiness receipt before di
   assert.match(workflow, /pester-run-receipt\.json/);
   assert.match(workflow, /Upload raw Pester execution artifact/);
   assert.match(workflow, /Emit execution contract/);
+  assert.match(workflow, /Upload execution contract artifact/);
   assert.doesNotMatch(workflow, /Install Pester/);
   assert.doesNotMatch(workflow, /Invoke-DockerRuntimeManager\.ps1/);
   assert.doesNotMatch(workflow, /Write-PesterSummaryToStepSummary\.ps1/);
@@ -73,6 +76,8 @@ test('pester evidence classifies seam defects explicitly from raw execution outp
 
   assert.match(workflow, /name:\s+Pester evidence/);
   assert.match(workflow, /runs-on:\s+ubuntu-latest/);
+  assert.match(workflow, /execution_receipt_artifact_name:/);
+  assert.match(workflow, /Download execution receipt artifact/);
   assert.match(workflow, /Download raw execution artifact/);
   assert.match(workflow, /Validate execution receipt artifact/);
   assert.match(workflow, /execution-receipt-missing/);


### PR DESCRIPTION
## Summary
- preserve service-model execution outputs when self-hosted execution is skipped
- separate the execution contract from raw execution outputs
- make evidence consume the execution contract artifact first-class

## Why
The additive service-model pilot proved remotely, but the skip path still had two concrete defects:
- reusable-workflow outputs collapsed when execution never started
- execution receipt was coupled to the raw artifact path

This PR fixes both defects and keeps the standing debt/evidence chain on `#2069`.

## Evidence
- standing issue: #2069
- remote proof before skip-path hardening: run `23802276898`
- remote proof after finalize output hardening: run `23802588431`
- remote proof after dedicated execution-contract artifact: run `23802755645`
