### PR TITLE
[ops]: classify readiness-blocked Pester evidence explicitly

### DIFF
--- a/.github/workflows/pester-evidence.yml
+++ b/.github/workflows/pester-evidence.yml
@@ -269,18 +269,20 @@ jobs:
           $summaryPath = Join-Path $resultsDir 'pester-summary.json'
           $classification = 'seam-defect'
           $reasons = New-Object System.Collections.Generic.List[string]
+          $readinessStatus = '${{ inputs.readiness_status }}'
+          $executionJobResult = '${{ inputs.execution_job_result }}'
           $executionReceiptPresent = '${{ steps.execution_receipt.outputs.present }}'
           $executionReceiptStatus = '${{ steps.execution_receipt.outputs.status }}'
-          if ('${{ inputs.readiness_status }}' -ne 'ready') {
-            $reasons.Add(("readiness-status={0}" -f '${{ inputs.readiness_status }}')) | Out-Null
+          if ($readinessStatus -ne 'ready') {
+            $reasons.Add(("readiness-status={0}" -f $readinessStatus)) | Out-Null
           }
-          if ('${{ inputs.execution_job_result }}' -eq 'skipped') {
+          if ($executionJobResult -eq 'skipped') {
             $reasons.Add('execution-job-skipped') | Out-Null
-          } elseif ('${{ inputs.execution_job_result }}' -eq 'cancelled') {
+          } elseif ($executionJobResult -eq 'cancelled') {
             $reasons.Add('execution-job-cancelled') | Out-Null
-          } elseif ('${{ inputs.execution_job_result }}' -eq 'seam-defect') {
+          } elseif ($executionJobResult -eq 'seam-defect') {
             $reasons.Add('execution-job-seam-defect') | Out-Null
-          } elseif ('${{ inputs.execution_job_result }}' -eq 'unknown') {
+          } elseif ($executionJobResult -eq 'unknown') {
             $reasons.Add('execution-job-unknown') | Out-Null
           }
           if ('${{ steps.artifact_name.outputs.should_download }}' -eq 'true' -and '${{ steps.download.outcome }}' -ne 'success') {
@@ -290,6 +292,8 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($dispatcherExitCode)) { $dispatcherExitCode = '-1' }
           if ($executionReceiptPresent -ne 'true') {
             $reasons.Add('execution-receipt-missing') | Out-Null
+          } elseif ($readinessStatus -ne 'ready' -and $executionJobResult -in @('skipped','cancelled')) {
+            $classification = 'readiness-blocked'
           } elseif ($executionReceiptStatus -eq 'seam-defect') {
             $reasons.Add('execution-receipt-seam-defect') | Out-Null
           } elseif ($executionReceiptStatus -eq 'test-failures') {
@@ -315,8 +319,8 @@ jobs:
           $receipt = [ordered]@{
             schema             = 'pester-evidence-classification@v1'
             generatedAtUtc     = [DateTime]::UtcNow.ToString('o')
-            readinessStatus    = '${{ inputs.readiness_status }}'
-            executionJobResult = '${{ inputs.execution_job_result }}'
+            readinessStatus    = $readinessStatus
+            executionJobResult = $executionJobResult
             rawArtifactDownload = if ('${{ steps.artifact_name.outputs.should_download }}' -eq 'true') { '${{ steps.download.outcome }}' } else { 'skipped' }
             dispatcherExitCode = [int]$dispatcherExitCode
             summaryPresent     = Test-Path -LiteralPath $summaryPath

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -71,7 +71,7 @@ test('pester run is execution-only and validates the readiness receipt before di
   assert.doesNotMatch(workflow, /Invoke-DevDashboard\.ps1/);
 });
 
-test('pester evidence classifies seam defects explicitly from raw execution outputs', () => {
+test('pester evidence distinguishes readiness-blocked skips from seam defects', () => {
   const workflow = readRepoFile('.github/workflows/pester-evidence.yml');
 
   assert.match(workflow, /name:\s+Pester evidence/);
@@ -85,6 +85,8 @@ test('pester evidence classifies seam defects explicitly from raw execution outp
   assert.match(workflow, /Ensure-SessionIndex\.ps1/);
   assert.match(workflow, /Invoke-DevDashboard\.ps1/);
   assert.match(workflow, /classification = 'seam-defect'/);
+  assert.match(workflow, /\$classification = 'readiness-blocked'/);
+  assert.match(workflow, /\$readinessStatus -ne 'ready' -and \$executionJobResult -in @\('skipped','cancelled'\)/);
   assert.match(workflow, /raw-artifact-download=/);
   assert.match(workflow, /execution-receipt-seam-defect/);
   assert.match(workflow, /Upload evidence artifact/);


### PR DESCRIPTION
## Summary
- classify readiness-blocked skipped execution as `readiness-blocked` instead of `seam-defect`
- stop letting expected `summary-missing` dominate that path when the execution receipt is already present and truthful
- extend the service-model workflow contract test for the new evidence outcome

## Why
Integration-mounted proof `#2071` showed the next real semantic defect in the service-model control plane:
- trusted routing worked
- execution normalization/finalize worked
- evidence still failed as `seam-defect` because it treated a readiness-blocked skipped execution as if the system itself had broken

This PR makes the evidence layer tell the truth without hiding the blocked outcome.

## Evidence
- standing issue: #2069
- failing integration-mounted proof: `#2071`
- local proof:
  - `node --test tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs`
  - `git diff --check`
