### PR TITLE
[ops]: remove trusted pilot path filter

### DIFF
--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -4,8 +4,6 @@ on:
   pull_request_target:
     types: [labeled, reopened, synchronize]
     branches: [main, develop, integration/**, release/**]
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
     inputs:
       sample_id:

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -111,6 +111,7 @@ test('trusted PR pilot router only runs self-hosted service-model proof for work
   assert.match(workflow, /name:\s+Pester service-model pilot on trusted PR label/);
   assert.match(workflow, /pull_request_target:/);
   assert.match(workflow, /types:\s*\[labeled, reopened, synchronize\]/);
+  assert.doesNotMatch(workflow, /paths-ignore:/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /labels -contains 'pester-service-model'/);
   assert.match(workflow, /PR_LABELS_JSON:\s+\$\{\{\s*toJson\(github\.event\.pull_request\.labels\.\*\.name\)\s*\}\}/);


### PR DESCRIPTION
## Summary
- remove `paths-ignore` from the trusted Pester pilot router
- keep the additive pilot reachable on empty or metadata-only integration proof branches
- extend the workflow contract test so the path filter cannot return silently

## Why
The refreshed integration-mounted proof on `#2071` exposed a real trigger debt: the trusted pilot route did not rerun reliably on the integration proving rail once the probe branch no longer carried a non-empty diff. The pilot is additive and label-gated already, so path filtering was suppressing a legitimate proof surface.

## Evidence
- standing issue: #2069
- local proof:
  - `node --test tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs`
  - `git diff --check`
