### PR TITLE
fix: normalize vi history paths on windows proof surfaces

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,9 +2,11 @@ self-hosted-runner:
   labels:
     - comparevi
     - capability-ingress
+    - docker-lane
     - labview-2026
     - lv32
-    - docker-lane
-    - teststand
-    - self-hosted-docker-linux
-    - hosted-docker-linux
+
+paths:
+  .github/workflows/release.yml:
+    ignore:
+      - 'SC2016:info:.*Expressions don''t expand in single quotes'

--- a/.github/workflows/pester-service-model-quality.yml
+++ b/.github/workflows/pester-service-model-quality.yml
@@ -111,6 +111,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: true
+          failIfEmpty: false
           args: >-
             --no-progress
             docs/knowledgebase/Pester-Service-Model.md

--- a/.github/workflows/pester-service-model-release-evidence.yml
+++ b/.github/workflows/pester-service-model-release-evidence.yml
@@ -119,10 +119,11 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: true
+          failIfEmpty: false
+          format: json
+          output: tests/results/_agent/pester-service-model/docs-link-check.json
           args: >-
             --no-progress
-            --format json
-            --output tests/results/_agent/pester-service-model/docs-link-check.json
             docs/knowledgebase/Pester-Service-Model.md
             docs/architecture/pester-service-model-control-plane.md
             docs/architecture/ADR-2078-pester-service-model-requirements.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -787,10 +787,13 @@ jobs:
         id: downstream_proving_policy
         if: always()
         shell: bash
+        env:
+          RELEASE_SOURCE_SHA: ${{ steps.release_source.outputs.source_sha }}
+          CURRENT_DEVELOP_SHA: ${{ steps.current_develop.outputs.develop_sha }}
         run: |
           set -euo pipefail
-          source_sha="${{ steps.release_source.outputs.source_sha }}"
-          develop_sha="${{ steps.current_develop.outputs.develop_sha }}"
+          source_sha="${RELEASE_SOURCE_SHA}"
+          develop_sha="${CURRENT_DEVELOP_SHA}"
           mode="advisory-replay"
           reason="release-publication-mode-not-publish"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -791,6 +791,7 @@ jobs:
           RELEASE_SOURCE_SHA: ${{ steps.release_source.outputs.source_sha }}
           CURRENT_DEVELOP_SHA: ${{ steps.current_develop.outputs.develop_sha }}
         run: |
+          # shellcheck disable=SC2016
           set -euo pipefail
           source_sha="${RELEASE_SOURCE_SHA}"
           develop_sha="${CURRENT_DEVELOP_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -789,18 +789,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          source_sha='${{ steps.release_source.outputs.source_sha }}'
-          develop_sha='${{ steps.current_develop.outputs.develop_sha }}'
-          mode='advisory-replay'
-          reason='release-publication-mode-not-publish'
+          source_sha="${{ steps.release_source.outputs.source_sha }}"
+          develop_sha="${{ steps.current_develop.outputs.develop_sha }}"
+          mode="advisory-replay"
+          reason="release-publication-mode-not-publish"
 
-          if [[ "${RELEASE_PUBLICATION_MODE}" == 'publish' ]]; then
+          if [[ "${RELEASE_PUBLICATION_MODE}" == "publish" ]]; then
             if [[ "$source_sha" == "$develop_sha" ]]; then
-              mode='required'
-              reason='release-source-matches-current-develop'
+              mode="required"
+              reason="release-source-matches-current-develop"
             else
-              mode='deferred-release-source-not-current-develop'
-              reason='release-source-differs-from-current-develop'
+              mode="deferred-release-source-not-current-develop"
+              reason="release-source-differs-from-current-develop"
             fi
           fi
 

--- a/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
+++ b/docs/DOWNSTREAM_DEVELOP_PROMOTION_CONTRACT.md
@@ -19,8 +19,15 @@ It is not a second feature-development branch.
 - Optional LV32 shadow proof receipt output:
   `tests/results/_agent/promotion/vi-history-lv32-shadow-proof-receipt.json`
 - Template-agent verification lane report: `tests/results/_agent/promotion/template-agent-verification-report.json`
-- Authoritative template verification overlay: `tests/results/_agent/promotion/template-agent-verification-report.local.json`, projected during bootstrap from the latest matching downstream proving artifact for the current `develop` source SHA
-- Supported template-proof authority synthesis: `tests/results/_agent/promotion/template-agent-verification-report.supported.json`, projected from the latest supported `template-smoke` `workflow_dispatch` proof on a supported consumer fork when that proof is aligned to the current canonical template head
+- Authoritative template verification overlay:
+  `tests/results/_agent/promotion/template-agent-verification-report.local.json`,
+  projected during bootstrap from the latest matching downstream proving
+  artifact for the current `develop` source SHA
+- Supported template-proof authority synthesis:
+  `tests/results/_agent/promotion/template-agent-verification-report.supported.json`,
+  projected from the latest supported `template-smoke` `workflow_dispatch`
+  proof on a supported consumer fork when that proof is aligned to the current
+  canonical template head
 - Selection resolver: `tools/priority/resolve-downstream-proving-artifact.mjs`
 - Selection schema: `docs/schemas/downstream-proving-selection-v1.schema.json`
 - Selection output: `tests/results/_agent/release/downstream-proving-selection.json`

--- a/docs/architecture/ADR-2078-pester-service-model-requirements.md
+++ b/docs/architecture/ADR-2078-pester-service-model-requirements.md
@@ -14,6 +14,7 @@ yet fully specified or traceable as a control plane.
 ## Decision
 
 Create a dedicated assurance packet for the Pester service model with:
+
 - an SRS
 - an RTM
 - an architecture packet

--- a/docs/architecture/pester-service-model-control-plane.md
+++ b/docs/architecture/pester-service-model-control-plane.md
@@ -103,10 +103,15 @@
   `REQ-PSM-012` maps to selection plus explicit execution-pack entrypoints.
   `REQ-PSM-013` maps to `tools/PesterPathHygiene.ps1`, local harness path
   hygiene, and session-lock safety before dispatch.
-  `REQ-PSM-014` maps to `tools/Replay-PesterServiceModelArtifacts.Local.ps1`, `tools/Invoke-PesterEvidenceClassification.ps1`, and local replay of retained postprocess and evidence layers.
+  `REQ-PSM-014` maps to
+  `tools/Replay-PesterServiceModelArtifacts.Local.ps1`,
+  `tools/Invoke-PesterEvidenceClassification.ps1`, and local replay of
+  retained postprocess and evidence layers.
   `REQ-PSM-015` maps to the dispatch/finalize/postprocess/evidence split.
   `REQ-PSM-016` maps to durable execution telemetry.
-  `REQ-PSM-017` maps to schema-governed retained artifacts and readers, including explicit `unsupported-schema` outcomes for postprocess, evidence, and local replay.
+  `REQ-PSM-017` maps to schema-governed retained artifacts and readers,
+  including explicit `unsupported-schema` outcomes for postprocess, evidence,
+  and local replay.
   `REQ-PSM-018` maps to `pester-service-model-promotion-comparison.json`,
   release-evidence bundles, and representative baseline comparison rendered into
   the promotion dossier.
@@ -115,13 +120,22 @@
   `release-evidence-provenance.json`, and
   `promotion-dossier-provenance.json` across evidence, local replay, and
   promotion views.
