### PR TITLE
[ops]: exercise trusted Pester router on same-owner develop PR

### DIFF
--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -1,4 +1,5 @@
 name: Pester service-model pilot on trusted PR label
+# Router proof branch: same-owner upstream develop PR exercise
 
 on:
   pull_request_target:


### PR DESCRIPTION
## Summary
- create a same-owner upstream PR directly against `develop`
- exercise the trusted Pester router on the branch surface that is actually registered today

## Why
This is a pure router proof PR.
It exists to separate:
- fork-trust behavior
- integration-branch reachability
- same-owner develop PR routing

## Scope
- one proof-only comment in `.github/workflows/pester-service-model-on-label.yml`
- no product-behavior change
