### PR TITLE
ci(auto): require squash auto-merge on integration rail

### DIFF
--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          gh pr merge -R "${{ github.repository }}" --auto "${{ github.event.pull_request.number }}"
+          gh pr merge -R "${{ github.repository }}" --auto --squash "${{ github.event.pull_request.number }}"

--- a/tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs
+++ b/tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs
@@ -18,6 +18,6 @@ test('pr-automerge workflow uses gh CLI with GH_TOKEN fallback', () => {
   assert.match(workflow, /pull_request_target:\s*\r?\n\s+types:\s*\[labeled, synchronize, reopened\]/);
   assert.match(workflow, /if:\s*contains\(github\.event\.pull_request\.labels\.\*\.name,\s*'automerge'\)/);
   assert.match(workflow, /GH_TOKEN:\s*\$\{\{\s*secrets\.GH_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
-  assert.match(workflow, /gh pr merge -R "\$\{\{\s*github\.repository\s*\}\}" --auto "\$\{\{\s*github\.event\.pull_request\.number\s*\}\}"/);
+  assert.match(workflow, /gh pr merge -R "\$\{\{\s*github\.repository\s*\}\}" --auto --squash "\$\{\{\s*github\.event\.pull_request\.number\s*\}\}"/);
   assert.doesNotMatch(workflow, /enable-pull-request-automerge@v3/);
 });


### PR DESCRIPTION
## Summary
- require `--squash` when enabling auto-merge through the integration-rail helper
- tighten the workflow contract so the allowed non-interactive merge strategy is explicit

## Why
- after #2084 repaired the base helper path, #2083 exposed the next exact defect
- `gh pr merge --auto` now runs, but this repository rejects merge commits and gh requires an explicit strategy in non-interactive mode
- this PR closes that method mismatch on the base integration rail so workflow-edit PRs stop failing for helper reasons

## Validation
- `node --test tools/priority/__tests__/pr-automerge-workflow-contract.test.mjs`
- `actionlint -color .github/workflows/pr-automerge.yml`
- `git diff --check`

Ref: #2069
Unblocks: #2083