-  `REQ-PSM-021` maps to operator-explainable gate outcomes, including `pester-operator-outcome.json` and shared summary or top-failure rendering from the same outcome contract.
-  `REQ-PSM-022` maps to the local autonomy loop that selects the next bounded requirement slice.
+  `REQ-PSM-021` maps to operator-explainable gate outcomes, including
+  `pester-operator-outcome.json` and shared summary or top-failure rendering
+  from the same outcome contract.
+  `REQ-PSM-022` maps to the local autonomy loop that selects the next bounded
+  requirement slice.
   `REQ-PSM-023` maps to the explicit autonomy policy and stop-condition surface.
-  `REQ-PSM-024` maps to representative retained-artifact replay compatibility, including schema-lite summary repair and legacy receipt tolerance.
-  `REQ-PSM-025` maps to the bounded local Windows-container surrogate for Docker Desktop Windows engine plus the pinned NI Windows image.
-  `REQ-PSM-026` maps to proof-check aware autonomy that reopens implemented requirements when representative replay regresses.
-  `REQ-PSM-027` maps to the machine-readable next-step escalation packet that hands off to the required proof surface when the current host cannot satisfy it.
+  `REQ-PSM-024` maps to representative retained-artifact replay
+  compatibility, including schema-lite summary repair and legacy receipt
+  tolerance.
+  `REQ-PSM-025` maps to the bounded local Windows-container surrogate for
+  Docker Desktop Windows engine plus the pinned NI Windows image.
+  `REQ-PSM-026` maps to proof-check aware autonomy that reopens implemented
+  requirements when representative replay regresses.
+  `REQ-PSM-027` maps to the machine-readable next-step escalation packet that
+  hands off to the required proof surface when the current host cannot satisfy
+  it.
 - Decision rationale:
   The service model exists to separate concerns and make failures classifiable by
   layer instead of inferred from one coupled self-hosted run.

--- a/docs/testing/local-proof-autonomy-program-test-plan.md
+++ b/docs/testing/local-proof-autonomy-program-test-plan.md
@@ -10,10 +10,10 @@
 
 | Test ID | Coverage | Layer | Priority | Notes |
 | --- | --- | --- | --- | --- |
-| `TEST-LPAP-001` packet aggregation and requirement ranking coverage | Assurance/Program | High | Verifies the program consumes sibling packet next-step artifacts and ranks requirement work ahead of escalation work |
-| `TEST-LPAP-002` shared-surface escalation merge coverage | Assurance/Program | High | Verifies shared escalations to the same external surface collapse into one bounded handoff packet |
-| `TEST-LPAP-003` post-local promotion escalation coverage | Assurance/Program | High | Verifies the program emits a machine-readable promotion escalation instead of `null` when local packets are complete |
-| `TEST-LPAP-004` concurrent bundle workspace safety coverage | Assurance/Program | High | Verifies packet-local CI surfaces use run-scoped audit bundle roots instead of deleting a shared `surface-bundle` workspace |
+| `TEST-LPAP-001` | Packet aggregation and requirement ranking coverage | Assurance/Program | High | Verifies the program consumes sibling packet next-step artifacts and ranks requirement work ahead of escalation work |
+| `TEST-LPAP-002` | Shared-surface escalation merge coverage | Assurance/Program | High | Verifies shared escalations to the same external surface collapse into one bounded handoff packet |
+| `TEST-LPAP-003` | Post-local promotion escalation coverage | Assurance/Program | High | Verifies the program emits a machine-readable promotion escalation instead of `null` when local packets are complete |
+| `TEST-LPAP-004` | Concurrent bundle workspace safety coverage | Assurance/Program | High | Verifies packet-local CI surfaces use run-scoped audit bundle roots instead of deleting a shared `surface-bundle` workspace |
 
 ## Entry Criteria
 

--- a/docs/testing/vi-history-local-proof-test-plan.md
+++ b/docs/testing/vi-history-local-proof-test-plan.md
@@ -10,18 +10,18 @@
 
 | Test ID | Coverage | Layer | Priority | Notes |
 | --- | --- | --- | --- | --- |
-| `TEST-VHLP-001` local Windows workflow replay coverage | Contract/Replay | High | Verifies the governed `vi-history-scenarios-windows` replay lane emits a bounded receipt and compare artifact paths, including bridge-backed Windows launch from Unix or WSL coordinators |
-| `TEST-VHLP-002` local refinement profile coverage | Execution/Local | High | Verifies `proof`, `dev-fast`, `warm-dev`, and `windows-mirror-proof` local refinement behavior and retained receipts |
-| `TEST-VHLP-003` local operator-session coverage | Operator/Local | High | Verifies local operator-session wrappers consume the refinement helper and emit canonical local session contracts |
-| `TEST-VHLP-004` workflow-readiness envelope coverage | Evidence/Decision | High | Verifies the VI History workflow-readiness envelope captures lane lifecycle, verdict, and recommendation |
-| `TEST-VHLP-005` local autonomy-loop coverage | Assurance/Contract | High | Verifies local VI History CI emits a report, ranked backlog, and next-step artifact |
-| `TEST-VHLP-006` next-step escalation coverage | Assurance/Contract | High | Verifies local VI History CI emits a machine-readable escalation step to the shared Windows Docker Desktop + NI image surface only after native or reachable bridge-backed Windows checks cannot satisfy it |
-| `TEST-VHLP-007` shared local-program selector coverage | Assurance/Contract | High | Verifies the shared program selector can choose VI History requirement work explicitly and merge the shared Windows Docker Desktop + NI image escalation across sibling packets |
-| `TEST-VHLP-008` clone-backed live-history candidate governance coverage | Assurance/Contract | High | Verifies the packet names `ni/labview-icon-editor` plus `Tooling/deployment/VIP_Pre-Uninstall Custom Action.vi` as the governed clone-backed live-history candidate |
-| `TEST-VHLP-009` live-history candidate readiness coverage | Assurance/Contract | High | Verifies local VI History CI validates clone presence, target path presence, and git history, then emits a bounded clone-preparation escalation when the candidate is unavailable |
-| `TEST-VHLP-010` explicit Windows replay next-step coverage | Assurance/Contract | High | Verifies local VI History CI emits `vi-history-windows-workflow-replay` as the next step when the shared Windows surface and live-history candidate are ready, instead of launching the replay lane during packet selection |
-| `TEST-VHLP-011` bounded Windows replay lifecycle coverage | Contract/Replay | High | Verifies the governed Windows workflow replay lane terminates or fails closed within bounded helper-process timeouts and still emits a replay receipt on timeout |
-| `TEST-VHLP-012` replay receipt consumption coverage | Assurance/Contract | High | Verifies local VI History CI treats an existing passing `vi-history-scenarios-windows` replay receipt as satisfied local replay proof and advances beyond replay re-selection |
+| `TEST-VHLP-001` | Local Windows workflow replay coverage | Contract/Replay | High | Verifies the governed `vi-history-scenarios-windows` replay lane emits a bounded receipt and compare artifact paths, including bridge-backed Windows launch from Unix or WSL coordinators |
+| `TEST-VHLP-002` | Local refinement profile coverage | Execution/Local | High | Verifies `proof`, `dev-fast`, `warm-dev`, and `windows-mirror-proof` local refinement behavior and retained receipts |
+| `TEST-VHLP-003` | Local operator-session coverage | Operator/Local | High | Verifies local operator-session wrappers consume the refinement helper and emit canonical local session contracts |
+| `TEST-VHLP-004` | Workflow-readiness envelope coverage | Evidence/Decision | High | Verifies the VI History workflow-readiness envelope captures lane lifecycle, verdict, and recommendation |
+| `TEST-VHLP-005` | Local autonomy-loop coverage | Assurance/Contract | High | Verifies local VI History CI emits a report, ranked backlog, and next-step artifact |
+| `TEST-VHLP-006` | Next-step escalation coverage | Assurance/Contract | High | Verifies local VI History CI emits a machine-readable escalation step to the shared Windows Docker Desktop + NI image surface only after native or reachable bridge-backed Windows checks cannot satisfy it |
+| `TEST-VHLP-007` | Shared local-program selector coverage | Assurance/Contract | High | Verifies the shared program selector can choose VI History requirement work explicitly and merge the shared Windows Docker Desktop + NI image escalation across sibling packets |
+| `TEST-VHLP-008` | Clone-backed live-history candidate governance coverage | Assurance/Contract | High | Verifies the packet names `ni/labview-icon-editor` plus `Tooling/deployment/VIP_Pre-Uninstall Custom Action.vi` as the governed clone-backed live-history candidate |
+| `TEST-VHLP-009` | Live-history candidate readiness coverage | Assurance/Contract | High | Verifies local VI History CI validates clone presence, target path presence, and git history, then emits a bounded clone-preparation escalation when the candidate is unavailable |
+| `TEST-VHLP-010` | Explicit Windows replay next-step coverage | Assurance/Contract | High | Verifies local VI History CI emits `vi-history-windows-workflow-replay` as the next step when the shared Windows surface and live-history candidate are ready, instead of launching the replay lane during packet selection |
+| `TEST-VHLP-011` | Bounded Windows replay lifecycle coverage | Contract/Replay | High | Verifies the governed Windows workflow replay lane terminates or fails closed within bounded helper-process timeouts and still emits a replay receipt on timeout |
+| `TEST-VHLP-012` | Replay receipt consumption coverage | Assurance/Contract | High | Verifies local VI History CI treats an existing passing `vi-history-scenarios-windows` replay receipt as satisfied local replay proof and advances beyond replay re-selection |
 
 ## Entry Criteria
 
