### PR TITLE
[ops]: fix auto-merge helper for workflow-edit PRs

### DIFF
--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -14,9 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge (merge method)
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: MERGE
-
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge -R "${{ github.repository }}" --auto "${{ github.event.pull_request.number }}"

--- a/tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('pr-automerge workflow uses gh CLI with GH_TOKEN fallback', () => {
+  const workflow = readRepoFile('.github/workflows/pr-automerge.yml');
+
+  assert.match(workflow, /name:\s*PR Auto-merge \(on label\)/);
+  assert.match(workflow, /pull_request_target:\s*\r?\n\s+types:\s*\[labeled, synchronize, reopened\]/);
+  assert.match(workflow, /if:\s*contains\(github\.event\.pull_request\.labels\.\*\.name,\s*'automerge'\)/);
+  assert.match(workflow, /GH_TOKEN:\s*\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
+  assert.match(workflow, /gh pr merge -R "\$\{\{\s*github\.repository\s*\}\}" --auto "\$\{\{\s*github\.event\.pull_request\.number\s*\}\}"/);
+  assert.doesNotMatch(workflow, /enable-pull-request-automerge@v3/);
+});


### PR DESCRIPTION
## Summary
- replace the workflow auto-merge action with an explicit `gh pr merge --auto` invocation
- prefer `secrets.GH_TOKEN || secrets.GITHUB_TOKEN` so workflow-edit PRs can be queued truthfully
- add a workflow-contract test for the helper control plane

## Why
`PR Auto-merge (on label)` is now confirmed technical debt under `#2069`.
On workflow-edit PRs, the current helper uses `${{ secrets.GITHUB_TOKEN }}` through `peter-evans/enable-pull-request-automerge@v3`, and GitHub refuses `enablePullRequestAutoMerge` without workflow-level permission. That leaves a red helper context and can drop the auto-merge request after a push.

## Evidence
- standing issue: #2069
- failing helper on workflow-edit PR: `#2073`
- local proof:
  - `node --test tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs`
  - `git diff --check`
