### PR TITLE
[ops]: allow trusted Pester router on integration branches

### DIFF
--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -3,7 +3,7 @@ name: Pester service-model pilot on trusted PR label
 on:
   pull_request_target:
     types: [labeled, reopened, synchronize]
-    branches: [main, develop, release/**]
+    branches: [main, develop, integration/**, release/**]
     paths-ignore:
       - '**/*.md'
   workflow_dispatch:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1535,43 +1535,26 @@ jobs:
           'docker-lane'
         )
         $requiredHealthReceipts = @()
-        $notes = @(
-          'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
-          'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'
-        )
-        $args = @(
-          '-NoLogo',
-          '-NoProfile',
-          '-File',
-          'tools/Resolve-SelfHostedWindowsLanePlan.ps1',
-          '-Repository',
-          '${{ github.repository }}',
-          '-RequiredLabels'
-        ) + $requiredLabels + @(
-          '-ExecutionModel',
-          'self-hosted-windows-docker-lane',
-          '-RunnerImage',
-          'self-hosted-windows-docker-lane',
-          '-ExpectedContext',
-          'desktop-windows',
-          '-ExpectedOs',
-          'windows',
-          '-Notes'
-        ) + $notes + @(
-          '-Token',
-          $env:GITHUB_TOKEN,
-          '-OutputJsonPath',
-          $planPath,
-          '-GitHubOutputPath',
-          $env:GITHUB_OUTPUT,
-          '-StepSummaryPath',
-          $env:GITHUB_STEP_SUMMARY
-        )
-        if ($requiredHealthReceipts.Count -gt 0) {
-          $args += '-RequiredHealthReceipts'
-          $args += $requiredHealthReceipts
+        $plannerArgs = @{
+          Repository = '${{ github.repository }}'
+          RequiredLabels = $requiredLabels
+          ExecutionModel = 'self-hosted-windows-docker-lane'
+          RunnerImage = 'self-hosted-windows-docker-lane'
+          ExpectedContext = 'desktop-windows'
+          ExpectedOs = 'windows'
+          Notes = @(
+            'Availability means an online, idle repository runner advertises the ingress plus docker-lane labels.',
+            'The lane may mutate Docker Desktop into the Windows engine and then restores the starting context after proof capture.'
+          )
+          Token = $env:GITHUB_TOKEN
+          OutputJsonPath = $planPath
+          GitHubOutputPath = $env:GITHUB_OUTPUT
+          StepSummaryPath = $env:GITHUB_STEP_SUMMARY
         }
-        & pwsh @args
+        if ($requiredHealthReceipts.Count -gt 0) {
+          $plannerArgs.RequiredHealthReceipts = $requiredHealthReceipts
+        }
+        & tools/Resolve-SelfHostedWindowsLanePlan.ps1 @plannerArgs
 
     - name: Append VI history Windows runner plan
       shell: pwsh

--- a/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
+++ b/tools/priority/__tests__/validate-vi-history-dispatch-contract.test.mjs
@@ -66,12 +66,13 @@ test('validate workflow Windows VI-history lane is gated by shared dispatch plan
   assert.match(planSection, /permissions:\s*\r?\n\s+contents: read/);
   assert.match(planSection, /Resolve self-hosted Windows Docker lane/);
   assert.match(planSection, /tools\/Resolve-SelfHostedWindowsLanePlan\.ps1/);
-  assert.match(planSection, /\$args = @\(/);
-  assert.match(planSection, /'-RequiredLabels'/);
-  assert.match(planSection, /\) \+ \$requiredLabels \+ @\(/);
+  assert.match(planSection, /\$plannerArgs = @\{/);
+  assert.match(planSection, /RequiredLabels = \$requiredLabels/);
+  assert.match(planSection, /Notes = @\(/);
   assert.match(planSection, /if \(\$requiredHealthReceipts\.Count -gt 0\)/);
-  assert.match(planSection, /\$args \+= '-RequiredHealthReceipts'/);
-  assert.match(planSection, /& pwsh @args/);
+  assert.match(planSection, /\$plannerArgs\.RequiredHealthReceipts = \$requiredHealthReceipts/);
+  assert.match(planSection, /& tools\/Resolve-SelfHostedWindowsLanePlan\.ps1 @plannerArgs/);
+  assert.doesNotMatch(planSection, /& pwsh @args/);
   assert.match(planSection, /docker-lane/);
   assert.match(planSection, /outputs:\s*\r?\n\s+available:\s+\$\{\{\s*steps\.plan\.outputs\.available\s*\}\}/);
 


### PR DESCRIPTION
## Summary
- allow the trusted Pester service-model router to target `integration/**` branches
- carry the integration reachability fix that missed `#2070`
- keep `#2069` as the standing debt/evidence ledger

## Why
`#2070` merged the skip-path hardening, but the integration-branch reachability fix landed too late to be included. The router is already proven on same-owner `develop` PRs; this follow-up closes the remaining branch-filter debt for integration-mounted upstream proofs.

## Evidence
- standing issue: #2069
- same-owner develop router proof: PR `#2072`, run `23803961995`
- integration reachability fix was proven locally and first carried on branch commit `9acfba4e`