@@ -33,7 +33,8 @@
 - Contract tests and PowerShell tests covering the packet pass.
 - The local VI History CI emits a machine-readable next step.
 - The clone-backed live-history candidate is governed explicitly.
-- If the current host cannot satisfy the Windows replay lane, the next step is an explicit escalation packet rather than a prose-only advisory.
+- If the current host cannot satisfy the Windows replay lane, the next step is
+  an explicit escalation packet rather than a prose-only advisory.
 
 ## Traceability Notes
 

--- a/docs/testing/windows-docker-shared-surface-test-plan.md
+++ b/docs/testing/windows-docker-shared-surface-test-plan.md
@@ -10,16 +10,16 @@
 
 | Test ID | Coverage | Layer | Priority | Notes |
 | --- | --- | --- | --- | --- |
-| `TEST-WDSS-001` shared-surface readiness probe coverage | Probe/Receipt | High | Verifies the shared Windows readiness probe emits bounded readiness states and a machine-readable receipt |
-| `TEST-WDSS-002` bootstrap and preflight contract coverage | Bootstrap/Host | High | Verifies the deterministic Windows host bootstrap/preflight commands remain explicit and stable |
-| `TEST-WDSS-003` path-hygiene coverage | Safety/Local | High | Verifies the shared surface detects OneDrive-like managed roots and emits a relocation escalation |
-| `TEST-WDSS-004` local assurance-loop coverage | Assurance/Contract | High | Verifies the shared-surface local CI emits a report, proof checks, and next-step artifact |
-| `TEST-WDSS-005` host-unavailable escalation coverage | Assurance/Contract | High | Verifies local CI emits a machine-readable escalation to `windows-docker-desktop-ni-image` when the current host cannot satisfy the surface |
-| `TEST-WDSS-006` shared local-program selector coverage | Assurance/Contract | High | Verifies the shared surface participates explicitly in the program selector beside Pester and VI History |
-| `TEST-WDSS-007` reachable Windows host bridge coverage | Assurance/Contract | High | Verifies a Unix or WSL coordinator uses a reachable Windows host bridge for probe and preflight work before emitting host-unavailable escalation |
-| `TEST-WDSS-008` UNC-backed WSL staging coverage | Runtime/Windows Docker | High | Verifies UNC-backed WSL inputs and report paths are staged into a Windows-local mount root, synchronized back, and cleaned up after compare execution |
-| `TEST-WDSS-009` authoritative CI gate coverage | Workflow/Contract | High | Verifies Windows image-backed CI gates route through the shared Windows NI proof workflow and not through the generic Pester reusable workflow |
-| `TEST-WDSS-010` bounded timeout coverage | Runtime/Workflow | High | Verifies Windows preflight and runtime-manager Docker operations fail closed on timeout and the hosted preflight step carries an explicit workflow timeout |
+| `TEST-WDSS-001` | Shared-surface readiness probe coverage | Probe/Receipt | High | Verifies the shared Windows readiness probe emits bounded readiness states and a machine-readable receipt |
+| `TEST-WDSS-002` | Bootstrap and preflight contract coverage | Bootstrap/Host | High | Verifies the deterministic Windows host bootstrap/preflight commands remain explicit and stable |
+| `TEST-WDSS-003` | Path-hygiene coverage | Safety/Local | High | Verifies the shared surface detects OneDrive-like managed roots and emits a relocation escalation |
+| `TEST-WDSS-004` | Local assurance-loop coverage | Assurance/Contract | High | Verifies the shared-surface local CI emits a report, proof checks, and next-step artifact |
+| `TEST-WDSS-005` | Host-unavailable escalation coverage | Assurance/Contract | High | Verifies local CI emits a machine-readable escalation to `windows-docker-desktop-ni-image` when the current host cannot satisfy the surface |
+| `TEST-WDSS-006` | Shared local-program selector coverage | Assurance/Contract | High | Verifies the shared surface participates explicitly in the program selector beside Pester and VI History |
+| `TEST-WDSS-007` | Reachable Windows host bridge coverage | Assurance/Contract | High | Verifies a Unix or WSL coordinator uses a reachable Windows host bridge for probe and preflight work before emitting host-unavailable escalation |
+| `TEST-WDSS-008` | UNC-backed WSL staging coverage | Runtime/Windows Docker | High | Verifies UNC-backed WSL inputs and report paths are staged into a Windows-local mount root, synchronized back, and cleaned up after compare execution |
+| `TEST-WDSS-009` | Authoritative CI gate coverage | Workflow/Contract | High | Verifies Windows image-backed CI gates route through the shared Windows NI proof workflow and not through the generic Pester reusable workflow |
+| `TEST-WDSS-010` | Bounded timeout coverage | Runtime/Workflow | High | Verifies Windows preflight and runtime-manager Docker operations fail closed on timeout and the hosted preflight step carries an explicit workflow timeout |
 
 ## Entry Criteria
 
@@ -30,7 +30,8 @@
 
 - Contract and local-CI tests covering the packet pass.
 - The shared-surface local CI emits a machine-readable next step.
-- On a non-Windows host with no reachable Windows bridge, the next step is an explicit escalation packet rather than prose-only guidance.
+- On a non-Windows host with no reachable Windows bridge, the next step is an
+  explicit escalation packet rather than prose-only guidance.
 
 ## Traceability Notes
 

