### PR TITLE
ci(pester): grant issues read to trusted router

### DIFF
--- a/.github/workflows/pester-service-model-on-label.yml
+++ b/.github/workflows/pester-service-model-on-label.yml
@@ -28,6 +28,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: read
 
 jobs:

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -174,6 +174,7 @@ test('trusted PR pilot router only runs self-hosted service-model proof for work
 
   assert.match(workflow, /name:\s+Pester service-model pilot on trusted PR label/);
   assert.match(workflow, /pull_request_target:/);
+  assert.match(workflow, /permissions:\s*\n\s+contents:\s+read\s*\n\s+issues:\s+read\s*\n\s+pull-requests:\s+read/);
   assert.match(workflow, /types:\s*\[labeled, reopened, synchronize\]/);
   assert.doesNotMatch(workflow, /paths-ignore:/);
   assert.match(workflow, /group:\s+trusted-pilot-router-\$\{\{\s*github\.event\.pull_request\.number \|\| github\.event\.inputs\.sample_id \|\| github\.ref\s*\}\}/);


### PR DESCRIPTION
## Summary
- grant `issues: read` to `pester-service-model-on-label.yml`
- ensure the trusted router passes enough permission to `pester-context.yml` for standing-priority resolution
- lock that contract with a workflow test

## Testing
- node --test tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
- /tmp/compare-vi-cli-action-wt-2078/bin/actionlint -color .github/workflows/pester-service-model-on-label.yml
- git diff --check

Refs: #2069