### PR TITLE
ci(pester): isolate service-model concurrency groups

### DIFF
--- a/.github/workflows/pester-context.yml
+++ b/.github/workflows/pester-context.yml
@@ -47,7 +47,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
+  group: pester-context-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pester-run.yml
+++ b/.github/workflows/pester-run.yml
@@ -98,7 +98,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-pester-run-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
+  group: pester-run-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pester-selection.yml
+++ b/.github/workflows/pester-selection.yml
@@ -57,7 +57,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
+  group: pester-selection-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/selfhosted-readiness.yml
+++ b/.github/workflows/selfhosted-readiness.yml
@@ -38,7 +38,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
+  group: selfhosted-readiness-${{ github.event.inputs.sample_id || inputs.sample_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
@@ -47,6 +47,7 @@ test('pester context owns repo/control-plane receipts before host readiness begi
 
   assert.match(workflow, /name:\s+Pester context/);
   assert.match(workflow, /workflow_call:/);
+  assert.match(workflow, /group:\s+pester-context-\$\{\{\s*github\.event\.inputs\.sample_id \|\| inputs\.sample_id \|\| github\.ref\s*\}\}/);
   assert.match(workflow, /receipt_status:/);
   assert.match(workflow, /standing_priority_issue:/);
   assert.match(workflow, /standing_priority_reason:/);
@@ -62,6 +63,7 @@ test('selfhosted readiness owns host-plane certification and emits a receipt art
 
   assert.match(workflow, /name:\s+Self-hosted readiness/);
   assert.match(workflow, /workflow_call:/);
+  assert.match(workflow, /group:\s+selfhosted-readiness-\$\{\{\s*github\.event\.inputs\.sample_id \|\| inputs\.sample_id \|\| github\.ref\s*\}\}/);
   assert.match(workflow, /receipt_status:/);
   assert.match(workflow, /runs-on:\s*\[self-hosted, Windows, X64, comparevi, capability-ingress\]/);
   assert.match(workflow, /repository:\s+\$\{\{\s*inputs\.checkout_repository \|\| github\.repository\s*\}\}/);
@@ -81,6 +83,7 @@ test('pester selection owns pack shaping and dispatcher profile resolution befor
 
   assert.match(workflow, /name:\s+Pester selection/);
   assert.match(workflow, /workflow_call:/);
+  assert.match(workflow, /group:\s+pester-selection-\$\{\{\s*github\.event\.inputs\.sample_id \|\| inputs\.sample_id \|\| github\.ref\s*\}\}/);
   assert.match(workflow, /receipt_status:/);
   assert.match(workflow, /receipt_artifact_name:/);
   assert.match(workflow, /Normalize include_integration/);
@@ -97,6 +100,7 @@ test('pester run is execution-only and validates context, readiness, and selecti
 
   assert.match(workflow, /name:\s+Pester run/);
   assert.match(workflow, /name:\s+Pester \(execution only\)/);
+  assert.match(workflow, /group:\s+pester-run-\$\{\{\s*github\.event\.inputs\.sample_id \|\| inputs\.sample_id \|\| github\.ref\s*\}\}/);
   assert.match(workflow, /if:\s+\$\{\{\s*inputs\.context_status == 'ready' && inputs\.readiness_status == 'ready' && inputs\.selection_status == 'ready'\s*\}\}/);
   assert.match(workflow, /execution_status:/);
   assert.match(workflow, /execution_receipt_artifact_name:/);


### PR DESCRIPTION
## Summary
- give context, readiness, selection, and run distinct concurrency namespaces
- stop parallel service-model layers from cancelling each other on the integration proof path
- lock the group contract in the workflow test

## Testing
- node --test tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs
- /tmp/compare-vi-cli-action-wt-2078/bin/actionlint -color .github/workflows/pester-context.yml .github/workflows/selfhosted-readiness.yml .github/workflows/pester-selection.yml .github/workflows/pester-run.yml
- git diff --check

Refs: #2069