--- a/tests/CompareVI.GitRefs.VI2.Tests.ps1
+++ b/tests/CompareVI.GitRefs.VI2.Tests.ps1
@@ -2,24 +2,36 @@
 Describe 'CompareVI with Git refs (VI2.vi at two commits)' -Tag 'CompareVI','Integration' {
   BeforeAll {
     $ErrorActionPreference = 'Stop'
+    $script:_skipCompareVIGitRefsReason = $null
     try { git --version | Out-Null } catch { throw 'git is required for this test' }
     $repoRoot = (Get-Location).Path
     $target = 'VI2.vi'
     if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $target))) {
-      Set-ItResult -Skipped -Because "Target file not found: $target"
+      $script:_skipCompareVIGitRefsReason = "Target file not found: $target"
+      return
     }
 
     $revList = & git rev-list --max-count=50 HEAD -- $target
-    if (-not $revList) { Set-ItResult -Skipped -Because 'No history for target'; return }
+    if (-not $revList) {
+      $script:_skipCompareVIGitRefsReason = 'No history for target'
+      return
+    }
     $pairs = @()
     foreach ($a in $revList) { foreach ($b in $revList) { if ($a -ne $b) { $pairs += [pscustomobject]@{ A=$a; B=$b } } } }
-    if (-not $pairs) { Set-ItResult -Skipped -Because 'Not enough refs' }
+    if (-not $pairs) {
+      $script:_skipCompareVIGitRefsReason = 'Not enough refs'
+      return
+    }
     Set-Variable -Name '_repo' -Value $repoRoot -Scope Script
     Set-Variable -Name '_pairs' -Value $pairs -Scope Script
     Set-Variable -Name '_target' -Value $target -Scope Script
   }
 
   It 'produces exec and summary JSON from two refs (non-failing check)' {
+    if ($script:_skipCompareVIGitRefsReason) {
+      Set-ItResult -Skipped -Because $script:_skipCompareVIGitRefsReason
+      return
+    }
     $pair = $null
     foreach ($p in $_pairs) {
       & git show --no-renames -- "$($p.A):$_target" 1>$null 2>$null; $okA = ($LASTEXITCODE -eq 0)
@@ -55,5 +67,52 @@ Describe 'CompareVI with Git refs (VI2.vi at two commits)' -Tag 'CompareVI','Int
     $s.schema | Should -Be 'ref-compare-summary/v1'
 
     "VI2 refs: A=$($pair.A) B=$($pair.B) expectDiff=$($s.computed.expectDiff) cliDiff=$($s.cli.diff) exit=$($s.cli.exitCode)" | Write-Host
+  }
+
+  It 'strips provider-qualified results paths from emitted ref-compare artifacts' {
+    if ($script:_skipCompareVIGitRefsReason) {
+      Set-ItResult -Skipped -Because $script:_skipCompareVIGitRefsReason
+      return
+    }
+    $pair = $null
+    foreach ($p in $_pairs) {
+      & git show --no-renames -- "$($p.A):$_target" 1>$null 2>$null; $okA = ($LASTEXITCODE -eq 0)
+      & git show --no-renames -- "$($p.B):$_target" 1>$null 2>$null; $okB = ($LASTEXITCODE -eq 0)
+      if ($okA -and $okB) { $pair = $p; break }
+    }
+    if (-not $pair) { Set-ItResult -Skipped -Because 'No valid ref pair with content'; return }
+
+    $rd = Join-Path $TestDrive 'ref-compare-vi2-provider'
+    New-Item -ItemType Directory -Path $rd -Force | Out-Null
+    $providerResultsDir = "Microsoft.PowerShell.Core\FileSystem::$rd"
+    $stubPath = Join-Path $_repo 'tests/stubs/Invoke-LVCompare.stub.ps1'
+
+    & pwsh -NoLogo -NoProfile -File (Join-Path $_repo 'tools/Compare-RefsToTemp.ps1') `
+      -Path $_target `
+      -RefA $pair.A `
+      -RefB $pair.B `
+      -ResultsDir $providerResultsDir `
+      -OutName 'vi2-provider' `
+      -Detailed `
+      -RenderReport `
+      -InvokeScriptPath $stubPath `
+      -FailOnDiff:$false | Out-Null
+
+    $sum = Join-Path $rd 'vi2-provider-summary.json'
+    $sum | Should -Exist
+    $summary = Get-Content -LiteralPath $sum -Raw | ConvertFrom-Json -Depth 10
+    foreach ($pathValue in @(
+      [string]$summary.out.execJson,
+      [string]$summary.out.captureJson,
+      [string]$summary.out.stdout,
+      [string]$summary.out.stderr,
+      [string]$summary.out.reportHtml,
+      [string]$summary.out.reportPath,
+      [string]$summary.out.artifactDir
+    )) {
+      if (-not [string]::IsNullOrWhiteSpace($pathValue)) {
+        $pathValue | Should -Not -Match 'Microsoft\.PowerShell\.Core\\FileSystem::'
+      }
+    }
   }
 }

--- a/tests/TestFileExistsAtRef.Tests.ps1
+++ b/tests/TestFileExistsAtRef.Tests.ps1
@@ -235,4 +235,204 @@ exit 0
     $manifest.stats.missing | Should -Be 0
     $manifest.comparisons | Should -Not -BeNullOrEmpty
   }
+
+  It 'emits native history paths when results dir is provider-qualified' {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $compareHistoryScript = Join-Path $repoRoot 'tools' 'Compare-VIHistory.ps1'
+
+    $tempRepo = Join-Path $TestDrive 'crossrepo-history-provider'
+    New-Item -ItemType Directory -Path $tempRepo -Force | Out-Null
+
+    Push-Location $tempRepo
+    try {
+      & git init | Out-Null
+      & git config user.name 'CompareVI Tests' | Out-Null
+      & git config user.email 'comparevi.tests@example.com' | Out-Null
+
+      $targetRelPath = 'Tooling/deployment/VIP_Post-Install Custom Action.vi'
+      New-Item -ItemType Directory -Path (Split-Path -Parent $targetRelPath) -Force | Out-Null
+
+      'base version' | Set-Content -LiteralPath $targetRelPath -Encoding utf8
+      & git add . | Out-Null
+      & git commit -m 'feat: add VIP post-install action' | Out-Null
+
+      'updated version' | Set-Content -LiteralPath $targetRelPath -Encoding utf8
+      & git add . | Out-Null
+      & git commit -m 'fix: adjust VIP post-install action' | Out-Null
+      $headCommit = (& git rev-parse HEAD).Trim()
+    }
+    finally {
+      Pop-Location
+    }
+
+    $stubPath = Join-Path $TestDrive 'Invoke-LVCompare.crossrepo.provider.stub.ps1'
+    @'
+param(
+  [Parameter(Mandatory = $true)][string]$BaseVi,
+  [Parameter(Mandatory = $true)][string]$HeadVi,
+  [string]$OutputDir,
+  [string]$LabVIEWExePath,
+  [string]$LabVIEWBitness = "64",
+  [string]$LVComparePath,
+  [string[]]$Flags,
+  [switch]$ReplaceFlags,
+  [switch]$AllowSameLeaf,
+  [switch]$RenderReport,
+  [ValidateSet("html","xml","text")][string[]]$ReportFormat = "html",
+  [string]$JsonLogPath,
+  [switch]$Quiet,
+  [switch]$LeakCheck,
+  [double]$LeakGraceSeconds = 0,
+  [string]$LeakJsonPath,
+  [string]$CaptureScriptPath,
+  [switch]$Summary,
+  [Nullable[int]]$TimeoutSeconds,
+  [Parameter(ValueFromRemainingArguments = $true)][string[]]$PassThru
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $OutputDir) {
+  $OutputDir = Join-Path $env:TEMP ("history-stub-" + [guid]::NewGuid().ToString("N"))
+}
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+$reportPath = Join-Path $OutputDir 'compare-report.html'
+$capturePath = Join-Path $OutputDir 'lvcompare-capture.json'
+$stdoutPath = Join-Path $OutputDir 'lvcompare-stdout.txt'
+$stderrPath = Join-Path $OutputDir 'lvcompare-stderr.txt'
+
+"<html><body><h1>Stub Compare Report</h1></body></html>" | Set-Content -LiteralPath $reportPath -Encoding utf8
+"" | Set-Content -LiteralPath $stdoutPath -Encoding utf8
+"" | Set-Content -LiteralPath $stderrPath -Encoding utf8
+
+[ordered]@{
+  schema    = 'lvcompare-capture-v1'
+  timestamp = (Get-Date).ToString('o')
+  base      = $BaseVi
+  head      = $HeadVi
+  cliPath   = 'stub'
+  args      = $Flags
+  exitCode  = 0
+  seconds   = 0.05
+  command   = 'stub'
+} | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $capturePath -Encoding utf8
+
+$parentDir = Split-Path -Parent $OutputDir
+$outLeaf = Split-Path -Leaf $OutputDir
+if ($outLeaf -like '*-artifacts') {
+  $outName = $outLeaf.Substring(0, $outLeaf.Length - '-artifacts'.Length)
+} else {
+  $outName = $outLeaf
+}
+$summaryPath = Join-Path $parentDir ("{0}-summary.json" -f $outName)
+$execPath = Join-Path $parentDir ("{0}-exec.json" -f $outName)
+
+[ordered]@{
+  schema      = 'ref-compare-summary/v1'
+  generatedAt = (Get-Date).ToString('o')
+  name        = Split-Path -Leaf $HeadVi
+  path        = $HeadVi
+  refA        = $BaseVi
+  refB        = $HeadVi
+  temp        = $OutputDir
+  reportFormat= 'html'
+  out         = [pscustomobject]@{
+    captureJson = $capturePath
+    reportPath  = $reportPath
+    stdout      = $stdoutPath
+    stderr      = $stderrPath
+  }
+  computed    = [ordered]@{
+    baseBytes  = 0
+    headBytes  = 0
+    baseSha    = 'stub-base'
+    headSha    = 'stub-head'
+    expectDiff = $false
+  }
+  cli         = [pscustomobject]@{
+    exitCode   = 0
+    diff       = $false
+    duration_s = 0.05
+    command    = 'stub'
+    cliPath    = 'stub'
+  }
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+[ordered]@{
+  schema      = 'compare-exec/v1'
+  generatedAt = (Get-Date).ToString('o')
+  cliPath     = 'stub'
+  command     = 'stub'
+  args        = @()
+  exitCode    = 0
+  diff        = $false
+  cwd         = (Get-Location).Path
+  duration_s  = 0.05
+  base        = $BaseVi
+  head        = $HeadVi
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $execPath -Encoding utf8
+
+exit 0
+'@ | Set-Content -LiteralPath $stubPath -Encoding utf8
+
+    $resultsDir = Join-Path $TestDrive 'crossrepo-history-provider-results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+    $providerResultsDir = "Microsoft.PowerShell.Core\FileSystem::$resultsDir"
+    $previousScriptsRoot = $env:COMPAREVI_SCRIPTS_ROOT
+    $env:COMPAREVI_SCRIPTS_ROOT = $repoRoot
+    try {
+      Push-Location $tempRepo
+      try {
+        $args = @(
+          '-NoLogo','-NoProfile','-File', $compareHistoryScript,
+          '-TargetPath', 'Tooling/deployment/VIP_Post-Install Custom Action.vi',
+          '-StartRef', $headCommit,
+          '-MaxPairs', '1',
+          '-RenderReport',
+          '-FailOnDiff:$false',
+          '-ResultsDir', $providerResultsDir,
+          '-InvokeScriptPath', $stubPath,
+          '-Quiet'
+        )
+        & pwsh @args | Out-Null
+      }
+      finally {
+        Pop-Location
+      }
+    }
+    finally {
+      if ($null -ne $previousScriptsRoot) {
+        $env:COMPAREVI_SCRIPTS_ROOT = $previousScriptsRoot
+      } else {
+        Remove-Item Env:COMPAREVI_SCRIPTS_ROOT -ErrorAction SilentlyContinue
+      }
+    }
+
+    $aggregateManifestPath = Join-Path $resultsDir 'manifest.json'
+    $modeManifestPath = Join-Path $resultsDir 'default' 'manifest.json'
+    $historySummaryPath = Join-Path $resultsDir 'history-summary.json'
+
+    $aggregateManifestPath | Should -Exist
+    $modeManifestPath | Should -Exist
+    $historySummaryPath | Should -Exist
+
+    $aggregateManifest = Get-Content -LiteralPath $aggregateManifestPath -Raw | ConvertFrom-Json -Depth 8
+    $modeManifest = Get-Content -LiteralPath $modeManifestPath -Raw | ConvertFrom-Json -Depth 8
+    $historySummary = Get-Content -LiteralPath $historySummaryPath -Raw | ConvertFrom-Json -Depth 8
+
+    foreach ($pathValue in @(
+      [string]$aggregateManifest.modes[0].manifestPath,
+      [string]$aggregateManifest.modes[0].resultsDir,
+      [string]$modeManifest.resultsDir,
+      [string]$historySummary.execution.resultsDir,
+      [string]$historySummary.execution.manifestPath,
+      [string]$historySummary.reports.markdownPath,
+      [string]$historySummary.reports.htmlPath
+    )) {
+      if (-not [string]::IsNullOrWhiteSpace($pathValue)) {
+        $pathValue | Should -Not -Match 'Microsoft\.PowerShell\.Core\\FileSystem::'
+      }
+    }
+  }
 }

--- a/tools/Compare-RefsToTemp.ps1
+++ b/tools/Compare-RefsToTemp.ps1
@@ -29,6 +29,36 @@ try { git --version | Out-Null } catch { throw 'git is required on PATH to fetch
 
 $repoRoot = (Get-Location).Path
 
+function Convert-ToNativeFileSystemPath {
+  param([AllowNull()][string]$PathValue)
+  if ([string]::IsNullOrWhiteSpace($PathValue)) { return $PathValue }
+
+  $candidate = [string]$PathValue
+  $lastProviderSeparator = $candidate.LastIndexOf('::', [System.StringComparison]::Ordinal)
+  if ($lastProviderSeparator -ge 0) {
+    $candidate = $candidate.Substring($lastProviderSeparator + 2)
+  }
+  $candidate = ($candidate -replace '^[A-Za-z][A-Za-z0-9.+-]*::', '')
+  if ($candidate -match '^[\\/](wsl\.localhost|wsl\$)[\\/]') {
+    $candidate = [System.IO.Path]::DirectorySeparatorChar + $candidate
+  }
+  try {
+    $resolved = Resolve-Path -LiteralPath $candidate -ErrorAction Stop | Select-Object -First 1
+    $providerPath = [string]$resolved.ProviderPath
+    if (-not [string]::IsNullOrWhiteSpace($providerPath)) {
+      return [System.IO.Path]::GetFullPath($providerPath)
+    }
+  } catch {}
+
+  try {
+    return [System.IO.Path]::GetFullPath($candidate)
+  } catch {
+    return $candidate
+  }
+}
+
+$repoRoot = Convert-ToNativeFileSystemPath -PathValue $repoRoot
+
 function Resolve-CompareVIScriptsRoot {
   param([string]$PrimaryRoot)
 
@@ -80,7 +110,13 @@ function Split-ArgString {
 function Normalize-ExistingPath {
   param([string]$Candidate)
   if ([string]::IsNullOrWhiteSpace($Candidate)) { return $null }
-  try { return (Resolve-Path -LiteralPath $Candidate -ErrorAction Stop).Path } catch { return $Candidate }
+  try { return Convert-ToNativeFileSystemPath -PathValue $Candidate } catch { return $Candidate }
+}
+
+function Resolve-NativeExistingPath {
+  param([string]$Candidate)
+  if ([string]::IsNullOrWhiteSpace($Candidate)) { return $null }
+  try { return Convert-ToNativeFileSystemPath -PathValue $Candidate } catch { return $Candidate }
 }
 
 function Resolve-TempRoot {
@@ -636,6 +672,7 @@ Get-FileAtRef -ref $RefA -relPath $Path -dest $base
 Get-FileAtRef -ref $RefB -relPath $Path -dest $head
 
 $rd = if ([System.IO.Path]::IsPathRooted($ResultsDir)) { $ResultsDir } else { Join-Path $repoRoot $ResultsDir }
+$rd = Convert-ToNativeFileSystemPath -PathValue $rd
 New-Item -ItemType Directory -Path $rd -Force | Out-Null
 $execPath = Join-Path $rd ("$OutName-exec.json")
 $sumPath  = Join-Path $rd ("$OutName-summary.json")
@@ -838,7 +875,7 @@ if ($detailRequested) {
       if (-not $candidatePath) { continue }
       if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
         try {
-          $leakResolvedPath = (Resolve-Path -LiteralPath $candidatePath).Path
+          $leakResolvedPath = Resolve-NativeExistingPath -Candidate $candidatePath
         } catch {
           $leakResolvedPath = $candidatePath
         }
@@ -875,18 +912,18 @@ if ($detailRequested) {
     }
   }
 
-  if (Test-Path -LiteralPath $capturePath) { $detailPaths.captureJson = (Resolve-Path -LiteralPath $capturePath).Path }
-  if (Test-Path -LiteralPath $stdoutPath)  { $detailPaths.stdout       = (Resolve-Path -LiteralPath $stdoutPath).Path }
-  if (Test-Path -LiteralPath $stderrPath)  { $detailPaths.stderr       = (Resolve-Path -LiteralPath $stderrPath).Path }
+  if (Test-Path -LiteralPath $capturePath) { $detailPaths.captureJson = Resolve-NativeExistingPath -Candidate $capturePath }
+  if (Test-Path -LiteralPath $stdoutPath)  { $detailPaths.stdout       = Resolve-NativeExistingPath -Candidate $stdoutPath }
+  if (Test-Path -LiteralPath $stderrPath)  { $detailPaths.stderr       = Resolve-NativeExistingPath -Candidate $stderrPath }
   $reportResolved = $null
   if ($reportFile -and (Test-Path -LiteralPath $reportFile)) {
-    $reportResolved = (Resolve-Path -LiteralPath $reportFile).Path
+    $reportResolved = Resolve-NativeExistingPath -Candidate $reportFile
     $detailPaths.reportPath = $reportResolved
     if ($reportFormatEffective -eq 'html') {
       $detailPaths.reportHtml = $reportResolved
     }
   }
-  if (Test-Path -LiteralPath $imagesDir)   { $detailPaths.imagesDir    = (Resolve-Path -LiteralPath $imagesDir).Path }
+  if (Test-Path -LiteralPath $imagesDir)   { $detailPaths.imagesDir    = Resolve-NativeExistingPath -Candidate $imagesDir }
   if ($reportFormatEffective -eq 'html' -and $reportResolved) {
     $includedAttributes = Get-IncludedAttributesFromReport -ReportPath $reportResolved
     $reportMetadata = Get-ReportCategoryMetadata -ReportPath $reportResolved
@@ -933,14 +970,14 @@ if (-not $cliDiff -and $cliExit -eq $null) { $cliExit = 0 }
 
 $exec = Get-Content -LiteralPath $execPath -Raw | ConvertFrom-Json -Depth 6
 
-$outPaths = [ordered]@{ execJson = (Resolve-Path -LiteralPath $execPath).Path }
+$outPaths = [ordered]@{ execJson = (Resolve-NativeExistingPath -Candidate $execPath) }
 foreach ($k in @('captureJson','stdout','stderr','reportHtml','reportPath','imagesDir')) {
   if ($detailPaths.Contains($k) -and $detailPaths[$k]) { $outPaths[$k] = $detailPaths[$k] }
 }
 if ($detailPaths.Contains('leakJson') -and $detailPaths['leakJson']) {
   $outPaths.leakJson = $detailPaths['leakJson']
 }
-if ($artifactDir) { $outPaths.artifactDir = (Resolve-Path -LiteralPath $artifactDir).Path }
+if ($artifactDir) { $outPaths.artifactDir = Resolve-NativeExistingPath -Candidate $artifactDir }
 
 $cliSummary = [ordered]@{
   exitCode    = $cliExit

--- a/tools/Compare-VIHistory.ps1
+++ b/tools/Compare-VIHistory.ps1
@@ -722,6 +722,47 @@ function Invoke-ProcessCapture {
   }
 }
 
+function Convert-ToNativeFileSystemPath {
+  param([AllowNull()][string]$PathValue)
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $PathValue
+  }
+
+  $candidate = [string]$PathValue
+  $lastProviderSeparator = $candidate.LastIndexOf('::', [System.StringComparison]::Ordinal)
+  if ($lastProviderSeparator -ge 0) {
+    $candidate = $candidate.Substring($lastProviderSeparator + 2)
+  }
+  $candidate = ($candidate -replace '^[A-Za-z][A-Za-z0-9.+-]*::', '')
+  if ($candidate -match '^[\\/](wsl\.localhost|wsl\$)[\\/]') {
+    $candidate = [System.IO.Path]::DirectorySeparatorChar + $candidate
+  }
+  try {
+    $resolved = Resolve-Path -LiteralPath $candidate -ErrorAction Stop | Select-Object -First 1
+    $providerPath = [string]$resolved.ProviderPath
+    if (-not [string]::IsNullOrWhiteSpace($providerPath)) {
+      return [System.IO.Path]::GetFullPath($providerPath)
+    }
+  } catch {}
+
+  try {
+    return [System.IO.Path]::GetFullPath($candidate)
+  } catch {
+    return $candidate
+  }
+}
+
+function Resolve-NativeExistingPath {
+  param([AllowNull()][string]$PathValue)
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $PathValue
+  }
+
+  return Convert-ToNativeFileSystemPath -PathValue $PathValue
+}
+
 function Invoke-Git {
   param(
     [Parameter(Mandatory = $true)][string[]]$Arguments,
@@ -1448,9 +1489,7 @@ if ($labVIEWIniPath) {
 }
 
 $repoRoot = Resolve-RepoRoot
-try {
-  $repoRoot = [System.IO.Path]::GetFullPath($repoRoot)
-} catch {}
+$repoRoot = Convert-ToNativeFileSystemPath -PathValue $repoRoot
 
 if ([string]::IsNullOrWhiteSpace($TargetPath)) {
   throw 'TargetPath cannot be empty.'
@@ -1461,7 +1500,7 @@ try {
   if (-not [System.IO.Path]::IsPathRooted($targetFullPath)) {
     $targetFullPath = Join-Path $repoRoot $targetFullPath
   }
-  $targetFullPath = [System.IO.Path]::GetFullPath($targetFullPath)
+  $targetFullPath = Convert-ToNativeFileSystemPath -PathValue $targetFullPath
 } catch {
   throw ("Unable to resolve TargetPath '{0}': {1}" -f $TargetPath, $_.Exception.Message)
 }
@@ -1470,25 +1509,40 @@ if (-not (Test-Path -LiteralPath $targetFullPath -PathType Leaf)) {
   Write-Verbose ("TargetPath '{0}' not found on disk; continuing with git history refs." -f $targetFullPath)
 }
 
-$targetRel = $targetFullPath
-try {
-  if ($repoRoot) {
-    $rootNormalized = [System.IO.Path]::GetFullPath($repoRoot)
-    $rootPrefix = $rootNormalized.TrimEnd('\','/')
-    if ($rootPrefix.Length -gt 0) {
-      $rootPrefix = $rootPrefix + [System.IO.Path]::DirectorySeparatorChar
+$targetRel = [string]$TargetPath
+$targetRelProviderStripped = $targetRel -replace '^[A-Za-z][A-Za-z0-9.+-]*::', ''
+$preferOriginalRelativeTargetPath = (
+  -not [string]::IsNullOrWhiteSpace($targetRelProviderStripped) -and
+  -not [System.IO.Path]::IsPathRooted($targetRelProviderStripped) -and
+  -not $targetRelProviderStripped.StartsWith('\\') -and
+  -not $targetRelProviderStripped.StartsWith('//')
+)
+
+if ($preferOriginalRelativeTargetPath) {
+  $targetRel = $targetRelProviderStripped
+} else {
+  $targetRel = $targetFullPath
+  try {
+    if ($repoRoot) {
+      $rootNormalized = [System.IO.Path]::GetFullPath($repoRoot)
+      $rootPrefix = $rootNormalized.TrimEnd('\','/')
+      if ($rootPrefix.Length -gt 0) {
+        $rootPrefix = $rootPrefix + [System.IO.Path]::DirectorySeparatorChar
+      }
+      if ($targetFullPath.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $targetRel = $targetFullPath.Substring($rootPrefix.Length).TrimStart('\','/')
+      }
     }
-    if ($targetFullPath.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-      $targetRel = $targetFullPath.Substring($rootPrefix.Length).TrimStart('\','/')
-    }
-  }
-} catch {}
+  } catch {}
+}
+
+$targetRel = ($targetRel -replace '^[A-Za-z][A-Za-z0-9.+-]*::', '')
 $targetRel = ($targetRel -replace '\\','/').Trim('/')
 if ([string]::IsNullOrWhiteSpace($targetRel)) {
   throw ("TargetPath '{0}' could not be normalized relative to repository root '{1}'." -f $TargetPath, $repoRoot)
 }
 Write-Verbose ("Normalized target path: {0}" -f $targetRel)
-$targetLeaf = Split-Path $targetRel -Leaf
+$targetLeaf = @($targetRel -split '/+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
 if ([string]::IsNullOrWhiteSpace($targetLeaf)) { $targetLeaf = 'vi' }
 
 $startRef = if ([string]::IsNullOrWhiteSpace($StartRef)) { 'HEAD' } else { $StartRef.Trim() }
@@ -1544,8 +1598,9 @@ if ($resolvedStartRef -ne $startRef) {
 }
 
 $resultsRoot = if ([System.IO.Path]::IsPathRooted($ResultsDir)) { $ResultsDir } else { Join-Path $repoRoot $ResultsDir }
+$resultsRoot = Convert-ToNativeFileSystemPath -PathValue $resultsRoot
 New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
-$resultsRootResolved = (Resolve-Path -LiteralPath $resultsRoot).Path
+$resultsRootResolved = Resolve-NativeExistingPath -PathValue $resultsRoot
 
 $aggregateManifestPath = if ($ManifestPath) {
   if ([System.IO.Path]::IsPathRooted($ManifestPath)) { $ManifestPath } else { Join-Path $repoRoot $ManifestPath }
@@ -1807,8 +1862,9 @@ foreach ($modeSpec in $modeSpecs) {
   Write-Verbose ("Mode {0} flags: {1}" -f $modeName, $mf)
 
   $modeResultsRoot = Join-Path $resultsRoot $modeSlug
+  $modeResultsRoot = Convert-ToNativeFileSystemPath -PathValue $modeResultsRoot
   New-Item -ItemType Directory -Path $modeResultsRoot -Force | Out-Null
-  $modeResultsResolved = (Resolve-Path -LiteralPath $modeResultsRoot).Path
+  $modeResultsResolved = Resolve-NativeExistingPath -PathValue $modeResultsRoot
   $modeResultsRelative = $null
   if ($modeResultsResolved) {
     try {
@@ -2076,7 +2132,7 @@ foreach ($modeSpec in $modeSpecs) {
         if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
           Write-Warning ("Summary not found at {0}; generating fallback summary from exec data." -f $summaryPath)
           $fallbackOut = [ordered]@{
-            execJson = if (Test-Path -LiteralPath $execPath -PathType Leaf) { (Resolve-Path -LiteralPath $execPath).Path } else { $null }
+            execJson = if (Test-Path -LiteralPath $execPath -PathType Leaf) { (Resolve-NativeExistingPath -PathValue $execPath) } else { $null }
           }
           $fallbackCli = [ordered]@{
             exitCode    = $null
@@ -2127,8 +2183,8 @@ foreach ($modeSpec in $modeSpecs) {
 
       $diff = [bool]$summaryJson.cli.diff
       $comparisonRecord.result = [ordered]@{
-        summaryPath = (Resolve-Path -LiteralPath $summaryPath).Path
-        execPath    = if (Test-Path -LiteralPath $execPath) { (Resolve-Path -LiteralPath $execPath).Path } else { $null }
+        summaryPath = Resolve-NativeExistingPath -PathValue $summaryPath
+        execPath    = if (Test-Path -LiteralPath $execPath) { (Resolve-NativeExistingPath -PathValue $execPath) } else { $null }
         diff        = $diff
         exitCode    = $summaryJson.cli.exitCode
         duration_s  = $summaryJson.cli.duration_s
@@ -2302,7 +2358,7 @@ foreach ($modeSpec in $modeSpecs) {
             Remove-Item -LiteralPath $artifactDir -Recurse -Force -ErrorAction SilentlyContinue
           }
         } elseif (Test-Path -LiteralPath $artifactDir) {
-          $comparisonRecord.result.artifactDir = (Resolve-Path -LiteralPath $artifactDir).Path
+          $comparisonRecord.result.artifactDir = Resolve-NativeExistingPath -PathValue $artifactDir
         }
       }
       $categoryDetails = $null
@@ -2450,7 +2506,7 @@ foreach ($modeSpec in $modeSpecs) {
   $collapsedNoiseStats.count = $noiseCollapsedCount
 
   $modeManifest | ConvertTo-Json -Depth 8 | Out-File -FilePath $modeManifestPath -Encoding utf8
-  $modeManifestResolved = (Resolve-Path -LiteralPath $modeManifestPath).Path
+  $modeManifestResolved = Resolve-NativeExistingPath -PathValue $modeManifestPath
 
   if (-not $hasStepSummary) {
     $summaryLines += ''
@@ -2724,7 +2780,7 @@ if ($executedModeNames.Count -gt 0) {
 }
 
 $aggregate | ConvertTo-Json -Depth 8 | Out-File -FilePath $aggregateManifestPath -Encoding utf8
-$aggregateManifestResolved = (Resolve-Path -LiteralPath $aggregateManifestPath).Path
+$aggregateManifestResolved = Resolve-NativeExistingPath -PathValue $aggregateManifestPath
 Write-GitHubOutput -Key 'manifest-path' -Value $aggregateManifestResolved -DestPath $GitHubOutputPath
 Write-GitHubOutput -Key 'results-dir' -Value $resultsRootResolved -DestPath $GitHubOutputPath
 Write-GitHubOutput -Key 'mode-count' -Value $aggregate.modes.Count -DestPath $GitHubOutputPath
@@ -2886,11 +2942,11 @@ if (-not $renderSucceeded) {
 }
 
 if (Test-Path -LiteralPath $historyReportMarkdownPath -PathType Leaf) {
-  $historyReportMarkdownResolved = (Resolve-Path -LiteralPath $historyReportMarkdownPath).Path
+  $historyReportMarkdownResolved = Resolve-NativeExistingPath -PathValue $historyReportMarkdownPath
   Write-GitHubOutput -Key 'history-report-md' -Value $historyReportMarkdownResolved -DestPath $GitHubOutputPath
 }
 if ($historyReportHtmlPath -and (Test-Path -LiteralPath $historyReportHtmlPath -PathType Leaf)) {
-  $historyReportHtmlResolved = (Resolve-Path -LiteralPath $historyReportHtmlPath).Path
+  $historyReportHtmlResolved = Resolve-NativeExistingPath -PathValue $historyReportHtmlPath
   Write-GitHubOutput -Key 'history-report-html' -Value $historyReportHtmlResolved -DestPath $GitHubOutputPath
 }
 

--- a/tools/Render-VIHistoryReport.ps1
+++ b/tools/Render-VIHistoryReport.ps1
@@ -22,6 +22,34 @@ try {
   }
 } catch {}
 
+function Convert-ToNativeFileSystemPath {
+  param([AllowNull()][string]$PathValue)
+  if ([string]::IsNullOrWhiteSpace($PathValue)) { return $PathValue }
+
+  $candidate = [string]$PathValue
+  $lastProviderSeparator = $candidate.LastIndexOf('::', [System.StringComparison]::Ordinal)
+  if ($lastProviderSeparator -ge 0) {
+    $candidate = $candidate.Substring($lastProviderSeparator + 2)
+  }
+  $candidate = ($candidate -replace '^[A-Za-z][A-Za-z0-9.+-]*::', '')
+  if ($candidate -match '^[\\/](wsl\.localhost|wsl\$)[\\/]') {
+    $candidate = [System.IO.Path]::DirectorySeparatorChar + $candidate
+  }
+  try {
+    $resolved = Resolve-Path -LiteralPath $candidate -ErrorAction Stop | Select-Object -First 1
+    $providerPath = [string]$resolved.ProviderPath
+    if (-not [string]::IsNullOrWhiteSpace($providerPath)) {
+      return [System.IO.Path]::GetFullPath($providerPath)
+    }
+  } catch {}
+
+  try {
+    return [System.IO.Path]::GetFullPath($candidate)
+  } catch {
+    return $candidate
+  }
+}
+
 function Resolve-ExistingPath {
   param(
     [string]$Path,
@@ -36,7 +64,7 @@ function Resolve-ExistingPath {
     if ($Optional.IsPresent) { return $null }
     throw ("{0} file not found: {1}" -f $Description, $Path)
   }
-  return (Resolve-Path -LiteralPath $Path).Path
+  return Convert-ToNativeFileSystemPath -PathValue $Path
 }
 
 function Ensure-Directory {
@@ -45,14 +73,14 @@ function Ensure-Directory {
   if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
     New-Item -ItemType Directory -Force -Path $Path | Out-Null
   }
-  return (Resolve-Path -LiteralPath $Path).Path
+  return Convert-ToNativeFileSystemPath -PathValue $Path
 }
 
 function Resolve-FullPath {
   param([string]$Path)
   if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
   try {
-    return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    return Convert-ToNativeFileSystemPath -PathValue $Path
   } catch {
     if ([System.IO.Path]::IsPathRooted($Path)) {
       return [System.IO.Path]::GetFullPath($Path)
@@ -1639,7 +1667,7 @@ if ($contextResolved) {
 
 $markdownContent = $summaryLines -join [Environment]::NewLine
 [System.IO.File]::WriteAllText($MarkdownPath, $markdownContent, [System.Text.Encoding]::UTF8)
-$markdownOutPath = (Resolve-Path -LiteralPath $MarkdownPath).Path
+$markdownOutPath = Convert-ToNativeFileSystemPath -PathValue $MarkdownPath
 
 $htmlOutPath = $null
 if ($emitHtml -and $HtmlPath) {
@@ -2041,7 +2069,7 @@ if ($emitHtml -and $HtmlPath) {
 
   $htmlContent = $htmlBuilder.ToString()
   [System.IO.File]::WriteAllText($HtmlPath, $htmlContent, [System.Text.Encoding]::UTF8)
-  $htmlOutPath = (Resolve-Path -LiteralPath $HtmlPath).Path
+  $htmlOutPath = Convert-ToNativeFileSystemPath -PathValue $HtmlPath
   Write-GitHubOutput -Key 'history-report-html' -Value $htmlOutPath -DestPath $GitHubOutputPath
 }
 
@@ -2162,7 +2190,7 @@ $historySummary = [ordered]@{
   modes = @($modeFacadeEntries)
 }
 $historySummary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $SummaryJsonPath -Encoding utf8
-$summaryJsonOutPath = (Resolve-Path -LiteralPath $SummaryJsonPath).Path
+$summaryJsonOutPath = Convert-ToNativeFileSystemPath -PathValue $SummaryJsonPath
 
 Write-GitHubOutput -Key 'history-report-md' -Value $markdownOutPath -DestPath $GitHubOutputPath
 Write-GitHubOutput -Key 'history-summary-json' -Value $summaryJsonOutPath -DestPath $GitHubOutputPath


### PR DESCRIPTION
## Summary
- normalize VI history outputs to native filesystem paths on Windows proof surfaces
- strip provider-qualified results paths before nested compare and report serialization
- add regression coverage for emitted history and ref-compare artifacts

## Why
The Windows NI proof against `ni/labview-icon-editor` surfaced provider-qualified paths like `Microsoft.PowerShell.Core\\FileSystem::\\wsl.localhost\...` leaking into VI history artifacts. That broke the clean-history contract expected by downstream proof consumers.

## Validation
- `Invoke-Pester -Path tests/TestFileExistsAtRef.Tests.ps1 -Output Detailed`
- focused `CompareVI.GitRefs.VI2.Tests.ps1` run with clean skip behavior when fixture VI is absent
- Windows NI local proof against `Tooling/deployment/VIP_Pre-Install Custom Action.vi`
- verified no `Microsoft.PowerShell.Core\\FileSystem::` leakage remained in final history outputs
