### PR TITLE
ci(pester): split execution finalize side effects

### DIFF
--- a/Invoke-PesterTests.ps1
+++ b/Invoke-PesterTests.ps1
@@ -1645,6 +1645,73 @@ function Write-SessionIndex {
   } catch { Write-Warning "Failed to write session index: $_" }
 }
 
+function Invoke-ExecutionFinalizeHelper {
+  [CmdletBinding(DefaultParameterSetName = 'Build')]
+  param(
+    [Parameter(ParameterSetName = 'Build')]
+    [AllowEmptyString()]
+    [string]$SummaryText,
+    [Parameter(ParameterSetName = 'Build')]
+    $SummaryPayload,
+    [Parameter(ParameterSetName = 'Build')]
+    $ArtifactTrail,
+    [Parameter(ParameterSetName = 'Reuse')]
+    [switch]$ReuseExistingContext
+  )
+
+  try {
+    $finalizeToolPath = Join-Path $PSScriptRoot 'tools/Invoke-PesterExecutionFinalize.ps1'
+    if (-not (Test-Path -LiteralPath $finalizeToolPath -PathType Leaf)) {
+      throw "Invoke-PesterExecutionFinalize.ps1 not found: $finalizeToolPath"
+    }
+
+    $contextPath = $null
+    if ($PSCmdlet.ParameterSetName -eq 'Reuse') {
+      if ([string]::IsNullOrWhiteSpace($script:executionFinalizeContextPath) -or -not (Test-Path -LiteralPath $script:executionFinalizeContextPath -PathType Leaf)) {
+        return $false
+      }
+      $contextPath = $script:executionFinalizeContextPath
+    } else {
+      $finalizeContext = [ordered]@{
+        schema                   = 'pester-execution-finalize-context@v1'
+        generatedAtUtc           = [DateTime]::UtcNow.ToString('o')
+        repoRoot                 = $root
+        resultsDir               = $resultsDir
+        jsonSummaryPath          = $JsonSummaryPath
+        includeIntegration       = [bool]$includeIntegrationBool
+        integrationMode          = $script:integrationModeResolved
+        integrationSource        = $script:integrationModeReason
+        summarySchemaVersion     = $SchemaSummaryVersion
+        manifestVersion          = $SchemaManifestVersion
+        failuresSchemaVersion    = $SchemaFailuresVersion
+        leakReportSchemaVersion  = ${SchemaLeakReportVersion}
+        diagnosticsSchemaVersion = ${SchemaDiagnosticsVersion}
+      }
+      if ($PSBoundParameters.ContainsKey('SummaryText')) {
+        $finalizeContext['summaryText'] = $SummaryText
+      }
+      if ($null -ne $SummaryPayload) {
+        $finalizeContext['summaryPayload'] = $SummaryPayload
+      }
+      if ($null -ne $ArtifactTrail) {
+        $finalizeContext['artifactTrail'] = $ArtifactTrail
+      }
+      $contextPath = Join-Path $resultsDir 'pester-execution-finalize-context.json'
+      $finalizeContext | ConvertTo-Json -Depth 12 | Out-File -FilePath $contextPath -Encoding utf8 -ErrorAction Stop
+      $script:executionFinalizeContextPath = $contextPath
+    }
+
+    & $finalizeToolPath -ContextPath $contextPath | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+      throw "Invoke-PesterExecutionFinalize.ps1 failed with exit code $LASTEXITCODE."
+    }
+    return $true
+  } catch {
+    Write-Warning "Failed to finalize execution side effects: $_"
+    return $false
+  }
+}
+
 # Optional pre-clean of LabVIEW if explicitly requested
 if ($CleanLabVIEW) {
   Write-Host "Pre-run cleanup: stopping LabVIEW.exe" -ForegroundColor DarkGray
@@ -1655,6 +1722,7 @@ if ($CleanLabVIEW) {
 
 # Artifact tracking pre-snapshot (optional)
 $script:artifactTrail = $null
+$script:executionFinalizeContextPath = $null
 $preIndex = $null
 $artifactRoots = @()
 if ($TrackArtifacts) {
@@ -1959,31 +2027,29 @@ if ($testFiles.Count -eq 0) {
     $placeholder | Out-File -FilePath $xmlPathEmpty -Encoding utf8 -ErrorAction SilentlyContinue
   }
   $summaryPathEarly = Join-Path $resultsDir 'pester-summary.txt'
-  if (-not (Test-Path -LiteralPath $summaryPathEarly)) {
-    "=== Pester Test Summary ===`nTotal Tests: 0`nPassed: 0`nFailed: 0`nErrors: 0`nSkipped: 0`nDuration: 0.00s" | Out-File -FilePath $summaryPathEarly -Encoding utf8 -ErrorAction SilentlyContinue
-  }
-  $jsonSummaryEarly = Join-Path $resultsDir $JsonSummaryPath
-  if (-not (Test-Path -LiteralPath $jsonSummaryEarly)) {
-    $jsonObj = [pscustomobject]@{
-      total             = 0
-      passed            = 0
-      failed            = 0
-      errors            = 0
-      skipped           = 0
-      duration_s        = 0.0
-      timestamp         = (Get-Date).ToString('o')
-      pesterVersion     = ''
-      includeIntegration= [bool]$includeIntegrationBool
-      integrationMode   = $script:integrationModeResolved
-      integrationSource = $script:integrationModeReason
-      meanTest_ms       = $null
-      p95Test_ms        = $null
-      maxTest_ms        = $null
-      timedOut          = $false
-      discoveryFailures = 0
-      schemaVersion     = $SchemaSummaryVersion
-    }
-    $jsonObj | ConvertTo-Json -Depth 4 | Out-File -FilePath $jsonSummaryEarly -Encoding utf8 -ErrorAction SilentlyContinue
+  $summaryTextEarly = "=== Pester Test Summary ===`nTotal Tests: 0`nPassed: 0`nFailed: 0`nErrors: 0`nSkipped: 0`nDuration: 0.00s"
+  $jsonObj = [pscustomobject]@{
+    total                    = 0
+    passed                   = 0
+    failed                   = 0
+    errors                   = 0
+    skipped                  = 0
+    duration_s               = 0.0
+    timestamp                = (Get-Date).ToString('o')
+    pesterVersion            = ''
+    includeIntegration       = [bool]$includeIntegrationBool
+    integrationMode          = $script:integrationModeResolved
+    integrationSource        = $script:integrationModeReason
+    meanTest_ms              = $null
+    p95Test_ms               = $null
+    maxTest_ms               = $null
+    timedOut                 = $false
+    discoveryFailures        = 0
+    executionPostprocessStatus = 'complete'
+    resultsXmlStatus         = 'complete'
+    resultsXmlSummarySource  = 'placeholder'
+    resultsXmlCloseTagPresent = $true
+    schemaVersion            = $SchemaSummaryVersion
   }
 
   # Optional: run leak detection even when no tests discovered
@@ -2030,8 +2096,7 @@ if ($testFiles.Count -eq 0) {
       if ($leakDetected -and $FailOnLeaks) { Write-Error 'Failing run due to detected leaks (processes/jobs)'; exit 1 }
     } catch { Write-Warning "Leak detection (early-exit) failed: $_" }
   }
-  Write-ArtifactManifest -Directory $resultsDir -SummaryJsonPath $jsonSummaryEarly -ManifestVersion $SchemaManifestVersion
-  Write-SessionIndex -ResultsDirectory $resultsDir -SummaryJsonPath $jsonSummaryEarly
+  Invoke-ExecutionFinalizeHelper -SummaryText $summaryTextEarly -SummaryPayload $jsonObj -ArtifactTrail $script:artifactTrail | Out-Null
   Write-Host 'No test files found. Placeholder artifacts emitted.' -ForegroundColor Yellow
   exit 0
 }
@@ -2477,31 +2542,39 @@ if (-not $script:UseSingleInvoker) {
   $testDuration = $testEndTime - $testStartTime
   if ($script:stuckGuardEnabled) { _Write-HeartbeatLine 'stop' }
   
-  # Emit minimal JSON summary so downstream artifact/indices have data without running the classic path
   try {
-    $jsonSummaryPath = Join-Path $resultsDir $JsonSummaryPath
     $loadedPester = Get-Module Pester -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+    $summaryText = @(
+      '=== Pester Test Summary ===',
+      ('Total Tests: {0}' -f [int]($aggregate.passed + $aggregate.failed + $aggregate.errors + $aggregate.skipped)),
+      ('Passed: {0}' -f [int]$aggregate.passed),
+      ('Failed: {0}' -f [int]$aggregate.failed),
+      ('Errors: {0}' -f [int]$aggregate.errors),
+      ('Skipped: {0}' -f [int]$aggregate.skipped),
+      ('Duration: {0}s' -f ([math]::Round($testDuration.TotalSeconds, 2).ToString('0.00')))
+    ) -join "`n"
     $jsonObj = [PSCustomObject]@{
-      total              = [int]($aggregate.passed + $aggregate.failed + $aggregate.errors + $aggregate.skipped)
-      passed             = [int]$aggregate.passed
-      failed             = [int]$aggregate.failed
-      errors             = [int]$aggregate.errors
-      skipped            = [int]$aggregate.skipped
-      duration_s         = [math]::Round($testDuration.TotalSeconds, 6)
-      timestamp          = (Get-Date).ToString('o')
-      pesterVersion      = $loadedPester.Version.ToString()
-      includeIntegration = [bool]$includeIntegrationBool
-      schemaVersion      = $SchemaSummaryVersion
-      timedOut           = $false
-      discoveryFailures  = 0
+      total                    = [int]($aggregate.passed + $aggregate.failed + $aggregate.errors + $aggregate.skipped)
+      passed                   = [int]$aggregate.passed
+      failed                   = [int]$aggregate.failed
+      errors                   = [int]$aggregate.errors
+      skipped                  = [int]$aggregate.skipped
+      duration_s               = [math]::Round($testDuration.TotalSeconds, 6)
+      timestamp                = (Get-Date).ToString('o')
+      pesterVersion            = if ($loadedPester) { $loadedPester.Version.ToString() } else { '' }
+      includeIntegration       = [bool]$includeIntegrationBool
+      integrationMode          = $script:integrationModeResolved
+      integrationSource        = $script:integrationModeReason
+      schemaVersion            = $SchemaSummaryVersion
+      timedOut                 = $false
+      discoveryFailures        = 0
+      executionPostprocessStatus = 'complete'
+      resultsXmlStatus         = 'complete'
+      resultsXmlSummarySource  = 'single-invoker-aggregate'
+      resultsXmlCloseTagPresent = $true
     }
-    if (-not (Test-Path -LiteralPath $resultsDir -PathType Container)) { New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null }
-    $jsonObj | ConvertTo-Json -Depth 4 | Out-File -FilePath $jsonSummaryPath -Encoding utf8 -ErrorAction Stop
-  } catch { Write-Warning "[single-invoker] Failed to write JSON summary: $_" }
-
-  # Write artifact manifest and session index for parity
-  try { Write-ArtifactManifest -Directory $resultsDir -SummaryJsonPath $jsonSummaryPath -ManifestVersion $SchemaManifestVersion } catch {}
-  try { Write-SessionIndex -ResultsDirectory $resultsDir -SummaryJsonPath $jsonSummaryPath } catch {}
+    Invoke-ExecutionFinalizeHelper -SummaryText $summaryText -SummaryPayload $jsonObj -ArtifactTrail $script:artifactTrail | Out-Null
+  } catch { Write-Warning "[single-invoker] Failed to finalize summary/artifact side effects: $_" }
 
   # Print concise outcome and exit early to avoid re-entering the classic path
   $failTotal = [int]($aggregate.failed + $aggregate.errors)
@@ -3084,58 +3157,6 @@ if ($EmitResultShapeDiagnostics) {
   } catch { Write-Warning "Failed to emit result shape diagnostics: $_" }
 }
 
-# Write summary to file
-$summaryPath = Join-Path $resultsDir 'pester-summary.txt'
-try {
-  $summary | Out-File -FilePath $summaryPath -Encoding utf8 -ErrorAction Stop
-  Write-Host "Summary written to: $summaryPath" -ForegroundColor Gray
-} catch {
-  Write-Warning "Failed to write summary file: $_"
-}
-
-# Optional: append diagnostics footer to Pester summary
-try {
-  $diagJsonPath = Join-Path $resultsDir 'result-shapes.json'
-  $diagTotalEntries = $null; $diagHasPath = $null; $diagHasTags = $null
-  if (Test-Path -LiteralPath $diagJsonPath -PathType Leaf) {
-    try {
-      $diagJsonRaw = Get-Content -LiteralPath $diagJsonPath -Raw
-      $diagObj = $diagJsonRaw | ConvertFrom-Json -ErrorAction Stop
-      $diagTotalEntries = [int]$diagObj.totalEntries
-      $diagHasPath = [int]$diagObj.overall.hasPath
-      $diagHasTags = [int]$diagObj.overall.hasTags
-    } catch {}
-  }
-  if ($null -eq $diagTotalEntries -and $result -and $result.Tests) {
-    try { $testsLocal=@($result.Tests); $diagTotalEntries=$testsLocal.Count; $diagHasPath=@($testsLocal | Where-Object { $_.PSObject.Properties.Name -contains 'Path' }).Count; $diagHasTags=@($testsLocal | Where-Object { $_.PSObject.Properties.Name -contains 'Tags' }).Count } catch {}
-  }
-  if ($null -ne $diagTotalEntries) {
-    function _pctTxt { param([int]$n,[int]$d) if ($d -le 0) { return '0%' } ('{0:P1}' -f ([double]$n/[double]$d)) }
-    $pPath = _pctTxt $diagHasPath $diagTotalEntries
-    $pTags = _pctTxt $diagHasTags $diagTotalEntries
-    $footer = @()
-    $footer += ''
-    $footer += '---'
-    $footer += 'Diagnostics Summary'
-    $footer += ''
-    $footer += ('Total entries: {0}' -f $diagTotalEntries)
-    $footer += ('Has Path: {0} ({1})' -f $diagHasPath,$pPath)
-    $footer += ('Has Tags: {0} ({1})' -f $diagHasTags,$pTags)
-    Add-Content -LiteralPath $summaryPath -Value ($footer -join "`n") -Encoding utf8
-  }
-} catch { Write-Host "(warn) failed to append diagnostics footer: $_" -ForegroundColor DarkYellow }
-
-# Persist artifact trail (if collected)
-if ($TrackArtifacts -and $script:artifactTrail) {
-  try {
-    # Update procsAfter right before writing trail
-    $script:artifactTrail.procsAfter = @(_Get-ProcsSummary -Names @('LVCompare','LabVIEW'))
-    $trailPath = Join-Path $resultsDir 'pester-artifacts-trail.json'
-    $script:artifactTrail | ConvertTo-Json -Depth 6 | Out-File -FilePath $trailPath -Encoding utf8 -ErrorAction Stop
-    Write-Host "Artifact trail written to: $trailPath" -ForegroundColor Gray
-  } catch { Write-Warning "Failed to write artifact trail: $_" }
-}
-
 # Machine-readable JSON summary (adjacent enhancement for CI consumers)
 $jsonSummaryPath = Join-Path $resultsDir $JsonSummaryPath
 try {
@@ -3451,223 +3472,12 @@ try {
       } catch { Write-Warning "Failed to attach fallback aggregation hints: $_" }
     }
   }
