### PR TITLE
ci(auto): restore gh-based automerge on integration rail

### DIFF
--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -14,9 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge (merge method)
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: MERGE
-
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge -R "${{ github.repository }}" --auto "${{ github.event.pull_request.number }}"

--- a/tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+test('pr-automerge workflow uses gh CLI with GH_TOKEN fallback', () => {
+  const workflow = readRepoFile('.github/workflows/pr-automerge.yml');
+
+  assert.match(workflow, /name:\s*PR Auto-merge \(on label\)/);
+  assert.match(workflow, /pull_request_target:\s*\r?\n\s+types:\s*\[labeled, synchronize, reopened\]/);
+  assert.match(workflow, /if:\s*contains\(github\.event\.pull_request\.labels\.\*\.name,\s*'automerge'\)/);
+  assert.match(workflow, /GH_TOKEN:\s*\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
+  assert.match(workflow, /gh pr merge -R "\$\{\{\s*github\.repository\s*\}\}" --auto "\$\{\{\s*github\.event\.pull_request\.number\s*\}\}"/);
+  assert.doesNotMatch(workflow, /enable-pull-request-automerge@v3/);
+});


### PR DESCRIPTION
## Summary
- restore the integration-rail pr-automerge workflow to use `gh pr merge --auto`
- use `GH_TOKEN` with `secrets.GH_TOKEN || secrets.GITHUB_TOKEN`
- add a workflow contract test so the helper regression does not re-enter the rail

## Why
- PR #2083 surfaced that `pull_request_target` is still executing the stale base-branch helper on `integration/pester-service-model`
- that means #2083 cannot self-heal the helper failure from its own head changes
- this PR repairs the base-branch helper so subsequent service-model slices are judged on their own logic, not stale automerge debt

## Validation
- `node --test tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs`
- `actionlint -color .github/workflows/pr-automerge.yml`
- `git diff --check`

Ref: #2069
Unblocks: #2083