### PR TITLE
Fix Windows preflight process capture deadlock

### DIFF
--- a/tests/Invoke-DockerRuntimeManager.Tests.ps1
+++ b/tests/Invoke-DockerRuntimeManager.Tests.ps1
@@ -109,8 +109,16 @@ if ($Args[0] -eq 'info') {
 }
 
 if ($Args[0] -eq 'manifest' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') {
+  $paddingBytes = [Environment]::GetEnvironmentVariable('DOCKER_STUB_MANIFEST_PADDING_BYTES')
+  $padding = ''
+  if (-not [string]::IsNullOrWhiteSpace($paddingBytes)) {
+    $padding = ('x' * [int]$paddingBytes)
+  }
   $manifest = [ordered]@{
     schemaVersion = 2
+    annotations = [ordered]@{
+      padding = $padding
+    }
     manifests = @(
       [ordered]@{
         digest = 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
@@ -242,6 +250,7 @@ exit 0
       DOCKER_STUB_RUN_FAIL_LINUX = $env:DOCKER_STUB_RUN_FAIL_LINUX
       DOCKER_STUB_INFO_SLEEP_SECONDS = $env:DOCKER_STUB_INFO_SLEEP_SECONDS
       DOCKER_STUB_INSPECT_SLEEP_SECONDS = $env:DOCKER_STUB_INSPECT_SLEEP_SECONDS
+      DOCKER_STUB_MANIFEST_PADDING_BYTES = $env:DOCKER_STUB_MANIFEST_PADDING_BYTES
       DOCKER_STUB_PULL_SLEEP_WINDOWS = $env:DOCKER_STUB_PULL_SLEEP_WINDOWS
       DOCKER_STUB_PULL_SLEEP_LINUX = $env:DOCKER_STUB_PULL_SLEEP_LINUX
       DOCKER_STUB_RUN_SLEEP_WINDOWS = $env:DOCKER_STUB_RUN_SLEEP_WINDOWS
@@ -454,6 +463,32 @@ exit 0
     $json.status | Should -Be 'failure'
     $json.failureClass | Should -Be 'runtime-probe-timeout'
     $json.probes.windows.probe.status | Should -Be 'timeout'
+  }
+
+  It 'handles large manifest output without deadlocking the timeout helper' {
+    $work = Join-Path $TestDrive 'large-manifest-output'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_MANIFEST_PADDING_BYTES '20000'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $output = @(& pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -ProbeScope windows `
+      -OutputJsonPath $jsonPath `
+      -CommandTimeoutSeconds 5 `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1)
+
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.status | Should -Be 'success'
+    $json.probes.windows.status | Should -Be 'success'
+    $json.probes.windows.digest | Should -Be 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
   }
 
   It 'fails with lock timeout when the runtime manager lock is held by another process' {

--- a/tests/Test-WindowsNI2026q1HostPreflight.Tests.ps1
+++ b/tests/Test-WindowsNI2026q1HostPreflight.Tests.ps1
@@ -76,6 +76,31 @@ if ($Args[0] -eq 'info') {
   exit 0
 }
 
+if ($Args[0] -eq 'manifest' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') {
+  $paddingBytes = [Environment]::GetEnvironmentVariable('DOCKER_STUB_MANIFEST_PADDING_BYTES')
+  $padding = ''
+  if (-not [string]::IsNullOrWhiteSpace($paddingBytes)) {
+    $padding = ('x' * [int]$paddingBytes)
+  }
+  $manifest = [ordered]@{
+    schemaVersion = 2
+    annotations = [ordered]@{
+      padding = $padding
+    }
+    manifests = @(
+      [ordered]@{
+        digest = 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
+        platform = [ordered]@{
+          os = 'windows'
+          architecture = 'amd64'
+        }
+      }
+    )
+  }
+  ($manifest | ConvertTo-Json -Depth 10) | Write-Output
+  exit 0
+}
+
 if ($Args[0] -eq 'image' -and $Args.Count -ge 2 -and $Args[1] -eq 'inspect') {
   $inspectSleep = [Environment]::GetEnvironmentVariable('DOCKER_STUB_INSPECT_SLEEP_SECONDS')
   if (-not [string]::IsNullOrWhiteSpace($inspectSleep)) {
@@ -165,6 +190,7 @@ exit 0
       DOCKER_STUB_INFO_EXITCODE = $env:DOCKER_STUB_INFO_EXITCODE
       DOCKER_STUB_RUN_STDERR = $env:DOCKER_STUB_RUN_STDERR
       DOCKER_STUB_RUN_EXITCODE = $env:DOCKER_STUB_RUN_EXITCODE
+      DOCKER_STUB_MANIFEST_PADDING_BYTES = $env:DOCKER_STUB_MANIFEST_PADDING_BYTES
       DOCKER_STUB_INSPECT_SLEEP_SECONDS = $env:DOCKER_STUB_INSPECT_SLEEP_SECONDS
       DOCKER_STUB_PULL_SLEEP_SECONDS = $env:DOCKER_STUB_PULL_SLEEP_SECONDS
       DOCKER_STUB_RUN_SLEEP_SECONDS = $env:DOCKER_STUB_RUN_SLEEP_SECONDS
@@ -350,5 +376,35 @@ exit 0
     $json.runtimeDeterminism.failureClass | Should -Be 'docker-engine-mismatch'
     $json.bootstrap.attempted | Should -BeFalse
     $json.probe.attempted | Should -BeFalse
+  }
+
+  It 'keeps desktop-local preflight ready when manifest output is large' {
+    $work = Join-Path $TestDrive 'desktop-local-large-manifest'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerHostedStubs -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_MANIFEST_PADDING_BYTES '20000'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $resultsRoot = Join-Path $work 'results'
+    $outputJsonPath = Join-Path $resultsRoot 'windows-ni-2026q1-host-preflight.json'
+
+    $output = @(& pwsh -NoLogo -NoProfile -File $script:ToolPath `
+      -Image 'nationalinstruments/labview:2026q1-windows' `
+      -ResultsDir $resultsRoot `
+      -ExecutionSurface 'desktop-local' `
+      -CommandTimeoutSeconds 5 `
+      -OutputJsonPath $outputJsonPath `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '' 2>&1)
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'ready'
+    $json.bootstrap.imagePresent | Should -BeTrue
+    $json.probe.status | Should -Be 'success'
   }
 }

--- a/tools/Assert-DockerRuntimeDeterminism.ps1
+++ b/tools/Assert-DockerRuntimeDeterminism.ps1
@@ -90,6 +90,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+. (Join-Path $PSScriptRoot 'ProcessTimeoutHelper.ps1')
+
 function Write-GitHubOutput {
   param(
     [Parameter(Mandatory = $true)][string]$Key,
@@ -193,41 +195,13 @@ function Invoke-ProcessWithTimeout {
     exception = ''
   }
 
-  $psi = [System.Diagnostics.ProcessStartInfo]::new()
-  $psi.FileName = $resolvedFilePath
-  $psi.UseShellExecute = $false
-  $psi.RedirectStandardOutput = $true
-  $psi.RedirectStandardError = $true
-  $psi.CreateNoWindow = $true
-  foreach ($arg in @($effectiveArguments)) {
-    [void]$psi.ArgumentList.Add([string]$arg)
-  }
-
-  $proc = [System.Diagnostics.Process]::new()
-  $proc.StartInfo = $psi
-
-  try {
-    [void]$proc.Start()
-    $completed = $proc.WaitForExit($safeTimeout * 1000)
-    if (-not $completed) {
-      $result.timedOut = $true
-      try { $proc.Kill($true) } catch {}
-      return [pscustomobject]$result
-    }
-
-    $result.exitCode = [int]$proc.ExitCode
-    $result.stdout = @(Split-OutputLines -Text $proc.StandardOutput.ReadToEnd())
-    $result.stderr = @(Split-OutputLines -Text $proc.StandardError.ReadToEnd())
-  } catch {
-    $result.exception = [string]$_.Exception.Message
-    try {
-      if (-not $proc.HasExited) {
-        $proc.Kill($true)
-      }
-    } catch {}
-  } finally {
-    $proc.Dispose()
-  }
+  $invoke = Invoke-ProcessWithTimeoutCore -FilePath $resolvedFilePath -Arguments @($effectiveArguments) -TimeoutSeconds $safeTimeout
+  $result.timedOut = [bool]$invoke.TimedOut
+  $result.exitCode = $invoke.ExitCode
+  $result.stdout = @($invoke.Stdout | ForEach-Object { [string]$_ })
+  $result.stderr = @($invoke.Stderr | ForEach-Object { [string]$_ })
+  $result.command = [string]$invoke.Command
+  $result.exception = [string]$invoke.Exception
 
   return [pscustomobject]$result
 }

--- a/tools/Invoke-DockerRuntimeManager.ps1
+++ b/tools/Invoke-DockerRuntimeManager.ps1
@@ -44,6 +44,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+. (Join-Path $PSScriptRoot 'ProcessTimeoutHelper.ps1')
+
 function Resolve-AbsolutePath {
   param([Parameter(Mandatory)][string]$Path)
   if ([System.IO.Path]::IsPathRooted($Path)) {
@@ -146,41 +148,13 @@ function Invoke-ProcessWithTimeout {
     exception = ''
   }
 
-  $psi = [System.Diagnostics.ProcessStartInfo]::new()
-  $psi.FileName = $resolvedFilePath
-  $psi.UseShellExecute = $false
-  $psi.RedirectStandardOutput = $true
-  $psi.RedirectStandardError = $true
-  $psi.CreateNoWindow = $true
-  foreach ($arg in @($effectiveArguments)) {
-    [void]$psi.ArgumentList.Add([string]$arg)
-  }
-
-  $proc = [System.Diagnostics.Process]::new()
-  $proc.StartInfo = $psi
-
-  try {
-    [void]$proc.Start()
-    $completed = $proc.WaitForExit($safeTimeout * 1000)
-    if (-not $completed) {
-      $result.timedOut = $true
-      try { $proc.Kill($true) } catch {}
-      return [pscustomobject]$result
-    }
-
-    $result.exitCode = [int]$proc.ExitCode
-    $result.stdout = @(Split-OutputLines -Text $proc.StandardOutput.ReadToEnd())
-    $result.stderr = @(Split-OutputLines -Text $proc.StandardError.ReadToEnd())
-  } catch {
-    $result.exception = [string]$_.Exception.Message
-    try {
-      if (-not $proc.HasExited) {
-        $proc.Kill($true)
-      }
-    } catch {}
-  } finally {
-    $proc.Dispose()
-  }
+  $invoke = Invoke-ProcessWithTimeoutCore -FilePath $resolvedFilePath -Arguments @($effectiveArguments) -TimeoutSeconds $safeTimeout
+  $result.timedOut = [bool]$invoke.TimedOut
+  $result.exitCode = $invoke.ExitCode
+  $result.stdout = @($invoke.Stdout | ForEach-Object { [string]$_ })
+  $result.stderr = @($invoke.Stderr | ForEach-Object { [string]$_ })
+  $result.command = [string]$invoke.Command
+  $result.exception = [string]$invoke.Exception
 
   return [pscustomobject]$result
 }

--- a/tools/ProcessTimeoutHelper.ps1
+++ b/tools/ProcessTimeoutHelper.ps1
@@ -1,0 +1,147 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not ('CompareVI.ProcessInvokeHelper' -as [type])) {
+  Add-Type -TypeDefinition @"
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace CompareVI {
+  public sealed class ProcessInvokeResult {
+    public bool TimedOut { get; set; }
+    public int? ExitCode { get; set; }
+    public string[] Stdout { get; set; } = Array.Empty<string>();
+    public string[] Stderr { get; set; } = Array.Empty<string>();
+    public string Command { get; set; } = "";
+    public string Exception { get; set; } = "";
+  }
+
+  public static class ProcessInvokeHelper {
+    private static string[] SplitLines(string value) {
+      if (string.IsNullOrEmpty(value)) {
+        return Array.Empty<string>();
+      }
+
+      return value
+        .Replace("\r\n", "\n")
+        .Replace('\r', '\n')
+        .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    public static ProcessInvokeResult Run(string filePath, string[] arguments, int timeoutSeconds) {
+      var safeTimeoutSeconds = Math.Max(5, timeoutSeconds);
+      var result = new ProcessInvokeResult();
+
+      using var stdoutClosed = new ManualResetEventSlim(false);
+      using var stderrClosed = new ManualResetEventSlim(false);
+      var stdout = new StringBuilder();
+      var stderr = new StringBuilder();
+
+      var psi = new ProcessStartInfo {
+        FileName = filePath,
+        UseShellExecute = false,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        CreateNoWindow = true
+      };
+
+      if (arguments != null) {
+        foreach (var argument in arguments) {
+          psi.ArgumentList.Add(argument ?? string.Empty);
+        }
+      }
+
+      result.Command = psi.FileName + (psi.ArgumentList.Count > 0 ? " " + string.Join(" ", psi.ArgumentList) : string.Empty);
+
+      using var process = new Process {
+        StartInfo = psi,
+        EnableRaisingEvents = true
+      };
+
+      process.OutputDataReceived += (_, eventArgs) => {
+        if (eventArgs.Data == null) {
+          stdoutClosed.Set();
+          return;
+        }
+
+        lock (stdout) {
+          stdout.AppendLine(eventArgs.Data);
+        }
+      };
+
+      process.ErrorDataReceived += (_, eventArgs) => {
+        if (eventArgs.Data == null) {
+          stderrClosed.Set();
+          return;
+        }
+
+        lock (stderr) {
+          stderr.AppendLine(eventArgs.Data);
+        }
+      };
+
+      try {
+        if (!process.Start()) {
+          result.Exception = "Process failed to start.";
+          return result;
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        if (!process.WaitForExit(safeTimeoutSeconds * 1000)) {
+          result.TimedOut = true;
+          try {
+            process.Kill(true);
+          } catch {
+          }
+        }
+
+        try {
+          process.WaitForExit();
+        } catch {
+        }
+
+        stdoutClosed.Wait(2000);
+        stderrClosed.Wait(2000);
+
+        if (!result.TimedOut) {
+          result.ExitCode = process.ExitCode;
+        }
+      } catch (Exception ex) {
+        result.Exception = ex.Message;
+        try {
+          if (!process.HasExited) {
+            process.Kill(true);
+          }
+        } catch {
+        }
+      }
+
+      result.Stdout = SplitLines(stdout.ToString());
+      result.Stderr = SplitLines(stderr.ToString());
+      return result;
+    }
+  }
+}
+"@ -Language CSharp
+}
+
+function Invoke-ProcessWithTimeoutCore {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$FilePath,
+    [string[]]$Arguments = @(),
+    [int]$TimeoutSeconds = 45
+  )
+
+  return [CompareVI.ProcessInvokeHelper]::Run(
+    [string]$FilePath,
+    [string[]]@($Arguments),
+    [Math]::Max(5, [int]$TimeoutSeconds)
+  )
+}

--- a/tools/Test-WindowsNI2026q1HostPreflight.ps1
+++ b/tools/Test-WindowsNI2026q1HostPreflight.ps1
@@ -39,6 +39,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+. (Join-Path $PSScriptRoot 'ProcessTimeoutHelper.ps1')
+
 function Resolve-AbsolutePath {
   param([Parameter(Mandatory)][string]$Path)
   return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
@@ -158,41 +160,13 @@ function Invoke-ProcessWithTimeout {
     exception = ''
   }
 
-  $psi = [System.Diagnostics.ProcessStartInfo]::new()
-  $psi.FileName = $resolvedFilePath
-  $psi.UseShellExecute = $false
-  $psi.RedirectStandardOutput = $true
-  $psi.RedirectStandardError = $true
-  $psi.CreateNoWindow = $true
-  foreach ($arg in @($effectiveArguments)) {
-    [void]$psi.ArgumentList.Add([string]$arg)
-  }
-
-  $proc = [System.Diagnostics.Process]::new()
-  $proc.StartInfo = $psi
-
-  try {
-    [void]$proc.Start()
-    $completed = $proc.WaitForExit($safeTimeout * 1000)
-    if (-not $completed) {
-      $result.timedOut = $true
-      try { $proc.Kill($true) } catch {}
-      return [pscustomobject]$result
-    }
-
-    $result.exitCode = [int]$proc.ExitCode
-    $result.stdout = @(Split-OutputLines -Text $proc.StandardOutput.ReadToEnd())
-    $result.stderr = @(Split-OutputLines -Text $proc.StandardError.ReadToEnd())
-  } catch {
-    $result.exception = [string]$_.Exception.Message
-    try {
-      if (-not $proc.HasExited) {
-        $proc.Kill($true)
-      }
-    } catch {}
-  } finally {
-    $proc.Dispose()
-  }
+  $invoke = Invoke-ProcessWithTimeoutCore -FilePath $resolvedFilePath -Arguments @($effectiveArguments) -TimeoutSeconds $safeTimeout
+  $result.timedOut = [bool]$invoke.TimedOut
+  $result.exitCode = $invoke.ExitCode
+  $result.stdout = @($invoke.Stdout | ForEach-Object { [string]$_ })
+  $result.stderr = @($invoke.Stderr | ForEach-Object { [string]$_ })
+  $result.command = [string]$invoke.Command
+  $result.exception = [string]$invoke.Exception
 
   return [pscustomobject]$result
 }


### PR DESCRIPTION
## Summary
- centralize timeout-bounded process capture into a shared helper that drains stdout/stderr without PowerShell runspace callbacks
- update Windows preflight/runtime scripts to use the shared helper
- add regression coverage for oversized docker manifest output on both the runtime manager and host preflight paths

## Validation
- `Invoke-Pester -Path 'tests/Invoke-DockerRuntimeManager.Tests.ps1','tests/Test-WindowsNI2026q1HostPreflight.Tests.ps1' -Output Detailed -CI`
- benchmark proof against `ni/labview-icon-editor` `Tooling/deployment/VIP_Pre-Install Custom Action.vi` commit pair `45a553d -> 66c6bdc` via the Windows NI image path