-  $jsonObj | ConvertTo-Json -Depth 4 | Out-File -FilePath $jsonSummaryPath -Encoding utf8 -ErrorAction Stop
-  Write-Host "JSON summary written to: $jsonSummaryPath" -ForegroundColor Gray
 } catch {
-  Write-Warning "Failed to write JSON summary file: $_"
+  Write-Warning "Failed to build JSON summary payload: $_"
 }
 
 Write-Host "Results written to: $xmlPath" -ForegroundColor Gray
 Write-Host ""
-
-# Best-effort: copy any compare report produced by tests into the results directory for standardized artifact pickup
-try {
-  $destReport = Join-Path $resultsDir 'compare-report.html'
-  $candidates = @()
-  $fixedCandidates = @(
-    (Join-Path $root 'tests' 'results' 'integration-compare-report.html'),
-    (Join-Path $root 'tests' 'results' 'compare-report.html'),
-    (Join-Path $root 'tests' 'results-single' 'pr-body-compare-report.html')
-  )
-  foreach ($p in $fixedCandidates) { if (Test-Path -LiteralPath $p -PathType Leaf) { try { $candidates += (Get-Item -LiteralPath $p -ErrorAction SilentlyContinue) } catch {} } }
-  try {
-    $dynamic = Get-ChildItem -LiteralPath (Join-Path $root 'tests' 'results') -Filter '*compare-report*.html' -Recurse -File -ErrorAction SilentlyContinue
-    if ($dynamic) { $candidates += $dynamic }
-  } catch {}
-  if ($candidates.Count -gt 0) {
-    $latest = $candidates | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
-    # Copy the latest to the canonical filename (skip if it's already the canonical file)
-    try {
-      $normalizePath = {
-        param(
-          [string]$Path,
-          [string]$BasePath = $null
-        )
-
-        if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
-
-        $candidate = $Path
-        $basePath = if ([string]::IsNullOrWhiteSpace($BasePath)) { (Get-Location).ProviderPath } else { $BasePath }
-
-        if (-not [System.IO.Path]::IsPathRooted($candidate)) {
-          try {
-            $candidate = [System.IO.Path]::Combine($basePath, $candidate)
-          } catch {
-            return $candidate
-          }
-        }
-
-        $attempts = @($candidate)
-        if (-not $candidate.StartsWith('\?\', [System.StringComparison]::OrdinalIgnoreCase)) {
-          if ($candidate.StartsWith('\', [System.StringComparison]::Ordinal)) {
-            $attempts += ('\?\UNC\' + $candidate.Substring(2))
-          } else {
-            $attempts += ('\?\' + $candidate)
-          }
-        }
-
-        foreach ($probe in $attempts) {
-          try {
-            $full = [System.IO.Path]::GetFullPath($probe)
-            try {
-              $resolved = Resolve-Path -LiteralPath $full -ErrorAction Stop
-              if ($resolved -and $resolved.ProviderPath) {
-                $full = $resolved.ProviderPath
-              }
-            } catch {
-              # Resolve-Path can fail when the target does not exist yet; fall back to the computed path.
-            }
-            if ($full.StartsWith('\?\UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {
-              return ('\' + $full.Substring(8))
-            }
-            if ($full.StartsWith('\?\', [System.StringComparison]::OrdinalIgnoreCase)) {
-              return $full.Substring(4)
-            }
-            return $full
-          } catch {
-          }
-        }
-
-        return $candidate
-      }
-
-      $destFullPath   = & $normalizePath $destReport $root
-      $latestFullPath = & $normalizePath $latest.FullName $root
-      $shouldCopyLatest = $true
-      if ($latestFullPath -and $destFullPath) {
-        if ([string]::Equals($latestFullPath, $destFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
-          $shouldCopyLatest = $false
-        }
-      }
-
-      if ($shouldCopyLatest) {
-        $destDir = [System.IO.Path]::GetDirectoryName($destReport)
-        if ($destDir -and $latest.DirectoryName) {
-          if ([string]::Equals($latest.DirectoryName, $destDir, [System.StringComparison]::OrdinalIgnoreCase) -and
-              [string]::Equals($latest.Name, 'compare-report.html', [System.StringComparison]::OrdinalIgnoreCase)) {
-            $shouldCopyLatest = $false
-          }
-        }
-      }
-
-      if ($shouldCopyLatest) {
-        try {
-          Copy-Item -LiteralPath $latest.FullName -Destination $destReport -Force -ErrorAction Stop
-          Write-Host ("Compare report copied to: {0}" -f $destReport) -ForegroundColor Gray
-        } catch {
-          if ($_.Exception -and $_.Exception.Message -match 'Cannot overwrite .+ with itself') {
-            Write-Verbose 'Compare report already present at destination; skipping copy.'
-          } else {
-            Write-Warning "Failed to copy compare report: $_"
-          }
-        }
-      }
-    } catch { Write-Warning "Failed to copy compare report: $_" }
-    # Also copy all candidates preserving their base filenames to the results directory
-    foreach ($cand in ($candidates | Sort-Object LastWriteTimeUtc)) {
-      try {
-        $destName = (Split-Path -Leaf $cand.FullName)
-        $destFull = Join-Path $resultsDir $destName
-        $destFullPath   = & $normalizePath $destFull $root
-        $candFullPath   = & $normalizePath $cand.FullName $root
-        $shouldCopyCandidate = $true
-        if ($destFullPath -and $candFullPath) {
-          if ([string]::Equals($destFullPath, $candFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $shouldCopyCandidate = $false
-          }
-        }
-
-        if ($shouldCopyCandidate) {
-          if ([string]::Equals($cand.DirectoryName, $resultsDir, [System.StringComparison]::OrdinalIgnoreCase) -and
-              [string]::Equals($cand.Name, $destName, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $shouldCopyCandidate = $false
-          }
-        }
-
-        if ($shouldCopyCandidate) {
-          try {
-            Copy-Item -LiteralPath $cand.FullName -Destination $destFull -Force -ErrorAction Stop
-          } catch {
-            if ($_.Exception -and $_.Exception.Message -match 'Cannot overwrite .+ with itself') {
-              continue
-            }
-            Write-Host "(warn) failed to copy extra report '$($cand.FullName)': $_" -ForegroundColor DarkYellow
-          }
-        }
-      } catch { Write-Host "(warn) failed to copy extra report '$($cand.FullName)': $_" -ForegroundColor DarkYellow }
-    }
-    # Generate a small deterministic index HTML linking to all report variants
-    try {
-  $indexPath = Join-Path $resultsDir 'results-index.html'
-      # Gather all report htmls in results dir (including canonical)
-  $reports = @(Get-ChildItem -LiteralPath $resultsDir -Filter '*compare-report*.html' -File -ErrorAction SilentlyContinue | Sort-Object Name)
-      function _HtmlEncode {
-        param([string]$s)
-        if ([string]::IsNullOrEmpty($s)) { return '' }
-        $t = $s.Replace('&','&amp;').Replace('<','&lt;').Replace('>','&gt;').Replace('"','&quot;').Replace("'",'&#39;')
-        return $t
-      }
-      $now = (Get-Date).ToString('u')
-      $lines = @()
-      $lines += '<!DOCTYPE html>'
-      $lines += '<html lang="en">'
-      $lines += '<head><meta charset="utf-8"/><title>Compare Reports Index</title><style>body{font-family:Segoe UI,SegoeUI,Helvetica,Arial,sans-serif;margin:16px} ul{line-height:1.6} .meta{color:#666} code{background:#f5f5f5;padding:2px 4px;border-radius:3px}</style></head>'
-      $lines += '<body>'
-      $lines += '<h1>Compare Reports Index</h1>'
-      $lines += ('<p class=''meta''>Generated at <code>{0}</code></p>' -f (_HtmlEncode $now))
-      $lines += ('<p>Total reports: <strong>{0}</strong> — canonical: <code>compare-report.html</code></p>' -f $reports.Count)
-      if ($reports.Count -gt 0) {
-        $lines += '<ul>'
-        foreach ($r in $reports) {
-          $nameEnc = _HtmlEncode $r.Name
-          $ts = _HtmlEncode ($r.LastWriteTimeUtc.ToString('u'))
-          $size = '{0:N0} bytes' -f $r.Length
-          $meta = ('last write: {0}; size: {1}' -f $ts, (_HtmlEncode $size))
-          $canonicalTag = if ($r.Name -ieq 'compare-report.html') { ' <em class="meta">(canonical)</em>' } else { '' }
-          $lines += ('<li><a href="{0}">{0}</a>{2} <span class=''meta''>({1})</span></li>' -f $nameEnc,$meta,$canonicalTag)
-        }
-        $lines += '</ul>'
-      } else {
-        $lines += '<p class="meta">No compare-report HTML files found in this results directory.</p>'
-      }
-      # Diagnostics links (if present)
-      try {
-        $diagTxt = Join-Path $resultsDir 'result-shapes.txt'
-        $diagJson = Join-Path $resultsDir 'result-shapes.json'
-        if ((Test-Path -LiteralPath $diagTxt) -or (Test-Path -LiteralPath $diagJson)) {
-          $lines += '<hr/>'
-          $lines += '<h3>Diagnostics</h3>'
-          $lines += '<ul>'
-          if (Test-Path -LiteralPath $diagTxt) { $lines += '<li><a href="result-shapes.txt">result-shapes.txt</a></li>' }
-          if (Test-Path -LiteralPath $diagJson) { $lines += '<li><a href="result-shapes.json">result-shapes.json</a></li>' }
-          $lines += '</ul>'
-          # Optional: show a compact summary table if JSON exists
-          if (Test-Path -LiteralPath $diagJson) {
-            try {
-              $diagObj = Get-Content -LiteralPath $diagJson -Raw | ConvertFrom-Json -ErrorAction Stop
-              $total = [int]($diagObj.totalEntries)
-              $hasPath = [int]($diagObj.overall.hasPath)
-              $hasTags = [int]($diagObj.overall.hasTags)
-              function _pct { param([int]$num,[int]$den) if ($den -le 0) { return '0%' } else { return ('{0:P1}' -f ([double]$num/[double]$den)) } }
-              $pPath = _pct $hasPath $total
-              $pTags = _pct $hasTags $total
-              $lines += '<table style="border-collapse:collapse;margin-top:8px">'
-              $lines += '<thead><tr><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #e5e7eb">Metric</th><th style="text-align:right;padding:4px 8px;border-bottom:1px solid #e5e7eb">Count</th><th style="text-align:right;padding:4px 8px;border-bottom:1px solid #e5e7eb">Percent</th></tr></thead>'
-              $lines += '<tbody>'
-              $lines += ('<tr><td style="padding:4px 8px">Total entries</td><td style="text-align:right;padding:4px 8px">{0}</td><td style="text-align:right;padding:4px 8px">-</td></tr>' -f $total)
-              $lines += ('<tr><td style="padding:4px 8px">Has Path</td><td style="text-align:right;padding:4px 8px">{0}</td><td style="text-align:right;padding:4px 8px">{1}</td></tr>' -f $hasPath,$pPath)
-              $lines += ('<tr><td style="padding:4px 8px">Has Tags</td><td style="text-align:right;padding:4px 8px">{0}</td><td style="text-align:right;padding:4px 8px">{1}</td></tr>' -f $hasTags,$pTags)
-              $lines += '</tbody></table>'
-            } catch { }
-          }
-        }
-      } catch {}
-      $lines += '</body></html>'
-      Set-Content -LiteralPath $indexPath -Value ($lines -join "`n") -Encoding UTF8
-      Write-Host ("Results index written to: {0}" -f $indexPath) -ForegroundColor Gray
-    } catch { Write-Host "(warn) failed to write results index: $_" -ForegroundColor DarkYellow }
-  }
-} catch { Write-Host "(warn) compare report copy step failed: $_" -ForegroundColor DarkYellow }
 
 # Optional: Write diagnostics summary to GitHub Step Summary (Markdown)
 try {
@@ -3834,12 +3644,28 @@ try {
   }
 } catch { Write-Warning "Failed to evaluate integration execution note: $_" }
 
+# Normalize failure diagnostics before finalizing execution side effects so the manifest and session index see the
+# same failure surface that the exit path will expose.
+if ($failed -gt 0 -or $errors -gt 0) {
+  if ($null -ne $result) {
+    Write-FailureDiagnostics -PesterResult $result -ResultsDirectory $resultsDir -SkippedCount $skipped -FailuresSchemaVersion $SchemaFailuresVersion
+  } elseif ($EmitFailuresJsonAlways) {
+    Ensure-FailuresJson -Directory $resultsDir -Force
+  }
+} elseif ($EmitFailuresJsonAlways) {
+  Ensure-FailuresJson -Directory $resultsDir -Normalize -Quiet
+}
+
+if ($TrackArtifacts -and $script:artifactTrail) {
+  try {
+    $script:artifactTrail.procsAfter = @(_Get-ProcsSummary -Names @('LVCompare','LabVIEW'))
+  } catch { Write-Warning "Failed to finalize artifact trail process snapshot: $_" }
+}
+
+Invoke-ExecutionFinalizeHelper -SummaryText $summary -SummaryPayload $jsonObj -ArtifactTrail $script:artifactTrail | Out-Null
+
 # Exit with appropriate code
 if ($failed -gt 0 -or $errors -gt 0) {
-  # Emit failure diagnostics using helper function (guard null result)
-  if ($null -ne $result) { Write-FailureDiagnostics -PesterResult $result -ResultsDirectory $resultsDir -SkippedCount $skipped -FailuresSchemaVersion $SchemaFailuresVersion }
-  elseif ($EmitFailuresJsonAlways) { Ensure-FailuresJson -Directory $resultsDir -Force }
-  Write-ArtifactManifest -Directory $resultsDir -SummaryJsonPath $jsonSummaryPath -ManifestVersion $SchemaManifestVersion
   $failureLine = "❌ Tests failed: $failed failure(s), $errors error(s)"
   if ($discoveryFailureCount -gt 0) { $failureLine += " (includes $discoveryFailureCount discovery failure(s))" }
   Write-Host $failureLine -ForegroundColor Red
@@ -3862,9 +3688,6 @@ if ($discoveryFailureCount -gt 0) {
   Write-Error "Test execution completed with discovery failures"
   exit 1
 }
-if ($EmitFailuresJsonAlways) { Ensure-FailuresJson -Directory $resultsDir -Normalize -Quiet }
-  Write-ArtifactManifest -Directory $resultsDir -SummaryJsonPath $jsonSummaryPath -ManifestVersion $SchemaManifestVersion
-  Write-SessionIndex -ResultsDirectory $resultsDir -SummaryJsonPath $jsonSummaryPath
   } finally {
   # Ensure any background Pester job is stopped/removed to avoid lingering runs across sessions
   try {
@@ -3912,8 +3735,8 @@ if ($EmitFailuresJsonAlways) { Ensure-FailuresJson -Directory $resultsDir -Norma
           notes         = @('Final sweep leak report to ensure artifact presence; see main leak block for full details when enabled')
         }
         $report | ConvertTo-Json -Depth 6 | Out-File -FilePath $finalLeakPath -Encoding utf8 -ErrorAction SilentlyContinue
-        # Opportunistically refresh manifest to include jsonLeaks entry
-        try { Write-ArtifactManifest -Directory $resultsDir -SummaryJsonPath (Join-Path $resultsDir $JsonSummaryPath) -ManifestVersion $SchemaManifestVersion } catch {}
+        # Refresh finalize-owned artifacts so the late leak report is reflected in the manifest/session index.
+        Invoke-ExecutionFinalizeHelper -ReuseExistingContext | Out-Null
       }
     }
   } catch { Write-Warning "Failed to emit final sweep leak report: $_" }

--- a/scripts/Pester-Invoker.psm1
+++ b/scripts/Pester-Invoker.psm1
@@ -29,7 +29,7 @@ function Write-InvokerEvent {
     if ($RunId) { $payload.runId = $RunId }
     if ($Seed)  { $payload.seed  = $Seed }
     if ($Data) { foreach ($k in $Data.Keys) { $payload[$k] = $Data[$k] } }
-    ($payload | ConvertTo-Json -Compress) | Add-Content -Path $LogPath
+    ($payload | ConvertTo-Json -Depth 8 -Compress) | Add-Content -Path $LogPath
   } catch { Write-Warning ("[pester-invoker] failed to write crumb: {0}" -f $_.Exception.Message) }
 }
 

--- a/tests/Invoke-PesterExecutionFinalize.Tests.ps1
+++ b/tests/Invoke-PesterExecutionFinalize.Tests.ps1
@@ -1,0 +1,116 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Invoke-PesterExecutionFinalize' {
+  BeforeAll {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $toolPath = Join-Path $repoRoot 'tools/Invoke-PesterExecutionFinalize.ps1'
+  }
+
+  It 'writes summary, trail, compare-report index, manifest, and session index from the finalize context' {
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("pester-finalize-" + [Guid]::NewGuid().ToString('N'))
+    $resultsDir = Join-Path $tempRoot 'artifacts'
+    $repoResultsDir = Join-Path $tempRoot 'tests/results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $repoResultsDir -Force | Out-Null
+
+    try {
+      @(
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<test-results name="sample" total="3" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0"></test-results>'
+      ) -join [Environment]::NewLine | Set-Content -LiteralPath (Join-Path $resultsDir 'pester-results.xml') -Encoding UTF8
+      '[]' | Set-Content -LiteralPath (Join-Path $resultsDir 'pester-failures.json') -Encoding UTF8
+      '{"schema":"pester-leak-report@v1","leakDetected":false}' | Set-Content -LiteralPath (Join-Path $resultsDir 'pester-leak-report.json') -Encoding UTF8
+      '{"schema":"pester-result-shapes/v1","schemaVersion":"1.1.0","generatedAt":"2026-03-31T00:00:00Z","totalEntries":3,"overall":{"hasPath":3,"hasTags":2},"byType":[]}' | Set-Content -LiteralPath (Join-Path $resultsDir 'result-shapes.json') -Encoding UTF8
+      'shape text' | Set-Content -LiteralPath (Join-Path $resultsDir 'result-shapes.txt') -Encoding UTF8
+      '<html><body>compare report</body></html>' | Set-Content -LiteralPath (Join-Path $repoResultsDir 'integration-compare-report.html') -Encoding UTF8
+
+      $contextPath = Join-Path $resultsDir 'pester-execution-finalize-context.json'
+      $context = [ordered]@{
+        schema                   = 'pester-execution-finalize-context@v1'
+        generatedAtUtc           = [DateTime]::UtcNow.ToString('o')
+        repoRoot                 = $tempRoot
+        resultsDir               = $resultsDir
+        jsonSummaryPath          = 'pester-summary.json'
+        summaryText              = "=== Pester Test Summary ===`nTotal Tests: 3`nPassed: 3`nFailed: 0`nErrors: 0`nSkipped: 0`nDuration: 1.23s"
+        summaryPayload           = [ordered]@{
+          total                    = 3
+          passed                   = 3
+          failed                   = 0
+          errors                   = 0
+          skipped                  = 0
+          duration_s               = 1.23
+          timestamp                = '2026-03-31T00:00:00Z'
+          schemaVersion            = '1.7.1'
+          meanTest_ms              = 10
+          p95Test_ms               = 20
+          maxTest_ms               = 30
+          aggregatorBuildMs        = 4.5
+          executionPostprocessStatus = 'complete'
+          resultsXmlStatus         = 'complete'
+        }
+        artifactTrail            = [ordered]@{
+          schema      = 'pester-artifact-trail/v1'
+          generatedAt = [DateTime]::UtcNow.ToString('o')
+          created     = @()
+          deleted     = @()
+          modified    = @()
+          procsBefore = @()
+          procsAfter  = @()
+        }
+        includeIntegration       = $false
+        integrationMode          = 'exclude'
+        integrationSource        = 'explicit'
+        summarySchemaVersion     = '1.7.1'
+        manifestVersion          = '1.0.0'
+        failuresSchemaVersion    = '1.0.0'
+        leakReportSchemaVersion  = '1.0.0'
+        diagnosticsSchemaVersion = '1.1.0'
+      }
+      $context | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $contextPath -Encoding UTF8
+
+      & $toolPath -ContextPath $contextPath | Out-Host
+      $LASTEXITCODE | Should -Be 0
+
+      $summaryPath = Join-Path $resultsDir 'pester-summary.txt'
+      $summaryJsonPath = Join-Path $resultsDir 'pester-summary.json'
+      $trailPath = Join-Path $resultsDir 'pester-artifacts-trail.json'
+      $indexPath = Join-Path $resultsDir 'results-index.html'
+      $manifestPath = Join-Path $resultsDir 'pester-artifacts.json'
+      $sessionIndexPath = Join-Path $resultsDir 'session-index.json'
+      $compareReportPath = Join-Path $resultsDir 'compare-report.html'
+
+      Test-Path -LiteralPath $summaryPath | Should -BeTrue
+      Test-Path -LiteralPath $summaryJsonPath | Should -BeTrue
+      Test-Path -LiteralPath $trailPath | Should -BeTrue
+      Test-Path -LiteralPath $compareReportPath | Should -BeTrue
+      Test-Path -LiteralPath $indexPath | Should -BeTrue
+      Test-Path -LiteralPath $manifestPath | Should -BeTrue
+      Test-Path -LiteralPath $sessionIndexPath | Should -BeTrue
+
+      (Get-Content -LiteralPath $summaryPath -Raw) | Should -Match 'Diagnostics Summary'
+
+      $summaryJson = Get-Content -LiteralPath $summaryJsonPath -Raw | ConvertFrom-Json
+      $summaryJson.total | Should -Be 3
+      $summaryJson.executionPostprocessStatus | Should -Be 'complete'
+
+      $sessionIndex = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json
+      $sessionIndex.summary.total | Should -Be 3
+      $sessionIndex.files.pesterSummaryJson | Should -Be 'pester-summary.json'
+      $sessionIndex.files.compareReportHtml | Should -Be 'compare-report.html'
+      $sessionIndex.files.resultsIndexHtml | Should -Be 'results-index.html'
+
+      $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+      $artifactFiles = @($manifest.artifacts | ForEach-Object { $_.file })
+      $artifactFiles | Should -Contain 'pester-summary.json'
+      $artifactFiles | Should -Contain 'pester-artifacts-trail.json'
+      $artifactFiles | Should -Contain 'session-index.json'
+      $artifactFiles | Should -Contain 'compare-report.html'
+      $artifactFiles | Should -Contain 'results-index.html'
+    } finally {
+      if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    }
+  }
+}

--- a/tools/Invoke-PesterExecutionFinalize.ps1
+++ b/tools/Invoke-PesterExecutionFinalize.ps1
@@ -1,0 +1,728 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$ContextPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Read-JsonObject {
+  param([Parameter(Mandatory = $true)][string]$PathValue)
+
+  if (-not (Test-Path -LiteralPath $PathValue -PathType Leaf)) {
+    throw "JSON file not found: $PathValue"
+  }
+
+  return (Get-Content -LiteralPath $PathValue -Raw | ConvertFrom-Json -ErrorAction Stop)
+}
+
+function Set-ObjectProperty {
+  param(
+    [Parameter(Mandatory = $true)]$InputObject,
+    [Parameter(Mandatory = $true)][string]$Name,
+    $Value
+  )
+
+  $property = $InputObject.PSObject.Properties[$Name]
+  if ($property) {
+    $property.Value = $Value
+  } else {
+    Add-Member -InputObject $InputObject -Name $Name -MemberType NoteProperty -Value $Value
+  }
+}
+
+function Get-RunnerProfileSnapshot {
+  $runnerProfile = $null
+  try {
+    if (-not (Get-Command -Name Get-RunnerProfile -ErrorAction SilentlyContinue)) {
+      $repoRoot = Split-Path -Parent $PSScriptRoot
+      $runnerModule = Join-Path $repoRoot 'tools/RunnerProfile.psm1'
+      if (Test-Path -LiteralPath $runnerModule -PathType Leaf) {
+        Import-Module $runnerModule -Force
+      }
+    }
+    if (Get-Command -Name Get-RunnerProfile -ErrorAction SilentlyContinue) {
+      $runnerProfile = Get-RunnerProfile
+    }
+  } catch {}
+
+  return $runnerProfile
+}
+
+function Get-ResultShapeSummary {
+  param([Parameter(Mandatory = $true)][string]$ResultsDirectory)
+
+  $diagJsonPath = Join-Path $ResultsDirectory 'result-shapes.json'
+  if (-not (Test-Path -LiteralPath $diagJsonPath -PathType Leaf)) {
+    return $null
+  }
+
+  try {
+    $diagObj = Get-Content -LiteralPath $diagJsonPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    return [pscustomobject]@{
+      totalEntries = [int]$diagObj.totalEntries
+      hasPath      = [int]$diagObj.overall.hasPath
+      hasTags      = [int]$diagObj.overall.hasTags
+    }
+  } catch {
+    return $null
+  }
+}
+
+function Append-DiagnosticsFooterToSummary {
+  param(
+    [Parameter(Mandatory = $true)][string]$SummaryPath,
+    [Parameter(Mandatory = $true)][string]$ResultsDirectory
+  )
+
+  $diag = Get-ResultShapeSummary -ResultsDirectory $ResultsDirectory
+  if ($null -eq $diag) {
+    return
+  }
+
+  function Get-PercentText {
+    param([int]$Numerator,[int]$Denominator)
+    if ($Denominator -le 0) { return '0%' }
+    return ('{0:P1}' -f ([double]$Numerator / [double]$Denominator))
+  }
+
+  $footer = @()
+  $footer += ''
+  $footer += '---'
+  $footer += 'Diagnostics Summary'
+  $footer += ''
+  $footer += ('Total entries: {0}' -f $diag.totalEntries)
+  $footer += ('Has Path: {0} ({1})' -f $diag.hasPath, (Get-PercentText -Numerator $diag.hasPath -Denominator $diag.totalEntries))
+  $footer += ('Has Tags: {0} ({1})' -f $diag.hasTags, (Get-PercentText -Numerator $diag.hasTags -Denominator $diag.totalEntries))
+  Add-Content -LiteralPath $SummaryPath -Value ($footer -join "`n") -Encoding utf8
+}
+
+function Copy-CompareReportsAndWriteIndex {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$ResultsDirectory
+  )
+
+  $destReport = Join-Path $ResultsDirectory 'compare-report.html'
+  $candidates = @()
+  $fixedCandidates = @(
+    (Join-Path $RepoRoot 'tests' 'results' 'integration-compare-report.html'),
+    (Join-Path $RepoRoot 'tests' 'results' 'compare-report.html'),
+    (Join-Path $RepoRoot 'tests' 'results-single' 'pr-body-compare-report.html')
+  )
+  foreach ($pathValue in $fixedCandidates) {
+    if (Test-Path -LiteralPath $pathValue -PathType Leaf) {
+      try { $candidates += (Get-Item -LiteralPath $pathValue -ErrorAction SilentlyContinue) } catch {}
+    }
+  }
+  try {
+    $dynamic = Get-ChildItem -LiteralPath (Join-Path $RepoRoot 'tests' 'results') -Filter '*compare-report*.html' -Recurse -File -ErrorAction SilentlyContinue
+    if ($dynamic) { $candidates += $dynamic }
+  } catch {}
+
+  function Normalize-PathValue {
+    param(
+      [string]$PathValue,
+      [string]$BasePath = $null
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) { return $null }
+
+    $candidate = $PathValue
+    $basePath = if ([string]::IsNullOrWhiteSpace($BasePath)) { (Get-Location).ProviderPath } else { $BasePath }
+
+    if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+      try {
+        $candidate = [System.IO.Path]::Combine($basePath, $candidate)
+      } catch {
+        return $candidate
+      }
+    }
+
+    $attempts = @($candidate)
+    if (-not $candidate.StartsWith('\\?\', [System.StringComparison]::OrdinalIgnoreCase)) {
+      if ($candidate.StartsWith('\\', [System.StringComparison]::Ordinal)) {
+        $attempts += ('\\?\UNC\' + $candidate.Substring(2))
+      } else {
+        $attempts += ('\\?\' + $candidate)
+      }
+    }
+
+    foreach ($probe in $attempts) {
+      try {
+        $full = [System.IO.Path]::GetFullPath($probe)
+        try {
+          $resolved = Resolve-Path -LiteralPath $full -ErrorAction Stop
+          if ($resolved -and $resolved.ProviderPath) {
+            $full = $resolved.ProviderPath
+          }
+        } catch {}
+
+        if ($full.StartsWith('\\?\UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {
+          return ('\\' + $full.Substring(8))
+        }
+        if ($full.StartsWith('\\?\', [System.StringComparison]::OrdinalIgnoreCase)) {
+          return $full.Substring(4)
+        }
+        return $full
+      } catch {}
+    }
+
+    return $candidate
+  }
+
+  if ($candidates.Count -gt 0) {
+    $latest = $candidates | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    try {
+      $destFullPath = Normalize-PathValue -PathValue $destReport -BasePath $RepoRoot
+      $latestFullPath = Normalize-PathValue -PathValue $latest.FullName -BasePath $RepoRoot
+      $shouldCopyLatest = $true
+      if ($latestFullPath -and $destFullPath -and [string]::Equals($latestFullPath, $destFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $shouldCopyLatest = $false
+      }
+
+      if ($shouldCopyLatest) {
+        $destDir = [System.IO.Path]::GetDirectoryName($destReport)
+        if ($destDir -and $latest.DirectoryName -and
+            [string]::Equals($latest.DirectoryName, $destDir, [System.StringComparison]::OrdinalIgnoreCase) -and
+            [string]::Equals($latest.Name, 'compare-report.html', [System.StringComparison]::OrdinalIgnoreCase)) {
+          $shouldCopyLatest = $false
+        }
+      }
+
+      if ($shouldCopyLatest) {
+        try {
+          Copy-Item -LiteralPath $latest.FullName -Destination $destReport -Force -ErrorAction Stop
+          Write-Host ("Compare report copied to: {0}" -f $destReport) -ForegroundColor Gray
+        } catch {
+          if (-not ($_.Exception -and $_.Exception.Message -match 'Cannot overwrite .+ with itself')) {
+            Write-Warning "Failed to copy compare report: $_"
+          }
+        }
+      }
+    } catch {
+      Write-Warning "Failed to copy compare report: $_"
+    }
+
+    foreach ($candidate in ($candidates | Sort-Object LastWriteTimeUtc)) {
+      try {
+        $destName = Split-Path -Leaf $candidate.FullName
+        $destFull = Join-Path $ResultsDirectory $destName
+        $destFullPath = Normalize-PathValue -PathValue $destFull -BasePath $RepoRoot
+        $candidateFullPath = Normalize-PathValue -PathValue $candidate.FullName -BasePath $RepoRoot
+        $shouldCopyCandidate = $true
+        if ($destFullPath -and $candidateFullPath -and [string]::Equals($destFullPath, $candidateFullPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+          $shouldCopyCandidate = $false
+        }
+        if ($shouldCopyCandidate -and
+            [string]::Equals($candidate.DirectoryName, $ResultsDirectory, [System.StringComparison]::OrdinalIgnoreCase) -and
+            [string]::Equals($candidate.Name, $destName, [System.StringComparison]::OrdinalIgnoreCase)) {
+          $shouldCopyCandidate = $false
+        }
+
+        if ($shouldCopyCandidate) {
+          try {
+            Copy-Item -LiteralPath $candidate.FullName -Destination $destFull -Force -ErrorAction Stop
+          } catch {
+            if (-not ($_.Exception -and $_.Exception.Message -match 'Cannot overwrite .+ with itself')) {
+              Write-Host "(warn) failed to copy extra report '$($candidate.FullName)': $_" -ForegroundColor DarkYellow
+            }
+          }
+        }
+      } catch {
+        Write-Host "(warn) failed to copy extra report '$($candidate.FullName)': $_" -ForegroundColor DarkYellow
+      }
+    }
+  }
+
+  try {
+    $indexPath = Join-Path $ResultsDirectory 'results-index.html'
+    $reports = @(Get-ChildItem -LiteralPath $ResultsDirectory -Filter '*compare-report*.html' -File -ErrorAction SilentlyContinue | Sort-Object Name)
+    function Html-Encode {
+      param([string]$TextValue)
+      if ([string]::IsNullOrEmpty($TextValue)) { return '' }
+      return $TextValue.Replace('&','&amp;').Replace('<','&lt;').Replace('>','&gt;').Replace('"','&quot;').Replace("'",'&#39;')
+    }
+    $now = (Get-Date).ToString('u')
+    $lines = @()
+    $lines += '<!DOCTYPE html>'
+    $lines += '<html lang="en">'
+    $lines += '<head><meta charset="utf-8"/><title>Compare Reports Index</title><style>body{font-family:Segoe UI,SegoeUI,Helvetica,Arial,sans-serif;margin:16px} ul{line-height:1.6} .meta{color:#666} code{background:#f5f5f5;padding:2px 4px;border-radius:3px}</style></head>'
+    $lines += '<body>'
+    $lines += '<h1>Compare Reports Index</h1>'
+    $lines += ("<p class='meta'>Generated at <code>{0}</code></p>" -f (Html-Encode -TextValue $now))
+    $lines += ("<p>Total reports: <strong>{0}</strong> — canonical: <code>compare-report.html</code></p>" -f $reports.Count)
+    if ($reports.Count -gt 0) {
+      $lines += '<ul>'
+      foreach ($report in $reports) {
+        $nameEnc = Html-Encode -TextValue $report.Name
+        $ts = Html-Encode -TextValue ($report.LastWriteTimeUtc.ToString('u'))
+        $size = '{0:N0} bytes' -f $report.Length
+        $meta = ('last write: {0}; size: {1}' -f $ts, (Html-Encode -TextValue $size))
+        $canonicalTag = if ($report.Name -ieq 'compare-report.html') { ' <em class="meta">(canonical)</em>' } else { '' }
+        $lines += ('<li><a href="{0}">{0}</a>{2} <span class=''meta''>({1})</span></li>' -f $nameEnc, $meta, $canonicalTag)
+      }
+      $lines += '</ul>'
+    } else {
+      $lines += '<p class="meta">No compare-report HTML files found in this results directory.</p>'
+    }
+    try {
+      $diagTxt = Join-Path $ResultsDirectory 'result-shapes.txt'
+      $diagJson = Join-Path $ResultsDirectory 'result-shapes.json'
+      if ((Test-Path -LiteralPath $diagTxt) -or (Test-Path -LiteralPath $diagJson)) {
+        $lines += '<hr/>'
+        $lines += '<h3>Diagnostics</h3>'
+        $lines += '<ul>'
+        if (Test-Path -LiteralPath $diagTxt) { $lines += '<li><a href="result-shapes.txt">result-shapes.txt</a></li>' }
+        if (Test-Path -LiteralPath $diagJson) { $lines += '<li><a href="result-shapes.json">result-shapes.json</a></li>' }
+        $lines += '</ul>'
+        if (Test-Path -LiteralPath $diagJson) {
+          try {
+            $diagObj = Get-Content -LiteralPath $diagJson -Raw | ConvertFrom-Json -ErrorAction Stop
+            $totalEntries = [int]$diagObj.totalEntries
+            $hasPath = [int]$diagObj.overall.hasPath
+            $hasTags = [int]$diagObj.overall.hasTags
+            function Get-PercentHtml {
+              param([int]$Numerator,[int]$Denominator)
+              if ($Denominator -le 0) { return '0%' }
+              return ('{0:P1}' -f ([double]$Numerator / [double]$Denominator))
+            }
+            $lines += '<table style="border-collapse:collapse;margin-top:8px">'
+            $lines += '<thead><tr><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #e5e7eb">Metric</th><th style="text-align:right;padding:4px 8px;border-bottom:1px solid #e5e7eb">Count</th><th style="text-align:right;padding:4px 8px;border-bottom:1px solid #e5e7eb">Percent</th></tr></thead>'
+            $lines += '<tbody>'
+            $lines += ('<tr><td style="padding:4px 8px">Total entries</td><td style="text-align:right;padding:4px 8px">{0}</td><td style="text-align:right;padding:4px 8px">-</td></tr>' -f $totalEntries)
+            $lines += ('<tr><td style="padding:4px 8px">Has Path</td><td style="text-align:right;padding:4px 8px">{0}</td><td style="text-align:right;padding:4px 8px">{1}</td></tr>' -f $hasPath, (Get-PercentHtml -Numerator $hasPath -Denominator $totalEntries))
+            $lines += ('<tr><td style="padding:4px 8px">Has Tags</td><td style="text-align:right;padding:4px 8px">{0}</td><td style="text-align:right;padding:4px 8px">{1}</td></tr>' -f $hasTags, (Get-PercentHtml -Numerator $hasTags -Denominator $totalEntries))
+            $lines += '</tbody></table>'
+          } catch {}
+        }
+      }
+    } catch {}
+    $lines += '</body></html>'
+    Set-Content -LiteralPath $indexPath -Value ($lines -join "`n") -Encoding UTF8
+    Write-Host ("Results index written to: {0}" -f $indexPath) -ForegroundColor Gray
+  } catch {
+    Write-Host "(warn) failed to write results index: $_" -ForegroundColor DarkYellow
+  }
+}
+
+function Write-ArtifactManifest {
+  param(
+    [Parameter(Mandatory = $true)][string]$Directory,
+    [Parameter(Mandatory = $true)][string]$SummaryJsonPath,
+    [Parameter(Mandatory = $true)][string]$ManifestVersion,
+    [Parameter(Mandatory = $true)][string]$SummarySchemaVersion,
+    [Parameter(Mandatory = $true)][string]$FailuresSchemaVersion,
+    [Parameter(Mandatory = $true)][string]$LeakReportSchemaVersion,
+    [Parameter(Mandatory = $true)][string]$DiagnosticsSchemaVersion
+  )
+
+  if (-not (Test-Path -LiteralPath $Directory -PathType Container)) {
+    New-Item -ItemType Directory -Force -Path $Directory | Out-Null
+  }
+
+  $artifacts = @()
+  $xmlPath = Join-Path $Directory 'pester-results.xml'
+  if (Test-Path -LiteralPath $xmlPath) {
+    $artifacts += [pscustomobject]@{ file = 'pester-results.xml'; type = 'nunitXml' }
+  }
+  $txtPath = Join-Path $Directory 'pester-summary.txt'
+  if (Test-Path -LiteralPath $txtPath) {
+    $artifacts += [pscustomobject]@{ file = 'pester-summary.txt'; type = 'textSummary' }
+  }
+  $cmpPath = Join-Path $Directory 'compare-report.html'
+  if (Test-Path -LiteralPath $cmpPath) {
+    $artifacts += [pscustomobject]@{ file = 'compare-report.html'; type = 'htmlCompare' }
+  }
+  $idxPath = Join-Path $Directory 'results-index.html'
+  if (Test-Path -LiteralPath $idxPath) {
+    $artifacts += [pscustomobject]@{ file = 'results-index.html'; type = 'htmlIndex' }
+  }
+  try {
+    $extraHtml = @(Get-ChildItem -LiteralPath $Directory -Filter '*compare-report*.html' -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne 'compare-report.html' })
+    foreach ($item in $extraHtml) {
+      $artifacts += [pscustomobject]@{ file = $item.Name; type = 'htmlCompare' }
+    }
+  } catch {}
+
+  $jsonSummaryFile = Split-Path -Leaf $SummaryJsonPath
+  if ($jsonSummaryFile) {
+    $jsonPath = Join-Path $Directory $jsonSummaryFile
+    if (Test-Path -LiteralPath $jsonPath) {
+      $artifacts += [pscustomobject]@{ file = $jsonSummaryFile; type = 'jsonSummary'; schemaVersion = $SummarySchemaVersion }
+    }
+  }
+  $failuresPath = Join-Path $Directory 'pester-failures.json'
+  if (Test-Path -LiteralPath $failuresPath) {
+    $artifacts += [pscustomobject]@{ file = 'pester-failures.json'; type = 'jsonFailures'; schemaVersion = $FailuresSchemaVersion }
+  }
+  $trailPath = Join-Path $Directory 'pester-artifacts-trail.json'
+  if (Test-Path -LiteralPath $trailPath) {
+    $artifacts += [pscustomobject]@{ file = 'pester-artifacts-trail.json'; type = 'jsonTrail' }
+  }
+  $sessionIdx = Join-Path $Directory 'session-index.json'
+  if (Test-Path -LiteralPath $sessionIdx) {
+    $artifacts += [pscustomobject]@{ file = 'session-index.json'; type = 'jsonSessionIndex' }
+  }
+  $leakPath = Join-Path $Directory 'pester-leak-report.json'
+  if (Test-Path -LiteralPath $leakPath) {
+    $artifacts += [pscustomobject]@{ file = 'pester-leak-report.json'; type = 'jsonLeaks'; schemaVersion = $LeakReportSchemaVersion }
+  }
+  $diagTxt = Join-Path $Directory 'result-shapes.txt'
+  if (Test-Path -LiteralPath $diagTxt) {
+    $artifacts += [pscustomobject]@{ file = 'result-shapes.txt'; type = 'textDiagnostics' }
+  }
+  $diagJson = Join-Path $Directory 'result-shapes.json'
+  if (Test-Path -LiteralPath $diagJson) {
+    $artifacts += [pscustomobject]@{ file = 'result-shapes.json'; type = 'jsonDiagnostics'; schemaVersion = $DiagnosticsSchemaVersion }
+  }
+
+  $metrics = $null
+  try {
+    if ($jsonSummaryFile) {
+      $jsonPath = Join-Path $Directory $jsonSummaryFile
+      if (Test-Path -LiteralPath $jsonPath) {
+        $summaryJson = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        $meanTestMs = if ($summaryJson.PSObject.Properties['meanTest_ms']) { $summaryJson.meanTest_ms } else { $null }
+        $p95TestMs = if ($summaryJson.PSObject.Properties['p95Test_ms']) { $summaryJson.p95Test_ms } else { $null }
+        $maxTestMs = if ($summaryJson.PSObject.Properties['maxTest_ms']) { $summaryJson.maxTest_ms } else { $null }
+        $aggMsValue = $null
+        if ($summaryJson.PSObject.Properties.Name -contains 'aggregatorBuildMs' -and $null -ne $summaryJson.aggregatorBuildMs) {
+          $aggMsValue = $summaryJson.aggregatorBuildMs
+        }
+        $metrics = [pscustomobject]@{
+          totalTests        = $summaryJson.total
+          failed            = $summaryJson.failed
+          skipped           = $summaryJson.skipped
+          duration_s        = $summaryJson.duration_s
+          meanTest_ms       = $meanTestMs
+          p95Test_ms        = $p95TestMs
+          maxTest_ms        = $maxTestMs
+          aggregatorBuildMs = $aggMsValue
+        }
+      }
+    }
+  } catch {
+    Write-Warning "Failed to enrich manifest metrics: $_"
+  }
+
+  $manifest = [pscustomobject]@{
+    manifestVersion = $ManifestVersion
+    generatedAt     = (Get-Date).ToString('o')
+    artifacts       = $artifacts
+    metrics         = $metrics
+  }
+  $manifestPath = Join-Path $Directory 'pester-artifacts.json'
+  $manifest | ConvertTo-Json -Depth 5 | Out-File -FilePath $manifestPath -Encoding utf8 -ErrorAction Stop
+  Write-Host ("Artifact manifest written to: {0}" -f $manifestPath) -ForegroundColor Gray
+  return $manifestPath
+}
+
+function Write-SessionIndex {
+  param(
+    [Parameter(Mandatory = $true)][string]$ResultsDirectory,
+    [Parameter(Mandatory = $true)][string]$SummaryJsonPath,
+    [Parameter(Mandatory = $true)][bool]$IncludeIntegration,
+    [Parameter()][string]$IntegrationMode,
+    [Parameter()][string]$IntegrationSource
+  )
+
+  if (-not (Test-Path -LiteralPath $ResultsDirectory -PathType Container)) {
+    throw "Results directory not found: $ResultsDirectory"
+  }
+
+  $idx = [ordered]@{
+    schema             = 'session-index/v1'
+    schemaVersion      = '1.0.0'
+    generatedAtUtc     = (Get-Date).ToUniversalTime().ToString('o')
+    resultsDir         = $ResultsDirectory
+    includeIntegration = $IncludeIntegration
+    integrationMode    = $IntegrationMode
+    integrationSource  = $IntegrationSource
+    files              = [ordered]@{}
+  }
+
+  $runnerProfile = Get-RunnerProfileSnapshot
+  $addIf = {
+    param($Name, $File)
+    $pathValue = Join-Path $ResultsDirectory $File
+    if (Test-Path -LiteralPath $pathValue -PathType Leaf) {
+      $idx.files[$Name] = $File
+    }
+  }
+
+  & $addIf 'pesterResultsXml' 'pester-results.xml'
+  & $addIf 'pesterSummaryTxt' 'pester-summary.txt'
+  $jsonLeaf = Split-Path -Leaf $SummaryJsonPath
+  if ($jsonLeaf) {
+    & $addIf 'pesterSummaryJson' $jsonLeaf
+    try {
+      $sumPath = Join-Path $ResultsDirectory $jsonLeaf
+      if (Test-Path -LiteralPath $sumPath -PathType Leaf) {
+        $summary = Get-Content -LiteralPath $sumPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        $idx['summary'] = [ordered]@{
+          total         = $summary.total
+          passed        = $summary.passed
+          failed        = $summary.failed
+          errors        = $summary.errors
+          skipped       = $summary.skipped
+          duration_s    = $summary.duration_s
+          meanTest_ms   = $summary.meanTest_ms
+          p95Test_ms    = $summary.p95Test_ms
+          maxTest_ms    = $summary.maxTest_ms
+          schemaVersion = $summary.schemaVersion
+        }
+        $status = if (($summary.failed -gt 0) -or ($summary.errors -gt 0)) { 'fail' } else { 'ok' }
+        $idx['status'] = $status
+        $resultsRelative = $ResultsDirectory
+        try {
+          $cwd = (Get-Location).Path
+          if ($resultsRelative.StartsWith($cwd, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $relative = $resultsRelative.Substring($cwd.Length).TrimStart('\', '/')
+            if (-not [string]::IsNullOrWhiteSpace($relative)) {
+              $resultsRelative = $relative
+            }
+          }
+        } catch {}
+        $lines = @()
+        $lines += '### Session Overview'
+        $lines += ''
+        $lines += ("- Status: {0}" -f $status)
+        $lines += ("- Total: {0} | Passed: {1} | Failed: {2} | Errors: {3} | Skipped: {4}" -f $summary.total, $summary.passed, $summary.failed, $summary.errors, $summary.skipped)
+        $lines += ("- Duration (s): {0}" -f $summary.duration_s)
+        $lines += ("- Include Integration: {0}" -f $IncludeIntegration)
+        $lines += ("- Integration Mode: {0}" -f $IntegrationMode)
+        if ($IntegrationSource) { $lines += ("- Integration Source: {0}" -f $IntegrationSource) }
+        $lines += ''
+        $lines += 'Artifacts (paths):'
+        $present = @()
+        foreach ($key in @('pesterSummaryJson','pesterResultsXml','pesterSummaryTxt','artifactManifestJson','artifactTrailJson','leakReportJson','compareReportHtml','resultsIndexHtml')) {
+          if ($idx.files[$key]) { $present += (Join-Path $resultsRelative $idx.files[$key]) }
+        }
+        foreach ($pathValue in $present) { $lines += ("- {0}" -f $pathValue) }
+        $runnerName = if ($runnerProfile -and $runnerProfile.PSObject.Properties.Name -contains 'name' -and $runnerProfile.name) { $runnerProfile.name } else { $env:RUNNER_NAME }
+        $runnerOs = if ($runnerProfile -and $runnerProfile.PSObject.Properties.Name -contains 'os' -and $runnerProfile.os) { $runnerProfile.os } else { $env:RUNNER_OS }
+        $runnerArch = if ($runnerProfile -and $runnerProfile.PSObject.Properties.Name -contains 'arch' -and $runnerProfile.arch) { $runnerProfile.arch } else { $env:RUNNER_ARCH }
+        $runnerEnvironment = if ($runnerProfile -and $runnerProfile.PSObject.Properties.Name -contains 'environment' -and $runnerProfile.environment) { $runnerProfile.environment } else { $env:RUNNER_ENVIRONMENT }
+        $runnerMachine = if ($runnerProfile -and $runnerProfile.PSObject.Properties.Name -contains 'machine' -and $runnerProfile.machine) { $runnerProfile.machine } else { [System.Environment]::MachineName }
+        $runnerLabels = @()
+        try {
+          if ($runnerProfile -and $runnerProfile.PSObject.Properties.Name -contains 'labels') {
+            $runnerLabels = @($runnerProfile.labels | Where-Object { $_ -and $_ -ne '' })
+          } elseif (Get-Command -Name Get-RunnerLabels -ErrorAction SilentlyContinue) {
+            $runnerLabels = @(Get-RunnerLabels | Where-Object { $_ -and $_ -ne '' })
+          }
+        } catch {}
+        if ($runnerName -or $runnerOs -or $runnerArch -or $runnerEnvironment -or $runnerMachine -or ($runnerLabels -and $runnerLabels.Count -gt 0)) {
+          $lines += ''
+          $lines += '### Runner'
+          $lines += ''
+          if ($runnerName) { $lines += ("- Name: {0}" -f $runnerName) }
+          if ($runnerOs -and $runnerArch) {
+            $lines += ("- OS/Arch: {0}/{1}" -f $runnerOs, $runnerArch)
+          } elseif ($runnerOs) {
+            $lines += ("- OS: {0}" -f $runnerOs)
+          } elseif ($runnerArch) {
+            $lines += ("- Arch: {0}" -f $runnerArch)
+          }
+          if ($runnerEnvironment) { $lines += ("- Environment: {0}" -f $runnerEnvironment) }
+          if ($runnerMachine) { $lines += ("- Machine: {0}" -f $runnerMachine) }
+          if ($runnerLabels -and $runnerLabels.Count -gt 0) {
+            $lines += ("- Labels: {0}" -f (($runnerLabels | Select-Object -Unique) -join ', '))
+          }
+        }
+        $idx['stepSummary'] = ($lines -join "`n")
+      }
+    } catch {}
+  }
+
+  & $addIf 'pesterFailuresJson' 'pester-failures.json'
+  & $addIf 'artifactManifestJson' 'pester-artifacts.json'
+  & $addIf 'artifactTrailJson' 'pester-artifacts-trail.json'
+  & $addIf 'dispatcherEventsNdjson' 'dispatcher-events.ndjson'
+  & $addIf 'leakReportJson' 'pester-leak-report.json'
+  & $addIf 'compareReportHtml' 'compare-report.html'
+  & $addIf 'resultsIndexHtml' 'results-index.html'
+
+  try {
+    $driftRoot = Join-Path (Get-Location) 'results/fixture-drift'
+    if (Test-Path -LiteralPath $driftRoot -PathType Container) {
+      $dirs = Get-ChildItem -LiteralPath $driftRoot -Directory
+      $tsDirs = @($dirs | Where-Object { $_.Name -match '^[0-9]{8}T[0-9]{6}Z$' })
+      $latest = if ($tsDirs.Count -gt 0) { $tsDirs | Sort-Object Name -Descending | Select-Object -First 1 } else { $dirs | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1 }
+      if ($latest) {
+        $sumPath = Join-Path $latest.FullName 'drift-summary.json'
+        $status = $null
+        if (Test-Path -LiteralPath $sumPath) {
+          try { $driftSummary = Get-Content -LiteralPath $sumPath -Raw | ConvertFrom-Json -ErrorAction Stop; $status = $driftSummary.status } catch {}
+        }
+        $idx['drift'] = [ordered]@{
+          latestRunDir  = $latest.FullName
+          latestSummary = if (Test-Path -LiteralPath $sumPath) { $sumPath } else { $null }
+          status        = $status
+        }
+      }
+    }
+  } catch {}
+
+  try {
+    $runContext = [ordered]@{
+      repository = $env:GITHUB_REPOSITORY
+      ref        = (if ($env:GITHUB_HEAD_REF) { $env:GITHUB_HEAD_REF } else { $env:GITHUB_REF })
+      commitSha  = $env:GITHUB_SHA
+      workflow   = $env:GITHUB_WORKFLOW
+      runId      = $env:GITHUB_RUN_ID
+      runAttempt = $env:GITHUB_RUN_ATTEMPT
+    }
+    if ($env:GITHUB_JOB) { $runContext['job'] = $env:GITHUB_JOB }
+    if ($env:RUNNER_NAME) { $runContext['runner'] = $env:RUNNER_NAME }
+    if ($env:RUNNER_OS) { $runContext['runnerOS'] = $env:RUNNER_OS }
+    if ($env:RUNNER_ARCH) { $runContext['runnerArch'] = $env:RUNNER_ARCH }
+    if ($env:RUNNER_ENVIRONMENT) { $runContext['runnerEnvironment'] = $env:RUNNER_ENVIRONMENT }
+    $machineName = try { [System.Environment]::MachineName } catch { $null }
+    if ($machineName) { $runContext['runnerMachine'] = $machineName }
+    if ($env:RUNNER_TRACKING_ID) { $runContext['runnerTrackingId'] = $env:RUNNER_TRACKING_ID }
+    if ($env:ImageOS) { $runContext['runnerImageOS'] = $env:ImageOS }
+    if ($env:ImageVersion) { $runContext['runnerImageVersion'] = $env:ImageVersion }
+    if ($runnerProfile) {
+      $map = @{
+        name         = 'runner'
+        os           = 'runnerOS'
+        arch         = 'runnerArch'
+        environment  = 'runnerEnvironment'
+        machine      = 'runnerMachine'
+        trackingId   = 'runnerTrackingId'
+        imageOS      = 'runnerImageOS'
+        imageVersion = 'runnerImageVersion'
+      }
+      foreach ($entry in $map.GetEnumerator()) {
+        $source = $entry.Key
+        $target = $entry.Value
+        if ($runnerProfile.PSObject.Properties.Name -contains $source) {
+          $value = $runnerProfile.$source
+          if ($null -ne $value -and "$value" -ne '') {
+            $runContext[$target] = $value
+          }
+        }
+      }
+      if ($runnerProfile.PSObject.Properties.Name -contains 'labels') {
+        $labelValues = @($runnerProfile.labels | Where-Object { $_ -and $_ -ne '' })
+        if ($labelValues.Count -gt 0) { $runContext['runnerLabels'] = $labelValues }
+      }
+    } elseif (Get-Command -Name Get-RunnerLabels -ErrorAction SilentlyContinue) {
+      try {
+        $labelsFallback = @(Get-RunnerLabels | Where-Object { $_ -and $_ -ne '' })
+        if ($labelsFallback.Count -gt 0) { $runContext['runnerLabels'] = $labelsFallback }
+      } catch {}
+    }
+    $idx['runContext'] = $runContext
+    if ($env:GITHUB_REPOSITORY) {
+      $repoUrl = "https://github.com/$($env:GITHUB_REPOSITORY)"
+      $urls = [ordered]@{ repository = $repoUrl }
+      if ($env:GITHUB_RUN_ID) { $urls.run = "$repoUrl/actions/runs/$($env:GITHUB_RUN_ID)" }
+      if ($env:GITHUB_SHA) { $urls.commit = "$repoUrl/commit/$($env:GITHUB_SHA)" }
+      try {
+        $refValue = $env:GITHUB_REF
+        if ($refValue -and $refValue -match 'refs/pull/(?<num>\d+)/') {
+          $urls.pullRequest = "$repoUrl/pull/$($Matches.num)"
+        }
+      } catch {}
+      $idx['urls'] = $urls
+    }
+  } catch {}
+
+  try {
+    $handshakeFiles = @(Get-ChildItem -Path $ResultsDirectory -Recurse -Filter 'handshake-*.json' -File -ErrorAction SilentlyContinue)
+    if ($handshakeFiles.Count -gt 0) {
+      $sortedHandshake = @($handshakeFiles | Sort-Object LastWriteTimeUtc)
+      $last = $sortedHandshake[-1]
+      $lastRel = try { ($last.FullName).Substring(((Get-Location).Path).Length).TrimStart('\','/') } catch { $last.Name }
+      $lastJson = $null
+      try { $lastJson = Get-Content -LiteralPath $last.FullName -Raw | ConvertFrom-Json -ErrorAction Stop } catch {}
+      $lastPhase = if ($lastJson.name) { [string]$lastJson.name } else { [string]([IO.Path]::GetFileNameWithoutExtension($last.Name) -replace '^handshake-','') }
+      $lastAtUtc = if ($lastJson.atUtc) { [string]$lastJson.atUtc } else { $last.LastWriteTimeUtc.ToString('o') }
+      $lastStatus = if ($lastJson.status) { [string]$lastJson.status } else { $null }
+      $markerRel = @()
+      foreach ($file in $sortedHandshake) {
+        $relativePath = try { ($file.FullName).Substring(((Get-Location).Path).Length).TrimStart('\','/') } catch { $file.Name }
+        $markerRel += $relativePath
+      }
+      if (-not $idx['runContext']) { $idx['runContext'] = [ordered]@{} }
+      $idx.runContext['handshake'] = [ordered]@{
+        lastPhase   = $lastPhase
+        lastAtUtc   = $lastAtUtc
+        lastStatus  = $lastStatus
+        markerPaths = $markerRel
+      }
+      try {
+        $handshakeLines = @()
+        $handshakeLines += ("- Handshake Last Phase: {0}" -f $lastPhase)
+        if ($lastStatus) { $handshakeLines += ("- Handshake Last Status: {0}" -f $lastStatus) }
+        $firstTwo = @($markerRel | Select-Object -First 2)
+        foreach ($marker in $firstTwo) { $handshakeLines += ("- Marker: {0}" -f $marker) }
+        if ($idx['stepSummary']) {
+          $idx['stepSummary'] = $idx['stepSummary'] + "`n`n" + ($handshakeLines -join "`n")
+        } else {
+          $idx['stepSummary'] = ($handshakeLines -join "`n")
+        }
+      } catch {}
+    }
+  } catch {}
+
+  $dest = Join-Path $ResultsDirectory 'session-index.json'
+  $idx | ConvertTo-Json -Depth 6 | Out-File -FilePath $dest -Encoding utf8 -ErrorAction Stop
+  Write-Host ("Session index written to: {0}" -f $dest) -ForegroundColor Gray
+  return $dest
+}
+
+$resolvedContextPath = [System.IO.Path]::GetFullPath($ContextPath)
+$context = Read-JsonObject -PathValue $resolvedContextPath
+$resultsDir = [System.IO.Path]::GetFullPath([string]$context.resultsDir)
+$repoRoot = [System.IO.Path]::GetFullPath([string]$context.repoRoot)
+$jsonSummaryLeaf = if ([string]::IsNullOrWhiteSpace([string]$context.jsonSummaryPath)) { 'pester-summary.json' } else { [string]$context.jsonSummaryPath }
+$summaryPath = Join-Path $resultsDir 'pester-summary.txt'
+$summaryJsonPath = Join-Path $resultsDir $jsonSummaryLeaf
+$artifactTrailPath = Join-Path $resultsDir 'pester-artifacts-trail.json'
+$summaryTextValue = if ($context.PSObject.Properties['summaryText']) { [string]$context.summaryText } else { $null }
+$hasSummaryPayload = [bool]$context.PSObject.Properties['summaryPayload']
+$hasArtifactTrail = [bool]$context.PSObject.Properties['artifactTrail']
+
+if (-not (Test-Path -LiteralPath $resultsDir -PathType Container)) {
+  New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+}
+
+if (-not [string]::IsNullOrWhiteSpace($summaryTextValue)) {
+  $summaryTextValue | Out-File -FilePath $summaryPath -Encoding utf8 -ErrorAction Stop
+  Append-DiagnosticsFooterToSummary -SummaryPath $summaryPath -ResultsDirectory $resultsDir
+  Write-Host ("Summary written to: {0}" -f $summaryPath) -ForegroundColor Gray
+}
+
+if ($hasSummaryPayload -and $null -ne $context.summaryPayload) {
+  $context.summaryPayload | ConvertTo-Json -Depth 12 | Out-File -FilePath $summaryJsonPath -Encoding utf8 -ErrorAction Stop
+  Write-Host ("JSON summary written to: {0}" -f $summaryJsonPath) -ForegroundColor Gray
+}
+
+if ($hasArtifactTrail -and $null -ne $context.artifactTrail) {
+  $context.artifactTrail | ConvertTo-Json -Depth 8 | Out-File -FilePath $artifactTrailPath -Encoding utf8 -ErrorAction Stop
+  Write-Host ("Artifact trail written to: {0}" -f $artifactTrailPath) -ForegroundColor Gray
+}
+
+Copy-CompareReportsAndWriteIndex -RepoRoot $repoRoot -ResultsDirectory $resultsDir
+$sessionIndexPath = Write-SessionIndex -ResultsDirectory $resultsDir -SummaryJsonPath $jsonSummaryLeaf -IncludeIntegration ([bool]$context.includeIntegration) -IntegrationMode ([string]$context.integrationMode) -IntegrationSource ([string]$context.integrationSource)
+$manifestPath = Write-ArtifactManifest -Directory $resultsDir -SummaryJsonPath $jsonSummaryLeaf -ManifestVersion ([string]$context.manifestVersion) -SummarySchemaVersion ([string]$context.summarySchemaVersion) -FailuresSchemaVersion ([string]$context.failuresSchemaVersion) -LeakReportSchemaVersion ([string]$context.leakReportSchemaVersion) -DiagnosticsSchemaVersion ([string]$context.diagnosticsSchemaVersion)
+
+if ($env:GITHUB_OUTPUT) {
+  "summary_path=$summaryPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+  "summary_json_path=$summaryJsonPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+  "session_index_path=$sessionIndexPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+  "manifest_path=$manifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}
+
+Write-Host '### Pester execution finalize' -ForegroundColor Cyan
+Write-Host ("summary      : {0}" -f $summaryPath)
+Write-Host ("summary json : {0}" -f $summaryJsonPath)
+Write-Host ("session idx  : {0}" -f $sessionIndexPath)
+Write-Host ("manifest     : {0}" -f $manifestPath)
+
+exit 0

--- a/tools/priority/__tests__/pester-service-model-local-harness-contract.test.mjs
+++ b/tools/priority/__tests__/pester-service-model-local-harness-contract.test.mjs
@@ -21,6 +21,7 @@ test('package.json exposes the local execution harness as a first-class entrypoi
 
 test('local execution harness owns lock lifecycle, preflight, dispatch, and receipt generation', () => {
   const harness = readRepoFile('tools/Run-PesterExecutionOnly.Local.ps1');
+  const invoker = readRepoFile('scripts/Pester-Invoker.psm1');
 
   assert.match(harness, /\[string\]\$SessionLockRoot/);
   assert.match(harness, /\$resolvedSessionLockRoot = if \(\[string\]::IsNullOrWhiteSpace\(\$SessionLockRoot\)\)/);
@@ -39,6 +40,23 @@ test('local execution harness owns lock lifecycle, preflight, dispatch, and rece
   assert.match(harness, /results-xml-truncated/);
   assert.match(harness, /summaryPresent/);
   assert.match(harness, /sessionLockRoot = ConvertTo-PortablePath \$resolvedSessionLockRoot/);
+  assert.match(invoker, /ConvertTo-Json -Depth 8 -Compress/);
+});
+
+test('dispatcher path delegates summary, artifact, and session-index side effects to the execution finalize helper', () => {
+  const dispatcher = readRepoFile('Invoke-PesterTests.ps1');
+  const finalize = readRepoFile('tools/Invoke-PesterExecutionFinalize.ps1');
+
+  assert.match(dispatcher, /Invoke-PesterExecutionFinalize\.ps1/);
+  assert.match(dispatcher, /pester-execution-finalize-context@v1/);
+  assert.match(dispatcher, /Invoke-ExecutionFinalizeHelper\s+-SummaryText\s+\$summary\s+-SummaryPayload\s+\$jsonObj\s+-ArtifactTrail\s+\$script:artifactTrail/);
+  assert.match(dispatcher, /Invoke-ExecutionFinalizeHelper\s+-ReuseExistingContext/);
+  assert.doesNotMatch(dispatcher, /Write-ArtifactManifest\s+-Directory/);
+  assert.doesNotMatch(dispatcher, /Write-SessionIndex\s+-ResultsDirectory/);
+  assert.match(finalize, /pester-artifacts\.json/);
+  assert.match(finalize, /session-index\.json/);
+  assert.match(finalize, /compare-report\.html/);
+  assert.match(finalize, /results-index\.html/);
 });
 
 test('knowledgebase documents the local harness as the workflow-shell-free execution entrypoint', () => {


### PR DESCRIPTION
## Summary
- move summary, artifact, and session-index side effects out of `Invoke-PesterTests.ps1` and into `tools/Invoke-PesterExecutionFinalize.ps1`
- route the normal path, the no-tests path, and the single-invoker path through the same finalize helper and refresh finalize-owned artifacts after the late leak sweep
- harden the local harness and single-invoker proof surface with focused tests and a deeper JSON event serialization contract

## Validation
- `node --test tools/priority/__tests__/pester-service-model-local-harness-contract.test.mjs tools/priority/__tests__/pester-service-model-workflow-contract.test.mjs`
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path tests/Invoke-PesterExecutionFinalize.Tests.ps1,tests/Get-PesterResultXmlSummary.Tests.ps1,tests/Invoke-PesterExecutionPostprocess.Tests.ps1 -Output Detailed'`
- `pwsh -NoLogo -NoProfile -File tools/Run-PesterExecutionOnly.Local.ps1 -TestsPath tests -ResultsPath /tmp/pester-local-harness-finalize-proof-4 -IntegrationMode exclude -IncludePatterns tests/Get-PesterResultXmlSummary.Tests.ps1 -EmitFailuresJsonAlways`
- `git diff --check`

Refs #2069
