### PR TITLE
[ops]: harden trusted pilot routing outputs

### DIFF
--- a/.github/workflows/pester-gate.yml
+++ b/.github/workflows/pester-gate.yml
@@ -3,6 +3,18 @@ name: Pester gate (service model pilot)
 on:
   workflow_call:
     inputs:
+      route_should_run:
+        required: false
+        default: 'true'
+        type: string
+      route_reason:
+        required: false
+        default: ''
+        type: string
+      route_trust_mode:
+        required: false
+        default: ''
+        type: string
       include_integration:
         required: false
         default: 'false'
@@ -25,6 +37,22 @@ on:
         type: string
   workflow_dispatch:
     inputs:
+      route_should_run:
+        description: 'Whether the service-model pilot should run or emit a routed skip'
+        required: false
+        default: 'true'
+        type: choice
+        options: ['false', 'true']
+      route_reason:
+        description: 'Optional skip reason emitted by the outer router'
+        required: false
+        default: ''
+        type: string
+      route_trust_mode:
+        description: 'Optional trust-mode emitted by the outer router'
+        required: false
+        default: ''
+        type: string
       include_integration:
         description: "Include Integration-tagged tests in the execution pack"
         required: false
@@ -57,7 +85,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  skipped:
+    if: ${{ !fromJSON(inputs.route_should_run || 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Append routed skip summary
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_STEP_SUMMARY) {
+            $lines = @('### Pester gate (service model pilot)', '')
+            $lines += ('- Status: skipped')
+            $lines += ('- Reason: {0}' -f '${{ inputs.route_reason || 'route-should-not-run' }}')
+            $lines += ('- Trust mode: {0}' -f '${{ inputs.route_trust_mode || 'unspecified' }}')
+            $lines += ('- Checkout repository: {0}' -f '${{ inputs.checkout_repository || github.repository }}')
+            $lines += ('- Checkout ref: {0}' -f '${{ inputs.checkout_ref || github.sha }}')
+            $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+
   readiness:
+    if: ${{ fromJSON(inputs.route_should_run || 'true') }}
     uses: ./.github/workflows/selfhosted-readiness.yml
     with:
       sample_id: ${{ inputs.sample_id || '' }}
@@ -66,7 +112,7 @@ jobs:
 
   pester-run:
     needs: readiness
-    if: always()
+    if: ${{ always() && fromJSON(inputs.route_should_run || 'true') }}
     uses: ./.github/workflows/pester-run.yml
     with:
       include_integration: ${{ inputs.include_integration || 'false' }}
@@ -79,7 +125,7 @@ jobs:
 
   pester-evidence:
     needs: [readiness, pester-run]
-    if: always()
+    if: ${{ always() && fromJSON(inputs.route_should_run || 'true') }}
     uses: ./.github/workflows/pester-evidence.yml
     with:
       raw_artifact_name: ${{ needs.pester-run.outputs.raw_artifact_name }}

--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -4,8 +4,6 @@ on:
   pull_request_target:
     types: [labeled, reopened, synchronize]
     branches: [main, develop, integration/**, release/**]
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
     inputs:
       sample_id:
@@ -81,15 +79,25 @@ jobs:
               $reason = 'trusted-same-owner-head'
             }
           }
-          "should_run=$shouldRun" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "checkout_repository=$checkoutRepository" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "checkout_ref=$checkoutRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "trust_mode=$trustMode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "reason=$reason" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "should_run=$shouldRun"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "checkout_repository=$checkoutRepository"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "checkout_ref=$checkoutRef"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "trust_mode=$trustMode"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "reason=$reason"
+          if ($env:GITHUB_STEP_SUMMARY) {
+            $lines = @('### Trusted pilot routing', '')
+            $lines += ('- Event: {0}' -f $eventName)
+            $lines += ('- Should run: {0}' -f $shouldRun)
+            $lines += ('- Reason: {0}' -f $reason)
+            $lines += ('- Trust mode: {0}' -f $trustMode)
+            $lines += ('- Checkout repository: {0}' -f $checkoutRepository)
+            $lines += ('- Checkout ref: {0}' -f $checkoutRef)
+            $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
 
   pilot:
     needs: trust-context
-    if: ${{ needs.trust-context.outputs.should_run == 'true' }}
+    if: ${{ fromJSON(needs.trust-context.outputs.should_run || 'false') }}
     uses: ./.github/workflows/pester-gate.yml
     with:
       include_integration: ${{ 'true' }}
@@ -99,7 +107,7 @@ jobs:
 
   skipped:
     needs: trust-context
-    if: ${{ needs.trust-context.outputs.should_run != 'true' }}
+    if: ${{ !fromJSON(needs.trust-context.outputs.should_run || 'false') }}
     runs-on: ubuntu-latest
     steps:
       - name: Append skip summary

--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -97,26 +97,12 @@ jobs:
 
   pilot:
     needs: trust-context
-    if: ${{ fromJSON(needs.trust-context.outputs.should_run || 'false') }}
     uses: ./.github/workflows/pester-gate.yml
     with:
+      route_should_run: ${{ needs.trust-context.outputs.should_run || 'false' }}
+      route_reason: ${{ needs.trust-context.outputs.reason || '' }}
+      route_trust_mode: ${{ needs.trust-context.outputs.trust_mode || '' }}
       include_integration: ${{ 'true' }}
       sample_id: ${{ github.event.inputs.sample_id || '' }}
       checkout_repository: ${{ needs.trust-context.outputs.checkout_repository }}
       checkout_ref: ${{ needs.trust-context.outputs.checkout_ref }}
-
-  skipped:
-    needs: trust-context
-    if: ${{ !fromJSON(needs.trust-context.outputs.should_run || 'false') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Append skip summary
-        shell: pwsh
-        run: |
-          if ($env:GITHUB_STEP_SUMMARY) {
-            $lines = @('### Pester service-model pilot', '')
-            $lines += ('- Status: skipped')
-            $lines += ('- Reason: {0}' -f '${{ needs.trust-context.outputs.reason }}')
-            $lines += ('- Trust mode: {0}' -f '${{ needs.trust-context.outputs.trust_mode }}')
-            $lines -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-          }

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -111,11 +111,16 @@ test('trusted PR pilot router only runs self-hosted service-model proof for work
   assert.match(workflow, /name:\s+Pester service-model pilot on trusted PR label/);
   assert.match(workflow, /pull_request_target:/);
   assert.match(workflow, /types:\s*\[labeled, reopened, synchronize\]/);
+  assert.doesNotMatch(workflow, /paths-ignore:/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /labels -contains 'pester-service-model'/);
   assert.match(workflow, /PR_LABELS_JSON:\s+\$\{\{\s*toJson\(github\.event\.pull_request\.labels\.\*\.name\)\s*\}\}/);
   assert.match(workflow, /ConvertFrom-Json -InputObject \$env:PR_LABELS_JSON/);
   assert.match(workflow, /head\.repo\.owner\.login/);
+  assert.match(workflow, /Add-Content -Path \$env:GITHUB_OUTPUT -Value "should_run=\$shouldRun"/);
+  assert.match(workflow, /### Trusted pilot routing/);
+  assert.match(workflow, /if:\s+\$\{\{\s*fromJSON\(needs\.trust-context\.outputs\.should_run \|\| 'false'\)\s*\}\}/);
+  assert.match(workflow, /if:\s+\$\{\{\s*!fromJSON\(needs\.trust-context\.outputs\.should_run \|\| 'false'\)\s*\}\}/);
   assert.match(workflow, /\$trustMode = 'same-owner-head'/);
   assert.match(workflow, /reason = 'untrusted-cross-owner-fork'/);
   assert.match(workflow, /uses:\s+\.\s*\/\.github\/workflows\/pester-gate\.yml/);

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -17,15 +17,20 @@ test('pester gate pilot routes readiness, execution, and evidence through separa
   assert.match(workflow, /name:\s+Pester gate \(service model pilot\)/);
   assert.match(workflow, /workflow_call:/);
   assert.match(workflow, /workflow_dispatch:/);
-  assert.match(workflow, /jobs:\s*\n\s*readiness:\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/selfhosted-readiness\.yml/);
-  assert.match(workflow, /\n\s*pester-run:\s*\n\s+needs:\s+readiness\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-run\.yml/);
+  assert.match(workflow, /route_should_run:/);
+  assert.match(workflow, /route_reason:/);
+  assert.match(workflow, /route_trust_mode:/);
+  assert.match(workflow, /jobs:\s*\n\s*skipped:\s*\n\s+if:\s+\$\{\{\s*!fromJSON\(inputs\.route_should_run \|\| 'true'\)\s*\}\}/);
+  assert.match(workflow, /\n\s*readiness:\s*\n\s+if:\s+\$\{\{\s*fromJSON\(inputs\.route_should_run \|\| 'true'\)\s*\}\}\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/selfhosted-readiness\.yml/);
+  assert.match(workflow, /\n\s*pester-run:\s*\n\s+needs:\s+readiness\s*\n\s+if:\s+\$\{\{\s*always\(\) && fromJSON\(inputs\.route_should_run \|\| 'true'\)\s*\}\}\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-run\.yml/);
   assert.match(workflow, /readiness_artifact_name:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_artifact_name\s*\|\|\s*'pester-readiness'/);
   assert.match(workflow, /readiness_status:\s+\$\{\{\s*needs\.readiness\.outputs\.receipt_status\s*\|\|\s*needs\.readiness\.result/);
   assert.match(workflow, /checkout_repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
   assert.match(workflow, /checkout_ref:\s+\$\{\{\s*inputs\.checkout_ref \|\| github\.sha\s*\}\}/);
-  assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+always\(\)\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
+  assert.match(workflow, /\n\s*pester-evidence:\s*\n\s+needs:\s+\[readiness, pester-run\]\s*\n\s+if:\s+\$\{\{\s*always\(\) && fromJSON\(inputs\.route_should_run \|\| 'true'\)\s*\}\}\s*\n\s+uses:\s+\.\s*\/\.github\/workflows\/pester-evidence\.yml/);
   assert.match(workflow, /execution_job_result:\s+\$\{\{\s*needs\.pester-run\.outputs\.execution_status\s*\|\|\s*needs\.pester-run\.result/);
   assert.match(workflow, /execution_receipt_artifact_name:\s+\$\{\{\s*needs\.pester-run\.outputs\.execution_receipt_artifact_name/);
+  assert.match(workflow, /### Pester gate \(service model pilot\)/);
 });
 
 test('selfhosted readiness owns host-plane certification and emits a receipt artifact', () => {
@@ -119,10 +124,11 @@ test('trusted PR pilot router only runs self-hosted service-model proof for work
   assert.match(workflow, /head\.repo\.owner\.login/);
   assert.match(workflow, /Add-Content -Path \$env:GITHUB_OUTPUT -Value "should_run=\$shouldRun"/);
   assert.match(workflow, /### Trusted pilot routing/);
-  assert.match(workflow, /if:\s+\$\{\{\s*fromJSON\(needs\.trust-context\.outputs\.should_run \|\| 'false'\)\s*\}\}/);
-  assert.match(workflow, /if:\s+\$\{\{\s*!fromJSON\(needs\.trust-context\.outputs\.should_run \|\| 'false'\)\s*\}\}/);
   assert.match(workflow, /\$trustMode = 'same-owner-head'/);
   assert.match(workflow, /reason = 'untrusted-cross-owner-fork'/);
   assert.match(workflow, /uses:\s+\.\s*\/\.github\/workflows\/pester-gate\.yml/);
+  assert.match(workflow, /route_should_run:\s+\$\{\{\s*needs\.trust-context\.outputs\.should_run \|\| 'false'\s*\}\}/);
+  assert.match(workflow, /route_reason:\s+\$\{\{\s*needs\.trust-context\.outputs\.reason \|\| ''\s*\}\}/);
+  assert.match(workflow, /route_trust_mode:\s+\$\{\{\s*needs\.trust-context\.outputs\.trust_mode \|\| ''\s*\}\}/);
   assert.match(workflow, /include_integration:\s+\$\{\{\s*'true'\s*\}\}/);
 });


### PR DESCRIPTION
## Summary
- remove the trusted pilot path filter from the router
- replace `Out-File -Encoding utf8` output writes with `Add-Content`
- make trusted pilot routing observable in step summary and gate on `fromJSON(...)`

## Why
The direct operator proof on the mounted integration baseline showed that `workflow_dispatch` reached `trust-context` but still admitted the `skipped` job instead of the `pilot` job. The integration proving rail also showed the additive pilot disappearing on the trusted PR surface even after mounting the evidence fix. This slice makes the routing contract observable and removes two likely sources of silent false negatives: path filtering and fragile string-based output handling.

## Evidence
- standing issue: #2069
- operator proof run: 23805747866
- local proof:
  - `node --test tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs`
  - `git diff --check`
